### PR TITLE
 Explicitly require Python version 3 for plugin scripts and automatically choose suitable binary.

### DIFF
--- a/synfig-studio/configure.ac
+++ b/synfig-studio/configure.ac
@@ -277,9 +277,6 @@ AC_SUBST(imagedir)
 plugindir="${datadir}/synfig/plugins"
 AC_SUBST(plugindir)
 
-pythonbinary="python"
-AC_SUBST(pythonbinary)
-
 AC_PATH_PROG(UPDATE_MIME_DATABASE, update-mime-database, no)
 AC_ARG_ENABLE(update-mimedb,
    AC_HELP_STRING([--disable-update-mimedb],

--- a/synfig-studio/src/gui/Makefile.am
+++ b/synfig-studio/src/gui/Makefile.am
@@ -116,5 +116,4 @@ synfigstudio_CXXFLAGS = \
 	-DIMAGE_DIR=\"$(imagedir)\" \
 	-DIMAGE_EXT=\"$(imageext)\" \
 	-DPLUGIN_DIR=\"$(plugindir)\" \
-	-DPYTHON_BINARY=\"$(pythonbinary)\" \
 	"-DLOCALEDIR=\"$(localedir)\""

--- a/synfig-studio/src/synfigapp/pluginmanager.h
+++ b/synfig-studio/src/synfigapp/pluginmanager.h
@@ -66,6 +66,7 @@ public:
 	~PluginLauncher();
 
 	bool execute( std::string script_path );
+	bool check_python_version( std::string path);
 	std::string get_result_path();
 	std::string get_original_path() { return filename_original; };
 	std::string get_output() { return output; };


### PR DESCRIPTION
Python binary could be named as "python" or "python3" - Synfig checks the version at runtime and chooses suitable binary.
