### PR TITLE
Fix bug #422: Crash: map_cairo_image(): Assertion failed 

### DIFF
--- a/synfig-core/src/modules/mod_png/mptr_cairo_png.cpp
+++ b/synfig-core/src/modules/mod_png/mptr_cairo_png.cpp
@@ -64,6 +64,11 @@ cairo_png_mptr::cairo_png_mptr(const char *file_name)
 {
 	filename=file_name;
 	csurface_=cairo_image_surface_create_from_png(file_name);
+	if(cairo_surface_status(csurface_))
+	{
+		throw strprintf("Unable to physically open %s",file_name);
+		return;
+	}
 	CairoSurface cairo_s;
 	cairo_s.set_cairo_surface(csurface_);
 	cairo_s.map_cairo_image();


### PR DESCRIPTION
There weren't any checking of the status of the cairo_surface_t when reading the image from file. This commit adds it and fixes the bug.
