### PR TITLE
Bug report #420  -  The Add keyframe button shouldn't be active if there is not timeline

### DIFF
--- a/synfig-studio/src/gui/actionmanagers/keyframeactionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/keyframeactionmanager.cpp
@@ -242,6 +242,19 @@ KeyframeActionManager::refresh()
 			action->set_sensitive(false);
 	}
 
+	//get the beginning and ending time of the time slider
+	Time begin_time=canvas_interface_->get_canvas()->rend_desc().get_time_start();
+	Time end_time=canvas_interface_->get_canvas()->rend_desc().get_time_end();
+	//enable add key frame action if animation duration != 0
+	if(begin_time==end_time)
+	{
+		action_group_->get_action("action-KeyframeAdd")->set_sensitive(false);
+	}
+	else
+	{
+		action_group_->get_action("action-KeyframeAdd")->set_sensitive(true);
+	}
+
 	ui_info="<ui><popup action='menu-main'><menu action='menu-keyframe'>"+ui_info+"</menu></popup></ui>";
 	popup_id_=get_ui_manager()->add_ui_from_string(ui_info);
 #ifdef ONE_ACTION_GROUP


### PR DESCRIPTION
Seems that KeyframeActionManager::refresh() is not called when time is updated
(caret/properti/time/... /apply)
but when the time bar is scrolled ....
at least, my patch eat the crash !
