### PR TITLE
Fix - Playing animation, hitting ALT= segfault!

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -2449,14 +2449,15 @@ bool
 CanvasView::on_key_press_event(GdkEventKey* event)
 {
 	Gtk::Widget* focused_widget = get_focus();
-	if(focused_widget_has_priority(focused_widget))
+	if(focused_widget && focused_widget_has_priority(focused_widget))
 	{
 		if(focused_widget->event((GdkEvent*)event))
 		return true;
 	}
 	else if(Gtk::Window::on_key_press_event(event))
-		return true;
-	else return focused_widget->event((GdkEvent*)event);
+			return true;
+		else
+			if (focused_widget) return focused_widget->event((GdkEvent*)event);
 	return false;
 }
 

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -623,7 +623,7 @@ public:
 	//! Hides the time bar
 	void hide_timebar();
 
-	//t Enables or disables interaction with the timebar
+	//! Enables or disables interaction with the timebar
 	void set_sensitive_timebar(bool sensitive);
 
 	void time_zoom_in();
@@ -738,6 +738,7 @@ private:
 
 	void on_meta_data_changed();
 
+	//! Keyboard event dispatcher following window priority
 	bool on_key_press_event(GdkEventKey* event);
 	bool focused_widget_has_priority(Gtk::Widget * focused);
 


### PR DESCRIPTION
Keyboard event dispatch , test focused_widget != NULL before use it.
