### PR TITLE
Fix - Sometime, hitting something around docks = segfault!

### DIFF
--- a/synfig-studio/src/gui/docks/dockdialog.cpp
+++ b/synfig-studio/src/gui/docks/dockdialog.cpp
@@ -250,14 +250,15 @@ bool
 DockDialog::on_key_press_event(GdkEventKey* event)
 {
 	Gtk::Widget* focused_widget = get_focus();
-	if(focused_widget_has_priority(focused_widget))
+	if(focused_widget && focused_widget_has_priority(focused_widget))
 	{
 		if(focused_widget->event((GdkEvent*)event))
 		return true;
 	}
 	else if(Gtk::Window::on_key_press_event(event))
-		return true;
-	else return focused_widget->event((GdkEvent*)event);
+			return true;
+		else
+			if (focused_widget) return focused_widget->event((GdkEvent*)event);
 	return false;
 }
 

--- a/synfig-studio/src/gui/docks/dockdialog.h
+++ b/synfig-studio/src/gui/docks/dockdialog.h
@@ -94,6 +94,7 @@ private:
 	void drop_on_append(const Glib::RefPtr<Gdk::DragContext>& context, int, int, const Gtk::SelectionData& selection_data, guint, guint time);
 	void drop_on_prepend(const Glib::RefPtr<Gdk::DragContext>& context, int, int, const Gtk::SelectionData& selection_data, guint, guint time);
 
+	//! Keyboard event dispatcher following window priority
 	bool on_key_press_event(GdkEventKey* event);
 
 	bool focused_widget_has_priority(Gtk::Widget* focused);


### PR DESCRIPTION
Keyboard event dispatch , test focused_widget != NULL before use it. :-)
