### PR TITLE
Bug report #330  -  Preview Window case a Synfig Studio crash

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1608,6 +1608,11 @@ CanvasView::init_menus()
 	action_group->add( Gtk::Action::create("dialog-flipbook", _("Preview Window")),
 		sigc::mem_fun0(*preview_dialog, &studio::Dialog_Preview::present)
 	);
+	// Prevent call to preview window before preview option has created the preview window
+	{
+		Glib::RefPtr< Gtk::Action > action = action_group->get_action("dialog-flipbook");
+		action->set_sensitive(false);
+	}
 
 	{
 		Glib::RefPtr<Gtk::ToggleAction> action;
@@ -4031,6 +4036,13 @@ CanvasView::on_preview_create(const PreviewInfo &info)
 	pd->set_default_size(700,510);
 	pd->set_preview(prev.get());
 	pd->present();
+
+	// Preview Window created, the action can be enabled
+	{
+		Glib::RefPtr< Gtk::Action > action = action_group->get_action("dialog-flipbook");
+		action->set_sensitive(true);
+	}
+
 }
 
 void


### PR DESCRIPTION
I have disabled Preview Window (sensitive = false) through the "dialog-flipbook" action (yes it's the call the preview window :) until the Preview Option is called (and the preview window is created.)
Then, the action is always enabled (the preview window is only hided on close_event, never is closed)

Possible improvement, let Preview Window action be always sensitive and call Preview Option the first time.
