### PR TITLE
Fix warning in filecontainerzip.cpp

### DIFF
--- a/synfig-core/src/synfig/filecontainerzip.cpp
+++ b/synfig-core/src/synfig/filecontainerzip.cpp
@@ -136,7 +136,8 @@ namespace synfig
 
 			inline static size_t offset_from_header()
 			{
-				return offsetof(LocalFileHeader, crc32);
+				const static LocalFileHeader dummy;
+				return (size_t)((const char *)&dummy.crc32 - (const char *)&dummy);
 			}
 		};
 


### PR DESCRIPTION
Fix warning in filecontainerzip.cpp
