### PR TITLE
Cleaned up synfig-core/configure.ac

### DIFF
--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -80,8 +80,8 @@ AC_CHECK_LIB(c, dlopen,
 	AC_CHECK_LIB(
 		dl,
 		dlopen,
-	DYNAMIC_LD_LIBS="-ldl",
-	    DYNAMIC_LD_LIBS=""
+		DYNAMIC_LD_LIBS="-ldl",
+		DYNAMIC_LD_LIBS=""
 	)
 )
 


### PR DESCRIPTION
I erased commented-out code and squeezed if-else blocks into equivalent AM_CONDITIONAL one-liners.

`configure --help` gives smaller and more consistent help messages.  [Here is a before-and-after comparison screenshot.](https://mediacru.sh/vBH-NfmeU6hl)
