### PR TITLE
Fix the description of "layer" param in Action::LayerSetDesc

### DIFF
--- a/synfig-studio/src/synfigapp/actions/layersetdesc.cpp
+++ b/synfig-studio/src/synfigapp/actions/layersetdesc.cpp
@@ -83,7 +83,7 @@ Action::LayerSetDesc::get_param_vocab()
 
 	ret.push_back(ParamDesc("layer",Param::TYPE_LAYER)
 		.set_local_name(_("Layer"))
-		.set_desc(_("Layer to be moved"))
+		.set_desc(_("Layer to be described"))
 	);
 
 	ret.push_back(ParamDesc("new_description",Param::TYPE_STRING)


### PR DESCRIPTION
"Layer to be moved" still is the description of Action::LayerMove
