### PR TITLE
Fix Enhancement #559 - Missing strings for translation + Fix Typo workscape --> workspace

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -825,7 +825,7 @@ init_ui_manager()
 
 	menus_action_group->add( Gtk::Action::create("menu-window", _("_Window")));
 	menus_action_group->add( Gtk::Action::create("menu-arrange", _("_Arrange")));
-	menus_action_group->add( Gtk::Action::create("menu-workspace", _("Work_scape")));
+	menus_action_group->add( Gtk::Action::create("menu-workspace", _("Work_space")));
 
 	menus_action_group->add( Gtk::Action::create("menu-help", _("_Help")) );
 


### PR DESCRIPTION
Open with history strings
+
Typo on Menu entry : workscape --> workspace
