### PR TITLE
Fix #325 - Color panel don't update by "Html Code" change with textfield...

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -373,6 +373,7 @@ Widget_ColorEdit::Widget_ColorEdit():
 		hex_color = manage(new Gtk::Entry());
 		hex_color->set_width_chars(8);
 		hex_color->signal_activate().connect(sigc::mem_fun(*this,&studio::Widget_ColorEdit::on_hex_edited));
+		hex_color->signal_focus_out_event().connect(sigc::mem_fun(*this, &studio::Widget_ColorEdit::on_hex_focus_out));
 		table->attach(*hex_color, 0, 1, 8, 9, Gtk::SHRINK, Gtk::SHRINK, 0, 0);
 	}
 	{
@@ -447,6 +448,13 @@ Widget_ColorEdit::on_hex_edited()
 	color.set_hex(s);
 	set_value(color);
 	signal_value_changed_();
+}
+
+bool
+Widget_ColorEdit::on_hex_focus_out(GdkEventFocus* event)
+{
+	on_hex_edited();
+	return true;
 }
 
 void

--- a/synfig-studio/src/gui/widgets/widget_coloredit.h
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.h
@@ -165,6 +165,7 @@ public:
 
 	void on_slider_moved(ColorSlider::Type type, float amount);
 	void on_hex_edited();
+	bool on_hex_focus_out(GdkEventFocus* event);
 
 	//Glib::SignalProxy0<void> signal_activate() { return spinbutton_A->signal_activate(); }
 


### PR DESCRIPTION
... on focus_out_event
- Connect focus_out_event of Widget_ColorEdit::hex_color ( Gtk::Entry )
- Widget_ColorEdit::on_hex_focus_out call Widget_ColorEdit::on_hex_edited
