### PR TITLE
Fix 517-After closing an exported Canvas it can't be reopened from Canvas Browser

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -958,6 +958,8 @@ void CanvasView::deactivate()
 void CanvasView::present()
 {
 	Dockable::present();
+	// If hided by CanvasView::close_view, time to come back to the show
+	if(!get_visible())show();
 	update_title();
 }
 

--- a/synfig-studio/src/gui/docks/dock_canvases.h
+++ b/synfig-studio/src/gui/docks/dock_canvases.h
@@ -66,7 +66,9 @@ private:
 	void refresh_instances();
 
 	bool close();
-
+	//! Signal handler of signal_row_activated, look for the desired canvas, and
+	//! give it the focus
+	/*! \see studio::Instance::focus */
 	void on_row_activate(const Gtk::TreeModel::Path &path, Gtk::TreeViewColumn *);
 	//bool on_tree_event(GdkEvent *event);
 

--- a/synfig-studio/src/gui/docks/dockbook.h
+++ b/synfig-studio/src/gui/docks/dockbook.h
@@ -79,6 +79,9 @@ public:
 
 	bool tab_button_pressed(GdkEventButton* event, Dockable* dockable);
 	void on_drag_data_received(const Glib::RefPtr<Gdk::DragContext>& context, int, int, const Gtk::SelectionData& selection_data, guint, guint time);
+	//! Overide the default handler of the signal Gtk::Notebook::signal_switch_page().
+	//! to do some extra work in case of CanvasView Dockable type
+	/*! \see App::set_selected_canvas_view */
 	void on_switch_page(GtkNotebookPage* page, guint page_num);
 }; // END of studio::DockBook
 


### PR DESCRIPTION
- The canvas_view was hided, but never show again. Show it on Canvasview::present
  +
- Some comments around
