### PR TITLE
Fix-161 - Align rows of Params Panel and Timetrack Panel

### DIFF
--- a/synfig-studio/src/gui/docks/dock_curves.cpp
+++ b/synfig-studio/src/gui/docks/dock_curves.cpp
@@ -123,6 +123,9 @@ Dock_Curves::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 		)
 	);
 
+	studio::LayerTree* tree_layer(dynamic_cast<studio::LayerTree*>(canvas_view->get_ext_widget("layers_cmp")));
+	tree_layer->signal_param_tree_header_height_changed().connect(sigc::mem_fun(*this, &studio::Dock_Curves::on_update_header_height));
+
 	canvas_view->set_ext_widget(get_name(),curves);
 }
 
@@ -190,4 +193,12 @@ Dock_Curves::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view
 	{
 		//clear_previous();
 	}
+}
+
+void
+Dock_Curves::on_update_header_height( int header_height)
+{
+	//add the border size
+	header_height+=2;
+	widget_timeslider_->set_size_request(-1,header_height+1);
 }

--- a/synfig-studio/src/gui/docks/dock_curves.h
+++ b/synfig-studio/src/gui/docks/dock_curves.h
@@ -65,7 +65,12 @@ public:
 
 	Dock_Curves();
 	~Dock_Curves();
-}; // END of Dock_Keyframes
+
+private:
+	//! Signal handler for studio::LayerTree::signal_param_tree_header_height_changed
+	/* \see studio::LayerTree::signal_param_tree_header_height_changed */
+	void on_update_header_height( int header_height);
+}; // END of Dock_Curves
 
 }; // END of namespace studio
 

--- a/synfig-studio/src/gui/docks/dock_timetrack.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack.cpp
@@ -418,7 +418,7 @@ Dock_Timetrack::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view
 	tree_view->signal_waypoint_clicked_timetrackview.connect(sigc::mem_fun(*canvas_view, &studio::CanvasView::on_waypoint_clicked_canvasview));
 
 	studio::LayerTree* tree_layer(dynamic_cast<studio::LayerTree*>(canvas_view->get_ext_widget("layers_cmp")));
-	tree_layer->signal_param_tree_header_size_changed().connect(sigc::mem_fun(*this, &studio::Dock_Timetrack::on_update_header_size));
+	tree_layer->signal_param_tree_header_height_changed().connect(sigc::mem_fun(*this, &studio::Dock_Timetrack::on_update_header_height));
 
 	canvas_view->time_adjustment().signal_value_changed().connect(sigc::mem_fun(*tree_view,&Gtk::TreeView::queue_draw));
 	canvas_view->time_adjustment().signal_changed().connect(sigc::mem_fun(*tree_view,&Gtk::TreeView::queue_draw));
@@ -512,10 +512,10 @@ Dock_Timetrack::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_v
 }
 
 void
-Dock_Timetrack::on_update_header_size( int header_size)
+Dock_Timetrack::on_update_header_height( int header_height)
 {
 	//add the border size
-	header_size+=2;
-	widget_timeslider_->set_size_request(-1,header_size-header_size/3+1);
-	widget_kf_list_->set_size_request(-1,header_size/3+1);
+	header_height+=2;
+	widget_timeslider_->set_size_request(-1,header_height-header_height/3+1);
+	widget_kf_list_->set_size_request(-1,header_height/3+1);
 }

--- a/synfig-studio/src/gui/docks/dock_timetrack.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack.h
@@ -66,8 +66,9 @@ public:
 	~Dock_Timetrack();
 
 private:
-	//! Signal handler for studio::LayerTree::
-	void on_update_header_size( int header_size);
+	//! Signal handler for studio::LayerTree::signal_param_tree_header_height_changed
+	/* \see studio::LayerTree::signal_param_tree_header_height_changed */
+	void on_update_header_height( int header_height);
 }; // END of Dock_Timetrack
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -431,7 +431,7 @@ LayerTree::create_param_tree()
 
 	// To get the initial style
 	param_tree_style_changed = true;
-	param_tree_header_size = 0;
+	param_tree_header_height = 0;
 
 	//column_time_track->set_visible(false);
 
@@ -1318,7 +1318,7 @@ LayerTree::on_param_tree_column_label_style_changed (const Glib::RefPtr< Gtk::St
 //{
 //	if (param_tree_style_changed)
 //	{
-//		if (update_param_tree_header_size())	signal_param_tree_header_size_changed()(param_tree_header_size);
+//		if (update_param_tree_header_height())	signal_param_tree_header_height_changed()(param_tree_header_height);
 //		param_tree_style_changed = false;
 //	}
 //	return true;
@@ -1329,16 +1329,17 @@ LayerTree::on_param_tree_column_label_expose_draw (GdkEventExpose * /*event*/)
 {
 	if (param_tree_style_changed)
 	{
-		if (update_param_tree_header_size())	signal_param_tree_header_size_changed()(param_tree_header_size);
+		if (update_param_tree_header_height())	signal_param_tree_header_height_changed()(param_tree_header_height);
 		param_tree_style_changed = false;
 	}
-	return true;
+	//tell gtkmm to pass (x window) signal to the next signal handler
+	return false;
 }
 
 bool
-LayerTree::update_param_tree_header_size()
+LayerTree::update_param_tree_header_height()
 {
-	bool header_size_updated = false;
+	bool header_height_updated = false;
 	const Gtk::TreeViewColumn* column = get_param_tree_view().get_column (0);
 	if (column)
 	{
@@ -1349,15 +1350,15 @@ LayerTree::update_param_tree_header_size()
 				const Gtk::Container* container;
 				if((container = column->get_widget()->get_parent()->get_parent()))
 				{
-					int header_size = container->get_height();
-					if (header_size != param_tree_header_size)
+					int header_height = container->get_height();
+					if (header_height != param_tree_header_height)
 					{
-						param_tree_header_size = header_size;
-						header_size_updated = true;
+						param_tree_header_height = header_height;
+						header_height_updated = true;
 					}
 				}
 			}
 		}
 	}
-	return header_size_updated;
+	return header_height_updated;
 }

--- a/synfig-studio/src/gui/trees/layertree.h
+++ b/synfig-studio/src/gui/trees/layertree.h
@@ -140,7 +140,7 @@ private:
 
 	sigc::signal<void,synfigapp::ValueDesc,std::set<synfig::Waypoint,std::less<synfig::UniqueID> >,int> signal_waypoint_clicked_layertree_;
 
-	sigc::signal<void,int> signal_param_tree_header_size_changed_;
+	sigc::signal<void,int> signal_param_tree_header_height_changed_;
 
 	bool disable_amount_changed_signal;
 
@@ -154,7 +154,7 @@ private:
 
 	bool param_tree_style_changed;
 
-	int param_tree_header_size;
+	int param_tree_header_height;
 
 	/*
  -- ** -- P R I V A T E   M E T H O D S ---------------------------------------
@@ -164,10 +164,10 @@ private:
 
 	Gtk::Widget* create_layer_tree();
 	Gtk::Widget* create_param_tree();
-	//! Update the param_tree_view header size.
-	/*! \return true if param_tree_header_size updated, else false
+	//! Update the param_tree_view header height.
+	/*! \return true if param_tree_header_height updated, else false
 	*/
-	bool update_param_tree_header_size();
+	bool update_param_tree_header_height();
 
 	/*
  -- ** -- S I G N A L   T E R M I N A L S -------------------------------------
@@ -262,9 +262,9 @@ public:
 
 	sigc::signal<void,synfigapp::ValueDesc,std::set<synfig::Waypoint,std::less<synfig::UniqueID> >,int>& signal_waypoint_clicked_layertree() { return signal_waypoint_clicked_layertree_; }
 
-	//! Signal fired when the param treeview header size has changed. The first parameter hold the header size
-	/*! \see LayerTree::update_param_tree_header_size() */
-	sigc::signal<void,int>& signal_param_tree_header_size_changed() { return signal_param_tree_header_size_changed_; }
+	//! Signal fired when the param treeview header height has changed. The first parameter hold the header height
+	/*! \see LayerTree::update_param_tree_header_height() */
+	sigc::signal<void,int>& signal_param_tree_header_height_changed() { return signal_param_tree_header_height_changed_; }
 
 	etl::handle<synfigapp::SelectionManager> get_selection_manager() { return layer_tree_store_->canvas_interface()->get_selection_manager(); }
 


### PR DESCRIPTION
- added a label widget to the param dock column to be able to catch style updated signal, then when the widget is drawn get retrieve the header height.
- send a signal the param dock header height has changed
- connect timetrack and curves docks to this signal to update both dock's headers

Nota : i have added some gtkmm3 commented function to make easier the migration
