### PR TITLE
Update broken link

### DIFF
--- a/synfig-studio/TODO
+++ b/synfig-studio/TODO
@@ -27,5 +27,5 @@
 
 ## User-requested features ##
 
-http://synfig.org/Wish_list
+http://www.synfig.org/issues/thebuggenie/synfig/issues/wishlist
 http://sf.net/tracker/?group_id=144022&atid=757419


### PR DESCRIPTION
Page http://synfig.org/Wish_list does not exist, and the Wish_list wiki page says that all items have now been moved to http://www.synfig.org/issues/thebuggenie/synfig.
