### PR TITLE
#620 - Tools shortcuts do not work ! - revert toolbox menu suppression

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1121,6 +1121,8 @@ DEFINE_ACTION("keyframe-properties","Properties");
 "		<menuitem action='properties'/>"
 "		<menuitem action='options'/>"
 "	</menu>"
+"	<menu action='menu-toolbox'>"
+"	</menu>"
 "	<menu action='menu-layer'>"
 "		<menu action='menu-layer-new'></menu>"
 "		<menuitem action='amount-inc'/>"

--- a/synfig-studio/src/gui/statemanager.cpp
+++ b/synfig-studio/src/gui/statemanager.cpp
@@ -103,6 +103,14 @@ StateManager::add_state(const Smach::state_base *state)
 		)
 	);
 
+	String uid_def;
+	uid_def = "<ui><popup action='menu-main'><menu action='menu-toolbox'><menuitem action='state-"+name+"' /></menu></popup></ui>";
+	merge_id_list.push_back(App::ui_manager()->add_ui_from_string(uid_def));
+	uid_def = "<ui><menubar action='menubar-main'><menu action='menu-toolbox'><menuitem action='state-"+name+"' /></menu></menubar></ui>";
+	merge_id_list.push_back(App::ui_manager()->add_ui_from_string(uid_def));
+
+	App::ui_manager()->ensure_update();
+
 	App::dock_toolbox->add_state(state);
 }
 


### PR DESCRIPTION
- Add menu-toolbox action to menu definition at global menu creation
- Add states action menu definitions at state management for both popup and
  menubar menus

With this modification, we are able to choose and affect shortcuts for the tools.

Actually tools shortcuts are still defined has Alt+Key, shortcuts who open item of
the main menu.
