### PR TITLE
Keyframe enhancements

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -362,7 +362,9 @@ Widget_Keyframe_List::on_event(GdkEvent *event)
 				//! Moving tooltip displaying the dragging time
 				{
 					int x_root = static_cast<int>(event->button.x_root);
-					int y_root = static_cast<int>(event->button.y_root);
+					int x_origin; int y_origin;
+					get_window()->get_origin (x_origin, y_origin);
+
 					Glib::ustring tooltip_label (_("Time : "));
 					tooltip_label.append( dragging_kf_time.get_string(fps,App::get_time_format()) );
 					tooltip_label.append("\n");
@@ -372,13 +374,12 @@ Widget_Keyframe_List::on_event(GdkEvent *event)
 
 					if(!moving_tooltip_->is_visible ())
 					{
-						moving_tooltip_->move(x_root, y_root);
+						//! Show the tooltip and fix his y coordinate (up to the widget)
 						moving_tooltip_->show();
+						moving_tooltip_y_ = y_origin - moving_tooltip_->get_height();
 					}
-					else
-					{
-						moving_tooltip_->move(x_root, y_root);
-					}
+					//! Move the tooltip to a nice position
+					moving_tooltip_->move(x_root, moving_tooltip_y_);
 				}
 
 				return true;

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.h
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.h
@@ -152,9 +152,12 @@ public:
 
 private:
 
-	//! Moving tooltip operation
+	//! The Moving handmade tooltip window
 	Gtk::Window *moving_tooltip_;
+	//! The Moving handmade tooltip label
 	Gtk::Label *moving_tooltip_label_;
+	//! The Moving handmade tooltip y fixed coordinate
+	int moving_tooltip_y_;
 
 }; // END of class Keyframe_List
 


### PR DESCRIPTION
- 548 - Display the keyframe's name (or "No name")
- micro Performance : do not perform any operation if the key frame list is empty
- Fix 626 - Key frame name losted after moving it from kf widget

**546 - Time indicator tooltip on kf drag**
- Tooltip is displayed up to the keyframe list widget, with y coordinate fixed
- 2 lines tooltip : time and old time
