### PR TITLE
Temp Fix for Win users (untested)

### DIFF
--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -456,6 +456,10 @@ StateBrush_Context::load_settings()
 		{
 			// force add Ubuntu path to mypaint brushes
 			paths.insert("/usr/share/mypaint/brushes");
+			// a small temp change to get the brushes working for Win Users 
+			#ifdef WIN32
+			paths.insert("C:\brushes");
+			#endif
 		}
 		refresh_tool_options();
 


### PR DESCRIPTION
This should allow Windows Users to use MyPaint brushes too for now.
Needs a better more general fix soon, but a daily build with this would be nice.
