### PR TITLE
build: define PATH_MAX if necessary to fix FTBFS on GHU Hurd:

### DIFF
--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -77,6 +77,10 @@
 
 #endif
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 using namespace std;
 using namespace etl;
 using namespace synfig;


### PR DESCRIPTION
```
main.cpp: In function 'synfig::String synfig::get_binary_path(const String&)':
main.cpp:458:20: error: 'PATH_MAX' was not declared in this scope
  size_t buf_size = PATH_MAX - 1;
                    ^
```
