### PR TITLE
705 - Desynchronized colors - what you choose is not what you get

### DIFF
--- a/synfig-core/src/synfig/cairoimporter.cpp
+++ b/synfig-core/src/synfig/cairoimporter.cpp
@@ -128,7 +128,7 @@ CairoImporter::open(const FileSystem::Identifier &identifier)
 }
 
 CairoImporter::CairoImporter(const FileSystem::Identifier &identifier):
-	gamma_(2.2),
+	gamma_(1.0),
 	identifier(identifier)
 {
 }

--- a/synfig-core/src/synfig/importer.cpp
+++ b/synfig-core/src/synfig/importer.cpp
@@ -128,7 +128,7 @@ Importer::open(const FileSystem::Identifier &identifier)
 }
 
 Importer::Importer(const FileSystem::Identifier &identifier):
-	gamma_(2.2),
+	gamma_(1.0),
 	identifier(identifier)
 {
 }


### PR DESCRIPTION
Fix the imported images color space

IMPORTANT : With this fix, Setup/Gamma, should be definitivly fixed to
Red/Green/Blue 1.0 and Black Level to 0,0%
