### PR TITLE
Fix 730 - Render : Extract Alpha in cairoPng render twice same file.

### DIFF
--- a/synfig-core/src/modules/mod_png/trgt_cairo_png.h
+++ b/synfig-core/src/modules/mod_png/trgt_cairo_png.h
@@ -1,6 +1,6 @@
 /* === S Y N F I G ========================================================= */
 /*!	\file trgt_cairo_png.h
-**	\brief Template Header
+**	\brief Template Header Target Png Cairo Module
 **
 **	$Id$
 **


### PR DESCRIPTION
Now Png Cairo Render with Extract Alpha produce original and mask files.
