### PR TITLE
Fixed locale bug in SVG module.

### DIFF
--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -98,7 +98,8 @@ Svg_parser::Svg_parser():
 	kux(60),
 	set_canvas(0), //we must run parser_canvas method
 	ox(0),
-	oy(0)
+	oy(0),
+	locale(LC_NUMERIC, "C")
 {
 	// 0.5 in gamma parameter of color correct layer is 1/0.5 = 2 (thinking) it must be 2.2!!!!
 	gamma.set_gamma(2.2);

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -128,6 +128,8 @@ public:
 		//void set_id(String source);
 
 private:
+		ChangeLocale locale;
+	
 		/* === PARSERS ==================================== */
 		void parser_node(const xmlpp::Node* node);
 		//parser headers


### PR DESCRIPTION
Fixed bug with locales in SVG module. The problem appeared when numeric format dosn't match with "C" format.