### PR TITLE
Fix memory leak.

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -306,8 +306,6 @@ CellRenderer_ValueBase::CellRenderer_ValueBase():
 #endif
 {
 	CellRendererText::signal_edited().connect(sigc::mem_fun(*this,&CellRenderer_ValueBase::string_edited_));
-	value_entry=new ValueBase_Entry();
-	value_entry->hide();
 
 	Pango::AttrList attr_list;
 	{


### PR DESCRIPTION
value_entry is dynamicaly created into CellRenderer_ValueBase::start_editing_vfunc
near line 678 ( https://github.com/synfig/synfig/blob/master/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp#L680 )

value_entry=manage(new ValueBase_Entry());		assert(get_canvas());
//delete value_entry;
value_entry=manage(new ValueBase_Entry());  // <---- here
value_entry->set_path(path);
value_entry->set_canvas(get_canvas());