### PR TITLE
Fix 754 : Onion skin broken ++

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -683,8 +683,8 @@ CanvasView::CanvasView(etl::loose_handle<Instance> instance,etl::handle<synfigap
 	toggleducksdial         (Gtk::IconSize::from_name("synfig-small_icon_16x16")),
 	resolutiondial         	(Gtk::IconSize::from_name("synfig-small_icon_16x16")),
 	quality_adjustment_		(Gtk::Adjustment::create(8,1,10,1,1,0)),
-	future_onion_adjustment_(Gtk::Adjustment::create(0,0,2,1,1,0)),
-	past_onion_adjustment_  (Gtk::Adjustment::create(0,0,2,1,1,0)),
+	future_onion_adjustment_(Gtk::Adjustment::create(0,0,ONION_SKIN_FUTURE,1,1,0)),
+	past_onion_adjustment_  (Gtk::Adjustment::create(0,0,ONION_SKIN_PAST,1,1,0)),
 
 	timeslider				(new Widget_Timeslider),
 	widget_kf_list			(new Widget_Keyframe_List),
@@ -1403,6 +1403,21 @@ CanvasView::create_display_bar()
 	// Separator
 	displaybar->append( *create_tool_separator() );
 
+	{ // Set up past onion skin spin button
+		past_onion_spin=Gtk::manage(new class Gtk::SpinButton(past_onion_adjustment_));
+		past_onion_spin->signal_value_changed().connect(
+			sigc::mem_fun(*this, &studio::CanvasView::set_onion_skins));
+		past_onion_spin->set_tooltip_text( _("Past onion skins"));
+		past_onion_spin->show();
+
+		Gtk::ToolItem *toolitem = Gtk::manage(new Gtk::ToolItem());
+		toolitem->add(*past_onion_spin);
+		toolitem->set_is_important(true);
+		toolitem->show();
+
+		displaybar->append(*toolitem);
+	}
+
 	{ // Set up the onion skin toggle button
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-toggle_onion_skin"), iconsize));
 		icon->set_padding(0, 0);
@@ -1418,22 +1433,6 @@ CanvasView::create_display_bar()
 		onion_skin->show();
 
 		displaybar->append(*onion_skin);
-	}
-
-/*
-	{ // Set up past onion skin spin button
-		past_onion_spin=Gtk::manage(new class Gtk::SpinButton(past_onion_adjustment_));
-		past_onion_spin->signal_value_changed().connect(
-			sigc::mem_fun(*this, &studio::CanvasView::set_onion_skins));
-		past_onion_spin->set_tooltip_text( _("Past onion skins"));
-		past_onion_spin->show();
-
-		Gtk::ToolItem *toolitem = Gtk::manage(new Gtk::ToolItem());
-		toolitem->add(*past_onion_spin);
-		toolitem->set_is_important(true);
-		toolitem->show();
-
-		displaybar->append(*toolitem);
 	}
 
 	{ // Set up future onion skin spin button
@@ -1453,7 +1452,6 @@ CanvasView::create_display_bar()
 
 	// Separator
 	displaybar->append( *create_tool_separator() );
-	*/
 	
 	{ // Setup refresh button
 		Gtk::Image *icon = Gtk::manage(new Gtk::Image(Gtk::StockID("gtk-refresh"), iconsize));
@@ -4006,6 +4004,9 @@ CanvasView::on_meta_data_changed()
 		onion_skin->set_active(work_area->get_onion_skin());
 		snap_grid->set_active(work_area->get_grid_snap());
 		show_grid->set_active(work_area->grid_status());
+		// Update the onion skin spins
+		past_onion_spin->set_value(work_area->get_onion_skins()[0]);
+		future_onion_spin->set_value(work_area->get_onion_skins()[1]);
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -111,6 +111,14 @@
 #include <jack/transport.h>
 #endif
 
+#ifndef ONION_SKIN_PAST
+	#define ONION_SKIN_PAST 2
+#endif
+
+#ifndef ONION_SKIN_FUTURE
+	#define ONION_SKIN_FUTURE 2
+#endif
+
 /* === M A C R O S ========================================================= */
 
 #ifndef DEBUGPOINT_CLASS

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -410,6 +410,7 @@ public:
 	bool get_onion_skin()const;
 	void toggle_onion_skin() { set_onion_skin(!get_onion_skin()); }
 	void set_onion_skins(int *onions);
+	int const * get_onion_skins()const;
 
 	void set_selected_value_node(etl::loose_handle<synfig::ValueNode> x);
 


### PR DESCRIPTION
* unhide future and past spin buttons ... and now working has expected.
(onion skin was not broken, just working with nothing to display!)

* add ONION_SKIN_FUTURE and ONION_SKIN_PAST #definition

* add "onion_skin_future" and "onion_skin_past" metadata entries
('full' onion skin state is now save&restored between working session)