### PR TITLE
Fix 856 - 	Guide, can't remove dragging them back onto the canvas window...

### DIFF
--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -2374,7 +2374,7 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 		if(dragging==DRAG_GUIDE)
 		{
 			double y,x;
-			if(event->button.axes)
+			if(*(event->button.axes))
 			{
 				x=(event->button.axes[0]);
 				y=(event->button.axes[1]);


### PR DESCRIPTION
... rulers

* check content of pointer (not pointer)

NOTA : maybe this bug is also present in Renderer_Guides::event_vfunc

	// Calculate the position of the
// input device in canvas coordinates
// and the buttons
if(!event->button.axes)  // <<<--- HERE
{

https://github.com/synfig/synfig/blob/master/synfig-studio/src/gui/workarearenderer/renderer_guides.cpp#L133