### PR TITLE
Fix #766: on and off states of a "Switch" node were linked by default

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
@@ -56,20 +56,20 @@ ValueNode_Switch::ValueNode_Switch(Type &x):
 {
 }
 
-ValueNode_Switch::ValueNode_Switch(const ValueNode::Handle &x):
-	LinkableValueNode(x->get_type())
+ValueNode_Switch::ValueNode_Switch(const ValueBase &x):
+	LinkableValueNode(x.get_type())
 {
 	Vocab ret(get_children_vocab());
 	set_children_vocab(ret);
-	set_link("link_off",x);
-	set_link("link_on",x);
+	set_link("link_off",ValueNode_Const::create(x));
+	set_link("link_on",ValueNode_Const::create(x));
 	set_link("switch",ValueNode_Const::create(bool(false)));
 }
 
 ValueNode_Switch*
 ValueNode_Switch::create(const ValueBase &x)
 {
-	return new ValueNode_Switch(ValueNode_Const::create(x));
+	return new ValueNode_Switch(x);
 }
 
 LinkableValueNode*

--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.h
@@ -48,7 +48,7 @@ public:
 
 	ValueNode_Switch(Type &x);
 
-	ValueNode_Switch(const ValueNode::Handle &x);
+	ValueNode_Switch(const ValueBase &x);
 
 //	static Handle create(Type &x);
 //	static Handle create(const ValueNode::Handle &x);


### PR DESCRIPTION
This is a fix for [this bug here](http://www.synfig.org/issues/thebuggenie/synfig/issues/766). When you made a "Switch" node, the "Link On" and "Link Off" parameters were linked by default, making it necessary to disconnect them before using it.