### PR TITLE
Make Time parameters convertible to Real

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
@@ -73,6 +73,9 @@ ValueNode_Real::ValueNode_Real(const ValueBase &x):
 	if (type == type_integer)
 		set_link("link", ValueNode_Const::create(float(x.get(int()))));
 	else
+	if (type == type_time)
+		set_link("link", ValueNode_Const::create(float(x.get(Time()))));
+	else
 	{
 		assert(0);
 		throw runtime_error(get_local_name()+_(":Bad type ")+x.get_type().description.local_name);
@@ -133,6 +136,8 @@ ValueNode_Real::operator()(Time t)const
 		return bool(real);
 	if (type == type_integer)
 		return int(real);
+	if (type == type_time)
+		return Time(real);
 
 	assert(0);
 	throw runtime_error(get_local_name()+_(":Bad type ")+get_type().description.local_name);
@@ -162,9 +167,10 @@ bool
 ValueNode_Real::check_type(Type &type __attribute__ ((unused)))
 {
 	return
-		type==type_angle ||
-		type==type_bool  ||
-		type==type_integer;
+		type==type_angle   ||
+		type==type_bool    ||
+		type==type_integer ||
+		type==type_time;
 }
 
 LinkableValueNode::Vocab


### PR DESCRIPTION
This patch simply adds the option to Convert a Time parameter to "Real". The value given is interpreted as a length of time in seconds.

As far as I know, it was only formerly possible to do this by converting to an Integer first, which has one obvious disadvantage... it's only accurate to the second.