### PR TITLE
Add time dilation for PasteCanvases/Groups

### DIFF
--- a/synfig-core/src/synfig/layers/layer_pastecanvas.h
+++ b/synfig-core/src/synfig/layers/layer_pastecanvas.h
@@ -58,6 +58,8 @@ private:
 	ValueBase param_transformation;
 	//! Parameter: (etl::loose_handle<synfig::Canvas>) The canvas parameter
 	etl::loose_handle<synfig::Canvas> canvas;
+	//! Parameter: (Real) Time dilation of the paste canvas layer
+	ValueBase param_time_dilation;
 	//! Parameter: (Time) Time offset of the paste canvas layer
 	ValueBase param_time_offset;
 	//! Parameter: (Real) The value to grow the children outline layers
@@ -141,6 +143,8 @@ public:
 	//! Sets the canvas parameter.
 	//! \see get_sub_canvas()
 	void set_sub_canvas(etl::handle<synfig::Canvas> x);
+	//! Gets time dilation parameter
+	Real get_time_dilation()const { return param_time_dilation.get(Real()); }
 	//! Gets time offset parameter
 	Time get_time_offset()const { return param_time_offset.get(Time()); }
 


### PR DESCRIPTION
This patch adds a "Time Dilation" parameter to Group layers, allowing speed of playback to be adjusted just like offset.

It was already possible to achieve this effect by converting the time offset to "Linear" and taking into account the natural progression of time, but that solution always seemed clunky to me, and it can produce some weird output in the editing preview.

Also, I've found it to be useful to use an exported canvas's timeline to select a pose rather than as an actual time. By setting the Group layer's time dilation to zero, this can be done much more easily.