### PR TITLE
Fix waypoints for time dilated canvases getting dragged to the wrong points

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
@@ -755,7 +755,9 @@ CellRenderer_TimeTrack::activate_vfunc(
 			if(event->button.button == 1)
 			{
 				bool delmode = (mode & DELETE_MASK) && !(mode & COPY_MASK);
-				deltatime = actual_time - actual_dragtime;
+				const synfig::Time time_dilation = get_time_dilation_from_vdesc(sel_value);
+				// todo: What if time_dilation == 0?
+				deltatime = (actual_time - actual_dragtime) * time_dilation;
 				if(sel_times.size() != 0 && (delmode || !deltatime.is_equal(Time(0))))
 				{
 					synfigapp::Action::ParamList param_list;


### PR DESCRIPTION
This fix makes it so that dragging a waypoint on the canvas parameter of a time dilated group moves it to where you would expect it to be moved. Prior to the fix, the waypoint would be moved by the same offset within the canvas regardless of the group's speed, meaning that it would overshoot if speed > 1, undershoot if speed < 1, and go in entirely the wrong direction if speed < 0.

Dragged waypoints will not move at all if speed == 0. This behavior will obviously have to change, but I guess _what_ it should change to hasn't been decided, so this will have to do for now.