### PR TITLE
Fix dragged waypoints from time-dilated subgroups not working properly

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
@@ -323,7 +323,6 @@ CellRenderer_TimeTrack::render_vfunc(
 				Time t = t_orig - time_offset;
 				if (time_dilation!=0)
 					t = t / time_dilation;
-				// todo: What if time_dilation == 0?
 				if(t<adjustment->get_lower() || t>adjustment->get_upper()) continue;
 
 				//if it found it... (might want to change comparison, and optimize
@@ -753,7 +752,6 @@ CellRenderer_TimeTrack::activate_vfunc(
 			{
 				bool delmode = (mode & DELETE_MASK) && !(mode & COPY_MASK);
 				const synfig::Time time_dilation = get_time_dilation_from_vdesc(sel_value);
-				// todo: What if time_dilation == 0?
 				deltatime = (actual_time - actual_dragtime) * time_dilation;
 				if(sel_times.size() != 0 && (delmode || !deltatime.is_equal(Time(0))))
 				{

--- a/synfig-studio/src/synfigapp/actions/timepointscopy.cpp
+++ b/synfig-studio/src/synfigapp/actions/timepointscopy.cpp
@@ -252,6 +252,7 @@ Action::TimepointsCopy::prepare()
 													end = match.waypointbiglist.end();
 		for(; i != end; ++i)
 		{
+			synfig::Time dilated_timedelta(timedelta * i->time_dilation);
 			//iterate through each waypoint for this specific valuenode
 			std::set<synfig::Waypoint>::const_iterator 	j = i->waypoints.begin(),
 														end = i->waypoints.end();
@@ -267,7 +268,7 @@ Action::TimepointsCopy::prepare()
 				//NOTE: We may want to store the old time for undoing the action...
 				Waypoint neww;
 				Waypoint w = *j;
-				w.set_time((w.get_time() + timedelta).round(fps));
+				w.set_time((w.get_time() + dilated_timedelta).round(fps));
 				w.mimic(neww); //make sure the new waypoint has a new id
 
 				action->set_param("waypoint",w);
@@ -287,6 +288,7 @@ Action::TimepointsCopy::prepare()
 													end = match.actpointbiglist.end();
 		for(; i != end; ++i)
 		{
+			synfig::Time dilated_timedelta(timedelta * i->time_dilation);
 			//iterate through each activepoint for this specific valuenode
 			std::set<synfig::Activepoint>::const_iterator 	j = i->activepoints.begin(),
 															jend = i->activepoints.end();
@@ -301,7 +303,7 @@ Action::TimepointsCopy::prepare()
 				//NOTE: We may want to store the old time for undoing the action...
 				Activepoint newa;
 				Activepoint a = *j;
-				a.set_time((a.get_time() + timedelta).round(fps));
+				a.set_time((a.get_time() + dilated_timedelta).round(fps));
 				a.mimic(newa); //make sure the new activepoint has a new id
 
 				action->set_param("activepoint",a);

--- a/synfig-studio/src/synfigapp/actions/timepointsmove.cpp
+++ b/synfig-studio/src/synfigapp/actions/timepointsmove.cpp
@@ -267,6 +267,8 @@ Action::TimepointsMove::prepare()
 			action->set_param("canvas_interface",get_canvas_interface());
 			action->set_param("value_node",ValueNode::Handle(i->val));
 
+			synfig::Time dilated_timemove(timemove * i->time_dilation);
+
 			//iterate through each waypoint for this specific valuenode
 			std::set<synfig::Waypoint>::const_iterator 	j = i->waypoints.begin(),
 														end = i->waypoints.end();
@@ -275,7 +277,7 @@ Action::TimepointsMove::prepare()
 				//synfig::info("add waypoint mod...");
 				//NOTE: We may want to store the old time for undoing the action...
 				Waypoint w = *j;
-				w.set_time((w.get_time() + timemove).round(fps));
+				w.set_time((w.get_time() + dilated_timemove).round(fps));
 				action->set_param("waypoint",w);
 			}
 
@@ -299,6 +301,8 @@ Action::TimepointsMove::prepare()
 			action->set_param("canvas_interface",get_canvas_interface());
 			action->set_param("value_desc",i->val);
 
+			synfig::Time dilated_timemove(timemove * i->time_dilation);
+
 			//iterate through each activepoint for this specific valuenode
 			std::set<synfig::Activepoint>::const_iterator 	j = i->activepoints.begin(),
 															jend = i->activepoints.end();
@@ -308,7 +312,7 @@ Action::TimepointsMove::prepare()
 
 				//NOTE: We may want to store the old time for undoing the action...
 				Activepoint a = *j;
-				a.set_time((a.get_time() + timemove).round(fps));
+				a.set_time((a.get_time() + dilated_timemove).round(fps));
 				action->set_param("activepoint",a);
 			}
 

--- a/synfig-studio/src/synfigapp/timegather.cpp
+++ b/synfig-studio/src/synfigapp/timegather.cpp
@@ -132,9 +132,15 @@ void synfigapp::recurse_layer(synfig::Layer::Handle h, const std::set<Time> &tli
 		//recurse into the canvas
 		const synfig::Node::time_set &tset = p->get_sub_canvas()->get_times();
 		synfig::Time subcanvas_time_offset(time_offset + p->get_time_offset());
+		synfig::Real subcanvas_time_dilation(p->get_time_dilation());
 
-		if(check_intersect(tset.begin(),tset.end(),tlist.begin(),tlist.end(),subcanvas_time_offset))
-			recurse_canvas(p->get_sub_canvas(),tlist,vals,subcanvas_time_offset);
+		std::set<Time> transformed_tlist;
+		for(std::set<Time>::iterator i = tlist.begin(), end = tlist.end(); i != end; ++i) {
+			transformed_tlist.insert(*i * subcanvas_time_dilation + subcanvas_time_offset);
+		}
+
+		if(check_intersect(tset.begin(),tset.end(),transformed_tlist.begin(),transformed_tlist.end()))
+			recurse_canvas(p->get_sub_canvas(),transformed_tlist,vals);
 	}
 
 	//check all the valuenodes regardless...

--- a/synfig-studio/src/synfigapp/timegather.h
+++ b/synfig-studio/src/synfigapp/timegather.h
@@ -49,11 +49,12 @@ class ValueDesc;
 struct ValueBaseTimeInfo
 {
 	synfig::ValueNode_Animated::Handle	val;
+	synfig::Real						time_dilation;
 	mutable std::set<synfig::Waypoint>	waypoints;
 
 	bool operator<(const ValueBaseTimeInfo &rhs) const
 	{
-		return val < rhs.val;
+		return val == rhs.val ? time_dilation < rhs.time_dilation : val < rhs.val;
 	}
 };
 
@@ -67,7 +68,9 @@ struct ActiveTimeInfo
 		}
 	};
 
-	synfigapp::ValueDesc						val;
+	synfigapp::ValueDesc							val;
+
+	synfig::Real									time_dilation;
 
 	typedef std::set<synfig::Activepoint,actcmp>	set;
 
@@ -76,7 +79,9 @@ struct ActiveTimeInfo
 	bool operator<(const ActiveTimeInfo &rhs) const
 	{
 		return val.get_parent_value_node() == rhs.val.get_parent_value_node() ?
-						val.get_index() < rhs.val.get_index() :
+						val.get_index() == rhs.val.get_index() ?
+							time_dilation < rhs.time_dilation :
+							val.get_index() < rhs.val.get_index() :
 						val.get_parent_value_node() < rhs.val.get_parent_value_node();
 	}
 };
@@ -84,30 +89,30 @@ struct ActiveTimeInfo
 struct timepoints_ref
 {
 	typedef std::set<ValueBaseTimeInfo>		waytracker;
-	typedef std::set<ActiveTimeInfo>	acttracker;
+	typedef std::set<ActiveTimeInfo>		acttracker;
 
 	waytracker		waypointbiglist;
 	acttracker		actpointbiglist;
 
-	void insert(synfig::ValueNode_Animated::Handle v, synfig::Waypoint w);
-	void insert(synfigapp::ValueDesc v, synfig::Activepoint a);
+	void insert(synfig::ValueNode_Animated::Handle v, synfig::Waypoint w, synfig::Real time_dilation = 1);
+	void insert(synfigapp::ValueDesc v, synfig::Activepoint a, synfig::Real time_dilation = 1);
 };
 
 //assumes they're sorted... (incremental advance)
 //checks the intersection of the two sets... might be something better in the stl
 template < typename I1, typename I2 >
-bool check_intersect(I1 b1, I1 end1, I2 b2, I2 end2, synfig::Time time_offset = 0)
+bool check_intersect(I1 b1, I1 end1, I2 b2, I2 end2, synfig::Time time_offset = 0, synfig::Real time_dilation = 1)
 {
 	if(b1 == end1 || b2 == end2)
 		return false;
 
 	for(; b1 != end1 && b2 != end2;)
 	{
-		if(*b1 < *b2 + time_offset) ++b1;
-		else if(*b2 + time_offset < *b1) ++b2;
+		if(*b1 < *b2 * time_dilation + time_offset) ++b1;
+		else if(*b2 * time_dilation + time_offset < *b1) ++b2;
 		else
 		{
-			assert(*b1 == *b2 + time_offset);
+			assert(*b1 == *b2 * time_dilation + time_offset);
 			return true;
 		}
 	}
@@ -121,11 +126,11 @@ bool get_closest_time(const synfig::Node::time_set &tset, const synfig::Time &t,
 //recursion functions based on time restrictions (can be expanded later)...
 //builds a list of relevant waypoints and activepoints inside the timepoints_ref structure
 void recurse_valuedesc(synfigapp::ValueDesc valdesc, const std::set<synfig::Time> &tlist,
-								timepoints_ref &vals, synfig::Time time = 0);
+								timepoints_ref &vals, synfig::Time time = 0, synfig::Real time_dilation = 1);
 void recurse_layer(synfig::Layer::Handle layer, const std::set<synfig::Time> &tlist,
-								timepoints_ref &vals, synfig::Time time = 0);
+								timepoints_ref &vals, synfig::Time time = 0, synfig::Real time_dilation = 1);
 void recurse_canvas(synfig::Canvas::Handle canvas, const std::set<synfig::Time> &tlist,
-								timepoints_ref &vals, synfig::Time time = 0);
+								timepoints_ref &vals, synfig::Time time = 0, synfig::Real time_dilation = 1);
 
 
 


### PR DESCRIPTION
Hopefully this will be the last of the trouble brought on by time dilation. When a group contained another group whose contents had waypoints, and the subgroup was time-dilated, dragging one of its waypoints on the canvas parameter of the supergroup wouldn't work correctly. Usually, it would simply do nothing, but occasionally, the wrong waypoint would be moved the wrong distance.

This fix makes dragging waypoints under those circumstances work as expected. You can even drag multiple waypoints from groups with different speeds at the same time.