### PR TITLE
Give Switch layer's "Active Layer Name" parameter a combo box

### DIFF
--- a/synfig-core/src/synfig/layers/layer_switch.cpp
+++ b/synfig-core/src/synfig/layers/layer_switch.cpp
@@ -90,6 +90,7 @@ Layer_Switch::get_param_vocab()const
 	ret.push_back(ParamDesc("layer_name")
 		.set_local_name(_("Active Layer Name"))
 		.set_description(_("Only layer with specified name are visible"))
+		.set_hint("sublayer_name")
 	);
 
 	return ret;

--- a/synfig-studio/po/POTFILES.in
+++ b/synfig-studio/po/POTFILES.in
@@ -196,6 +196,8 @@ src/gui/widgets/widget_keyframe_list.h
 src/gui/widgets/widget_link.h
 src/gui/widgets/widget_sound.cpp
 src/gui/widgets/widget_sound.h
+src/gui/widgets/widget_sublayer.cpp
+src/gui/widgets/widget_sublayer.h
 src/gui/widgets/widget_time.cpp
 src/gui/widgets/widget_time.h
 src/gui/widgets/widget_timeslider.cpp

--- a/synfig-studio/src/gui/widgets/Makefile_insert
+++ b/synfig-studio/src/gui/widgets/Makefile_insert
@@ -7,6 +7,7 @@ WIDGETS_HH = \
 	widgets/widget_defaults.h \
 	widgets/widget_distance.h \
 	widgets/widget_enum.h \
+	widgets/widget_sublayer.h \
 	widgets/widget_filename.h \
 	widgets/widget_gradient.h \
 	widgets/widget_link.h \
@@ -30,6 +31,7 @@ WIDGETS_CC = \
 	widgets/widget_defaults.cpp \
 	widgets/widget_distance.cpp \
 	widgets/widget_enum.cpp \
+	widgets/widget_sublayer.cpp \
 	widgets/widget_filename.cpp \
 	widgets/widget_gradient.cpp \
 	widgets/widget_link.cpp \

--- a/synfig-studio/src/gui/widgets/widget_sublayer.cpp
+++ b/synfig-studio/src/gui/widgets/widget_sublayer.cpp
@@ -1,0 +1,136 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file widget_sublayer.cpp
+**	\brief Template File
+**
+**	$Id$
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include <gtkmm/menu.h>
+#include "widgets/widget_sublayer.h"
+#include <ETL/stringf>
+#include <synfig/valuenode.h>
+#include <synfig/canvas.h>
+#include <synfig/context.h>
+#include <synfig/layers/layer_pastecanvas.h>
+
+#include "general.h"
+
+#endif
+
+/* === U S I N G =========================================================== */
+
+using namespace std;
+using namespace etl;
+using namespace synfig;
+using namespace studio;
+
+/* === M A C R O S ========================================================= */
+
+/* === G L O B A L S ======================================================= */
+
+/* === P R O C E D U R E S ================================================= */
+
+/* === M E T H O D S ======================================================= */
+
+Widget_Sublayer::Widget_Sublayer():
+	value()
+{
+	enum_TreeModel = Gtk::ListStore::create(enum_model);
+	set_model(enum_TreeModel);
+	pack_start(enum_model.name);
+}
+
+Widget_Sublayer::~Widget_Sublayer()
+{
+}
+
+void
+Widget_Sublayer::set_value_desc(const synfigapp::ValueDesc &x)
+{
+	value_desc=x;
+	// First clear the current items in the ComboBox
+	enum_TreeModel->clear();
+	cout << value_desc.get_layer() << endl;
+	etl::handle<synfig::Layer_PasteCanvas> p = etl::handle<synfig::Layer_PasteCanvas>::cast_dynamic(value_desc.get_layer());
+	if(p)
+	{
+		synfig::Canvas::Handle canvas = p->get_sub_canvas();
+		if(canvas)
+		{
+			// Fill the combo with the layers' descriptions
+			for(IndependentContext i = canvas->get_independent_context(); *i; i++)
+			{
+				Gtk::TreeModel::Row row = *(enum_TreeModel->append());
+				std::string desc = (*i)->get_description();
+				row[enum_model.value] = desc;
+				row[enum_model.name] = desc;
+			}
+		}
+	}
+	refresh();
+}
+
+void
+Widget_Sublayer::refresh()
+{
+	typedef Gtk::TreeModel::Children type_children;
+	type_children children = enum_TreeModel->children();
+	for(type_children::iterator iter = children.begin();
+		iter != children.end(); ++iter)
+	{
+		Gtk::TreeModel::Row row = *iter;
+		if(row.get_value(enum_model.value) == value)
+		{
+			set_active(iter);
+			return;
+		}
+	}
+}
+
+void
+Widget_Sublayer::set_value(string data)
+{
+	value=data;
+	refresh();
+}
+
+string
+Widget_Sublayer::get_value() const
+{
+	return value;
+}
+
+void
+Widget_Sublayer::on_changed()
+{
+	Gtk::TreeModel::iterator iter = get_active();
+	if(iter)
+	{
+		Gtk::TreeModel::Row row = *iter;
+		value = row.get_value(enum_model.value);
+	}
+}

--- a/synfig-studio/src/gui/widgets/widget_sublayer.h
+++ b/synfig-studio/src/gui/widgets/widget_sublayer.h
@@ -1,0 +1,76 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file widgets/widget_sublayer.h
+**	\brief Template Header
+**
+**	$Id$
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef __SYNFIG_STUDIO_WIDGET_SUBLAYER_H
+#define __SYNFIG_STUDIO_WIDGET_SUBLAYER_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <string>
+#include <gtkmm/combobox.h>
+#include <gtkmm/liststore.h>
+#include <synfigapp/value_desc.h>
+
+/* === M A C R O S ========================================================= */
+
+/* === T Y P E D E F S ===================================================== */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace studio {
+class Widget_Sublayer : public Gtk::ComboBox
+{
+	synfigapp::ValueDesc value_desc;
+	std::string value;
+protected:
+class Model : public Gtk::TreeModel::ColumnRecord
+	{
+		public:
+
+		Model()
+		{ add(value); add(name); }
+
+		Gtk::TreeModelColumn<std::string> value;
+		Gtk::TreeModelColumn<Glib::ustring> name;
+	};
+	Model enum_model;
+	Glib::RefPtr<Gtk::ListStore> enum_TreeModel;
+
+public:
+
+	Widget_Sublayer();
+	~Widget_Sublayer();
+
+	void set_value_desc(const synfigapp::ValueDesc &x);
+	void refresh();
+
+	void set_value(std::string data);
+	std::string get_value() const;
+	virtual void on_changed();
+}; // END of class Widget_Sublayer
+}; // END of namespace studio
+
+/* === E N D =============================================================== */
+
+#endif

--- a/synfig-studio/src/gui/widgets/widget_value.cpp
+++ b/synfig-studio/src/gui/widgets/widget_value.cpp
@@ -43,6 +43,7 @@
 #include "widgets/widget_vector.h"
 #include "widgets/widget_filename.h"
 #include "widgets/widget_enum.h"
+#include "widgets/widget_sublayer.h"
 #include "widgets/widget_coloredit.h"
 #include "widgets/widget_bonechooser.h"
 #include "widgets/widget_canvaschooser.h"
@@ -92,6 +93,9 @@ Widget_ValueBase::Widget_ValueBase():
 	enum_widget=manage(new class Widget_Enum());
 	pack_start(*enum_widget);
 
+	sublayer_widget=manage(new class Widget_Sublayer());
+	pack_start(*sublayer_widget);
+
 	real_widget=manage(new class Gtk::SpinButton(real_adjustment,0.05,DIGITS));
 	pack_start(*real_widget);
 
@@ -129,6 +133,7 @@ Widget_ValueBase::Widget_ValueBase():
 	vector_widget->signal_activate().connect(sigc::mem_fun(*this,&Widget_ValueBase::activate));
 	color_widget->signal_activate().connect(sigc::mem_fun(*this,&Widget_ValueBase::activate));
 	enum_widget->signal_changed().connect(sigc::mem_fun(*this,&Widget_ValueBase::activate));
+	sublayer_widget->signal_changed().connect(sigc::mem_fun(*this,&Widget_ValueBase::activate));
 	real_widget->signal_activate().connect(sigc::mem_fun(*this,&Widget_ValueBase::activate));
 	integer_widget->signal_activate().connect(sigc::mem_fun(*this,&Widget_ValueBase::activate));
 	angle_widget->signal_activate().connect(sigc::mem_fun(*this,&Widget_ValueBase::activate));
@@ -196,6 +201,7 @@ Widget_ValueBase::set_sensitive(bool x)
 	bone_widget->set_sensitive(x);
 	canvas_widget->set_sensitive(x);
 	enum_widget->set_sensitive(x);
+	sublayer_widget->set_sensitive(x);
 	angle_widget->set_sensitive(x);
 	filename_widget->set_sensitive(x);
 	time_widget->set_sensitive(x);
@@ -215,6 +221,7 @@ Widget_ValueBase::set_value(const synfig::ValueBase &data)
 	bone_widget->hide();
 	canvas_widget->hide();
 	enum_widget->hide();
+	sublayer_widget->hide();
 	angle_widget->hide();
 	filename_widget->hide();
 	time_widget->hide();
@@ -304,15 +311,21 @@ Widget_ValueBase::set_value(const synfig::ValueBase &data)
 		else
 		if (type == type_string)
 		{
-			if(child_param_desc.get_hint()!="filename" && param_desc.get_hint()!="filename")
-			{
-				string_widget->set_text(value.get(string()));
-				string_widget->show();
-			}
-			else
+			if(child_param_desc.get_hint()=="filename" || param_desc.get_hint()=="filename")
 			{
 				filename_widget->set_value(value.get(string()));
 				filename_widget->show();
+			}
+			else if(child_param_desc.get_hint()=="sublayer_name" || param_desc.get_hint()=="sublayer_name")
+			{
+				sublayer_widget->set_value_desc(value_desc);
+				sublayer_widget->set_value(value.get(string()));
+				sublayer_widget->show();
+			}
+			else
+			{
+				string_widget->set_text(value.get(string()));
+				string_widget->show();
 			}
 		}
 		else
@@ -381,13 +394,16 @@ Widget_ValueBase::get_value()
 	else
 	if (type == type_string)
 	{
-		if(param_desc.get_hint()!="filename")
+		if(param_desc.get_hint()=="filename")
 		{
-			value=string(string_widget->get_text());
+			value=string(filename_widget->get_value());
+		}
+		else if(param_desc.get_hint()=="sublayer_name") {
+			value=string(sublayer_widget->get_value());
 		}
 		else
 		{
-			value=string(filename_widget->get_value());
+			value=string(string_widget->get_text());
 		}
 	}
 	else
@@ -455,13 +471,16 @@ Widget_ValueBase::on_grab_focus()
 	else
 	if (type == type_string)
 	{
-		if(param_desc.get_hint()!="filename")
+		if(param_desc.get_hint()=="filename")
 		{
-			string_widget->grab_focus();
+			filename_widget->grab_focus();
+		}
+		else if(param_desc.get_hint()=="sublayer_name") {
+			sublayer_widget->grab_focus();
 		}
 		else
 		{
-			filename_widget->grab_focus();
+			string_widget->grab_focus();
 		}
 	}
 	else

--- a/synfig-studio/src/gui/widgets/widget_value.h
+++ b/synfig-studio/src/gui/widgets/widget_value.h
@@ -69,6 +69,7 @@ class Widget_Color;
 class Widget_ColorEdit;
 class Widget_CanvasChooser;
 class Widget_Enum;
+class Widget_Sublayer;
 class Widget_Filename;
 class Widget_Vector;
 class Widget_Time;
@@ -93,6 +94,7 @@ class Widget_ValueBase : public Gtk::HBox
 	Widget_ColorEdit *color_widget;
 	Widget_CanvasChooser *canvas_widget;
 	Widget_Enum *enum_widget;
+	Widget_Sublayer *sublayer_widget;
 	Widget_Filename *filename_widget;
 	Widget_Time *time_widget;
 	Gtk::Entry *string_widget;


### PR DESCRIPTION
This patch makes it so that editing the "Active Layer Name" parameter of a Switch Group directly will show a combo box with the names of all of its sublayers. This is much more intuitive and convenient than typing a layer's name manually.