### PR TITLE
Fixed typo in export dialog

### DIFF
--- a/synfig-core/src/modules/mod_png/trgt_png_spritesheet.cpp
+++ b/synfig-core/src/modules/mod_png/trgt_png_spritesheet.cpp
@@ -203,7 +203,7 @@ png_trgt_spritesheet::end_frame()
 	cur_y = 0;
 	if (params.dir == TargetParam::HR)
 	{
-		//Horisontal render. Columns increment
+		//Horizontal render. Columns increment
 		cur_col++;
 		if (cur_col >= (unsigned int)params.columns)
 		{

--- a/synfig-core/src/synfig/targetparam.h
+++ b/synfig-core/src/synfig/targetparam.h
@@ -35,7 +35,7 @@ struct TargetParam
 {
 	//Spritesheet render direction
 	enum Direction {
-		HR = 0, //Horisontal 
+		HR = 0, //Horizontal 
 		VR = 1  //Vertical
 	};
 	

--- a/synfig-studio/src/gui/dialogs/dialog_spritesheetparam.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_spritesheetparam.cpp
@@ -52,7 +52,7 @@ Dialog_SpriteSheetParam::Dialog_SpriteSheetParam(Gtk::Window &parent):
 	Gtk::Label* direction_label(manage(new Gtk::Label(_("Direction:"))));
 	direction_label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 	direction_box = Gtk::manage(new Gtk::ComboBoxText());
-	direction_box->append("horisontal");
+	direction_box->append("horizontal");
 	direction_box->append("vertical");
 	direction_box->set_active(0);
 	direction_box->signal_changed().connect(sigc::mem_fun(*this, &Dialog_SpriteSheetParam::on_dir_change));


### PR DESCRIPTION
While playing around with sprite sheet animation I stumbled across a little typo in the export dialog. It should read 'horizontal' instead of 'horisontal'.