### PR TITLE
Fix cppcheck reports:

### DIFF
--- a/synfig-core/src/synfig/cairoimporter.cpp
+++ b/synfig-core/src/synfig/cairoimporter.cpp
@@ -141,6 +141,6 @@ CairoImporter::~CairoImporter()
 	for(iter=__open_cairoimporters->begin();iter!=__open_cairoimporters->end();++iter)
 		if(iter->second==this)
 		{
-			__open_cairoimporters->erase(iter);
+			iter = __open_cairoimporters->erase(iter);
 		}
 }

--- a/synfig-core/src/synfig/importer.cpp
+++ b/synfig-core/src/synfig/importer.cpp
@@ -141,6 +141,6 @@ Importer::~Importer()
 	for(iter=__open_importers->begin();iter!=__open_importers->end();++iter)
 		if(iter->second==this)
 		{
-			__open_importers->erase(iter);
+			iter = __open_importers->erase(iter);
 		}
 }


### PR DESCRIPTION
[synfig-core/src/synfig/cairoimporter.cpp:141] -> [synfig-core/src/synfig/cairoimporter.cpp:144]: (error) Iterator 'iter' used after element has been erased.
[synfig-core/src/synfig/importer.cpp:141] -> [synfig-core/src/synfig/importer.cpp:144]: (error) Iterator 'iter' used after element has been erased.

There are still these:
[synfig-core/src/synfig/valuenode_bline.cpp:199]: (error) Invalid iterator 'prev' used.
[synfig-core/src/synfig/valuenode_bline.cpp:200]: (error) Invalid iterator 'prev' used.

[synfig-core/src/synfig/valuenode_bone.cpp:661]: (warning) Suspicious condition. The result of find() is an iterator, but it is not properly checked.
I noticed that "first" and "prev" aren't initialized

[synfig-studio/src/gui/widgets/widget_compselect.cpp:117]: (style) Variable 'iter' is assigned a value that is never used.
[synfig-studio/src/gui/trees/keyframetreestore.cpp:159]: (style) The function 'clear_iterator' is never used.
[synfig-studio/src/gui/trees/keyframetreestore.cpp:91]: (style) The function 'model_iter_2_keyframe_iter' is never used.