### PR TITLE
Option to show/hide file toolbar

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -298,6 +298,7 @@ bool studio::App::restrict_radius_ducks=true;
 bool studio::App::resize_imported_images=false;
 bool studio::App::enable_experimental_features=false;
 bool studio::App::use_dark_theme=false;
+bool studio::App::show_file_toolbar=true;
 String studio::App::custom_filename_prefix(DEFAULT_FILENAME_PREFIX);
 int studio::App::preferred_x_size=480;
 int studio::App::preferred_y_size=270;
@@ -568,6 +569,11 @@ public:
 				value=strprintf("%i",(int)App::use_dark_theme);
 				return true;
 			}
+			if(key=="show_file_toolbar")
+			{
+				value=strprintf("%i",(int)App::show_file_toolbar);
+				return true;
+			}
 			if(key=="browser_command")
 			{
 				value=App::browser_command;
@@ -732,6 +738,12 @@ public:
 				App::use_dark_theme=i;
 				return true;
 			}
+			if(key=="show_file_toolbar")
+			{
+				int i(atoi(value.c_str()));
+				App::show_file_toolbar=i;
+				return true;
+			}
 			if(key=="browser_command")
 			{
 				App::browser_command=value;
@@ -829,6 +841,7 @@ public:
 		ret.push_back("resize_imported_images");
 		ret.push_back("enable_experimental_features");
 		ret.push_back("use_dark_theme");
+		ret.push_back("show_file_toolbar");
 		ret.push_back("browser_command");
 		ret.push_back("brushes_path");
 		ret.push_back("custom_filename_prefix");
@@ -1447,6 +1460,9 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 
 		load_settings("pref.use_dark_theme");
 		App::apply_gtk_settings(App::use_dark_theme);
+
+		load_settings("pref.show_file_toolbar");
+		App::apply_gtk_settings(App::show_file_toolbar);
 
 		// Set experimental features
 		load_settings("pref.enable_experimental_features");

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -217,6 +217,7 @@ public:
 	static bool resize_imported_images;
 	static bool enable_experimental_features;
 	static bool use_dark_theme;
+	static bool show_file_toolbar;
 
 	static synfigapp::PluginManager plugin_manager;
 

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1332,14 +1332,16 @@ CanvasView::create_display_bar()
 	displaybar->set_toolbar_style(Gtk::TOOLBAR_BOTH_HORIZ);
 
 	// File
-	displaybar->append( *create_action_toolbutton( App::ui_manager()->get_action("/toolbar-main/new") ) );
-	displaybar->append( *create_action_toolbutton( App::ui_manager()->get_action("/toolbar-main/open") ) );
-	displaybar->append( *create_action_toolbutton( action_group->get_action("save") ) );
-	displaybar->append( *create_action_toolbutton( action_group->get_action("save-as") ) );
-	displaybar->append( *create_action_toolbutton( App::ui_manager()->get_action("/toolbar-main/save-all") ) );
+	if (App::show_file_toolbar) {
+		displaybar->append( *create_action_toolbutton( App::ui_manager()->get_action("/toolbar-main/new") ) );
+		displaybar->append( *create_action_toolbutton( App::ui_manager()->get_action("/toolbar-main/open") ) );
+		displaybar->append( *create_action_toolbutton( action_group->get_action("save") ) );
+		displaybar->append( *create_action_toolbutton( action_group->get_action("save-as") ) );
+		displaybar->append( *create_action_toolbutton( App::ui_manager()->get_action("/toolbar-main/save-all") ) );
 
-	// Separator
-	displaybar->append( *create_tool_separator() );
+		// Separator
+		displaybar->append( *create_tool_separator() );
+	}
 
 	// Edit
 	displaybar->append( *create_action_toolbutton( App::ui_manager()->get_action("/toolbar-main/undo") ) );

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -87,6 +87,7 @@ Dialog_Setup::Dialog_Setup(Gtk::Window& parent):
 	toggle_resize_imported_images(),
 	toggle_enable_experimental_features(),
 	toggle_use_dark_theme(),
+	toggle_show_file_toolbar(),
 	adj_pref_x_size(Gtk::Adjustment::create(480,1,10000,1,10,0)),
 	adj_pref_y_size(Gtk::Adjustment::create(270,1,10000,1,10,0)),
 	adj_pref_fps(Gtk::Adjustment::create(24.0,1.0,100,0.1,1,0))
@@ -602,6 +603,12 @@ Dialog_Setup::create_interface_page(PageInfo pi)
 	attach_label(pi.grid, _("Dark UI theme (if available)"), ++row);
 	pi.grid->attach(toggle_use_dark_theme, 1, row, 1, 1);
 
+	// Interface - Toolbars section
+	attach_label_section(pi.grid, _("Toolbars"), ++row);
+	// Interface - File Toolbar
+	attach_label(pi.grid, _("Show file toolbar (requires restart)"), ++row);
+	pi.grid->attach(toggle_show_file_toolbar, 1, row, 1, 1);
+
 	// Interface - Handle tooltip section
 	attach_label_section(pi.grid, _("Handle Tooltips"), ++row);
 	// Interface - width point tooltip
@@ -703,6 +710,10 @@ Dialog_Setup::on_apply_pressed()
 	// Set the dark theme flag
 	App::use_dark_theme=toggle_use_dark_theme.get_active();
 	App::apply_gtk_settings(App::use_dark_theme);
+
+	// Set file toolbar flag
+	App::show_file_toolbar=toggle_show_file_toolbar.get_active();
+	App::apply_gtk_settings(App::show_file_toolbar);
 
 	// Set the browser_command textbox
 	App::browser_command=textbox_browser_command.get_text();
@@ -951,6 +962,9 @@ Dialog_Setup::refresh()
 
 	// Refresh the status of the theme flag
 	toggle_use_dark_theme.set_active(App::use_dark_theme);
+
+	// Refresh the status of file toolbar flag
+	toggle_show_file_toolbar.set_active(App::show_file_toolbar);
 
 	// Refresh the browser_command textbox
 	textbox_browser_command.set_text(App::browser_command);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -234,6 +234,7 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::CheckButton toggle_resize_imported_images;
 	Gtk::CheckButton toggle_enable_experimental_features;
 	Gtk::CheckButton toggle_use_dark_theme;
+	Gtk::CheckButton toggle_show_file_toolbar;
 
 	Gtk::Entry textbox_browser_command;
 	Gtk::Entry textbox_brushe_path;


### PR DESCRIPTION
This is mostly to make onion skin controls usable on small screens (i choose file toolbar as least useful). Of course, it would be nice to have toolbar fully customizable, but even such optional hiding does the job.