### PR TITLE
Fix for dark time widget

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1213,7 +1213,6 @@ CanvasView::create_time_bar()
 	current_time_widget->set_size_request(0,-1); // request horizontal shrink
 	current_time_widget->set_width_chars(5);
 	current_time_widget->set_tooltip_text(_("Current time"));
-	current_time_widget->override_background_color(Gdk::RGBA("#FFFFFF"));
 	current_time_widget->show();
 
 	//Setup the FrameDial widget
@@ -2711,7 +2710,7 @@ CanvasView::on_time_changed()
 		get_canvas()->keyframe_list().find(time);
 		current_time_widget->override_color(Gdk::RGBA("#FF0000"));
 	}catch(...){
-		current_time_widget->override_color(Gdk::RGBA("#000000"));
+		current_time_widget->override_color(Gdk::RGBA(0));
 	}
 
 	if(get_time() != time_adjustment()->get_value())

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1213,6 +1213,7 @@ CanvasView::create_time_bar()
 	current_time_widget->set_size_request(0,-1); // request horizontal shrink
 	current_time_widget->set_width_chars(5);
 	current_time_widget->set_tooltip_text(_("Current time"));
+	current_time_widget->override_background_color(Gdk::RGBA("#FFFFFF"));
 	current_time_widget->show();
 
 	//Setup the FrameDial widget


### PR DESCRIPTION
In dark theme it's nearly impossible to see the time frame. This changes the background to white. Should work in both light and dark themes.