### PR TITLE
App::apply_gtk_settings - minor refactor

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1459,7 +1459,7 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 		studio_init_cb.task(_("Loading Basic Settings..."));
 
 		load_settings("pref.use_dark_theme");
-		App::apply_gtk_settings(App::use_dark_theme);
+		App::apply_gtk_settings();
 
 		load_settings("pref.show_file_toolbar");
 
@@ -2175,7 +2175,7 @@ App::restore_default_settings()
 }
 
 void
-App::apply_gtk_settings(bool use_dark)
+App::apply_gtk_settings()
 {
 	GtkSettings *gtk_settings;
 	gtk_settings = gtk_settings_get_default ();
@@ -2186,7 +2186,7 @@ App::apply_gtk_settings(bool use_dark)
 	}
 
 	// dark theme
-	g_object_set (G_OBJECT (gtk_settings), "gtk-application-prefer-dark-theme", use_dark, NULL);
+	g_object_set (G_OBJECT (gtk_settings), "gtk-application-prefer-dark-theme", App::use_dark_theme, NULL);
 
 	// enable menu icons
 	g_object_set (G_OBJECT (gtk_settings), "gtk-menu-images", TRUE, NULL);

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -324,7 +324,7 @@ public:
 	static void set_workspace_compositing();
 	static void set_workspace_animating();
 	static void restore_default_settings();
-	static void apply_gtk_settings(bool);
+	static void apply_gtk_settings();
 
 	static const std::list<std::string>& get_recent_files();
 

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -710,7 +710,7 @@ Dialog_Setup::on_apply_pressed()
 
 	// Set the dark theme flag
 	App::use_dark_theme=toggle_use_dark_theme.get_active();
-	App::apply_gtk_settings(App::use_dark_theme);
+	App::apply_gtk_settings();
 
 	// Set file toolbar flag
 	App::show_file_toolbar=toggle_show_file_toolbar.get_active();


### PR DESCRIPTION
We don't need to pass use_dark because it is already present in App