### PR TITLE
Fix zoomdial mouse control & revert to C++11

### DIFF
--- a/synfig-studio/src/gui/dials/zoomdial.h
+++ b/synfig-studio/src/gui/dials/zoomdial.h
@@ -34,6 +34,8 @@
 #include <gtkmm/button.h>
 #include <gtkmm/entry.h>
 
+#include <boost/optional.hpp>
+
 #include <synfig/real.h>
 
 /* === M A C R O S ========================================================= */
@@ -52,11 +54,10 @@ class ZoomDial : public Gtk::Table
 	Gtk::Button *zoom_fit;
 	Gtk::Button *zoom_norm;
 	Gtk::Entry *current_zoom;
+	bool already_selected = false;
 
 	Gtk::Button *create_icon(Gtk::IconSize size, const Gtk::BuiltinStockID & stockid,
 			const char * tooltip);
-	void after_event(GdkEvent *event);
-	bool current_zoom_event(GdkEvent* event);
 
 public:
 	ZoomDial(Gtk::IconSize &size);
@@ -67,8 +68,9 @@ public:
 	Glib::SignalProxy0<void> signal_zoom_norm() { return zoom_norm->signal_clicked(); }
 	Glib::SignalProxy0<void> signal_zoom_edit() { return current_zoom->signal_activate(); }
 
-	void set_zoom(synfig::Real value);
-	synfig::Real get_zoom(synfig::Real default_value = 0.0);
+	void set_zoom(synfig::Real zoom);
+	boost::optional<synfig::Real> get_zoom();
+
 }; // END of class ZoomDial
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -842,7 +842,9 @@ WorkArea::WorkArea(etl::loose_handle<synfigapp::CanvasInterface> canvas_interfac
 	zoomdial->signal_zoom_out().connect(sigc::mem_fun(*this, &studio::WorkArea::zoom_out));
 	zoomdial->signal_zoom_fit().connect(sigc::mem_fun(*this, &studio::WorkArea::zoom_fit));
 	zoomdial->signal_zoom_norm().connect(sigc::mem_fun(*this, &studio::WorkArea::zoom_norm));
-	zoomdial->signal_zoom_edit().connect(sigc::mem_fun(*this, &studio::WorkArea::zoom_edit));
+	zoomdial->signal_zoom_edit().connect([this]() {
+		set_zoom(zoomdial->get_zoom().value_or(zoom));
+	});
 
 	hbox->pack_end(*hscrollbar1, Gtk::PACK_EXPAND_WIDGET,0);
 	hscrollbar1->show();
@@ -3209,12 +3211,6 @@ studio::WorkArea::zoom_norm()
 	if (zoom == 1.0) return set_zoom(prev_zoom);
 	prev_zoom = zoom;
 	set_zoom(1.0f);
-}
-
-void
-studio::WorkArea::zoom_edit()
-{
-	set_zoom(zoomdial->get_zoom(zoom));
 }
 
 gboolean

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -602,7 +602,6 @@ public:
 	void zoom_out();
 	void zoom_fit();
 	void zoom_norm();
-	void zoom_edit();
 	float get_zoom()const { return zoom; } // zoom is declared in Duckmatic
 
 	void set_zoom(float z);


### PR DESCRIPTION
Ok, so i finally got back to that zoomdial issue. Here's a fix that allows using mouse after initial selection is done and i also reverted to c++11 (but not 14 as it was). @morevnaproject please test if it works for your build environment.