### PR TITLE
Module loading advanced configuration

### DIFF
--- a/synfig-core/src/modules/CMakeLists.txt
+++ b/synfig-core/src/modules/CMakeLists.txt
@@ -70,5 +70,5 @@ file(WRITE synfig_modules.cfg ${SYNFIG_MODULES_CONTENT})
 
 install(
     FILES synfig_modules.cfg
-    DESTINATION etc
+    DESTINATION etc/synfig
 )

--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -123,6 +123,8 @@ target_link_libraries(synfig
         ${MLT_LIBRARIES}
         ${ZLIB_LIBRARIES}
         ${FFTW_LIBRARIES}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_SYSTEM_LIBRARY}
         ${CMAKE_THREAD_LIBS_INIT}
 
         # TODO: properly detect ltdl


### PR DESCRIPTION
This might require adding boost system&filesystem libs to automake build.

Instead of reading single synfig_modules.cfg files, synfig now
also checks files in synfig_modules.cfg.d/ directory (if found
in the same location as synfig_modules.cfg).

This simplifies stand-alone module installation as module
installation script can now simply install a new file instead
of editing existing.