### PR TITLE
Fix dependencies for Debian Stretch/Sid

### DIFF
--- a/autobuild/synfigstudio-linux-build.sh
+++ b/autobuild/synfigstudio-linux-build.sh
@@ -869,7 +869,7 @@ get_dependencies()
 		libfreetype6-dev \
 		libfontconfig1-dev \
 		libxml2-dev \
-		libtiff4-dev \
+		libtiff5-dev \
 		libmlt-dev libmlt++-dev \
 		libjasper-dev \
 		x11proto-xext-dev libdirectfb-dev libxfixes-dev libxinerama-dev libxdamage-dev libxcomposite-dev libxcursor-dev libxft-dev libxrender-dev libxt-dev libxrandr-dev libxi-dev libxext-dev libx11-dev \

--- a/autobuild/synfigstudio-linux-build.sh
+++ b/autobuild/synfigstudio-linux-build.sh
@@ -863,12 +863,13 @@ get_dependencies()
 		libtool \
 		intltool \
 		gettext \
-		libpng12-dev \
+		libpng-dev \
+		libfftw3-dev \
 		fontconfig \
 		libfreetype6-dev \
 		libfontconfig1-dev \
 		libxml2-dev \
-		libtiff-dev \
+		libtiff4-dev \
 		libmlt-dev libmlt++-dev \
 		libjasper-dev \
 		x11proto-xext-dev libdirectfb-dev libxfixes-dev libxinerama-dev libxdamage-dev libxcomposite-dev libxcursor-dev libxft-dev libxrender-dev libxt-dev libxrandr-dev libxi-dev libxext-dev libx11-dev \


### PR DESCRIPTION
As described on http://www.synfig.org/forums/viewtopic.php?f=13&t=10478

Linux Autobuild on Debian Strech/Sid has some issue with the libtiff-dev & libpng-dev dependency:

```
Package libtiff-dev is a virtual package provided by:
  libtiff5-dev 4.0.7-5
  libtiff4-dev 3.9.6-11+deb7u3
You should explicitly select one to install.
```


and

```
The following packages have unmet dependencies:
 libpng-dev : Conflicts: libpng12-0-dev
              Conflicts: libpng12-dev but 1.2.50-2+deb8u3 is to be installed
              Conflicts: libpng3-dev
              Recommends: libpng-tools but it is not going to be installed
 libpng12-dev : Conflicts: libpng-dev
```

In addition, the `libfftw3` was missing.