### PR TITLE
Use fixed-point, not scientific notation for displaying Distance values

### DIFF
--- a/synfig-core/src/synfig/distance.cpp
+++ b/synfig-core/src/synfig/distance.cpp
@@ -114,7 +114,7 @@ synfig::String
 Distance::get_string(int digits)const
 {
 	digits=min(9,max(0,digits));
-	String fmt(strprintf("%%.%01dg",digits));
+	String fmt(strprintf("%%.%01df",digits));
 	String str(strprintf(fmt.c_str(),value_));
 	return strprintf("%s%s",str.c_str(),system_name(system_).c_str());
 }


### PR DESCRIPTION
Fixes #635 

