### PR TITLE
Remove double cancel dialog (#693)

### DIFF
--- a/synfig-studio/src/synfigapp/action.h
+++ b/synfig-studio/src/synfigapp/action.h
@@ -133,7 +133,7 @@ public:
 	}
 
 	Error(bool silent):
-		silent_(true)
+		silent_(silent)
 	{
 	}
 

--- a/synfig-studio/src/synfigapp/action.h
+++ b/synfig-studio/src/synfigapp/action.h
@@ -102,11 +102,13 @@ private:
 
 	Type type_;
 	synfig::String desc_;
+	bool silent_;
 
 public:
 
 	Error(Type type, const char *format, ...):
-		type_(type)
+		type_(type),
+		silent_(false)
 	{
 		va_list args;
 		va_start(args,format);
@@ -115,7 +117,8 @@ public:
 	}
 
 	Error(const char *format, ...):
-		type_(TYPE_UNKNOWN)
+		type_(TYPE_UNKNOWN),
+		silent_(false)
 	{
 		va_list args;
 		va_start(args,format);
@@ -124,12 +127,20 @@ public:
 	}
 
 	Error(Type type=TYPE_UNABLE):
-		type_(type)
+		type_(type),
+		silent_(false)
 	{
 	}
 
+	Error(bool silent):
+		silent_(true)
+	{
+	}
+
+	static inline Error create_silent_error() { return Error(true); };
 	Type get_type()const { return type_; }
 	synfig::String get_desc()const { return desc_; }
+	bool is_silent()const { return silent_; }
 
 }; // END of class Action::Error
 

--- a/synfig-studio/src/synfigapp/action_system.cpp
+++ b/synfig-studio/src/synfigapp/action_system.cpp
@@ -129,12 +129,14 @@ Action::System::perform_action(etl::handle<Action::Base> action)
 	// Perform the action
 	try { action->perform(); }
 	catch(Action::Error err) {
-		uim->task(action->get_local_name()+' '+_("Failed"));
-		if (err.get_type() != Action::Error::TYPE_UNABLE) {
-			if (err.get_desc().empty())
-				uim->error(action->get_local_name() + ": " + etl::strprintf("%d", err.get_type()));
-			else
-				uim->error(action->get_local_name() + ": " + err.get_desc());
+		if (!err.is_silent()) {
+			uim->task(action->get_local_name()+' '+_("Failed"));
+			if (err.get_type() != Action::Error::TYPE_UNABLE) {
+				if (err.get_desc().empty())
+					uim->error(action->get_local_name() + ": " + etl::strprintf("%d", err.get_type()));
+				else
+					uim->error(action->get_local_name() + ": " + err.get_desc());
+			}
 		}
 		// If action failed for whatever reason, just return false and do
 		// not add the action onto the list

--- a/synfig-studio/src/synfigapp/actions/valuedescset.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescset.cpp
@@ -1128,7 +1128,7 @@ Action::ValueDescSet::prepare()
 								 _("Yes"),
 								 synfigapp::UIInterface::RESPONSE_OK ))
 						{
-							throw Error(_("Cancelled by user"));
+							//throw Error(_("Cancelled by user")); //Issue  #693
 						}
 					}
 
@@ -1187,5 +1187,5 @@ Action::ValueDescSet::prepare()
 		throw Error(_("Unsupported ValueDesc type"));
 	}
 
-	
+
 }

--- a/synfig-studio/src/synfigapp/actions/valuedescset.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescset.cpp
@@ -1128,7 +1128,7 @@ Action::ValueDescSet::prepare()
 								 _("Yes"),
 								 synfigapp::UIInterface::RESPONSE_OK ))
 						{
-							//throw Error(_("Cancelled by user")); //Issue  #693
+							throw Error::create_silent_error(); //Issue #693
 						}
 					}
 


### PR DESCRIPTION
This contains a commit by BobSynfig which removes the second cancel dialog (issue #693), as well as two commits by me which makes canceling work again.