### PR TITLE
Improve outline smoothness

### DIFF
--- a/synfig-core/src/modules/mod_geometry/outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/outline.cpp
@@ -61,7 +61,7 @@ using namespace synfig;
 
 /* === M A C R O S ========================================================= */
 
-#define SAMPLES		10
+#define SAMPLES		50
 #define ROUND_END_FACTOR	(4)
 #define CUSP_THRESHOLD		(0.40)
 #define SPIKE_AMOUNT		(4)


### PR DESCRIPTION
**Change description**
In commit 90788ec4df1450785463c403556dfbda7d695aa2 the SAMPLES define was decreased from 50 to 10. This made the outline rough (see attachments for example). This patch reverts that change to make the outlines smooth again (the advanced outlines wasn't affected by this bug).

**Attachments**
Rendered outline in master (4aa255f9ad852e3de5a64046f243a8b9dc34d143):
![outlinebug-original](https://user-images.githubusercontent.com/10425127/52285735-2f184200-2967-11e9-843c-b72cd1a9feac.png)

Rendered outline in master with this commit:
![outlinebug-fixed](https://user-images.githubusercontent.com/10425127/52285809-553de200-2967-11e9-9114-d79f945c92fb.png)

Original .sif file:
[OutlineBug.zip](https://github.com/synfig/synfig/files/2832796/OutlineBug.zip)