### PR TITLE
Added Preview workarea rendering

### DIFF
--- a/synfig-core/src/synfig/rendering/renderer.cpp
+++ b/synfig-core/src/synfig/rendering/renderer.cpp
@@ -1017,7 +1017,7 @@ Renderer::unregister_renderer(const String &name)
 const Renderer::Handle&
 Renderer::get_renderer(const String &name)
 {
-	static const char default_engine[] = "software-preview";
+	static const char default_engine[] = "software";
 	return get_renderers().count(name) > 0           ? get_renderers().find(name)->second
 		 : get_renderers().count(default_engine) > 0 ? get_renderers().find(default_engine)->second
 		 : blank;

--- a/synfig-core/src/synfig/rendering/renderer.cpp
+++ b/synfig-core/src/synfig/rendering/renderer.cpp
@@ -46,6 +46,7 @@
 
 #include "software/renderersw.h"
 #include "software/rendererdraftsw.h"
+#include "software/rendererpreviewsw.h"
 #include "software/rendererlowressw.h"
 #include "software/renderersafe.h"
 #ifdef WITH_OPENGL
@@ -97,6 +98,7 @@ Renderer::initialize_renderers()
 
 	// register renderers
 	register_renderer("software", new RendererSW());
+	register_renderer("software-preview", new RendererPreviewSW());
 	register_renderer("software-draft", new RendererDraftSW());
 	register_renderer("software-low2",  new RendererLowResSW(2));
 	register_renderer("software-low4",  new RendererLowResSW(4));
@@ -1015,7 +1017,7 @@ Renderer::unregister_renderer(const String &name)
 const Renderer::Handle&
 Renderer::get_renderer(const String &name)
 {
-	static const char default_engine[] = "software";
+	static const char default_engine[] = "software-preview";
 	return get_renderers().count(name) > 0           ? get_renderers().find(name)->second
 		 : get_renderers().count(default_engine) > 0 ? get_renderers().find(default_engine)->second
 		 : blank;

--- a/synfig-core/src/synfig/rendering/software/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/software/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(synfig
         "${CMAKE_CURRENT_LIST_DIR}/rendererdraftsw.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/rendererlowressw.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderersafe.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/rendererpreviewsw.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderersw.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/surfacesw.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/surfaceswpacked.cpp"

--- a/synfig-core/src/synfig/rendering/software/Makefile_insert
+++ b/synfig-core/src/synfig/rendering/software/Makefile_insert
@@ -2,6 +2,7 @@ RENDERING_SOFTWARE_HH = \
 	rendering/software/rendererdraftsw.h \
 	rendering/software/rendererlowressw.h \
 	rendering/software/renderersafe.h \
+	rendering/software/rendererpreviewsw.h \
 	rendering/software/renderersw.h \
 	rendering/software/surfacesw.h \
 	rendering/software/surfaceswpacked.h
@@ -10,6 +11,7 @@ RENDERING_SOFTWARE_CC = \
 	rendering/software/rendererdraftsw.cpp \
 	rendering/software/rendererlowressw.cpp \
 	rendering/software/renderersafe.cpp \
+	rendering/software/rendererpreviewsw.cpp \
 	rendering/software/renderersw.cpp \
 	rendering/software/surfacesw.cpp \
 	rendering/software/surfaceswpacked.cpp

--- a/synfig-core/src/synfig/rendering/software/rendererpreviewsw.cpp
+++ b/synfig-core/src/synfig/rendering/software/rendererpreviewsw.cpp
@@ -1,0 +1,83 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file synfig/rendering/software/rendererpreviewsw.cpp
+**	\brief RendererSW
+**
+**	$Id$
+**
+**	\legal
+**	......... ... 2015 Ivan Mahonin
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include <synfig/localization.h>
+
+#include "rendererpreviewsw.h"
+
+#include  "task/tasksw.h"
+
+#include "../common/optimizer/optimizerblendassociative.h"
+#include "../common/optimizer/optimizerblendmerge.h"
+#include "../common/optimizer/optimizerblendtotarget.h"
+#include "../common/optimizer/optimizerlist.h"
+#include "../common/optimizer/optimizersplit.h"
+#include "../common/optimizer/optimizertransformation.h"
+#include "../common/optimizer/optimizerpass.h"
+#include "../common/optimizer/optimizerdraft.h"
+
+#include "function/fft.h"
+
+#endif
+
+using namespace synfig;
+using namespace rendering;
+
+/* === M A C R O S ========================================================= */
+
+/* === G L O B A L S ======================================================= */
+
+/* === P R O C E D U R E S ================================================= */
+
+/* === M E T H O D S ======================================================= */
+
+RendererPreviewSW::RendererPreviewSW()
+{
+	register_mode(TaskSW::mode_token.handle());
+
+	// register optimizers
+	register_optimizer(new OptimizerTransformation());
+	register_optimizer(new OptimizerDraftTransformation());
+	register_optimizer(new OptimizerPass(false));
+	register_optimizer(new OptimizerPass(true));
+	register_optimizer(new OptimizerBlendMerge());
+	register_optimizer(new OptimizerList());
+	register_optimizer(new OptimizerBlendToTarget());
+	register_optimizer(new OptimizerBlendAssociative());
+	//register_optimizer(new OptimizerSplit());
+}
+
+String RendererPreviewSW::get_name() const
+{
+	return _("Cobra Preview (software)");
+}
+
+/* === E N T R Y P O I N T ================================================= */

--- a/synfig-core/src/synfig/rendering/software/rendererpreviewsw.h
+++ b/synfig-core/src/synfig/rendering/software/rendererpreviewsw.h
@@ -1,0 +1,57 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file synfig/rendering/software/rendererpreviewsw.h
+**	\brief RendererPreviewSW Header
+**
+**	$Id$
+**
+**	\legal
+**	......... ... 2015 Ivan Mahonin
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef __SYNFIG_RENDERING_RENDERERPREVIEWSW_H
+#define __SYNFIG_RENDERING_RENDERERPREVIEWSW_H
+
+/* === H E A D E R S ======================================================= */
+
+#include "../renderer.h"
+
+/* === M A C R O S ========================================================= */
+
+/* === T Y P E D E F S ===================================================== */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace synfig
+{
+namespace rendering
+{
+
+class RendererPreviewSW: public Renderer
+{
+public:
+	typedef etl::handle<RendererPreviewSW> Handle;
+
+	RendererPreviewSW();
+	virtual String get_name() const;
+};
+
+}; /* end namespace rendering */
+}; /* end namespace synfig */
+
+/* -- E N D ----------------------------------------------------------------- */
+
+#endif

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1076,26 +1076,22 @@ CanvasView::create_tool_separator()
 	return separator;
 }
 
-void CanvasView::toggle_draft_render()
+void CanvasView::toggle_render_combobox()
 {
-	//if (App::workarea_renderer.empty()) return;
-
-	bool toggled = this->draft_button->get_active();
-	if (toggled) {
+	//get row number for value of render_combobox
+	int toggled = this->render_combobox->get_active_row_number();
+	// std::cout<<toggled<<" this is the value\n";
+	if (toggled == 0) {
+		
+		App::workarea_renderer = "software-preview";
+	}
+	if (toggled == 1) {
 		App::workarea_renderer = "software-draft";
-		this->draft_button->set_tooltip_text( _("Disable draft rendering"));
-	} else {
-		App::workarea_renderer = "";
-		this->draft_button->set_tooltip_text( _("Enable draft rendering"));
+	}
+	if (toggled == 2) {
+		App::workarea_renderer = "software";
 	}
 		
-
-	/*std::string test22 = "";
-	if (!App::workarea_renderer.empty()) test22 = App::workarea_renderer;
-	App::workarea_renderer = "software-draft";
-
-	test22 = App::workarea_renderer;*/
-
 	App::save_settings();
 	App::setup_changed();
 }
@@ -1240,15 +1236,20 @@ CanvasView::create_display_bar()
 		icon->set_padding(0, 0);
 		icon->show();
 
-		draft_button = Gtk::manage(new class Gtk::ToggleToolButton());
-		draft_button->set_icon_widget(*icon);
-		draft_button->signal_clicked().connect(sigc::mem_fun(*this, &CanvasView::toggle_draft_render));
-		draft_button->set_label(_("Draft"));
-		draft_button->set_tooltip_text( _("Enable draft rendering"));
-		draft_button->set_active(App::workarea_renderer == "software-draft");
-		draft_button->show();
+		render_combobox = Gtk::manage(new class Gtk::ComboBoxText());
+		render_combobox->append("Preview");
+		render_combobox->append("Draft");
+		render_combobox->append("Final");
+		render_combobox->signal_changed().connect(sigc::mem_fun(*this, &CanvasView::toggle_render_combobox));
+		render_combobox->set_tooltip_text( _("Select rendering mode"));
+		render_combobox->set_active(0);
+		render_combobox->show();
+		auto container = Gtk::manage(new class Gtk::ToolItem());
+		container->add(*render_combobox);
 
-		displaybar->append(*draft_button);
+		container->show();
+		displaybar->add(*container);// container pointer
+
 	}
 	
 	// Separator

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1242,7 +1242,7 @@ CanvasView::create_display_bar()
 		render_combobox->append("Final");
 		render_combobox->signal_changed().connect(sigc::mem_fun(*this, &CanvasView::toggle_render_combobox));
 		render_combobox->set_tooltip_text( _("Select rendering mode"));
-		render_combobox->set_active(0);
+		render_combobox->set_active(1);
 		render_combobox->show();
 		auto container = Gtk::manage(new class Gtk::ToolItem());
 		container->add(*render_combobox);

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1083,10 +1083,10 @@ void CanvasView::toggle_render_combobox()
 	// std::cout<<toggled<<" this is the value\n";
 	if (toggled == 0) {
 		
-		App::workarea_renderer = "software-preview";
+		App::workarea_renderer = "software-draft";
 	}
 	if (toggled == 1) {
-		App::workarea_renderer = "software-draft";
+		App::workarea_renderer = "software-preview";
 	}
 	if (toggled == 2) {
 		App::workarea_renderer = "software";
@@ -1237,8 +1237,8 @@ CanvasView::create_display_bar()
 		icon->show();
 
 		render_combobox = Gtk::manage(new class Gtk::ComboBoxText());
-		render_combobox->append("Preview");
 		render_combobox->append("Draft");
+		render_combobox->append("Preview");
 		render_combobox->append("Final");
 		render_combobox->signal_changed().connect(sigc::mem_fun(*this, &CanvasView::toggle_render_combobox));
 		render_combobox->set_tooltip_text( _("Select rendering mode"));

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -274,7 +274,7 @@ private:
 	Gtk::Button *stopbutton;
 	Gtk::ToggleToolButton *background_rendering_button;
 	Gtk::ToolButton *refreshbutton;
-	Gtk::ToggleToolButton *draft_button;
+	Gtk::ComboBoxText *render_combobox;
 	Gtk::VBox *timebar;
 	Gtk::Toolbar *displaybar;
 	Widget_Enum *widget_interpolation;
@@ -454,7 +454,7 @@ private:
 	void toggle_animatebutton();
 	void toggle_timetrackbutton();
 
-	void toggle_draft_render();
+	void toggle_render_combobox();
 
 	void on_play_timeout();
 	


### PR DESCRIPTION
Fixes #729 
I added the new rendering mode - "Cobra Preview" and made it the default renderer.
I verified it's working.

>So far we need only one Optimizer, which modifies how images are displayed: it disables supersampling and forces NearestNeighbour interpolation scaling method.

_The above line Implied to NEAREST INTERPOLATION so I used the OptimizerDraftTransformation_
For GUI I used Comboboxtext and replaced the Togglebutton
As I cannot directly place Combobox to Toolbar hence I placed the Combobox in a Gtk::Tool Item Container.
**The GUI looks as below:**
![1](https://user-images.githubusercontent.com/37617951/53898287-cdc6ba00-405d-11e9-9c8d-fe3c71d8c4fd.png)
![2](https://user-images.githubusercontent.com/37617951/53898288-cdc6ba00-405d-11e9-80a9-089da12ed55c.png)
 
@morevnaproject Please review the changes made :smiley: 

PS: Want to drive your attention towards the depreciation error which says **throws is deprecated in C++ 11** while building synfig, I think in ETL
