### PR TITLE
Fix auto_ptr is deprecated #751

### DIFF
--- a/autobuild/build.sh
+++ b/autobuild/build.sh
@@ -85,7 +85,7 @@ export PATH=${PREFIX}/bin:$PATH
 export LD_LIBRARY_PATH=${PREFIX}/lib:${PREFIX}/lib64:/usr/local/lib:$LD_LIBRARY_PATH
 export LDFLAGS="-Wl,-rpath -Wl,\\\$\$ORIGIN/lib ${LDFLAGS}"
 export CFLAGS="-fdiagnostics-color=always $CFLAGS"
-export CXXFLAGS="-fdiagnostics-color=always $CXXFLAGS"
+export CXXFLAGS="-fdiagnostics-color=always -Wno-deprecated-declarations $CXXFLAGS"
 
 #========================== FUNCTIONS ==================================
 


### PR DESCRIPTION
[https://www.cleancss.com/explain-command/gcc/4839](url)
As Mentioned in the above link
-Wno-deprecated-declarations can supress the auto_ptr warnings .
Can you please validate this ?

-export CXXFLAGS="-fdiagnostics-color=always $CXXFLAGS"
+export CXXFLAGS="-fdiagnostics-color=always -Wno-deprecated-declarations $CXXFLAGS"
