### PR TITLE
Pause in Menu->Navigation

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1456,7 +1456,7 @@ CanvasView::init_menus()
 	// the stop is not as normal stop but pause. So use "Pause" in UI, including TEXT and
 	// icon. the internal code is still using stop.
 	action_group->add( Gtk::Action::create("stop", Gtk::StockID("synfig-animate_pause")),
-		SLOT_EVENT(EVENT_STOP)
+		sigc::mem_fun(*this, &CanvasView::stop_async)
 	);
 
 	action_group->add( Gtk::Action::create("refresh", Gtk::StockID("gtk-refresh")),


### PR DESCRIPTION
Closes: #750
The "Pause" in Navigation menu now works. Consequently, the short key "Esc" which starts the "stop" action also works.
All the other options in the Navigation seem to be working fine.