### PR TITLE
Experimental features option. Disable brush tool.

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1724,7 +1724,7 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 		/* other */
 		state_manager->add_state(&state_text);
 		if(!getenv("SYNFIG_DISABLE_SKETCH" )) state_manager->add_state(&state_sketch);
-		if(!getenv("SYNFIG_DISABLE_BRUSH"  )) state_manager->add_state(&state_brush);
+		if(!getenv("SYNFIG_DISABLE_BRUSH"  ) && App::enable_experimental_features) state_manager->add_state(&state_brush);
 		state_manager->add_state(&state_zoom);
 
 

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -265,8 +265,7 @@ Dialog_Setup::create_system_page(PageInfo pi)
 	}
 	// System - 11 Experimental Features section
 	// System - enable_experimental_features
-	attach_label_section(pi.grid, _("Experimental Features"), ++row);
-	attach_label(pi.grid, _("Experimental features (requires restart)"), ++row);
+	attach_label_section(pi.grid, _("Experimental features (requires restart)"), ++row);
 	pi.grid->attach(toggle_enable_experimental_features, 1, row, 1, 1);
 	toggle_enable_experimental_features.set_halign(Gtk::ALIGN_START);
 	toggle_enable_experimental_features.set_hexpand(false);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -263,10 +263,13 @@ Dialog_Setup::create_system_page(PageInfo pi)
 		brush_path_btn_grid->set_halign(Gtk::ALIGN_END);
 		++row;
 	}
-	// System - 11 enable_experimental_features
-	//attach_label(pi.grid, _("Experimental features (restart needed)"), ++row);
-	//pi.grid->attach(toggle_enable_experimental_features, 1, row, 1, 1);
-	//toggle_enable_experimental_features.set_hexpand(true);
+	// System - 11 Experimental Features section
+	// System - enable_experimental_features
+	attach_label_section(pi.grid, _("Experimental Features"), ++row);
+	attach_label(pi.grid, _("Experimental features (requires restart)"), ++row);
+	pi.grid->attach(toggle_enable_experimental_features, 1, row, 1, 1);
+	toggle_enable_experimental_features.set_halign(Gtk::ALIGN_START);
+	toggle_enable_experimental_features.set_hexpand(false);
 
 #ifdef SINGLE_THREADED
 	// System - 12 single_threaded

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -263,8 +263,7 @@ Dialog_Setup::create_system_page(PageInfo pi)
 		brush_path_btn_grid->set_halign(Gtk::ALIGN_END);
 		++row;
 	}
-	// System - 11 Experimental Features section
-	// System - enable_experimental_features
+	// System - 11 enable_experimental_features
 	attach_label_section(pi.grid, _("Experimental features (requires restart)"), ++row);
 	pi.grid->attach(toggle_enable_experimental_features, 1, row, 1, 1);
 	toggle_enable_experimental_features.set_halign(Gtk::ALIGN_START);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -185,7 +185,7 @@ class Dialog_Setup : public Dialog_Template
 
 	Gtk::Switch toggle_restrict_radius_ducks;
 	Gtk::Switch toggle_resize_imported_images;
-	Gtk::CheckButton toggle_enable_experimental_features;
+	Gtk::Switch toggle_enable_experimental_features;
 	Gtk::Switch toggle_use_dark_theme;
 	Gtk::Switch toggle_show_file_toolbar;
 


### PR DESCRIPTION
Closes: #760
The option for enabling/disabling experimental features has been added.
The default value for enabling experimental features is "false", as seen here.
https://github.com/synfig/synfig/blob/9b3fe68804dd3d5bfb5d6ac43a74fa72138b6c18/synfig-studio/src/gui/app.cpp#L306

This feature is currently being used to disable the "Brush Tool". It can be extended to isolate other experimental features as well.

Thanks for locating the code for "Brush Tool" @morevnaproject.

^_^
