### PR TITLE
Added Edit Image in external tool

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3531,11 +3531,14 @@ try_open_img_external(const std::string &uri)
 	std::string s = "file://";
 	std::string::size_type i = new_uri.find(s);
 	if (i != std::string::npos)
-   		new_uri.erase(i, s.length());
-	size_t start_pos = 0;
+	{
+		new_uri.erase(i, s.length());
+	}
+   	size_t start_pos = 0;
 	std::string to = " ";
 	std::string from = "%20";
-    while((start_pos = new_uri.find(from, start_pos)) != std::string::npos) {
+    while((start_pos = new_uri.find(from, start_pos)) != std::string::npos) 
+	{
         new_uri.replace(start_pos, from.length(), to);
         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
     }
@@ -3543,19 +3546,17 @@ try_open_img_external(const std::string &uri)
 	if(App::image_editor_path!="")
 	{
 		#ifdef WIN32
-		char buffer[512];
-    	::snprintf(buffer, sizeof(buffer), "%s %s",App::image_editor_path.c_str(), new_uri.c_str());
-    	//::system(buffer);
-		Glib::spawn_command_line_sync(buffer);
+			char buffer[512];
+    		::snprintf(buffer, sizeof(buffer), "%s %s",App::image_editor_path.c_str(), new_uri.c_str());
+    		Glib::spawn_command_line_sync(buffer);
 		#elif defined(__APPLE__)
-    	char buffer[512];
-    	::snprintf(buffer, sizeof(buffer), "open -a %s %s", App::image_editor_path.c_str(), new_uri.c_str());
-    	::system(buffer);
+    		char buffer[512];
+    		::snprintf(buffer, sizeof(buffer), "open -a %s %s", App::image_editor_path.c_str(), new_uri.c_str());
+    		::system(buffer);
 		#else
-    	char buffer[512];
-    	::snprintf(buffer, sizeof(buffer), "%s %s",App::image_editor_path.c_str(), new_uri.c_str());
-    	//::system(buffer);
-		Glib::spawn_command_line_sync(buffer);
+    		char buffer[512];
+    		::snprintf(buffer, sizeof(buffer), "%s %s",App::image_editor_path.c_str(), new_uri.c_str());
+			Glib::spawn_command_line_sync(buffer);
 		#endif
 		return true;
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -314,7 +314,7 @@ String studio::App::predefined_fps               (DEFAULT_PREDEFINED_FPS);
 float  studio::App::preferred_fps                = 24.0;
 synfigapp::PluginManager studio::App::plugin_manager;
 std::set< String >       studio::App::brushes_path;
-String studio::App::IMAGE_EDITOR_PATH;
+String studio::App::image_editor_path;
 
 String studio::App::sequence_separator(".");
 String studio::App::navigator_renderer;
@@ -688,6 +688,11 @@ public:
 				value=strprintf("%il", (long)App::ui_handle_tooltip_flag);
 				return true;
 			}
+			if(key=="image_editor_path")
+			{
+				value=App::image_editor_path;
+				return true;
+			}
 		}
 		catch(...)
 		{
@@ -885,6 +890,11 @@ public:
 				App::ui_handle_tooltip_flag = l;
 				return true;
 			}
+			if(key=="image_editor_path")
+			{
+				App::image_editor_path=value;
+				return true;
+			}
 		}
 		catch(...)
 		{
@@ -929,6 +939,8 @@ public:
 		ret.push_back("use_render_done_sound");
 		ret.push_back("enable_mainwin_menubar");
 		ret.push_back("ui_handle_tooltip_flag");
+		ret.push_back("image_editor_path");
+
 
 		return ret;
 	}
@@ -1582,6 +1594,7 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 		load_settings("pref.default_background_layer_color");
 		load_settings("pref.default_background_layer_image");
 		load_settings("pref.preview_background_color");
+		load_settings("pref.image_editor_path");
 
 		studio_init_cb.task(_("Loading Plugins..."));
 		plugin_manager.load_dir(path_to_plugins);
@@ -2288,6 +2301,8 @@ App::restore_default_settings()
 	synfigapp::Main::settings().set_value("pref.ui_handle_tooltip_flag",         temp.str());
 	synfigapp::Main::settings().set_value("pref.autosave_backup",                "1");
 	synfigapp::Main::settings().set_value("pref.autosave_backup_interval",       "15000");
+	synfigapp::Main::settings().set_value("pref.image_editor_path",             "");
+
 }
 
 void
@@ -3525,20 +3540,20 @@ try_open_img_external(const std::string &uri)
         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
     }
 	new_uri = "\"" + new_uri + "\"";
-	if(App::IMAGE_EDITOR_PATH!="")
+	if(App::image_editor_path!="")
 	{
 		#ifdef WIN32
 		char buffer[512];
-    	::snprintf(buffer, sizeof(buffer), "%s %s",App::IMAGE_EDITOR_PATH.c_str(), new_uri.c_str());
+    	::snprintf(buffer, sizeof(buffer), "%s %s",App::image_editor_path.c_str(), new_uri.c_str());
     	//::system(buffer);
 		Glib::spawn_command_line_sync(buffer);
 		#elif defined(__APPLE__)
     	char buffer[512];
-    	::snprintf(buffer, sizeof(buffer), "open -a %s %s", App::IMAGE_EDITOR_PATH.c_str(), new_uri.c_str());
+    	::snprintf(buffer, sizeof(buffer), "open -a %s %s", App::image_editor_path.c_str(), new_uri.c_str());
     	::system(buffer);
 		#else
     	char buffer[512];
-    	::snprintf(buffer, sizeof(buffer), "%s %s",App::IMAGE_EDITOR_PATH.c_str(), new_uri.c_str());
+    	::snprintf(buffer, sizeof(buffer), "%s %s",App::image_editor_path.c_str(), new_uri.c_str());
     	//::system(buffer);
 		Glib::spawn_command_line_sync(buffer);
 		#endif
@@ -3581,7 +3596,7 @@ void App::open_img_in_external(const std::string &uri)
 	synfig::info("Opening with external tool: " + uri);
 	if(!try_open_img_external(uri))
 	{
-		Gtk::MessageDialog dialog(*App::main_window, _("No Preferred editing tool was set in Edit->Preferences->Editing:"), false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE, true);
+		Gtk::MessageDialog dialog(*App::main_window, _("Make sure Preferred editing tool was set in \n Edit->Preferences->Editing:"), false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE, true);
 		dialog.set_secondary_text(uri);
 		dialog.set_title(_("Error"));
 		dialog.run();

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3517,11 +3517,25 @@ try_open_img_external(const std::string &uri)
 	std::string::size_type i = new_uri.find(s);
 	if (i != std::string::npos)
    		new_uri.erase(i, s.length());
+	size_t start_pos = 0;
+	std::string to = " ";
+	std::string from = "%20";
+    while((start_pos = new_uri.find(from, start_pos)) != std::string::npos) {
+        new_uri.replace(start_pos, from.length(), to);
+        start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+    }
+	new_uri = "\"" + new_uri + "\"";
 	if(App::IMAGE_EDITOR_PATH!="")
 	{
 		#ifdef WIN32
-    	ShellExecute(GetActiveWindow(),
-        	 "open", url, NULL, NULL, SW_SHOWNORMAL);
+		char buffer[512];
+    	::snprintf(buffer, sizeof(buffer), "%s %s",App::IMAGE_EDITOR_PATH.c_str(), new_uri.c_str());
+    	//::system(buffer);
+		Glib::spawn_command_line_sync(buffer);
+		#elif defined(__APPLE__)
+    	char buffer[512];
+    	::snprintf(buffer, sizeof(buffer), "open -a %s %s", App::IMAGE_EDITOR_PATH.c_str(), new_uri.c_str());
+    	::system(buffer);
 		#else
     	char buffer[512];
     	::snprintf(buffer, sizeof(buffer), "%s %s",App::IMAGE_EDITOR_PATH.c_str(), new_uri.c_str());
@@ -3549,6 +3563,7 @@ try_open_uri(const std::string &uri)
 	return gtk_show_uri(NULL, uri.c_str(), GDK_CURRENT_TIME, NULL);
 #endif
 }
+
 
 void
 App::dialog_help()

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -227,7 +227,7 @@ public:
 	static bool show_file_toolbar;
 
 	static synfigapp::PluginManager plugin_manager;
-
+	static synfig::String IMAGE_EDITOR_PATH;
 	static std::set< synfig::String > brushes_path;
 	static synfig::String custom_filename_prefix;
 	static int preferred_x_size;
@@ -441,6 +441,8 @@ public:
 			const std::string &button3);
 
 	static void open_uri(const std::string &uri);
+	static void open_img_in_external(const std::string &uri);
+
 
 	static synfig::String get_config_file(const synfig::String& file);
 	// This will spread the changes made in preferences.

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -227,7 +227,7 @@ public:
 	static bool show_file_toolbar;
 
 	static synfigapp::PluginManager plugin_manager;
-	static synfig::String IMAGE_EDITOR_PATH;
+	static synfig::String image_editor_path;
 	static std::set< synfig::String > brushes_path;
 	static synfig::String custom_filename_prefix;
 	static int preferred_x_size;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -454,7 +454,8 @@ Dialog_Setup::create_editing_page(PageInfo pi)
 	 * OTHER
 	 *  [x] Linear color
 	 *  [x] Restrict radius
-	 *
+	 * EDIT IN EXTERNAL
+	 * 	Preferred image editor [image_editor_path] (choose..)
 	 *
 	 */
 
@@ -494,16 +495,19 @@ dragging the handle to the left bottom part of your 2D space.");
 
 	attach_label_section(pi.grid, _("Edit in external"), ++row);
 
+	attach_label(pi.grid,_("Preferred image editor"), ++row);
+
 	//create a button that will open the filechooserdialog to select image editor
-	Gtk::Button *choose_button(manage(new class Gtk::Button(Gtk::StockID(_("Choose preferred Image Editor")))));
+	Gtk::Button *choose_button(manage(new class Gtk::Button(Gtk::StockID(_("Choose..")))));
 	choose_button->show();
 	choose_button->set_tooltip_text("Choose the preferred Image editor for Edit in external tool option");
 	
 	//create a function to launch the dialog
 	choose_button->signal_clicked().connect(sigc::mem_fun(*this,&Dialog_Setup::on_choose_editor_pressed));
-	pi.grid->attach(*choose_button, 0,++row,1,1);
-	pi.grid->attach(image_editor_path, 1, row, 1, 1);
-	image_editor_path.set_hexpand(true);
+	pi.grid->attach(image_editor_path_entry, 1, row, 1, 1);
+	pi.grid->attach(*choose_button, 2,row,1,1);
+	image_editor_path_entry.set_hexpand(true);
+	image_editor_path_entry.set_text(App::image_editor_path);
 	
 }
 
@@ -511,9 +515,11 @@ dragging the handle to the left bottom part of your 2D space.");
 void
 Dialog_Setup::on_choose_editor_pressed()
 {
-	String filepath=image_editor_path.get_text();
+	//set the image editor path = filepath from dialog
+	String filepath=image_editor_path_entry.get_text();
 	if(select_path_dialog("Select Editor", filepath, RENDER_DIR_PREFERENCE))
-		image_editor_path.set_text(filepath);
+		image_editor_path_entry.set_text(filepath);
+		App::image_editor_path = filepath;
 }
 
 bool 
@@ -788,7 +794,7 @@ Dialog_Setup::on_apply_pressed()
 	App::custom_filename_prefix = textbox_custom_filename_prefix.get_text();
 
 	// Set the preferred image editor
-	App::IMAGE_EDITOR_PATH = image_editor_path.get_text();
+	App::image_editor_path = image_editor_path_entry.get_text();
 
 	// Set the preferred new Document X dimension
 	App::preferred_x_size       = int(adj_pref_x_size->get_value());
@@ -1045,7 +1051,7 @@ Dialog_Setup::refresh()
 	toggle_show_file_toolbar.set_active(App::show_file_toolbar);
 
 	// Refresh the preferred image editor path
-	image_editor_path.set_text("");
+	image_editor_path_entry.set_text(App::image_editor_path);
 
 	// Refresh the brush path(s)
 	Glib::RefPtr<Gtk::ListStore> liststore = Glib::RefPtr<Gtk::ListStore>::cast_dynamic(

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -528,7 +528,7 @@ Dialog_Setup::select_path_dialog(const std::string &title, std::string &filepath
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,title, Gtk::FILE_CHOOSER_ACTION_OPEN);
 	dialog->set_transient_for(*App::main_window);
 	#ifdef WIN32
-	dialog->set_current_folder("C:\Program Files");
+	dialog->set_current_folder("C:\\Program Files");
 
 	#elif defined(__APPLE__)
     dialog->set_current_folder("/Applications");

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -491,6 +491,32 @@ Option (ON by default) to make sure that if you ask for 50, you get 50% of the b
 (especially for radius) to be in the top right quadrant of the 2D space. Allow to set \
 the real value to any number and also easily reach the value of 0.0 just \
 dragging the handle to the left bottom part of your 2D space.");
+
+	attach_label_section(pi.grid, _("Edit in external"), ++row);
+	attach_label(pi.grid,_("Preferred image editor"), ++row);
+	pi.grid->attach(image_editor_path, 1, row, 1, 1);
+	image_editor_path.set_hexpand(true);
+
+
+
+// Brushes path buttons
+		// Gtk::Grid* brush_path_btn_grid(manage (new Gtk::Grid()));
+		// Gtk::Button* brush_path_add(manage (new Gtk::Button()));
+		// brush_path_add->set_image_from_icon_name("add", Gtk::ICON_SIZE_BUTTON);
+		// brush_path_btn_grid->attach(*brush_path_add, 0, 0, 1, 1);
+		// brush_path_add->set_halign(Gtk::ALIGN_END);
+		// brush_path_add->signal_clicked().connect(
+		// 		sigc::mem_fun(*this, &Dialog_Setup::on_brush_path_add_clicked));
+		// Gtk::Button* brush_path_remove(manage (new Gtk::Button()));
+		// brush_path_remove->set_image_from_icon_name("remove", Gtk::ICON_SIZE_BUTTON);
+		// brush_path_btn_grid->attach(*brush_path_remove, 0, 1, 1, 1);
+		// brush_path_remove->set_halign(Gtk::ALIGN_END);
+		// brush_path_remove->signal_clicked().connect(
+		// 		sigc::mem_fun(*this, &Dialog_Setup::on_brush_path_remove_clicked));
+		// pi.grid->attach(*brush_path_btn_grid, 0, ++row, 1, 2);
+		// brush_path_btn_grid->set_halign(Gtk::ALIGN_END);
+		// ++row;
+	
 }
 
 void

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -521,7 +521,15 @@ Dialog_Setup::select_path_dialog(const std::string &title, std::string &filepath
 {
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,title, Gtk::FILE_CHOOSER_ACTION_OPEN);
 	dialog->set_transient_for(*App::main_window);
-	dialog->set_current_folder("/usr/bin");
+	#ifdef WIN32
+	dialog->set_current_folder("C:/Program Files");
+
+	#elif defined(__APPLE__)
+    dialog->set_current_folder("/Applications");
+
+	#else
+    	dialog->set_current_folder("/usr/bin");
+	#endif
 
 	//Add response buttons the the dialog:
 	dialog->add_button("_Cancel", Gtk::RESPONSE_CANCEL);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -517,18 +517,18 @@ Dialog_Setup::on_choose_editor_pressed()
 {
 	//set the image editor path = filepath from dialog
 	String filepath=image_editor_path_entry.get_text();
-	if(select_path_dialog("Select Editor", filepath, RENDER_DIR_PREFERENCE))
+	if(select_path_dialog("Select Editor", filepath ))
 		image_editor_path_entry.set_text(filepath);
 		App::image_editor_path = filepath;
 }
 
 bool 
-Dialog_Setup::select_path_dialog(const std::string &title, std::string &filepath, std::string preference)
+Dialog_Setup::select_path_dialog(const std::string &title, std::string &filepath)
 {
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,title, Gtk::FILE_CHOOSER_ACTION_OPEN);
 	dialog->set_transient_for(*App::main_window);
 	#ifdef WIN32
-	dialog->set_current_folder("C:/Program Files");
+	dialog->set_current_folder("C:\Program Files");
 
 	#elif defined(__APPLE__)
     dialog->set_current_folder("/Applications");

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -493,32 +493,51 @@ the real value to any number and also easily reach the value of 0.0 just \
 dragging the handle to the left bottom part of your 2D space.");
 
 	attach_label_section(pi.grid, _("Edit in external"), ++row);
-	attach_label(pi.grid,_("Preferred image editor"), ++row);
-	pi.grid->attach(image_editor_path, 1, row, 1, 1);
-	image_editor_path.set_hexpand(true);
-
-
-
-// Brushes path buttons
-		// Gtk::Grid* brush_path_btn_grid(manage (new Gtk::Grid()));
-		// Gtk::Button* brush_path_add(manage (new Gtk::Button()));
-		// brush_path_add->set_image_from_icon_name("add", Gtk::ICON_SIZE_BUTTON);
-		// brush_path_btn_grid->attach(*brush_path_add, 0, 0, 1, 1);
-		// brush_path_add->set_halign(Gtk::ALIGN_END);
-		// brush_path_add->signal_clicked().connect(
-		// 		sigc::mem_fun(*this, &Dialog_Setup::on_brush_path_add_clicked));
-		// Gtk::Button* brush_path_remove(manage (new Gtk::Button()));
-		// brush_path_remove->set_image_from_icon_name("remove", Gtk::ICON_SIZE_BUTTON);
-		// brush_path_btn_grid->attach(*brush_path_remove, 0, 1, 1, 1);
-		// brush_path_remove->set_halign(Gtk::ALIGN_END);
-		// brush_path_remove->signal_clicked().connect(
-		// 		sigc::mem_fun(*this, &Dialog_Setup::on_brush_path_remove_clicked));
-		// pi.grid->attach(*brush_path_btn_grid, 0, ++row, 1, 2);
-		// brush_path_btn_grid->set_halign(Gtk::ALIGN_END);
-		// ++row;
+	Gtk::Button *choose_button(manage(new class Gtk::Button(Gtk::StockID(_("Choose Preferred Image Editor")))));
+	choose_button->show();
+	//create a function to launch the dialog
+	choose_button->signal_clicked().connect(sigc::mem_fun(*this,&Dialog_Setup::on_choose_editor_pressed));
+	pi.grid->attach(*choose_button, 0,++row,1,1);
+	pi.grid->attach(image_editor_path, 1, row, 3, 2);
+	// image_editor_path.set_hexpand(true);
 	
 }
 
+
+void
+Dialog_Setup::on_choose_editor_pressed()
+{
+	String filepath=image_editor_path.get_text();
+	std::cout<<"Filename "<<filepath<<"\n";
+	if(some_cool_fun("Select Editor", filepath, RENDER_DIR_PREFERENCE))
+		image_editor_path.set_text(filepath);
+}
+
+bool Dialog_Setup::some_cool_fun(const std::string &title, std::string &filepath, std::string preference)
+{
+
+	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
+				title, Gtk::FILE_CHOOSER_ACTION_OPEN);
+
+  dialog->set_transient_for(*App::main_window);
+  dialog->set_current_folder("/usr/bin");
+
+  //Add response buttons the the dialog:
+  dialog->add_button("_Cancel", Gtk::RESPONSE_CANCEL);
+  dialog->add_button("Select", Gtk::RESPONSE_OK);
+  	if(dialog->run() == Gtk::RESPONSE_OK) {
+		filepath = dialog->get_filename();
+		filepath = absolute_path(filepath);
+			std::cout<<"Filename "<<absolute_path(filepath)<<"\n";
+
+		// info("Saving preference %s = '%s' in App::dialog_open_file()", preference.c_str(), dirname(filename).c_str());
+		//_preferences.set_value(preference, dirname(filename));
+		delete dialog;
+		return true;
+	}
+	delete dialog;
+	return false;
+}
 void
 Dialog_Setup::create_render_page(PageInfo pi)
 {

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -226,6 +226,7 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::Switch toggle_handle_tooltip_radius;
 	Gtk::Switch toggle_handle_tooltip_transformation;
 	Gtk::Switch toggle_autobackup;
+	Gtk::Entry image_editor_path;
 
 	long pref_modification_flag;
 	//! Do not update state flag on refreshing

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -150,7 +150,7 @@ class Dialog_Setup : public Dialog_Template
 	void on_brush_path_add_clicked();
 	void on_brush_path_remove_clicked();
 	void on_choose_editor_pressed();
-	bool some_cool_fun(const std::string &title, std::string &filename, std::string preference);
+	bool select_path_dialog(const std::string &title, std::string &filename, std::string preference);
 
 	void create_gamma_page(PageInfo pi);
 	void create_system_page(PageInfo pi);
@@ -229,7 +229,6 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::Switch toggle_handle_tooltip_transformation;
 	Gtk::Switch toggle_autobackup;
 	Gtk::Entry image_editor_path;
-
 	long pref_modification_flag;
 	//! Do not update state flag on refreshing
 	bool refreshing;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -228,7 +228,7 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::Switch toggle_handle_tooltip_radius;
 	Gtk::Switch toggle_handle_tooltip_transformation;
 	Gtk::Switch toggle_autobackup;
-	Gtk::Entry image_editor_path;
+	Gtk::Entry image_editor_path_entry;
 	long pref_modification_flag;
 	//! Do not update state flag on refreshing
 	bool refreshing;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -150,7 +150,7 @@ class Dialog_Setup : public Dialog_Template
 	void on_brush_path_add_clicked();
 	void on_brush_path_remove_clicked();
 	void on_choose_editor_pressed();
-	bool select_path_dialog(const std::string &title, std::string &filename, std::string preference);
+	bool select_path_dialog(const std::string &title, std::string &filename);
 
 	void create_gamma_page(PageInfo pi);
 	void create_system_page(PageInfo pi);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -149,6 +149,8 @@ class Dialog_Setup : public Dialog_Template
 	void on_preview_background_color_changed();
 	void on_brush_path_add_clicked();
 	void on_brush_path_remove_clicked();
+	void on_choose_editor_pressed();
+	bool some_cool_fun(const std::string &title, std::string &filename, std::string preference);
 
 	void create_gamma_page(PageInfo pi);
 	void create_system_page(PageInfo pi);

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1731,19 +1731,35 @@ Instance::add_special_layer_actions_to_menu(Gtk::Menu *menu, const synfigapp::Se
 void
 Instance::add_special_layer_actions_to_group(const Glib::RefPtr<Gtk::ActionGroup>& action_group, synfig::String& ui_info, const synfigapp::SelectionManager::LayerList &layers) const
 {
+	vector <String> img_ext{".jpg",".jpeg",".png",".bmp",".gif"};
 	std::map<String, String> uris;
 	gather_uri(uris, layers);
 	int index = 0;
 	for(std::map<String, String>::const_iterator i = uris.begin(); i != uris.end(); ++i, ++index)
 	{
 		String action_name = etl::strprintf("special-action-open-file-%d", index);
-		String local_name = String(_("Open file")) + " '" + i->first + "'";
-		action_group->add(
-			Gtk::Action::create(
-				action_name,
-				Gtk::Stock::OPEN,
-				local_name, local_name ),
-			sigc::bind(sigc::ptr_fun(&App::open_uri), i->second) );
-		ui_info += strprintf("<menuitem action='%s' />", action_name.c_str());
+		//if the import layer is type image 
+		if(std::find(img_ext.begin(), img_ext.end(), filename_extension(i->second)) != img_ext.end())
+		{
+			String local_name = String(_("Edit image in external tool.."));
+			action_group->add(
+				Gtk::Action::create(
+					action_name,
+					Gtk::Stock::OPEN,
+					local_name, local_name ),
+				sigc::bind(sigc::ptr_fun(&App::open_img_in_external), i->second) );
+			ui_info += strprintf("<menuitem action='%s' />", action_name.c_str());
+		}
+		else
+		{
+			String local_name = String(_("Open file")) + " '" + i->first + "'";
+			action_group->add(
+				Gtk::Action::create(
+					action_name,
+					Gtk::Stock::OPEN,
+					local_name, local_name ),
+				sigc::bind(sigc::ptr_fun(&App::open_uri), i->second) );
+			ui_info += strprintf("<menuitem action='%s' />", action_name.c_str());
+		}
 	}
 }

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1592,14 +1592,14 @@ Instance::make_param_menu(Gtk::Menu *menu,synfig::Canvas::Handle canvas,const st
 		make_param_menu(menu,canvas,value_desc, 0.f, false);
 }
 
-
+// this one is useful for me
 void
 Instance::gather_uri(std::set<synfig::String> &x, const synfig::ValueNode::Handle &value_node) const
-{
+{	//check for null value
 	if (!value_node || !value_node->get_parent_canvas()) return;
-
+	
 	LinkableValueNode::Handle linkable_value_node = LinkableValueNode::Handle::cast_dynamic(value_node);
-	if (!linkable_value_node) return;
+	if (!linkable_value_node) return;	//check that linkable_value_node is not empty
 
 	FileSystem::Handle file_system = value_node->get_parent_canvas()->get_file_system();
 	if (!file_system) return;


### PR DESCRIPTION
As per #516 I added the option in preferences under **Edit -> Preferences-> Editing ** 
![Screenshot from 2019-03-14 14-20-58](https://user-images.githubusercontent.com/37617951/54343568-1c2f1680-4665-11e9-8994-f66d40893e43.png)

The button open a filechooserdialog (by default in usr/bin ) from where app can be selected
After which we can use the "Edit image in external tool " option for any image layer
![Screenshot from 2019-03-14 14-18-51](https://user-images.githubusercontent.com/37617951/54343715-6dd7a100-4665-11e9-8349-1d1fe6971fa9.png)

PS: Works fine in linux Mint OS, ~~Windows implementation is not done yet~~

@morevnaproject please suggest possible edits if any :)

**EDIT:** Added corresponding option for windows and OS X but cannot verify it's working :/ 