### PR TITLE
Fixed part 2 of #516

### DIFF
--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1631,26 +1631,63 @@ void
 Instance::gather_uri(std::set<synfig::String> &x, const synfig::Layer::Handle &layer) const
 {
 	if (!layer || !layer->get_canvas()) return;
+	int count =0; //will be used to count layers in the group
+	
+	//check if the layer is group layer
+	ParamVocab vocab = layer->get_param_vocab();
+	synfig::Layer::Handle layerfinal,lay;
+	bool some_bool = false;
+	for(ParamVocab::const_iterator i = vocab.begin(); i != vocab.end(); ++i)
+	{
+		if(i->get_description() == "Group content")
+		{
+			etl::handle<synfig::Layer_PasteCanvas> p = etl::handle<synfig::Layer_PasteCanvas>::cast_dynamic(layer);
+			synfig::Canvas::Handle canvas = p->get_sub_canvas();
+			if(canvas)
+			{
+				for(IndependentContext i = canvas->get_independent_context(); *i; i++)
+				{
+					lay = (*i);
+					count++;
+				}
+				if(count==1)
+				{
+					some_bool = true;//yes only one layer 
+				}				
+			}
+		}
+	}
 
 	FileSystem::Handle file_system = layer->get_canvas()->get_file_system();
 	if (!file_system) return;
 
-	ParamVocab vocab = layer->get_param_vocab();
+	//if yes then the layer inside group should be processed not the group!
+	if(some_bool)
+	{
+		vocab = lay->get_param_vocab();
+		layerfinal = lay;
+	}
+	else
+	{
+		layerfinal = layer;
+	}
+	
+
 	for(ParamVocab::const_iterator i = vocab.begin(); i != vocab.end(); ++i)
 	{
 		if (i->get_hint() == "filename")
 		{
-			ValueBase v = layer->get_param(i->get_name());
+			ValueBase v = layerfinal->get_param(i->get_name());
 			if (v.can_get(String()))
 			{
-				String filename = CanvasFileNaming::make_full_filename(layer->get_canvas()->get_file_name(), v.get(String()));
+				String filename = CanvasFileNaming::make_full_filename(layerfinal->get_canvas()->get_file_name(), v.get(String()));
 				String uri = file_system->get_real_uri(filename);
 				if (!uri.empty()) x.insert(uri);
 			}
 		}
 
-		Layer::DynamicParamList::const_iterator j = layer->dynamic_param_list().find(i->get_name());
-		if (j != layer->dynamic_param_list().end() && j->second)
+		Layer::DynamicParamList::const_iterator j = layerfinal->dynamic_param_list().find(i->get_name());
+		if (j != layerfinal->dynamic_param_list().end() && j->second)
 			gather_uri(x, j->second);
 	}
 
@@ -1670,6 +1707,9 @@ Instance::gather_uri(std::set<synfig::String> &x, const synfig::Canvas::Handle &
 		gather_uri(x, *i);
 }
 
+// this is the second function for gather_uri - call it gather_uri(set, layerlist)
+// iterate through all the layers and call gather_uri(set, layer) for each saperate layer 
+
 void
 Instance::gather_uri(std::set<synfig::String> &x, const synfigapp::SelectionManager::LayerList &layers) const
 {
@@ -1677,6 +1717,7 @@ Instance::gather_uri(std::set<synfig::String> &x, const synfigapp::SelectionMana
 		gather_uri(x, *i);
 }
 
+// this is the entry point for gather_uri - call it gather_uri(map, layerlist)
 void
 Instance::gather_uri(std::map<synfig::String, synfig::String> &x, const synfigapp::SelectionManager::LayerList &layers) const
 {
@@ -1728,6 +1769,8 @@ Instance::add_special_layer_actions_to_menu(Gtk::Menu *menu, const synfigapp::Se
 	}
 }
 
+// called whenever we right click any layer under layers panel
+// arguments - action_group: the current group of actions on the right click menu, layers: layerlist(because we can select multiple layer and then right click) 
 void
 Instance::add_special_layer_actions_to_group(const Glib::RefPtr<Gtk::ActionGroup>& action_group, synfig::String& ui_info, const synfigapp::SelectionManager::LayerList &layers) const
 {

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1632,47 +1632,31 @@ Instance::gather_uri(std::set<synfig::String> &x, const synfig::Layer::Handle &l
 {
 	if (!layer || !layer->get_canvas()) return;
 	int count =0; //will be used to count layers in the group
-	
+
+	synfig::Layer::Handle layerfinal,child_layer;
+
 	//check if the layer is group layer
-	ParamVocab vocab = layer->get_param_vocab();
-	synfig::Layer::Handle layerfinal,lay;
-	bool some_bool = false;
-	for(ParamVocab::const_iterator i = vocab.begin(); i != vocab.end(); ++i)
+	if (etl::handle<Layer_PasteCanvas> paste = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer)) 
 	{
-		if(i->get_description() == "Group content")
-		{
-			etl::handle<synfig::Layer_PasteCanvas> p = etl::handle<synfig::Layer_PasteCanvas>::cast_dynamic(layer);
-			synfig::Canvas::Handle canvas = p->get_sub_canvas();
+		synfig::Canvas::Handle canvas = paste->get_sub_canvas();
 			if(canvas)
 			{
 				for(IndependentContext i = canvas->get_independent_context(); *i; i++)
 				{
-					lay = (*i);
+					child_layer = (*i);
 					count++;
+					if(count>1) break;
 				}
-				if(count==1)
-				{
-					some_bool = true;//yes only one layer 
-				}				
 			}
-		}
 	}
-
+	
 	FileSystem::Handle file_system = layer->get_canvas()->get_file_system();
 	if (!file_system) return;
 
 	//if yes then the layer inside group should be processed not the group!
-	if(some_bool)
-	{
-		vocab = lay->get_param_vocab();
-		layerfinal = lay;
-	}
-	else
-	{
-		layerfinal = layer;
-	}
-	
+	(count==1)? layerfinal = child_layer: layerfinal=layer;
 
+	ParamVocab vocab = layerfinal->get_param_vocab();
 	for(ParamVocab::const_iterator i = vocab.begin(); i != vocab.end(); ++i)
 	{
 		if (i->get_hint() == "filename")


### PR DESCRIPTION
As this can be seen in fig now on a group containing a single image layer have an external edit tool option.
![SS1](https://user-images.githubusercontent.com/37617951/55673601-a450b680-58c7-11e9-8572-ce0a2c65115e.png)
And when there are more than one image layer or any kind of layer the option is not shown.
![SS2](https://user-images.githubusercontent.com/37617951/55673607-be8a9480-58c7-11e9-9db5-31645fb3913e.png)

@morevnaproject please review when you have time [^_^]
