### PR TITLE
 Fix "Edit image in external tool" command for workarea

### DIFF
--- a/synfig-studio/src/gui/instance.h
+++ b/synfig-studio/src/gui/instance.h
@@ -147,6 +147,8 @@ public:
 	sigc::signal<void,CanvasView*>& signal_canvas_view_created() { return signal_canvas_view_created_; }
 	sigc::signal<void,CanvasView*>& signal_canvas_view_deleted() { return signal_canvas_view_deleted_; }
 
+	bool is_img(synfig::String ext) const;
+
 	bool get_undo_status()const { return undo_status_; }
 
 	bool get_redo_status()const { return redo_status_; }


### PR DESCRIPTION
Fixes #810.  "Edit image in external tool" now works correctly when called from workarea. Replaced vector with set for fast find operation. created a function for confirming if the uri belongs to image layer or not.

@morevnaproject please review :)