### PR TITLE
core/geometry: Fix crash for degenerate looping primitives

### DIFF
--- a/synfig-core/src/modules/mod_geometry/outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/outline.cpp
@@ -227,8 +227,11 @@ Outline::sync_vfunc()
 		Vector first_tangent = bline.front().get(blank).get_tangent2();
 		Vector last_tangent = first_point.get_tangent1();
 
-		// if we are looped and drawing sharp cusps, we'll need a value for the incoming tangent
-		if (loop && sharp_cusps && last_tangent.is_equal_to(Vector::zero())) {
+		// If we are looped and drawing sharp cusps, we'll need a value
+		// for the incoming tangent. That said, if we are simply
+		// drawing a line, this code path fails, so we skip it since it
+		// doesn't really make semantic sense anyway
+		if (loop && sharp_cusps && last_tangent.is_equal_to(Vector::zero()) && bline.size() > 2) {
 			ValueBase::List::const_iterator prev = iter; --prev;
 			const BLinePoint &prev_point = prev->get(blank);
 			etl::hermite<Vector> curve(


### PR DESCRIPTION
Note that we index two nodes back from the end, which is a buffer
underflow for degenerate primitives (lines, mostly), causing a crash on
select sif's (that were fine on older Synfig versions... Now we don't
crash, but hang rendering...)

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>