### PR TITLE
Misc. documentation and source comment typo fixes

### DIFF
--- a/1-setup-linux-native.sh
+++ b/1-setup-linux-native.sh
@@ -223,7 +223,7 @@ elif which pacman >/dev/null; then
     sudo pacman -S --needed --noconfirm $PKG_LIST || true
 
 else
-    echo "WARNING: This build script does not works with package mangement systems other than yum, zypper or apt! You should install dependent packages manually."
+    echo "WARNING: This build script does not works with package management systems other than yum, zypper or apt! You should install dependent packages manually."
     echo "REQUIRED PACKAGES: "
     echo "libpng-devel libjpeg-devel freetype-devel fontconfig-devel atk-devel pango-devel cairo-devel gtk3-devel gettext-devel libxml2-devel libxml++-devel gcc-c++ autoconf automake libtool libtool-ltdl-devel shared-mime-info OpenEXR-devel libmng-devel ImageMagick-c++-devel gtkmm30-devel glibmm24-devel"
     echo ""

--- a/1-setup-osx-brew.sh
+++ b/1-setup-osx-brew.sh
@@ -33,7 +33,7 @@ export OS=`uname -r | cut -d "." -f1`
 if [ $OS -lt 15 ] && [ -z "$TRAVIS_BUILD_DIR" ]; then # For OSX < 10.11
     cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/
     git fetch --unshallow || true
-    git checkout a91becd6afc177b0cada2cf9cce2e3bde514053b # librsvg 2.40.20 (wothout rust) 2017.12.16
+    git checkout a91becd6afc177b0cada2cf9cce2e3bde514053b # librsvg 2.40.20 (without rust) 2017.12.16
     cd /usr/local/Homebrew/
     git checkout 1.4.1
     brew info gobject-introspection | grep --quiet 'Not installed' && brew install ${WORKDIR}/autobuild/osx/gobject-introspection.rb

--- a/2-build-cmake.sh
+++ b/2-build-cmake.sh
@@ -53,5 +53,5 @@ build_synfig_studio
 write_portable_run_code
 
 # Print success, restore the current directory and exit
-echo "Build successfull to: ${absolute_base_dir}/${cmake_build_dir}/${out_dir}"
+echo "Build successful to: ${absolute_base_dir}/${cmake_build_dir}/${out_dir}"
 cd "$pwd_dir"

--- a/2-build-debug.sh
+++ b/2-build-debug.sh
@@ -10,14 +10,14 @@
 #
 # = Examples: =
 #
-# == Standart mode ==
+# == Standard mode ==
 # Configure and (re)build:
 #    ./build.sh
 # Configure and make clean build:
 #    ./build.sh all full
 # Quick rebuild (without configure):
 #    ./build.sh all make
-# Quick rebuild od synfig-core (without configure):
+# Quick rebuild of synfig-core (without configure):
 #    ./build.sh core make
 
 set -e

--- a/2-build-production.sh
+++ b/2-build-production.sh
@@ -10,7 +10,7 @@
 #
 # = Examples: =
 #
-# == Standart mode ==
+# == Standard mode ==
 # Configure and (re)build:
 #    ./build.sh
 # Configure and make clean build:

--- a/ETL/ETL/_bit_rotate.h
+++ b/ETL/ETL/_bit_rotate.h
@@ -20,7 +20,7 @@
 ** This is an internal header file, included by other ETL headers.
 ** You should not attempt to use it directly.
 **
-** These template functions have not yet been throughly tested,
+** These template functions have not yet been thoroughly tested,
 ** and may be inaccurate or just plain wrong. You have been warned.
 **
 ** ========================================================================= */

--- a/ETL/ETL/_handle.h
+++ b/ETL/ETL/_handle.h
@@ -99,7 +99,7 @@ public:
 	}
 
 	//! Decrease reference counter without deletion of object
-	//! Returns \c false if references exeed and object should be deleted
+	//! Returns \c false if references exceed and object should be deleted
 	virtual bool unref_inactive()const
 	{
 		return (bool)(--refcount);
@@ -201,7 +201,7 @@ public:
 	{
 		if(x.get()==obj)
 			return *this;
-		// add referense before detach
+		// add reference before detach
 		pointer xobj(x.get());
 		if(xobj) xobj->ref();
 		detach();

--- a/ETL/ETL/_rect.h
+++ b/ETL/ETL/_rect.h
@@ -107,7 +107,7 @@ public:
 };
 
 
-//! We wan to do the edge compare test
+//! We want to do the edge compare test
 //!          |-----|
 //!    |------|        intersecting
 //!

--- a/ETL/ETL/_smart_ptr.h
+++ b/ETL/ETL/_smart_ptr.h
@@ -89,7 +89,7 @@ public:
 	/*! A new smart_ptr is created with a pointer
 		to a newly allocated object. We need
 		to be explicit with this so we don't
-		accidently have two smart_ptrs for one
+		accidentally have two smart_ptrs for one
 		object -- that would be bad.	*/
 	explicit smart_ptr(value_type* x):obj(x),refcount(x?true:false) {  }
 

--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -109,7 +109,7 @@ vstrprintf(const char *format, va_list args)
 #ifdef HAVE_VASPRINTF	// This is the preferred method (and safest)
 	char *buffer;
 	int count = vasprintf(&buffer,format,args);
-	if (count < 0) return ""; // error occured
+	if (count < 0) return ""; // error occurred
 
 	std::string rv(buffer, count); // passing size (count) for faster copying
 	free(buffer);

--- a/autobuild/build-cmake-common.sh
+++ b/autobuild/build-cmake-common.sh
@@ -171,7 +171,7 @@ print_build_settings() {
     echo "Build jobs: $make_jobs"
     [ ! $synfigstudio_data_prefix == "" ] && echo "Custom data prefix: $synfigstudio_data_prefix"
     
-    # If script was startet with '-p' stop the script here
+    # If script was started with '-p' stop the script here
     if [ $print_build_settings_and_exit == "true" ]
         then
             exit

--- a/autobuild/build.sh
+++ b/autobuild/build.sh
@@ -23,14 +23,14 @@
 #
 # = Examples: =
 #
-# == Standart mode ==
+# == Standard mode ==
 # Configure and (re)build:
 #    ./build.sh
 # Configure and make clean build:
 #    ./build.sh all full
 # Quick rebuild (without configure):
 #    ./build.sh all make
-# Quick rebuild od synfig-core (without configure):
+# Quick rebuild of synfig-core (without configure):
 #    ./build.sh core make
 
 set -e

--- a/autobuild/update-languages.sh
+++ b/autobuild/update-languages.sh
@@ -55,12 +55,12 @@ update_languages_inc() {
             NAME_MAP[$CODE]="$NAME"
             COMMENT_MAP[$CODE]="$COMMENT"
         else
-            # write all unknown rows to begining of file
+            # write all unknown rows to beginning of file
             echo "$LINE" >> "$TMPFILE"
         fi
     done < "$LANGUAGES_FILE"
 
-    # fit the colums to make beautifulest table in the world
+    # fit the columns to make beautifulest table in the world
     local CODE_LEN=0
     local NAME_LEN=0
     for i in ${!CODE_MAP[@]}; do

--- a/synfig-core/config/package
+++ b/synfig-core/config/package
@@ -1,5 +1,5 @@
 #! /bin/csh -ef
-# this file was orignally distributed by Apple in the Developer Tools package 
+# this file was originally distributed by Apple in the Developer Tools package 
 #it is distributed under the Apple Open Source License
 set version=0.2
 set prog = `/usr/bin/basename $0`
@@ -76,7 +76,7 @@ while ( $#argv > 0 )
 		breaksw
 	    endif
 	case -traditional:
-            echo useing standard tar
+            echo using standard tar
 	    set usetar
             unset usegnutar
 	    unset usepax

--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -17,7 +17,7 @@ AC_LIBLTDL_CONVENIENCE
 AC_SUBST(INCLTDL)
 AC_SUBST(LIBLTDL)
 
-AC_DEFINE(LT_SCOPE,[extern],[LibLTDL is linked staticly])
+AC_DEFINE(LT_SCOPE,[extern],[LibLTDL is linked statically])
 
 # -- V A R I A B L E S ----------------------------------------
 

--- a/synfig-core/doc/tangentproblem.txt
+++ b/synfig-core/doc/tangentproblem.txt
@@ -16,7 +16,7 @@ There are some solutions to solve that:
 
 
 
-1) PROPOSAL FOR TANGENTS 'CALCULATED' BASED ON NEIGBOUR VERTICES
+1) PROPOSAL FOR TANGENTS 'CALCULATED' BASED ON NEIGHBOR VERTICES
 ================================================================
 
 	param						convert type					value type
@@ -59,7 +59,7 @@ global position of the tangent:
 TG=V+T
 TG'=V'+T'
 
-T'=TG'-V' = (V+T)' -V' where ' means tranformed by bones.
+T'=TG'-V' = (V+T)' -V' where ' means transformed by bones.
 
 	param						convert type					value type
 	-----						------------					----------

--- a/synfig-core/m4/libxml.m4
+++ b/synfig-core/m4/libxml.m4
@@ -134,7 +134,7 @@ main()
         printf("*** being found. The easiest way to fix this is to remove the old version\n");
         printf("*** of LIBXML, but you can also set the XML_CONFIG environment to point to the\n");
         printf("*** correct copy of xml-config. (In this case, you will have to\n");
-        printf("*** modify your LD_LIBRARY_PATH enviroment variable, or edit /etc/ld.so.conf\n");
+        printf("*** modify your LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf\n");
         printf("*** so that the correct libraries are found at run-time))\n");
     }
   return 1;
@@ -176,7 +176,7 @@ main()
           echo "*** If you have an old version installed, it is best to remove it, although"
           echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH" ],
         [ echo "*** The test program failed to compile or link. See the file config.log for the"
-          echo "*** exact error that occured. This usually means LIBXML was incorrectly installed"
+          echo "*** exact error that occurred. This usually means LIBXML was incorrectly installed"
           echo "*** or that you have moved LIBXML since it was installed. In the latter case, you"
           echo "*** may want to edit the xml-config script: $XML_CONFIG" ])
           CFLAGS="$ac_save_CFLAGS"
@@ -323,7 +323,7 @@ main()
         printf("*** being found. The easiest way to fix this is to remove the old version\n");
         printf("*** of LIBXML, but you can also set the XML2_CONFIG environment to point to the\n");
         printf("*** correct copy of xml2-config. (In this case, you will have to\n");
-        printf("*** modify your LD_LIBRARY_PATH enviroment variable, or edit /etc/ld.so.conf\n");
+        printf("*** modify your LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf\n");
         printf("*** so that the correct libraries are found at run-time))\n");
     }
   return 1;
@@ -367,7 +367,7 @@ main()
           echo "*** If you have an old version installed, it is best to remove it, although"
           echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH" ],
         [ echo "*** The test program failed to compile or link. See the file config.log for the"
-          echo "*** exact error that occured. This usually means LIBXML was incorrectly installed"
+          echo "*** exact error that occurred. This usually means LIBXML was incorrectly installed"
           echo "*** or that you have moved LIBXML since it was installed. In the latter case, you"
           echo "*** may want to edit the xml2-config script: $XML2_CONFIG" ])
           CFLAGS="$ac_save_CFLAGS"

--- a/synfig-core/src/modules/CMakeLists.txt
+++ b/synfig-core/src/modules/CMakeLists.txt
@@ -40,7 +40,7 @@ set(MODS_ENABLED
     mod_ppm
     mod_svg
     mod_yuv420p
-#     mptr_mplayer - "This code has vulnerabilites"
+#     mptr_mplayer - "This code has vulnerabilities"
 )
 
 ## Magick++ support

--- a/synfig-core/src/modules/lyr_std/sphere_distort.cpp
+++ b/synfig-core/src/modules/lyr_std/sphere_distort.cpp
@@ -163,7 +163,7 @@ Layer_SphereDistort::get_param_vocab()const
 
 	ret.push_back(ParamDesc("clip")
 		.set_local_name(_("Clip"))
-		.set_description(_("When cheked, the area outside the Radius are not distorted"))
+		.set_description(_("When checked, the area outside the Radius are not distorted"))
 	);
 
 	ret.push_back(ParamDesc("type")

--- a/synfig-core/src/modules/lyr_std/timeloop.cpp
+++ b/synfig-core/src/modules/lyr_std/timeloop.cpp
@@ -148,7 +148,7 @@ Layer_TimeLoop::get_param_vocab()const
 
 	ret.push_back(ParamDesc("duration")
 		.set_local_name(_("Duration"))
-		.set_description(_("Lenght of the loop"))
+		.set_description(_("Length of the loop"))
 		.set_static(true)
 	);
 

--- a/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
@@ -175,7 +175,7 @@ Advanced_Outline::sync_vfunc()
 		vector<DashItem> dilist(dilist_.get_list_of(DashItem()));
 		// This is the list of widthpoints created for the dashed outlines
 		vector<WidthPoint> dwplist;
-		// This is the temporarly filtered (removed unused) list of dash widthpoints
+		// This is the temporarily filtered (removed unused) list of dash widthpoints
 		// it is a partial filtered of the previous dwplist and merged with wplist
 		// only allowing visible widthpoints.
 		vector<WidthPoint> fdwplist;
@@ -212,7 +212,7 @@ Advanced_Outline::sync_vfunc()
 		// last tangent: used to remember second tangent of the previous bezier
 		// when doing the cusp at the first blinepoint of the current bezier
 		Vector last_tangent;
-		// Bezier size is differnt depending on whether the bline is looped or not.
+		// Bezier size is different depending on whether the bline is looped or not.
 		// For one single blinepoint, bezier size is always 1.0
 		Real bezier_size = 1.0/(blineloop?bline_size:(bline_size==1?1.0:(bline_size-1)));
 		const vector<BLinePoint>::const_iterator bend(bline.end());
@@ -296,7 +296,7 @@ Advanced_Outline::sync_vfunc()
 				if(wpfront.get_side_type_before() == WidthPoint::TYPE_INTERPOLATE && wpfront.get_position()!=0.0)
 					// Add a fake widthpoint at position 0.0
 					wplist.push_back(WidthPoint(0.0, wpfront.get_width() , start_tip_, WidthPoint::TYPE_INTERPOLATE));
-				// if last widhtpoint interpolation after is INTERPOLATE and it is not exactly at 1.0
+				// if last widthpoint interpolation after is INTERPOLATE and it is not exactly at 1.0
 				if(wpback.get_side_type_after() == WidthPoint::TYPE_INTERPOLATE && wpback.get_position()!=1.0)
 				// Add a fake withpoint at position 1.0
 					wplist.push_back(WidthPoint(1.0, wpback.get_width() , WidthPoint::TYPE_INTERPOLATE, end_tip_));
@@ -370,7 +370,7 @@ Advanced_Outline::sync_vfunc()
 		// i.e.: where in the bline, and where in wplist so we could go
 		// faster or slower when needed.
 		Real step(1.0/SAMPLES/bline_size);
-		//////////////////// prepare the widhtpoints from the dash list
+		//////////////////// prepare the widthpoints from the dash list
 		if(dash_enabled)
 		{
 			Real blinelength(bline_length(bline, blineloop, NULL));
@@ -411,7 +411,7 @@ Advanced_Outline::sync_vfunc()
 						if(diter==dilist.end())
 							diter=dilist.begin();
 					};
-					// Correct the two last widthpoints triming its position to be <= 1.0
+					// Correct the two last widthpoints trimming its position to be <= 1.0
 					if(inserted_to_blinelength)
 					{
 						after=dwplist.back();
@@ -440,7 +440,7 @@ Advanced_Outline::sync_vfunc()
 					}
 					int inserted_to_zero(0);
 					//
-					// Now insert the widhtpoints from Dash Offset to 0.0
+					// Now insert the widthpoints from Dash Offset to 0.0
 					dpos=dash_offset>=0?dash_offset:dashes_length+dash_offset;;
 					while(dpos > 0.0)
 					{
@@ -459,7 +459,7 @@ Advanced_Outline::sync_vfunc()
 						if(rditer==dilist.rend())
 							rditer=dilist.rbegin();
 					};
-					// Correct the two first widthpoints triming its position to be >= 0.0
+					// Correct the two first widthpoints trimming its position to be >= 0.0
 					if(inserted_to_zero)
 					{
 						before=dwplist.front();
@@ -581,7 +581,7 @@ Advanced_Outline::sync_vfunc()
 		if(dash_enabled)
 		{
 			// ... replace the original widthpoint list
-			// with the filtered one, inlcuding the visible dash withpoints and
+			// with the filtered one, including the visible dash withpoints and
 			// the visible regular widthpoints.
 			wplist.assign(fdwplist.begin(), fdwplist.end());
 			// sort again the wplist
@@ -702,7 +702,7 @@ Advanced_Outline::sync_vfunc()
 				first_tangent=iter_t;
 				first=false;
 			}
-			// get the position of the next widhtpoint.
+			// get the position of the next widthpoint.
 			// Remember that it is the first widthpoint the first time
 			// code passes by here.
 			Real wnext_pos(wnext->get_position());
@@ -805,12 +805,12 @@ Advanced_Outline::sync_vfunc()
 					// widthpoint in the list, if the current one has not
 					//  interpolate side after the interpolated width is zero.
 					// see synfig::interpolate_width
-					// This modification fixes bad render when first widht
-					// point is not interpolate after and next widhtpoint is
-					//  interpolate before. Noticiable for the FLAT case
+					// This modification fixes bad render when first width
+					// point is not interpolate after and next widthpoint is
+					//  interpolate before. Noticeable for the FLAT case
 					// or when the width is smaller than the step on the bezier.
 					ipos=ipos+EPSILON;
-					// If we have just done a tip width side tipe after not interpolate
+					// If we have just done a tip width side type after not interpolate
 					if(witer->get_side_type_after()!=WidthPoint::TYPE_INTERPOLATE)
 						done_tip=true;
 					else
@@ -875,7 +875,7 @@ Advanced_Outline::sync_vfunc()
 			// If we stopped on an intermediate blinepoint (middle corner=true)...
 			if(middle_corner==true)
 			{
-				// ... do cusp at ipos if tangents are splitted
+				// ... do cusp at ipos if tangents are split
 				// Notice that if we are in the second blinepoint
 				// for the last bezier, we will be over a widthpoint
 				// artificially inserted, so here we only insert cusps

--- a/synfig-core/src/modules/mod_jpeg/mptr_jpeg.cpp
+++ b/synfig-core/src/modules/mod_jpeg/mptr_jpeg.cpp
@@ -143,7 +143,7 @@ jpeg_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &/*renddes
 	/* Now we can initialize the JPEG decompression object. */
 	jpeg_create_decompress(&cinfo);
 
-	/* Step 2: specify data source (eg, from memory thrue a String) */
+	/* Step 2: specify data source (eg, from memory thru a String) */
 
 	std::ostringstream tmp;
 	tmp << stream->rdbuf();

--- a/synfig-core/src/modules/mod_png/trgt_png_spritesheet.cpp
+++ b/synfig-core/src/modules/mod_png/trgt_png_spritesheet.cpp
@@ -357,7 +357,7 @@ png_trgt_spritesheet::read_png_file()
 	//Also see gamma.h and gamma.cpp
 	Gamma gamma_png(2.2);
 	
-	//From png bytes to synfig::Color convertion
+	//From png bytes to synfig::Color conversion
     for (unsigned int y = 0; y < in_image.height; y++) 
 	{
         png_byte* row = row_pointers[y];

--- a/synfig-core/src/modules/mod_png/trgt_png_spritesheet.cpp
+++ b/synfig-core/src/modules/mod_png/trgt_png_spritesheet.cpp
@@ -138,7 +138,7 @@ png_trgt_spritesheet::set_rend_desc(RendDesc *given_desc)
 	//Reset on uninitialized values
 	if ((params.columns == 0) || (params.rows == 0))
 	{
-		cout << "Uninitialized sheet parameteras. Reset parameters." << endl;
+		cout << "Uninitialized sheet parameters. Reset parameters." << endl;
 		params.columns = numimages;
 		params.rows = 1;
 		params.append = true;
@@ -178,7 +178,7 @@ png_trgt_spritesheet::set_rend_desc(RendDesc *given_desc)
 
 	if (sheet_width * sheet_height > 5000 * 2000)
 	{
-		synfig::error(strprintf(_("The image is too large. It's size must be not more than 5000*2000=10000000 px. Now is %d*%d=%d px."), 
+		synfig::error(strprintf(_("The image is too large. It's size must be not more than 5000*2000=10000000 px. Currently it's %d*%d=%d px."), 
 		                          sheet_width, sheet_height, sheet_width * sheet_height));
 		return false;
 	}

--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -46,7 +46,7 @@ using namespace synfig;
 
 //PARSER PREFERENCES
 
-//Seperate transformations: apply transformations on a per-layer basis, rather than on canvases
+//Separate transformations: apply transformations on a per-layer basis, rather than on canvases
 #define SVG_SEP_TRANSFORMS 1
 
 //Resolve BLine transformations: resolve transformations instead of creating transformation layers
@@ -1203,7 +1203,7 @@ Svg_parser::parser_radialGradient(const xmlpp::Node* node){
 
 		std::list<ColorStop*> *stops=NULL;
 		if(!link.empty()){
-			//inkscape always use link, i dont need parser stops here, but it's posible
+			//inkscape always use link, i don't need parser stops here, but it's possible
 			stops=find_colorStop (link);
 		}
 		if(stops)

--- a/synfig-core/src/modules/mptr_mplayer/mptr_mplayer.cpp
+++ b/synfig-core/src/modules/mptr_mplayer/mptr_mplayer.cpp
@@ -62,7 +62,7 @@ bool
 mplayer_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &renddesc, synfig::Time time, synfig::ProgressCallback *callback)
 {
 
-#error This code has vulnerabilites: arbitrary shell command execution and tmpfile issues
+#error This code has vulnerabilities: arbitrary shell command execution and tmpfile issues
 
 	int ret;
 	ret=system(

--- a/synfig-core/src/synfig/bone.h
+++ b/synfig-core/src/synfig/bone.h
@@ -114,7 +114,7 @@ public:
 	Bone();
 	//!Constructor by origin and tip
 	Bone(const Point &origin, const Point &tip);
-	//!Construtor by origin, legth and parent (default no parent)
+	//!Constructor by origin, length and parent (default no parent)
 	Bone(const String &name, const Point &origin, const Angle &angle, const Real &length, ValueNode_Bone* p=0);
 	//!Wrappers for name_
 	const String& get_name()const {return name_;}
@@ -254,7 +254,7 @@ public:
  *       ValueNode_Bone BoneN
  *
  * To perform the tasks 1), 2), 3) or 4) the ValueNode_Skeletons should perform a seek into the
- * list of bones by its UniqueID value. For example to calcualte the setup matrix it should
+ * list of bones by its UniqueID value. For example to calculate the setup matrix it should
  * reconstruct the bone hierarchy from the current bone to the root parent. Due to that now,
  * it is only stored the UniqueID of the parent (and not a pointer), it is the skeletons veluenode
  * who have to perform all the job: find all the parents and multiply in the correct order (depth) its

--- a/synfig-core/src/synfig/cairo_renddesc.cpp
+++ b/synfig-core/src/synfig/cairo_renddesc.cpp
@@ -121,7 +121,7 @@ cairo_renddesc_untransform(cairo_t* cr, RendDesc &renddesc)
 		return false;
 	}
 	
-	// Now let's tranform the renddesc corners with the calculated matrix
+	// Now let's transform the renddesc corners with the calculated matrix
 	cairo_matrix_transform_point(&cr_result, &tl_x, &tl_y);
 	cairo_matrix_transform_point(&cr_result, &tr_x, &tr_y);
 	cairo_matrix_transform_point(&cr_result, &bl_x, &bl_y);
@@ -132,7 +132,7 @@ cairo_renddesc_untransform(cairo_t* cr, RendDesc &renddesc)
 	pminy=min(min(min(tl_y, tr_y), bl_y), br_y);
 	pmaxx=max(max(max(tl_x, tr_x), bl_x), br_x);
 	pmaxy=max(max(max(tl_y, tr_y), bl_y), br_y);
-	// let's assign the right values to the meaningfull variables :)
+	// let's assign the right values to the meaningful variables :)
 	mtlx=pminx;
 	mtly=pmaxy;
 	mbrx=pmaxx;

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -113,8 +113,8 @@ Canvas::on_changed()
 Canvas::~Canvas()
 {
 	// we were having a crash where pastecanvas layers were still
-	// refering to a canvas after it had been destroyed;  this code
-	// will stop the pastecanvas layers from refering to the canvas
+	// referring to a canvas after it had been destroyed;  this code
+	// will stop the pastecanvas layers from referring to the canvas
 	// before the canvas is destroyed
 
 	// the set_sub_canvas(0) ends up deleting the parent-child link,
@@ -1610,7 +1610,7 @@ Canvas::show_structure(int i) const
 // #define DEBUG_INVOKE_SVNCR
 
 // this is only ever called from valuenode_dynamiclist.cpp and valuenode_staticlist.cpp
-// the container is a ValueNode_{Static,Dyanmic}List
+// the container is a ValueNode_{Static,Dynamic}List
 // the content is the entry
 void
 Canvas::invoke_signal_value_node_child_removed(etl::handle<ValueNode> container, etl::handle<ValueNode> content)

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -1401,7 +1401,7 @@ synfig::optimize_layers(Time time, Context context, Canvas::Handle op_canvas, bo
 		if(composite && layer_visibility < 1.0)
 		{
 			// Let's clone the composite layer if it is not a Paste Canvas
-			// (because paste will be always new layer)
+			// (because paste will always be new layer)
 			// Oops... not always...
 			//if(dynamic_cast<Layer_PasteCanvas*>(layer.get()) != NULL)
 				composite = etl::handle<Layer_Composite>::cast_dynamic(composite->simple_clone());

--- a/synfig-core/src/synfig/canvas.h
+++ b/synfig-core/src/synfig/canvas.h
@@ -105,7 +105,7 @@
  *
  * 0.8: git 82baee2702a65a9866f3dc4a28ef163dcf43795a
  *
- *      Added "homogenous" link to "BLineCalcVertex", "BLineCalcTangent"
+ *      Added "homogeneous" link to "BLineCalcVertex", "BLineCalcTangent"
  *      and "BLineCalcWidth" valuenodes.
  *
  * 0.9: git 6922776b8129fdae6cb42953b2715decc810786c
@@ -247,7 +247,7 @@ private:
 	//! Layer Signal Connection database. Seems to be unused.
 	std::map<etl::loose_handle<Layer>,std::vector<sigc::connection> > connections_;
 
-	//! Value to store temporarly the grow value for the child outline type layers
+	//! Value to store temporarily the grow value for the child outline type layers
 	/*! \see get_grow_value set_grow_value */
 	Real outline_grow;
 
@@ -593,19 +593,19 @@ public:
 	Context get_context_sorted(const ContextParams &params, CanvasBase &out_queue) const;
 
 	//! Returns the last Canvas layer queue iterator. Notice that it
-	/*! overrides the std::end() member that would return an interator
+	/*! overrides the std::end() member that would return an iterator
 	 * just past the last element of the queue.*/
 	iterator end();
 	//! Returns the last Canvas layer queue const_iterator. Notice that it
-	/*! overrides the std::end() member that would return an interator
+	/*! overrides the std::end() member that would return an iterator
 	 * just past the last element of the queue.*/
 	const_iterator end()const;
 	//! Returns the last Canvas layer queue reverse iterator. Notice that it
-	/*! overrides the std::rbegin() member that would return an interator
+	/*! overrides the std::rbegin() member that would return an iterator
 	 * just past the last element of the queue.*/
 	reverse_iterator rbegin();
 	//! Returns the last Canvas layer queue reverse const iterator. Notice that it
-	/*! overrides the std::rbegin() member that would return an interator
+	/*! overrides the std::rbegin() member that would return an iterator
 	 * just past the last element of the queue.*/
 	const_reverse_iterator rbegin()const;
 	//! Returns last layer in Canvas layer stack
@@ -615,7 +615,7 @@ public:
 	//! Inserts a layer just before the last layer.
 	//! \see end(), insert(iterator iter,etl::handle<Layer> x)
 	void push_back(etl::handle<Layer> x);
-	//! Inserts a layer just at the beggining of the Canvas layer dqueue
+	//! Inserts a layer just at the beginning of the Canvas layer dqueue
 	void push_front(etl::handle<Layer> x);
 	//! Inserts a layer in the last position of the Canvas layer dqueue
 	//! Uses the standard methods and doesn't perform any parentship

--- a/synfig-core/src/synfig/color/color.h
+++ b/synfig-core/src/synfig/color/color.h
@@ -119,7 +119,7 @@ public:
 	//! Converts a ColorReal \a c (0.0-1.0) into a 2 character hex string (00-ff)
 	static const String real2hex(ColorReal c);
 
-	//! Returns the color as a 6 character hex sting
+	//! Returns the color as a 6 character hex string
 	inline const String get_hex()const;
 
 	//! Sets the color's R, G, and B from a 3 or 6 character hex string

--- a/synfig-core/src/synfig/color/colormatrix.cpp
+++ b/synfig-core/src/synfig/color/colormatrix.cpp
@@ -87,7 +87,7 @@ namespace {
 		}
 
 
-		// transfrom func generator
+		// transform func generator
 
 		template<int channel, int mode_r, int mode_g, int mode_b, int mode_a, int mode_o>
 		static ColorMatrix::transform_func_ptr get_transform_func_crgbao()

--- a/synfig-core/src/synfig/color/colormatrix.h
+++ b/synfig-core/src/synfig/color/colormatrix.h
@@ -180,7 +180,7 @@ public:
 
 	//! operator*=. Multiplication and assignment of one matrix by a scalar
 	//! @param rhs the number to multiply by
-	//! @return the modifed resulting matrix
+	//! @return the modified resulting matrix
 	ColorMatrix operator*=(const value_type &rhs);
 
 	//! operator*. Multiplication of one matrix by another

--- a/synfig-core/src/synfig/context.h
+++ b/synfig-core/src/synfig/context.h
@@ -95,7 +95,7 @@ public:
 	Real z_range_position;
 	//! Defines the depth of the range of the Z_Depth visibility
 	Real z_range_depth;
-	//! Layers with z_Depth inside transition are partially visibile
+	//! Layers with z_Depth inside transition are partially visible
 	Real z_range_blur;
 
 	explicit ContextParams(bool render_excluded_contexts = false):

--- a/synfig-core/src/synfig/keyframe.h
+++ b/synfig-core/src/synfig/keyframe.h
@@ -47,7 +47,7 @@ namespace synfig {
 /*! \class Keyframe
 **  \brief Keyframe is used to record the state of the animation at that point (time_)
 *
-* A Keyframe can be described, actived or disabled and have an associated Waypoint::Model.
+* A Keyframe can be described, activated or disabled and have an associated Waypoint::Model.
 * Common comparison operators can be used for Keyframes operation ==, <, != .
 * \see Keyframe::set_description(String x), Keyframe::get_description(), Keyframe::enable(), Keyframe::disable ()
 */

--- a/synfig-core/src/synfig/layers/layer_bitmap.cpp
+++ b/synfig-core/src/synfig/layers/layer_bitmap.cpp
@@ -90,7 +90,7 @@ synfig::Layer_Bitmap::Layer_Bitmap():
 synfig::Surface&
 Layer_Bitmap::get_surface() const
 {
-	// TODO: not thread safe, return SurfaceResource instread
+	// TODO: not thread safe, return SurfaceResource instead
 	if (!rendering_surface || !rendering_surface->is_exists())
 		rendering_surface->create(128, 128);
 	rendering::SurfaceResource::LockWrite<rendering::SurfaceSW> lock(rendering_surface);

--- a/synfig-core/src/synfig/layers/layer_composite.cpp
+++ b/synfig-core/src/synfig/layers/layer_composite.cpp
@@ -131,7 +131,7 @@ Layer_Composite::accelerated_render(Context context,Surface *surface,int quality
 	// Sets the blend method to straight. See below
 	surfacelayer->set_blend_method(Color::BLEND_STRAIGHT);
 	// Push this layer on the image. The blending result is only this layer
-	// adn the surface layer. The rest of the context is ignored by the straight
+	// and the surface layer. The rest of the context is ignored by the straight
 	// blend method of surface layer
 	image.push_front(const_cast<synfig::Layer_Composite*>(this));
 

--- a/synfig-core/src/synfig/layers/layer_composite.h
+++ b/synfig-core/src/synfig/layers/layer_composite.h
@@ -79,7 +79,7 @@ public:
 	virtual bool is_solid_color()const { return param_amount.get(Real())==1.0f && param_blend_method.get(int())==Color::BLEND_STRAIGHT; }
 	//! Returns true if the amount is zero.
 	bool is_disabled()const { return param_amount.get(Real())==0.0f; }
-	//! Gets the parameter vocabulary. To be overrided by the derived.
+	//! Gets the parameter vocabulary. To be overridden by the derived.
 	virtual Vocab get_param_vocab()const;
 	//! Sets the value for the given parameter.
 	virtual bool set_param(const String &param, const ValueBase &value);

--- a/synfig-core/src/synfig/layers/layer_pastecanvas.h
+++ b/synfig-core/src/synfig/layers/layer_pastecanvas.h
@@ -58,7 +58,7 @@ public:
 private:
 	//! Parameter: (Origin) Position offset
 	ValueBase param_origin;
-	//! Parameter: (Transfromation) Position, rotation and scale of the paste canvas layer
+	//! Parameter: (Transformation) Position, rotation and scale of the paste canvas layer
 	ValueBase param_transformation;
 	//! Parameter: (etl::loose_handle<synfig::Canvas>) The canvas parameter
 	etl::loose_handle<synfig::Canvas> sub_canvas;

--- a/synfig-core/src/synfig/loadcanvas.h
+++ b/synfig-core/src/synfig/loadcanvas.h
@@ -66,7 +66,7 @@ class CanvasParser
 	*/
 
 private:
-	//! Maximun number of allowed warnings before fatal error is thrown
+	//! Maximum number of allowed warnings before fatal error is thrown
 	int max_warnings_;
 	//! Total number of warning during canvas parsing
     int total_warnings_;

--- a/synfig-core/src/synfig/matrix.cpp
+++ b/synfig-core/src/synfig/matrix.cpp
@@ -267,7 +267,7 @@ Matrix3::get_inverted()const
 		// result of transformation is not 3d
 		// all points always transforms into one plane (2d), or line (1d), or dot (0d)
 
-		// we cannot do thre real back transform, but we will try
+		// we cannot do the real back transform, but we will try
 		// to make valid matrix for X-axis only or for Y-axis only
 
 		// try to make back transform for X-axis

--- a/synfig-core/src/synfig/matrix.h
+++ b/synfig-core/src/synfig/matrix.h
@@ -104,13 +104,13 @@ public:
 	//! @return A matrix reference filled with the sx, sy values
 	Matrix2& set_scale(const value_type &sx, const value_type &sy);
 
-	//!set_scale member fucntion. Sets a scale matrix
+	//!set_scale member function. Sets a scale matrix
 	//! @param sxy Scale by X and Y axis
 	//! @return A matrix reference filled with the sxy values
 	Matrix2& set_scale(const value_type &sxy)
 		{ return set_scale(sxy, sxy); }
 
-	//!set_scale member fucntion. Sets a scale matrix
+	//!set_scale member function. Sets a scale matrix
 	//! @param s Vector that defines the scale
 	//! @return A matrix reference filled with the proper scale parameters
 	Matrix2& set_scale(const Vector &s)
@@ -144,7 +144,7 @@ public:
 
 	//! operator*=. Multiplication and assignment of one matrix by a scalar
 	//! @param rhs the number to multiply by
-	//! @return the modifed resulting matrix
+	//! @return the modified resulting matrix
 	Matrix2& operator*=(const value_type &rhs);
 
 	//! operator+=. Sum and assignment of two matrixes
@@ -280,13 +280,13 @@ public:
 	//! @return A matrix reference filled with the sx, sy values
 	Matrix3& set_scale(const value_type &sx, const value_type &sy);
 
-	//!set_scale member fucntion. Sets a scale matrix
+	//!set_scale member function. Sets a scale matrix
 	//! @param sxy Scale by X and Y axis
 	//! @return A matrix reference filled with the sxy values
 	Matrix3& set_scale(const value_type &sxy)
 		{ return set_scale(sxy, sxy); }
 
-	//!set_scale member fucntion. Sets a scale matrix
+	//!set_scale member function. Sets a scale matrix
 	//! @param s Vector that defines the scale
 	//! @return A matrix reference filled with the proper scale parameters
 	Matrix3& set_scale(const Vector &s)
@@ -337,7 +337,7 @@ public:
 
 	//! operator*=. Multiplication and assignment of one matrix by a scalar
 	//! @param rhs the number to multiply by
-	//! @return the modifed resulting matrix
+	//! @return the modified resulting matrix
 	Matrix3& operator*=(const value_type &rhs);
 
 	//! operator+=. Sum and assignment of two matrixes

--- a/synfig-core/src/synfig/rendering/common/optimizer/optimizerblendassociative.cpp
+++ b/synfig-core/src/synfig/rendering/common/optimizer/optimizerblendassociative.cpp
@@ -66,7 +66,7 @@ OptimizerBlendAssociative::run(const RunParams& params) const
 	//   blend1(a, blend0(b, c)) -> blend1(blend0(a, b), c)
 	// result chain may be converted to list
 	//
-	// as result actualy we will do following:
+	// as result actually we will do following:
 	//   blend1(a, list(...)) -> list(a, ...)
 	// if each task in list suits for this optimization
 	//

--- a/synfig-core/src/synfig/rendering/optimizer.h
+++ b/synfig-core/src/synfig/rendering/optimizer.h
@@ -200,7 +200,7 @@ public:
 	//! Set of categories of optimizers which should be processed again when this optimizer applied,
 	//! see Optimizer::CATEGORY_XXX enumerations
 	Category affects_to;
-	//! Mode determines what shoud do optimization system when this optimizer applied,
+	//! Mode determines what should do optimization system when this optimizer applied,
 	//! see Optimizer::MODE_XXXX enumerations
 	Mode mode;
 	//! Optimizer uses for list of tasks

--- a/synfig-core/src/synfig/rendering/primitive/contour.h
+++ b/synfig-core/src/synfig/rendering/primitive/contour.h
@@ -137,7 +137,7 @@ public:
 	void add_chunks(const ChunkList &chunks)
 		{ if (!chunks.empty()) add_chunks(&chunks.front(), &chunks.back() + 1); }
 
-	//! attached list from (end-1) to begin
+	//! attach list from (end-1) to begin
 	//! list will attached as line
 	//! curve information for first segment (begin) of incoming list will ignored, only p1 will used
 	void add_chunks_reverse(const Chunk *begin, const Chunk *end);

--- a/synfig-core/src/synfig/rendering/primitive/contour.h
+++ b/synfig-core/src/synfig/rendering/primitive/contour.h
@@ -138,8 +138,8 @@ public:
 		{ if (!chunks.empty()) add_chunks(&chunks.front(), &chunks.back() + 1); }
 
 	//! attach list from (end-1) to begin
-	//! list will attached as line
-	//! curve information for first segment (begin) of incoming list will ignored, only p1 will used
+	//! list will be attached as line
+	//! curve information for first segment (begin) of incoming list will be ignored, only p1 will be used
 	void add_chunks_reverse(const Chunk *begin, const Chunk *end);
 	void add_chunks_reverse(const ChunkList &chunks)
 		{ if (!chunks.empty()) add_chunks_reverse(&chunks.front(), &chunks.back() + 1); }
@@ -151,14 +151,14 @@ public:
 	Rect calc_bounds() const;
 	Rect calc_bounds(const Matrix &transform_matrix) const;
 
-	//! actualize internal value of bounds (if need) and return it
+	//! actualize internal value of bounds (if needed) and return it
 	//! method is thread-safe for constant contours - you must not modify a contour while this call
 	Rect get_bounds() const;
 	
 	void to_intersector(Intersector &intersector) const;
 	etl::handle<Intersector> crerate_intersector() const;
 
-	//! actualize internal copy of intersector (if need) and return it
+	//! actualize internal copy of intersector (if needed) and return it
 	//! method is thread-safe for constant contours - you must not modify a contour while this call
 	const Intersector& get_intersector() const;
 

--- a/synfig-core/src/synfig/rendering/primitive/contour.h
+++ b/synfig-core/src/synfig/rendering/primitive/contour.h
@@ -137,7 +137,7 @@ public:
 	void add_chunks(const ChunkList &chunks)
 		{ if (!chunks.empty()) add_chunks(&chunks.front(), &chunks.back() + 1); }
 
-	//! attache list from (end-1) to begin
+	//! attached list from (end-1) to begin
 	//! list will attached as line
 	//! curve information for first segment (begin) of incoming list will ignored, only p1 will used
 	void add_chunks_reverse(const Chunk *begin, const Chunk *end);

--- a/synfig-core/src/synfig/surface.cpp
+++ b/synfig-core/src/synfig/surface.cpp
@@ -335,12 +335,12 @@ CairoSurface::set_wh(int w, int h, int /*pitch*/)
 		cairo_surface_destroy(cs_image_);
 	// create a new cairo_surface image type
 	cs_image_=cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
-	// check wheter the new cairo surface is sane
+	// check whether the new cairo surface is sane
 	if(!cairo_surface_status(cs_image_))
 	{
 		int stride(cairo_image_surface_get_stride(cs_image_));
 		unsigned char* data(cairo_image_surface_get_data(cs_image_));
-		// pass the infromation to the etl::surface to be used directly.
+		// pass the information to the etl::surface to be used directly.
 		set_wh(w, h, data, stride);
 	}
 	else

--- a/synfig-core/src/synfig/surface.h
+++ b/synfig-core/src/synfig/surface.h
@@ -168,7 +168,7 @@ public:
 	// Use this function to reference one given generic cairo_surface 
 	// by this surface class.
 	// When the CairoSurface instance is destructed the reference counter of the
-	// cairo_surface_t shoud be decreased.
+	// cairo_surface_t should be decreased.
 	// It is also possible to detach the cairo surface passing NULL as argument.
 	// If the cairo surface is mapped at the time of call this function, then
 	// it is unmaped first.

--- a/synfig-core/src/synfig/target_cairo.cpp
+++ b/synfig-core/src/synfig/target_cairo.cpp
@@ -165,7 +165,7 @@ synfig::Target_Cairo::render(ProgressCallback *cb)
 				else
 				{
 					// Put the surface we renderer onto the target's device.
-					// and destrois cairo_surface_t
+					// and destroys cairo_surface_t
 					if(!put_surface(cairo_surface_reference(surface), cb))
 					{
 						if(cb)cb->error(_("Unable to put surface on target"));

--- a/synfig-core/src/synfig/target_cairo.h
+++ b/synfig-core/src/synfig/target_cairo.h
@@ -43,8 +43,8 @@ namespace synfig {
 class CairoSurface;
 
 /*!	\class Target_Cairo
-**	\brief This is a Target class that implements the render fucntion
-* for a CairoSurface
+**	\brief This is a Target class that implements the render function
+**     for a CairoSurface
 */
 class Target_Cairo : public Target
 {

--- a/synfig-core/src/synfig/target_cairo_tile.h
+++ b/synfig-core/src/synfig/target_cairo_tile.h
@@ -45,7 +45,7 @@ namespace synfig {
 class CairoSurface;
 
 /*!	\class Target_Cairo_Tile
-**	\brief This is a Target class that implements the render fucntion
+**	\brief This is a Target class that implements the render function
 * for a CairoSurface using tile mode
 */
 class Target_Cairo_Tile : public Target
@@ -100,9 +100,9 @@ public:
 	void set_threads(int x) { threads_=x; }
 	//!Gets the number of threads
 	int get_threads()const { return threads_; }
-	//!Sets the tile widht
+	//!Sets the tile width
 	void set_tile_w(int w) { tile_w_=w; }
-	//!Gets the tile widht
+	//!Gets the tile width
 	int get_tile_w()const { return tile_w_; }
 	//!Sets the tile height
 	void set_tile_h(int h) { tile_h_=h; }

--- a/synfig-core/src/synfig/target_scanline.h
+++ b/synfig-core/src/synfig/target_scanline.h
@@ -41,8 +41,8 @@ namespace synfig {
 namespace rendering { class SurfaceResource; }
 
 /*!	\class Target_Scanline
-**	\brief This is a Target class that implements the render fucntion
-* for a line by line render procedure
+**	\brief This is a Target class that implements the render function
+**     for a line by line render procedure
 */
 class Target_Scanline : public Target
 {

--- a/synfig-core/src/synfig/target_tile.h
+++ b/synfig-core/src/synfig/target_tile.h
@@ -111,9 +111,9 @@ public:
 	void set_threads(int x) { threads_=x; }
 	//!Gets the number of threads
 	int get_threads()const { return threads_; }
-	//!Sets the tile widht
+	//!Sets the tile width
 	void set_tile_w(int w) { tile_w_=w; }
-	//!Gets the tile widht
+	//!Gets the tile width
 	int get_tile_w()const { return tile_w_; }
 	//!Sets the tile height
 	void set_tile_h(int h) { tile_h_=h; }

--- a/synfig-core/src/synfig/time.cpp
+++ b/synfig-core/src/synfig/time.cpp
@@ -326,7 +326,7 @@ Time::get_string(float fps, Time::Format format)const
 Time
 Time::round(float fps)const
 {
-	// the aim is to make results for the same frame are absolutelly idential
+	// the aim is to make results for the same frame absolutely identical
 	assert(approximate_greater_lp(fps, 0.f));
 	if (!approximate_greater_lp(fps, 0.f)) return *this;
 	return Time(floor(value_*fps + 0.5)/fps);

--- a/synfig-core/src/synfig/value.h
+++ b/synfig-core/src/synfig/value.h
@@ -143,7 +143,7 @@ public:
 	//!Operator asignation for ValueBase classes. Does a exact copy of \x
 	ValueBase& operator=(const ValueBase& x);
 
-	//! Eqaul than operator. Segment, Gradient and Bline Points cannot be compared.
+	//! Equal than operator. Segment, Gradient and Bline Points cannot be compared.
 	bool operator==(const ValueBase& rhs)const;
 
 	//! Not equal than operator.

--- a/synfig-core/src/synfig/valuenode.h
+++ b/synfig-core/src/synfig/valuenode.h
@@ -311,7 +311,7 @@ protected:
 
 
 /*!	\class PlaceholderValueNode
-**	Seems to be a Place to hold a Value Node temporarly.
+**	Seems to be a Place to hold a Value Node temporarily.
 *
 * 	Doesn't seem to implement any functionality. Seems to be used when the
 * 	value node cannot be created using the Const, Animated or Linkable
@@ -444,7 +444,7 @@ protected:
 	//! Pure Virtual member to get the children vocabulary
 	virtual Vocab get_children_vocab_vfunc()const=0;
 
-	//! Virtual memebr to set the children vocabulary to a given value
+	//! Virtual member to set the children vocabulary to a given value
 	virtual void set_children_vocab(const Vocab& rvocab);
 
 	virtual void get_values_vfunc(std::map<Time, ValueBase> &x) const;

--- a/synfig-core/src/synfig/valuenode_registry.h
+++ b/synfig-core/src/synfig/valuenode_registry.h
@@ -94,7 +94,7 @@ public:
 	//! Creates a Linkable Value Node based on the name and the returned
 	//! value type. Returns a valid Handle if both (name and type) match
 	static LinkableValueNode::Handle create(const String &name, const ValueBase& x);
-	//! Each derived Linkable Value Node has to implement this fucntion and
+	//! Each derived Linkable Value Node has to implement this function and
 	//! should return true only if the type matches. \name is the name of
 	//! the linked value node and \x is the returned value type
 	static bool check_type(const String &name, Type &x);

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -338,7 +338,7 @@ synfig::std_to_hom(const ValueBase &bline, Real pos, bool index_loop, bool bline
 							blinepoint0.get_tangent2(), blinepoint1.get_tangent1());
 	// add the distance on the bezier we are on.
 	pl+=curve.find_distance(0.0, pos*size - from_vertex);
-	// and return the homogenous position
+	// and return the homogeneous position
 	return int_pos+pl/tl-one;
 }
 
@@ -408,12 +408,12 @@ synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline
 	blinepoint1 = *next;
 	etl::hermite<Vector> curve(blinepoint0.get_vertex(),   blinepoint1.get_vertex(),
 							blinepoint0.get_tangent2(), blinepoint1.get_tangent1());
-	// Find the solution to which is the standard postion which matches the current
-	// homogenous position
+	// Find the solution to which is the standard position which matches the current
+	// homogeneous position
 	// Secant method: http://en.wikipedia.org/wiki/Secant_method
 	Real sn(0.0); // the standard position on current bezier
 	Real sn1(0.0), sn2(1.0);
-	Real t0((mpl-pl)/bl); // the homogenous position on the current bezier
+	Real t0((mpl-pl)/bl); // the homogeneous position on the current bezier
 	int iterations=0;
 	int max_iterations=100;
 	Real max_error(0.00001);

--- a/synfig-core/src/synfig/valuenodes/valuenode_dilist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dilist.h
@@ -69,7 +69,7 @@ public:
 	virtual String get_local_name()const;
 	//! Inserts a new entry between the previous found
 	//! dashitem and the one where the action was called
-	//! \param index the index of the entry wher the action is done
+	//! \param index the index of the entry where the action is done
 	//! \param time the time when inserted in animation mode
 	//! \param origin unused. Always is in the middle.
 	//! \return the new List Entry

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamic.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamic.h
@@ -48,10 +48,10 @@ private:
 	ValueNode::RHandle origin_;        // Basement of the dynamic system
 	ValueNode::RHandle force_;         // External force applied on the mass center of gravity
 	ValueNode::RHandle torque_;        // Momentum applied at the origin
-	ValueNode::RHandle damping_coef_;  // Radial Damping coeficient 
-	ValueNode::RHandle friction_coef_; // Rotational friction coeficient
-	ValueNode::RHandle spring_coef_;   // Spring coeficient 
-	ValueNode::RHandle torsion_coef_;  // Torsion coeficient
+	ValueNode::RHandle damping_coef_;  // Radial Damping coefficient 
+	ValueNode::RHandle friction_coef_; // Rotational friction coefficient
+	ValueNode::RHandle spring_coef_;   // Spring coefficient 
+	ValueNode::RHandle torsion_coef_;  // Torsion coefficient
 	ValueNode::RHandle mass_;          // Mass 
 	ValueNode::RHandle inertia_;       // Moment of Inertia
 	ValueNode::RHandle spring_rigid_;  // True if spring is solid rigid

--- a/synfig-core/src/synfig/valuenodes/valuenode_wplist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_wplist.cpp
@@ -84,7 +84,7 @@ synfig::convert_bline_to_wplist(const ValueBase& bline)
 	// If the bline is not looped then make the cups type rounded for the
 	// first and last width points.
 	// In the future when this function is used to convert old blines to
-	// new wlines the end and start cups should be readed from the oultline
+	// new wlines the end and start cups should be read from the outline
 	// layer
 	if(!bline.get_loop())
 	{
@@ -329,7 +329,7 @@ ValueNode_WPList::operator()(Time t)const
 			Real curr_width(curr.get_width());
 			// linear interpolation by amount
 			curr.set_width(i_width*(1.0-amount)+(curr_width)*amount);
-			// now insert the calculated width point into the widht list
+			// now insert the calculated width point into the width list
 			ret_list.push_back(curr);
 		}
 	}

--- a/synfig-core/src/synfig/valuenodes/valuenode_wplist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_wplist.h
@@ -82,7 +82,7 @@ public:
 	//! Inserts a new entry between the previous found
 	//! widthpoint and the one where the action was called
 	//! with an average width and a middle position.
-	//! \param index the index of the entry wher the action is done
+	//! \param index the index of the entry where the action is done
 	//! \param time the time when inserted in animation mode
 	//! \param origin unused. Always is in the middle.
 	//! \return the new List Entry
@@ -97,7 +97,7 @@ public:
 	//! \param time the time when things are evaluated
 	//! \return a width point reference with the proper values
 	WidthPoint find_prev_valid_entry_by_position(Real position, Time time=0)const;
-	//! Interpolated width at a a given time based on surrounding full 'on' widht points
+	//! Interpolated width at a a given time based on surrounding full 'on' width points
 	//! \param position the position where to evaluate the width
 	//! \param time the time when evaluates
 	//! \return the interpolated width

--- a/synfig-core/src/synfig/waypoint.cpp
+++ b/synfig-core/src/synfig/waypoint.cpp
@@ -95,7 +95,7 @@ Waypoint::Waypoint():
 void
 Waypoint::set_value(const ValueBase &x)
 {
-	//! If the value node is not set and we are seting the value
+	//! If the value node is not set and we are setting the value
 	//! of an angle, then set both interpolation to linear... why?
 	if(!value_node && x.get_type()==type_angle)
 		after=before=INTERPOLATION_LINEAR;
@@ -109,7 +109,7 @@ Waypoint::set_value_node(const etl::handle<ValueNode> &x)
 
 	// printf("%s:%d Waypoint::set_value_node(%lx) = %lx (%s)\n", __FILE__, __LINE__, uintptr_t(this), uintptr_t(x), x->get_string().c_str());
 
-	//! If the value node is not set and we are seting the value
+	//! If the value node is not set and we are setting the value
 	//! of an angle, then set both interpolation to linear... why?
 
 	if(!value_node && x->get_type()==type_angle)

--- a/synfig-core/src/synfig/waypoint.h
+++ b/synfig-core/src/synfig/waypoint.h
@@ -70,7 +70,7 @@ public:
 /*! \class Waypoint::Model
  * 	\brief Waypoint::Model is a Waypoint model. It is used to store and
  * 	retrieve the values of the waypoint that is going to be modified. Once
- * 	the model is completely modifed then it can be applied to the waypoint
+ * 	the model is completely modified then it can be applied to the waypoint
  * 	itself by using the \apply_model() member
  */
 	class Model
@@ -241,7 +241,7 @@ public:
 	//!Gets the value hold by the Waypoint at time \t when it is animated
 	ValueBase get_value(const Time &t)const;
 	//!Sets the value of the Waypoint.
-	//!Maybe it would be posible to define set_value(const ValueBase &x, Time &t) ?
+	//!Maybe it would be possible to define set_value(const ValueBase &x, Time &t) ?
 	void set_value(const ValueBase &x);
 	//! Returns the handle to the value node
 	const etl::rhandle<ValueNode> &get_value_node()const { return value_node; }

--- a/synfig-core/src/synfig/widthpoint.h
+++ b/synfig-core/src/synfig/widthpoint.h
@@ -69,7 +69,7 @@ public:
 	void set_position(const Real& x);
 	// gets the normalised position: converts it to be inside [0,1]
 	Real get_norm_position(bool wplistloop)const;
-	// gets the postion inside the lower and upper boundaries
+	// gets the position inside the lower and upper boundaries
 	Real get_bound_position(bool wplistloop)const;
 	// changes the widthpoint's position to be inside [0,1)
 	void normalize(bool loop);

--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -856,7 +856,7 @@ void SynfigCommandLineParser::print_target_video_codecs_help() const
 
 #ifdef _DEBUG
 
-// DEBUG auxiliar functions
+// DEBUG auxiliary functions
 void guid_test()
 {
 	std::cout << "GUID Test" << std::endl;

--- a/synfig-docs/ca/interface/interface.sgml
+++ b/synfig-docs/ca/interface/interface.sgml
@@ -14,7 +14,7 @@ customizable dock dialogs. You can rearrange the contents of these however
 you wish by simply dragging the tab to where you want it. You can even create a 
 new dock dialog by dragging a tab out of the dock dialog it was inside of.</para>
 
-<para>If you ever accidently close a dock tabs (by dragging it out of the dock 
+<para>If you ever accidentally close a dock tabs (by dragging it out of the dock 
 dialog, and closing the new dock dialog that gets created), no worries. Simply 
 goto the toolbox and goto "File->Dialogs", and then click on the name of the 
 dialog you need.</para>

--- a/synfig-docs/ca/introduction/introduction.sgml
+++ b/synfig-docs/ca/introduction/introduction.sgml
@@ -41,10 +41,10 @@
  <para>darco has some fairly major re-implementations and optimizations that 
  he plans to implement that should quite dramatically improve the performance 
  of Synfig on all platforms. The goal is not a 200% speed increase, it is at 
- least a 2000% speed increase. With the optimizations that are planned to be 
- implemented, we will be able to pipeline operations in such a way that this 
- performance improvement can be realized. It should also pave the way to hardware 
- acceleration using todays powerful graphics processors, which should yield 
+ least a 2000% speed increase. With the optimizations that are planned to be
+ implemented, we will be able to pipeline operations in such a way that this
+ performance improvement can be realized. It should also pave the way to hardware
+ acceleration using today's powerful graphics processors, which should yield 
  further performance improvements measurable in orders of magnitude.</para>
 </chapter>
 <!-- Local Variables: -->

--- a/synfig-docs/ca/steps/layers/combining.sgml
+++ b/synfig-docs/ca/steps/layers/combining.sgml
@@ -6,7 +6,7 @@
 tool from the Synfig Toolbox, and click into the canvas once. You should note
 that another layer was added in the Layers Dialog called 'Gradient'. This is 
 nothing special. If you see no gradient but just a plain color, pick the normal
-tool, click into the canvas to acivate the gradient's ducks. You need to grab 
+tool, click into the canvas to activate the gradient's ducks. You need to grab 
 the one you see and move it a bit until a gradient appears.</para>
 
 <para>You now have a gradient but it is not what you wanted: It spreads the 

--- a/synfig-docs/ca/steps/layers/layers.sgml
+++ b/synfig-docs/ca/steps/layers/layers.sgml
@@ -13,7 +13,7 @@ application such as the GIMP, for instance.</para>
 respects:</para>
 <orderedlist>
   <listitem>
-   <para>You can organize layers into hierachical groups.</para>
+   <para>You can organize layers into hierarchical groups.</para>
   </listitem>
   <listitem>
    <para>You can use upper layers to change the behaviour (or look)

--- a/synfig-docs/ca/steps/layers/using.sgml
+++ b/synfig-docs/ca/steps/layers/using.sgml
@@ -3,7 +3,7 @@
 <sect2 id="using">
 <title>Using</title> 
 <para> However, there is still a problem: The gradient still covers the whole 
-canvas althought we wanted it to be restricted on the rectangle. To do so, 
+canvas although we wanted it to be restricted on the rectangle. To do so, 
 activate the gradient layer in the Layer tab. Now go to the Params Dialog (by 
 default a tab in the Params-Children-Keyframes window), and search the attribute
 called 'Blend Method'. Double-click the entry and select 'Onto' from the

--- a/synfig-docs/ca/steps/shapes.sgml
+++ b/synfig-docs/ca/steps/shapes.sgml
@@ -14,7 +14,7 @@ the layer(s) will still remain selected in the Layers Dialog. This is
 normal. Anything you create in the bline tool will be inserted above the
 currently selected layer. Keep in mind that if you want to insert a shape
 somewhere, you should select where you want to insert it before you go
-into the Bline tool-changing the selection afterward will automaticly
+into the Bline tool-changing the selection afterward will automatically
 swap you back to the normal tool.</para>
   <para>If you take a look at the tool options dialog, you'll notice that the
 first things you see are three checkboxes. Make sure that only "Fill"

--- a/synfig-docs/ca/synfig-studio.sgml
+++ b/synfig-docs/ca/synfig-studio.sgml
@@ -32,7 +32,7 @@
     <title><acronym>Synfig Studio</acronym>
     </title>
     <subtitle>Getting Started</subtitle>
-    <releaseinfo>Intial Release</releaseinfo>
+    <releaseinfo>Initial Release</releaseinfo>
     <authorgroup>
       <author>
 	<firstname>Miguel</firstname>

--- a/synfig-docs/en/interface/interface.sgml
+++ b/synfig-docs/en/interface/interface.sgml
@@ -14,7 +14,7 @@ customizable dock dialogs. You can rearrange the contents of these however
 you wish by simply dragging the tab to where you want it. You can even create a 
 new dock dialog by dragging a tab out of the dock dialog it was inside of.</para>
 
-<para>If you ever accidently close a dock tabs (by dragging it out of the dock 
+<para>If you ever accidentally close a dock tabs (by dragging it out of the dock 
 dialog, and closing the new dock dialog that gets created), no worries. Simply 
 goto the toolbox and goto "File->Dialogs", and then click on the name of the 
 dialog you need.</para>

--- a/synfig-docs/en/introduction/introduction.sgml
+++ b/synfig-docs/en/introduction/introduction.sgml
@@ -41,10 +41,10 @@
  <para>darco has some fairly major re-implementations and optimizations that 
  he plans to implement that should quite dramatically improve the performance 
  of Synfig on all platforms. The goal is not a 200% speed increase, it is at 
- least a 2000% speed increase. With the optimizations that are planned to be 
- implemented, we will be able to pipeline operations in such a way that this 
- performance improvement can be realized. It should also pave the way to hardware 
- acceleration using todays powerful graphics processors, which should yield 
+ least a 2000% speed increase. With the optimizations that are planned to be
+ implemented, we will be able to pipeline operations in such a way that this
+ performance improvement can be realized. It should also pave the way to hardware
+ acceleration using today's powerful graphics processors, which should yield 
  further performance improvements measurable in orders of magnitude.</para>
 </chapter>
 <!-- Local Variables: -->

--- a/synfig-docs/en/steps/layers/combining.sgml
+++ b/synfig-docs/en/steps/layers/combining.sgml
@@ -6,7 +6,7 @@
 tool from the Synfig Toolbox, and click into the canvas once. You should note
 that another layer was added in the Layers Dialog called 'Gradient'. This is 
 nothing special. If you see no gradient but just a plain color, pick the normal
-tool, click into the canvas to acivate the gradient's ducks. You need to grab 
+tool, click into the canvas to activate the gradient's ducks. You need to grab 
 the one you see and move it a bit until a gradient appears.</para>
 
 <para>You now have a gradient but it is not what you wanted: It spreads the 

--- a/synfig-docs/en/steps/layers/layers.sgml
+++ b/synfig-docs/en/steps/layers/layers.sgml
@@ -13,7 +13,7 @@ application such as the GIMP, for instance.</para>
 respects:</para>
 <orderedlist>
   <listitem>
-   <para>You can organize layers into hierachical groups.</para>
+   <para>You can organize layers into hierarchical groups.</para>
   </listitem>
   <listitem>
    <para>You can use upper layers to change the behaviour (or look)

--- a/synfig-docs/en/steps/layers/using.sgml
+++ b/synfig-docs/en/steps/layers/using.sgml
@@ -3,7 +3,7 @@
 <sect2 id="using">
 <title>Using</title> 
 <para> However, there is still a problem: The gradient still covers the whole 
-canvas althought we wanted it to be restricted on the rectangle. To do so, 
+canvas although we wanted it to be restricted on the rectangle. To do so, 
 activate the gradient layer in the Layer tab. Now go to the Params Dialog (by 
 default a tab in the Params-Children-Keyframes window), and search the attribute
 called 'Blend Method'. Double-click the entry and select 'Onto' from the

--- a/synfig-docs/en/steps/shapes.sgml
+++ b/synfig-docs/en/steps/shapes.sgml
@@ -14,7 +14,7 @@ the layer(s) will still remain selected in the Layers Dialog. This is
 normal. Anything you create in the bline tool will be inserted above the
 currently selected layer. Keep in mind that if you want to insert a shape
 somewhere, you should select where you want to insert it before you go
-into the Bline tool-changing the selection afterward will automaticly
+into the Bline tool-changing the selection afterward will automatically
 swap you back to the normal tool.</para>
   <para>If you take a look at the tool options dialog, you'll notice that the
 first things you see are three checkboxes. Make sure that only "Fill"

--- a/synfig-docs/en/synfig-studio.sgml
+++ b/synfig-docs/en/synfig-studio.sgml
@@ -32,7 +32,7 @@
     <title><acronym>Synfig Studio</acronym>
     </title>
     <subtitle>Getting Started</subtitle>
-    <releaseinfo>Intial Release</releaseinfo>
+    <releaseinfo>Initial Release</releaseinfo>
     <authorgroup>
       <author>
 	<firstname>xxxx</firstname>

--- a/synfig-osx/launcher/utils/README.txt
+++ b/synfig-osx/launcher/utils/README.txt
@@ -70,7 +70,7 @@ For example, to compile for Linux:
 INSTALLATION
 ============
 Install the dumpkeymap executable image in a location mentioned in the PATH
-environment variable.  Typicall locations for executable files are:
+environment variable.  Typical locations for executable files are:
 
     /usr/local/bin
     $(HOME)/bin

--- a/synfig-osx/launcher/utils/dumpkeymap.man
+++ b/synfig-osx/launcher/utils/dumpkeymap.man
@@ -159,7 +159,7 @@
 //-----------------------------------------------------------------------------
 ..
 .SH NAME
-dumpkeymap \- Dianostic dump of a .keymapping file
+dumpkeymap \- Diagnostic dump of a .keymapping file
 .SH SYNOPSIS
 .B dumpkeymap
 .RI [ options "] [-] [" file "...]"

--- a/synfig-studio/docs/bones_gui.txt
+++ b/synfig-studio/docs/bones_gui.txt
@@ -14,7 +14,7 @@ PRINCIPLES
    needed. (PEND)
 2) The bones are visible when the user select a skeleton layer.(DONE) When
    the user selects a layer that has a vertex under bone influence then
-   the correspoinding bones are shown too (DONE)
+   the corresponding bones are shown too (DONE)
 
 BASIC USAGE -WORKFLOW
 ---------------------
@@ -84,7 +84,7 @@ blob around the line that connects the Origin(0) and the Tip(0). It can
 be represented by a dashed line like the one I draw in the wiki to explain
 the "distance to a bone": See http://synfig.org/Image:Strength.png. (PEND)
 
-The usage of Strenght will be seen later.
+The usage of Strength will be seen later.
 
 All those ducks are modified by the Normal Tool of synfigstudio by click
 and drag.
@@ -193,8 +193,8 @@ templates to create the new bone tool.
 WEIGHT DUCKS (PEND)
 ------------
 There are weights per vertex and per bone. So the weights can be seen
-form the point of vew of the bone or from the point of view of the vertex.
-The most useful way of see the weigths are form the point of vew of the
+from the point of view of the bone or from the point of view of the vertex.
+The most useful way of see the weights are frpm the point of view of the
 vertex (or bilinepoint) that is bone influenced.
 
 So a proposal for the interface is:
@@ -226,10 +226,10 @@ Remove:
 When the user selects a bone in the skeleton layer can do right click
 and select remove item smart then the bone is removed from the list and
 that DOESN'T DELETE A VALUENODE, it just removed the valuenode
-form the list and keep it alive meanwhile anyone refereces to that
+form the list and keep it alive meanwhile anyone references to that
 valuenode. Even the history can keep a valuenode alive if it is not
 cleaned. So, any other bone that has that bone as parent keeps it as
-parent. It will be alive until any children refereces to it as parent,
+parent. It will be alive until any children references to it as parent,
 there were no history entry of it and it is not referenced in the child
 panel or any other valuenode. (DONE)
 
@@ -260,7 +260,7 @@ WORKFLOW:
 1) The user selects the drawn stuff
 2) The user selects a skeleton layer too.
 3) The user selects a vertex/blinepoint or a group of them
-4) The user does rigth click on a bone and select "Add to Bone Influence"
+4) The user does right click on a bone and select "Add to Bone Influence"
 
 Then the GUI should add the current bone where the right click was done
 to the Bone Weight Pair list of the selected vertices/blinepoints.

--- a/synfig-studio/m4/libxml.m4
+++ b/synfig-studio/m4/libxml.m4
@@ -134,7 +134,7 @@ main()
         printf("*** being found. The easiest way to fix this is to remove the old version\n");
         printf("*** of LIBXML, but you can also set the XML_CONFIG environment to point to the\n");
         printf("*** correct copy of xml-config. (In this case, you will have to\n");
-        printf("*** modify your LD_LIBRARY_PATH enviroment variable, or edit /etc/ld.so.conf\n");
+        printf("*** modify your LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf\n");
         printf("*** so that the correct libraries are found at run-time))\n");
     }
   return 1;
@@ -176,7 +176,7 @@ main()
           echo "*** If you have an old version installed, it is best to remove it, although"
           echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH" ],
         [ echo "*** The test program failed to compile or link. See the file config.log for the"
-          echo "*** exact error that occured. This usually means LIBXML was incorrectly installed"
+          echo "*** exact error that occurred. This usually means LIBXML was incorrectly installed"
           echo "*** or that you have moved LIBXML since it was installed. In the latter case, you"
           echo "*** may want to edit the xml-config script: $XML_CONFIG" ])
           CFLAGS="$ac_save_CFLAGS"
@@ -323,7 +323,7 @@ main()
         printf("*** being found. The easiest way to fix this is to remove the old version\n");
         printf("*** of LIBXML, but you can also set the XML2_CONFIG environment to point to the\n");
         printf("*** correct copy of xml2-config. (In this case, you will have to\n");
-        printf("*** modify your LD_LIBRARY_PATH enviroment variable, or edit /etc/ld.so.conf\n");
+        printf("*** modify your LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf\n");
         printf("*** so that the correct libraries are found at run-time))\n");
     }
   return 1;
@@ -367,7 +367,7 @@ main()
           echo "*** If you have an old version installed, it is best to remove it, although"
           echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH" ],
         [ echo "*** The test program failed to compile or link. See the file config.log for the"
-          echo "*** exact error that occured. This usually means LIBXML was incorrectly installed"
+          echo "*** exact error that occurred. This usually means LIBXML was incorrectly installed"
           echo "*** or that you have moved LIBXML since it was installed. In the latter case, you"
           echo "*** may want to edit the xml2-config script: $XML2_CONFIG" ])
           CFLAGS="$ac_save_CFLAGS"

--- a/synfig-studio/src/brushlib/brush.hpp
+++ b/synfig-studio/src/brushlib/brush.hpp
@@ -151,13 +151,13 @@ private:
     // precalculate stuff that does not change dynamically
 
     // Precalculate how the physical speed will be mapped to the speed input value.
-    // The forumla for this mapping is:
+    // The formula for this mapping is:
     //
     // y = log(gamma+x)*m + q;
     //
     // x: the physical speed (pixels per basic dab radius)
     // y: the speed input that will be reported
-    // gamma: parameter set by ths user (small means a logarithmic mapping, big linear)
+    // gamma: parameter set by this user (small means a logarithmic mapping, big linear)
     // m, q: parameters to scale and translate the curve
     //
     // The code below calculates m and q given gamma and two hardcoded constraints.
@@ -342,7 +342,7 @@ private:
     if (states[STATE_ACTUAL_RADIUS] < ACTUAL_RADIUS_MIN) states[STATE_ACTUAL_RADIUS] = ACTUAL_RADIUS_MIN;
     if (states[STATE_ACTUAL_RADIUS] > ACTUAL_RADIUS_MAX) states[STATE_ACTUAL_RADIUS] = ACTUAL_RADIUS_MAX;
 
-    // aspect ratio (needs to be caluclated here because it can affect the dab spacing)
+    // aspect ratio (needs to be calculated here because it can affect the dab spacing)
     states[STATE_ACTUAL_ELLIPTICAL_DAB_RATIO] = settings_value[BRUSH_ELLIPTICAL_DAB_RATIO];
     states[STATE_ACTUAL_ELLIPTICAL_DAB_ANGLE] = settings_value[BRUSH_ELLIPTICAL_DAB_ANGLE];
   }
@@ -508,7 +508,7 @@ private:
 
     // HSL color change
     if (settings_value[BRUSH_CHANGE_COLOR_L] || settings_value[BRUSH_CHANGE_COLOR_HSL_S]) {
-      // (calculating way too much here, can be optimized if neccessary)
+      // (calculating way too much here, can be optimized if necessary)
       // this function will CLAMP the inputs
       hsv_to_rgb_float (&color_h, &color_s, &color_v);
       rgb_to_hsl_float (&color_h, &color_s, &color_v);
@@ -686,7 +686,7 @@ public:
         TODO:
         if (dist_todo > 300) {
         // this happens quite often, eg when moving the cursor back into the window
-        // FIXME: bad to hardcode a distance treshold here - might look at zoomed image
+        // FIXME: bad to hardcode a distance threshold here - might look at zoomed image
         //        better detect leaving/entering the window and reset then.
         g_print ("Warning: NOT drawing %f dabs.\n", dist_todo);
         g_print ("dtime=%f, dx=%f\n", dtime, x-states[STATE_X]);
@@ -813,7 +813,7 @@ public:
       } else {
         // Usually we have pressure==0 here. But some brushes can paint
         // nothing at full pressure (eg gappy lines, or a stroke that
-        // fades out). In either case this is the prefered moment to split.
+        // fades out). In either case this is the preferred moment to split.
         if (stroke_total_painting_time+stroke_current_idling_time > 0.9 + 5*pressure) {
           return true;
         }

--- a/synfig-studio/src/gui/actionmanagers/keyframeactionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/keyframeactionmanager.cpp
@@ -158,7 +158,7 @@ KeyframeActionManager::on_keyframe_properties()
 }
 
 /*! \fn KeyframeActionManager::on_keyframe_toggle()
-**	\brief Signal handler for selected keyframe toogle
+**	\brief Signal handler for selected keyframe toggle
 */
 void
 KeyframeActionManager::on_keyframe_toggle()
@@ -259,7 +259,7 @@ KeyframeActionManager::refresh()
 	Glib::RefPtr<Gtk::Action> action_kf_toggle(Gtk::Action::create("keyframe-toggle", _("Toggle Keyframe"), _("Toggle Keyframe")));
 	action_group_->add(action_kf_toggle,sigc::mem_fun(*this,&KeyframeActionManager::on_keyframe_toggle));
 
-	// Keyframe description defintion
+	// Keyframe description definition
 	Glib::RefPtr<Gtk::Action> action_kf_description(Gtk::Action::create("keyframe-description-set", _("Set Keyframe Description"), _("Set Keyframe Description")));
 	action_group_->add(action_kf_description,sigc::mem_fun(*this,&KeyframeActionManager::on_keyframe_description_set));
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -589,7 +589,7 @@ public:
 				value=strprintf("%i",(int)App::show_file_toolbar);
 				return true;
 			}
-			//! "Keep brushes_path" preferences entry for backward compatibilty (15/12 - v1.0.3)
+			//! "Keep brushes_path" preferences entry for backward compatibility (15/12 - v1.0.3)
 			//! Now brush path(s) are hold by input preferences : brush.path_count & brush.path_%d
 			if(key=="brushes_path")
 			{
@@ -793,7 +793,7 @@ public:
 				App::show_file_toolbar=i;
 				return true;
 			}
-			//! "Keep brushes_path" preferences entry for backward compatibilty (15/12 - v1.0.3)
+			//! "Keep brushes_path" preferences entry for backward compatibility (15/12 - v1.0.3)
 			//! Now brush path(s) are hold by input preferences : brush.path_count & brush.path_%d
 			if(key=="brushes_path")
 			{
@@ -3901,7 +3901,7 @@ App::open_from_temporary_filesystem(std::string temporary_filename)
 			one_moment.hide();
 
 			if(instance->is_updated() && App::dialog_message_2b(
-				_("Newer version of this file avaliable on the CVS repository!"),
+				_("Newer version of this file available on the CVS repository!"),
 				_("Would you like to update now (It would probably be a good idea)"),
 				Gtk::MESSAGE_QUESTION,
 				_("Cancel"),
@@ -3961,7 +3961,7 @@ App::new_instance()
 	canvas->rend_desc().set_time_end(5.0);
 	canvas->rend_desc().set_x_res(DPI2DPM(72.0f));
 	canvas->rend_desc().set_y_res(DPI2DPM(72.0f));
-	// The top left and botton right positions are expressed in units
+	// The top left and bottom right positions are expressed in units
 	// Original convention is that 1 unit = 60 pixels
 	canvas->rend_desc().set_tl(Vector(-(preferred_x_size/60.0)/2.0,  (preferred_y_size/60.0)/2.0));
 	canvas->rend_desc().set_br(Vector( (preferred_x_size/60.0)/2.0, -(preferred_y_size/60.0)/2.0));

--- a/synfig-studio/src/gui/asyncrenderer.h
+++ b/synfig-studio/src/gui/asyncrenderer.h
@@ -53,9 +53,9 @@ namespace studio {
 
 class AsyncRenderer : public etl::shared_object, public sigc::trackable
 {
-	//! Signal emmited when target has been stopped or has finished
+	//! Signal emitted when target has been stopped or has finished
 	sigc::signal<void> signal_finished_;
-	//! Signal emmited when target has succedded
+	//! Signal emitted when target has succeeded
 	sigc::signal<void> signal_success_;
 
 	//! Seems to be unused
@@ -66,11 +66,11 @@ class AsyncRenderer : public etl::shared_object, public sigc::trackable
 
 	//! Set to true when target render fails.
 	bool error;
-	//! Set to true when target render succedded
+	//! Set to true when target render succeeded
 	bool success;
 
 	synfig::ProgressCallback *cb;
-	//! Signal to be emmited when the target is requested to stop
+	//! Signal to be emitted when the target is requested to stop
 	sigc::signal<void> signal_stop_;
 
 	Glib::Thread* render_thread;

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -753,7 +753,7 @@ void CanvasView::present()
 	App::set_selected_canvas_view(this);
 
 	Dockable::present();
-	// If hided by CanvasView::close_view, time to come back to the show
+	// If hidden by CanvasView::close_view, time to come back to the show
 	if(!get_visible())show();
 	update_title();
 }

--- a/synfig-studio/src/gui/dialogs/dialog_ffmpegparam.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_ffmpegparam.cpp
@@ -52,9 +52,9 @@ using namespace studio;
 /* === G L O B A L S ======================================================= */
 //! Allowed video codecs
 /*! \warning This variable is linked to allowed_video_codecs_description,
- *  if you change this you must change the other acordingly.
+ *  if you change this you must change the other accordingly.
  *  \warning These codecs are linked to the filename extensions for
- *  mod_ffmpeg. If you change this you must change the others acordingly.
+ *  mod_ffmpeg. If you change this you must change the others accordingly.
  */
 const char* allowed_video_codecs[] =
 {
@@ -65,7 +65,7 @@ const char* allowed_video_codecs[] =
 
 //! Allowed video codecs description.
 /*! \warning This variable is linked to allowed_video_codecs,
- *  if you change this you must change the other acordingly.
+ *  if you change this you must change the other accordingly.
  */
 const char* allowed_video_codecs_description[] =
 {
@@ -130,7 +130,7 @@ Dialog_FFmpegParam::Dialog_FFmpegParam(Gtk::Window &parent):
 void
 Dialog_FFmpegParam::init()
 {
-	// By defaut, set the active text to the Custom Video Codec
+	// By default, set the active text to the Custom Video Codec
 	vcodec->set_active_text(CUSTOM_VCODEC_DESCRIPTION);
 	customvcodec->set_text(CUSTOM_VCODEC);
 	//Compare the passed vcodec to the available and set it active if found

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -763,7 +763,7 @@ Dialog_Setup::on_apply_pressed()
 	// Set file toolbar flag
 	App::show_file_toolbar=toggle_show_file_toolbar.get_active();
 
-	//! TODO Create Change mecanism has Class for being used elsewhere
+	//! TODO Create Change mechanism has Class for being used elsewhere
 	// Set the preferred brush path(s)
 	if (pref_modification_flag&CHANGE_BRUSH_PATH)
 	{
@@ -821,8 +821,8 @@ Dialog_Setup::on_apply_pressed()
 
 	if (pref_modification_flag & CHANGE_UI_HANDLE_TOOLTIP)
 	{
-		// Set ui tooltip on widht point
-		App::ui_handle_tooltip_flag  = toggle_handle_tooltip_widthpoint.get_active()?Duck::STRUCT_WIDTHPOINT:Duck::STRUCT_NONE;
+		// Set ui tooltip on width point
+		App::ui_handle_tooltip_flag=toggle_handle_tooltip_widthpoint.get_active()?Duck::STRUCT_WIDTHPOINT:Duck::STRUCT_NONE;
 		// Set ui tooltip on radius
 		App::ui_handle_tooltip_flag |= toggle_handle_tooltip_radius.get_active()?Duck::STRUCT_RADIUS:Duck::STRUCT_NONE;
 		// Set ui tooltip on transformation
@@ -1048,7 +1048,7 @@ Dialog_Setup::refresh()
 	// Refresh the brush path(s)
 	Glib::RefPtr<Gtk::ListStore> liststore = Glib::RefPtr<Gtk::ListStore>::cast_dynamic(
 			listviewtext_brushes_path->get_model());
-	//! Keep "brushes_path" preferences entry for backward compatibilty (15/12 - v1.0.3)
+	//! Keep "brushes_path" preferences entry for backward compatibility (15/12 - v1.0.3)
 	//! Now brush path(s) are hold by input preferences : brush.path_count & brush.path_%d
 	String value;
 	Gtk::TreeIter ui_iter;

--- a/synfig-studio/src/gui/dialogs/dialog_targetparam.h
+++ b/synfig-studio/src/gui/dialogs/dialog_targetparam.h
@@ -43,7 +43,7 @@
 
 namespace studio {
 
-///@brief Abstract parrent for extra target parameters dialogs. 	
+///@brief Abstract parent for extra target parameters dialogs. 	
 class Dialog_TargetParam: public Gtk::Dialog
 {
 public:

--- a/synfig-studio/src/gui/dialogs/dialog_template.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_template.cpp
@@ -1,6 +1,6 @@
 /* === S Y N F I G ========================================================= */
 /*!	\file dialogs/dialog_template.cpp
-**	\brief Dialog design list and panel template Implemetation
+**	\brief Dialog design list and panel template Implementation
 **
 **	$Id$
 **

--- a/synfig-studio/src/gui/docks/dock_curves.cpp
+++ b/synfig-studio/src/gui/docks/dock_curves.cpp
@@ -95,7 +95,7 @@ _curve_selection_changed(Gtk::TreeView* param_tree_view,Widget_Curves* curves)
 void
 Dock_Curves::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 {
-	//! Curves is registred thrue CanvasView::set_ext_widget
+	//! Curves is registered thru CanvasView::set_ext_widget
 	//! and will be deleted during CanvasView::~CanvasView()
 	//! \see CanvasView::set_ext_widget
 	//! \see CanvasView::~CanvasView

--- a/synfig-studio/src/gui/docks/dock_layers.cpp
+++ b/synfig-studio/src/gui/docks/dock_layers.cpp
@@ -233,7 +233,7 @@ Dock_Layers::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 
 	canvas_view->set_tree_model(get_name(),layer_tree_store);
 
-	//! layer_tree is registred thrue CanvasView::set_ext_widget
+	//! layer_tree is registered thru CanvasView::set_ext_widget
 	//! and will be deleted during CanvasView::~CanvasView()
 	//! \see CanvasView::set_ext_widget
 	//! \see CanvasView::~CanvasView

--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -230,7 +230,7 @@ Dock_Toolbox::change_state_(const Smach::state_base *state)
 
 
 /*! \fn Dock_Toolbox::add_state(const Smach::state_base *state)
- *  \brief Add and connect a toogle button to the toolbox defined by a state
+ *  \brief Add and connect a toggle button to the toolbox defined by a state
  *  \param state a const pointer to Smach::state_base
 */
 void
@@ -250,7 +250,7 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 		stock_item.get_label() ));
 
 	Gtk::AccelKey key;
-	//Have a look to global fonction init_ui_manager() from app.cpp for "accel_path" definition
+	//Have a look to global function init_ui_manager() from app.cpp for "accel_path" definition
 	Gtk::AccelMap::lookup_entry ("<Actions>/action_group_state_manager/state-"+name, key);
 	//Gets the, is exist, accelerator representation for labels
 	Glib::ustring accel_path = !key.is_null() ? key.get_abbrev () :"";

--- a/synfig-studio/src/gui/docks/dockbook.h
+++ b/synfig-studio/src/gui/docks/dockbook.h
@@ -80,7 +80,7 @@ public:
 
 	bool tab_button_pressed(GdkEventButton* event, Dockable* dockable);
 	void on_drag_data_received(const Glib::RefPtr<Gdk::DragContext>& context, int, int, const Gtk::SelectionData& selection_data, guint, guint time);
-	//! Overide the default handler of the signal Gtk::Notebook::signal_switch_page().
+	//! Override the default handler of the signal Gtk::Notebook::signal_switch_page().
 	//! to do some extra work in case of CanvasView Dockable type
 	/*! \see App::set_selected_canvas_view */
 	void on_switch_page(Gtk::Widget* page, guint page_num);

--- a/synfig-studio/src/gui/docks/dockmanager.h
+++ b/synfig-studio/src/gui/docks/dockmanager.h
@@ -85,10 +85,10 @@ public:
 
 	DockDialog& find_dock_dialog(int id);
 	const DockDialog& find_dock_dialog(int id)const;
-	//! Connect to that signal to get the info a dock has been registred
+	//! Connect to that signal to get the info a dock has been registered
 	/*! \see studio::DockManager::register_dockable */
 	sigc::signal<void,Dockable*>& signal_dockable_registered() { return signal_dockable_registered_; }
-	//! Connect to that signal to get the info that a dock has been unregistred
+	//! Connect to that signal to get the info that a dock has been unregistered
 	/*! \see studio::DockManager::unregister_dockable */
 	sigc::signal<void,Dockable*>& signal_dockable_unregistered() { return signal_dockable_unregistered_; }
 

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -206,7 +206,7 @@ studio::Instance::run_plugin(std::string plugin_path)
 {
 	handle<synfigapp::UIInterface> uim = this->find_canvas_view(this->get_canvas())->get_ui_interface();
 
-	string message = strprintf(_("Do you realy want to run plugin for file \"%s\"?" ),
+	string message = strprintf(_("Do you really want to run plugin for file \"%s\"?" ),
 				this->get_canvas()->get_name().c_str());
 
 	string details = strprintf(_("This operation cannot be undone and all undo history will be cleared."));

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -8,7 +8,7 @@
 **	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
 **	Copyright (c) 2007 Chris Moore
 **	Copyright (c) 2011 Nikita Kitaev
-**	Coypright (c) 2012 Yu Chen
+**	Copyright (c) 2012 Yu Chen
 **
 **	This package is free software; you can redistribute it and/or
 **	modify it under the terms of the GNU General Public License as

--- a/synfig-studio/src/gui/trees/keyframetree.cpp
+++ b/synfig-studio/src/gui/trees/keyframetree.cpp
@@ -141,7 +141,7 @@ KeyframeTree::KeyframeTree() : editable_(false)
 	// Make us more sensitive to several events
 	add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK);
 
-	// Listen to the changed selection signal to perform kf synchro thrue canvas interface
+	// Listen to the changed selection signal to perform kf synchro thru canvas interface
 	get_selection()->signal_changed().connect(sigc::mem_fun(*this, &studio::KeyframeTree::on_selection_changed));
 	send_selection = false;
 }

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.h
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.h
@@ -78,7 +78,7 @@ class Widget_Keyframe_List : public Gtk::DrawingArea
 	//! The time of the selected keyframe
 	synfig::Time selected_kf_time;
 
-	//! The time of the selected keyframe during draging
+	//! The time of the selected keyframe during dragging
 	synfig::Time dragging_kf_time;
 
 	//! The Moving handmade tooltip window
@@ -123,7 +123,7 @@ public:
 	bool is_keyframe_selected() const { return selected; }
 	const synfig::Keyframe& get_selected_keyframe() const { return selected_kf; }
 
-	//! Performs the keyframe movement. Returns true if it was sucessful
+	//! Performs the keyframe movement. Returns true if it was successful
 	//! \param[in] delta If false permorm normal move. If true perform delta movement.
 	//! \return true: if success otherwise false
 	bool perform_move_kf(bool delta);

--- a/synfig-studio/src/gui/widgets/widget_timeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.cpp
@@ -275,7 +275,7 @@ Widget_Timeslider::on_draw(const Cairo::RefPtr<Cairo::Context> &cr)
 					time_model->get_frame_rate(),
 					App::get_time_format() ));
 
-			// Aproximately a font size of 8 pixels.
+			// Approximately a font size of 8 pixels.
 			// Pango::SCALE = 1024
 			// create_attr_size waits a number in 1000th of pixels.
 			// Should be user customizable in the future. Now it is fixed to 10

--- a/synfig-studio/src/gui/workarearenderer/renderer_bbox.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_bbox.cpp
@@ -1,6 +1,6 @@
 /* === S Y N F I G ========================================================= */
 /*!	\file renderer_bbox.cpp
-**  \brief Renderer_BBox classe is used to render in the workarea the bouding box
+**  \brief Renderer_BBox class is used to render in the workarea the bounding box
 ** of the selected layer(s)
 **
 **	$Id$

--- a/synfig-studio/src/gui/workarearenderer/renderer_bbox.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_bbox.h
@@ -1,6 +1,6 @@
 /* === S Y N F I G ========================================================= */
 /*!	\file renderer_bbox.h
-**  \brief Renderer_BBox classe is used to render in the workarea the bouding box
+**  \brief Renderer_BBox class is used to render in the workarea the bounding box
 ** of the selected layer(s)
 **
 **	$Id$

--- a/synfig-studio/src/gui/workarearenderer/renderer_canvas.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_canvas.cpp
@@ -101,7 +101,7 @@ Renderer_Canvas::Renderer_Canvas():
 	tiles_size(),
 	pixel_format()
 {
-	// check endianess
+	// check endianness
     union { int i; char c[4]; } checker = {0x01020304};
     bool big_endian = checker.c[0] == 1;
 

--- a/synfig-studio/src/gui/workarearenderer/renderer_dragbox.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_dragbox.cpp
@@ -1,6 +1,6 @@
 /* === S Y N F I G ========================================================= */
 /*!	\file renderer_dragbox.cpp
-**  \brief Renderer_Dragbox classe is used to display in the workarea
+**  \brief Renderer_Dragbox class is used to display in the workarea
 **  the interactive selection box, and select workarea objects (actually handles)
 **  accordingly to the shift/control modifier keys.
 **

--- a/synfig-studio/src/gui/workarearenderer/renderer_dragbox.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_dragbox.h
@@ -1,6 +1,6 @@
 /* === S Y N F I G ========================================================= */
 /*!	\file renderer_dragbox.h
-**	\brief Renderer_Dragbox classe is used to display in the workarea
+**	\brief Renderer_Dragbox class is used to display in the workarea
 **  the interactive selection box, and select workarea objects (actually handles)
 **  accordingly to the shift/control modifier keys.
 **

--- a/synfig-studio/src/gui/workarearenderer/renderer_ducks.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_ducks.h
@@ -33,7 +33,7 @@
 
 /* === M A C R O S ========================================================= */
 
-/** DUCK_COLOR_NOT_EDITABLE : light grey - for parameter (hanlde) like converted (linked also?) for example*/
+/** DUCK_COLOR_NOT_EDITABLE : light grey - for parameter (handle) like converted (linked also?) for example*/
 #define DUCK_COLOR_NOT_EDITABLE	Gdk::Color("#cfcfcf")
 /** DUCK_COLOR_ORIGIN : green */
 #define DUCK_COLOR_ORIGIN        Gdk::Color("#00ff00") // green

--- a/synfig-studio/src/synfigapp/actions/blinepointtangentmerge.cpp
+++ b/synfig-studio/src/synfigapp/actions/blinepointtangentmerge.cpp
@@ -130,7 +130,7 @@ Action::BLinePointTangentMerge::is_candidate(const ParamList &x)
 			ValueNode_RadialComposite::Handle radial_value_node;
 			radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(x.find("value_node")->second.get_value_node());
 			if(radial_value_node && radial_value_node->get_type()==type_vector)
-			// value_node is radial composite and vector (user rigth click on a tangent)
+			// value_node is radial composite and vector (user right click on a tangent)
 			{
 				ValueNode_Composite::Handle blinepoint=NULL;
 				std::set<Node*>::iterator iter;
@@ -170,7 +170,7 @@ Action::BLinePointTangentMerge::set_param(const synfig::String& name, const Acti
 		ValueNode_RadialComposite::Handle radial_value_node;
 		radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(param.get_value_node());
 		if(radial_value_node && radial_value_node->get_type()==type_vector)
-		// value_node is radial composite and vector (user rigth click on a tangent)
+		// value_node is radial composite and vector (user right click on a tangent)
 		{
 			ValueNode_Composite::Handle blinepoint;
 			std::set<Node*>::iterator iter;
@@ -287,7 +287,7 @@ Action::BLinePointTangentMergeRadius::is_candidate(const ParamList &x)
 			ValueNode_RadialComposite::Handle radial_value_node;
 			radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(x.find("value_node")->second.get_value_node());
 			if(radial_value_node && radial_value_node->get_type()==type_vector)
-				// value_node is radial composite and vector (user rigth click on a tangent)
+				// value_node is radial composite and vector (user right click on a tangent)
 			{
 				ValueNode_Composite::Handle blinepoint=NULL;
 				std::set<Node*>::iterator iter;
@@ -326,7 +326,7 @@ Action::BLinePointTangentMergeRadius::set_param(const synfig::String& name, cons
 		ValueNode_RadialComposite::Handle radial_value_node;
 		radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(param.get_value_node());
 		if(radial_value_node && radial_value_node->get_type()==type_vector)
-			// value_node is radial composite and vector (user rigth click on a tangent)
+			// value_node is radial composite and vector (user right click on a tangent)
 		{
 			ValueNode_Composite::Handle blinepoint;
 			std::set<Node*>::iterator iter;
@@ -427,7 +427,7 @@ Action::BLinePointTangentMergeAngle::is_candidate(const ParamList &x)
 			ValueNode_RadialComposite::Handle radial_value_node;
 			radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(x.find("value_node")->second.get_value_node());
 			if(radial_value_node && radial_value_node->get_type()==type_vector)
-				// value_node is radial composite and vector (user rigth click on a tangent)
+				// value_node is radial composite and vector (user right click on a tangent)
 			{
 				ValueNode_Composite::Handle blinepoint=NULL;
 				std::set<Node*>::iterator iter;
@@ -466,7 +466,7 @@ Action::BLinePointTangentMergeAngle::set_param(const synfig::String& name, const
 		ValueNode_RadialComposite::Handle radial_value_node;
 		radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(param.get_value_node());
 		if(radial_value_node && radial_value_node->get_type()==type_vector)
-			// value_node is radial composite and vector (user rigth click on a tangent)
+			// value_node is radial composite and vector (user right click on a tangent)
 		{
 			ValueNode_Composite::Handle blinepoint;
 			std::set<Node*>::iterator iter;

--- a/synfig-studio/src/synfigapp/actions/blinepointtangentsplit.cpp
+++ b/synfig-studio/src/synfigapp/actions/blinepointtangentsplit.cpp
@@ -130,7 +130,7 @@ Action::BLinePointTangentSplit::is_candidate(const ParamList &x)
 			ValueNode_RadialComposite::Handle radial_value_node;
 			radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(x.find("value_node")->second.get_value_node());
 			if(radial_value_node && radial_value_node->get_type()==type_vector)
-			// value_node is radial composite and vector (user rigth click on a tangent)
+			// value_node is radial composite and vector (user right click on a tangent)
 			{
 				ValueNode_Composite::Handle blinepoint=NULL;
 				std::set<Node*>::iterator iter;
@@ -170,7 +170,7 @@ Action::BLinePointTangentSplit::set_param(const synfig::String& name, const Acti
 		ValueNode_RadialComposite::Handle radial_value_node;
 		radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(param.get_value_node());
 		if(radial_value_node && radial_value_node->get_type()==type_vector)
-		// value_node is radial composite and vector (user rigth click on a tangent)
+		// value_node is radial composite and vector (user right click on a tangent)
 		{
 			ValueNode_Composite::Handle blinepoint;
 			std::set<Node*>::iterator iter;
@@ -285,7 +285,7 @@ Action::BLinePointTangentSplitRadius::is_candidate(const ParamList &x)
 			ValueNode_RadialComposite::Handle radial_value_node;
 			radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(x.find("value_node")->second.get_value_node());
 			if(radial_value_node && radial_value_node->get_type()==type_vector)
-				// value_node is radial composite and vector (user rigth click on a tangent)
+				// value_node is radial composite and vector (user right click on a tangent)
 			{
 				ValueNode_Composite::Handle blinepoint=NULL;
 				std::set<Node*>::iterator iter;
@@ -324,7 +324,7 @@ Action::BLinePointTangentSplitRadius::set_param(const synfig::String& name, cons
 		ValueNode_RadialComposite::Handle radial_value_node;
 		radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(param.get_value_node());
 		if(radial_value_node && radial_value_node->get_type()==type_vector)
-			// value_node is radial composite and vector (user rigth click on a tangent)
+			// value_node is radial composite and vector (user right click on a tangent)
 		{
 			ValueNode_Composite::Handle blinepoint;
 			std::set<Node*>::iterator iter;
@@ -423,7 +423,7 @@ Action::BLinePointTangentSplitAngle::is_candidate(const ParamList &x)
 			ValueNode_RadialComposite::Handle radial_value_node;
 			radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(x.find("value_node")->second.get_value_node());
 			if(radial_value_node && radial_value_node->get_type()==type_vector)
-				// value_node is radial composite and vector (user rigth click on a tangent)
+				// value_node is radial composite and vector (user right click on a tangent)
 			{
 				ValueNode_Composite::Handle blinepoint=NULL;
 				std::set<Node*>::iterator iter;
@@ -462,7 +462,7 @@ Action::BLinePointTangentSplitAngle::set_param(const synfig::String& name, const
 		ValueNode_RadialComposite::Handle radial_value_node;
 		radial_value_node=ValueNode_RadialComposite::Handle::cast_dynamic(param.get_value_node());
 		if(radial_value_node && radial_value_node->get_type()==type_vector)
-			// value_node is radial composite and vector (user rigth click on a tangent)
+			// value_node is radial composite and vector (user right click on a tangent)
 		{
 			ValueNode_Composite::Handle blinepoint;
 			std::set<Node*>::iterator iter;

--- a/synfig-studio/src/synfigapp/actions/valuedescbonelink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescbonelink.cpp
@@ -196,7 +196,7 @@ Action::ValueDescBoneLink::prepare()
 		{
 			ValueNode_BoneLink::Handle bone_link_node = ValueNode_BoneLink::Handle::cast_dynamic(value_desc.get_value_node());
 			if (bone_link_node) {
-				// add bone into existant BoneLink
+				// add bone into existent BoneLink
 				Action::Handle action = ValueNodeStaticListInsert::create();
 				action->set_param("canvas", get_canvas());
 				action->set_param("canvas_interface", get_canvas_interface());

--- a/synfig-studio/src/synfigapp/actions/valuedescconvert.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescconvert.cpp
@@ -116,7 +116,7 @@ Action::ValueDescConvert::is_candidate(const ParamList &x)
 		ValueDesc value_desc=x.find("value_desc")->second.get_value_desc();
 		if(!value_desc)
 			return false;
-		// Don't allow to export lower and upper boundaries of the WidhtPoint
+		// Don't allow to export lower and upper boundaries of the WidthPoint
 		if(value_desc.parent_is_linkable_value_node()
 			&& value_desc.get_parent_value_node()->get_name()=="composite"
 			&& value_desc.get_parent_value_node()->get_type()==type_width_point

--- a/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
@@ -121,7 +121,7 @@ Action::ValueDescExport::is_candidate(const ParamList &x)
 		{
 			return false;
 		}
-	// Don't allow to export lower and upper boundaries of the WidhtPoint
+	// Don't allow to export lower and upper boundaries of the WidthPoint
 		if(value_desc.parent_is_linkable_value_node()
 			&& value_desc.get_parent_value_node()->get_name()=="composite"
 			&& value_desc.get_parent_value_node()->get_type()==type_width_point

--- a/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
@@ -363,7 +363,7 @@ Action::ValueDescLink::prepare()
 	if(value_desc_list.begin()->parent_is_linkable_value_node())
 		current_scalar=value_desc_list.begin()->get_scalar();
 	bool found_inverse(false);
-	// Check if we are dealing the case of linking differnt types of tangents
+	// Check if we are dealing the case of linking different types of tangents
 	for(iter=value_desc_list.begin();iter!=value_desc_list.end();++iter)
 	{
 		ValueDesc& v_desc(*iter);
@@ -374,7 +374,7 @@ Action::ValueDescLink::prepare()
 			if(v_desc.get_index() == 4 || v_desc.get_index() == 5)
 			{
 				synfig::Real iter_scalar=v_desc.get_scalar();
-				// Let's compare the sign  of scalar of the value node witht the current one
+				// Let's compare the sign  of scalar of the value node with the current one
 				// and remember if a change of sign is seen.
 				if(iter_scalar*current_scalar < 0) // if they have different signs
 				{
@@ -395,7 +395,7 @@ Action::ValueDescLink::prepare()
 		}
 	}
 	// found_inverse =  true only if all they are tangents and some are inversed tangents
-	//Noe let's loop throug all the value desc
+	//Now let's loop through all the value desc
 	for(iter=value_desc_list.begin();iter!=value_desc_list.end();++iter)
 	{
 		ValueDesc& value_desc(*iter);
@@ -501,7 +501,7 @@ Action::ValueDescLink::prepare()
 				add_action_front(action);
 			}
 		} // found inverse
-		else // Not found inverse so do a regualr link
+		else // Not found inverse so do a regular link
 		{
 			//Let's connect the link value node to the value node
 			Action::Handle action(Action::create("ValueDescConnect"));

--- a/synfig-studio/src/synfigapp/actions/valuenodeconstunsetstatic.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuenodeconstunsetstatic.cpp
@@ -91,7 +91,7 @@ Action::ValueNodeConstUnSetStatic::is_candidate(const ParamList &x)
 		value_node = value_desc.get_value_node();
 	else
 		value_node = x.find("value_node")->second.get_value_node();
-	// Don't allow to unset static to lower and upper boundaries of the WidhtPoint
+	// Don't allow to unset static to lower and upper boundaries of the WidthPoint
 	if(value_desc.parent_is_linkable_value_node()
 		&& value_desc.get_parent_value_node()->get_name()=="composite"
 		&& value_desc.get_parent_value_node()->get_type()==type_width_point

--- a/synfig-studio/src/synfigapp/actions/valuenodedynamiclistloop.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuenodedynamiclistloop.cpp
@@ -125,7 +125,7 @@ Action::ValueNodeDynamicListLoop::set_param(const synfig::String& name, const Ac
 		value_node=ValueNode_DynamicList::Handle::cast_dynamic(value_desc.get_parent_value_node());
 		if (!value_node)
 		{
-			// we didn't found a dynamic list, let's check wheter the parent is a composite
+			// we didn't found a dynamic list, let's check whether the parent is a composite
 			if(ValueNode_Composite::Handle::cast_dynamic(value_desc.get_parent_value_node()))
 			{
 				ValueNode_Composite::Handle compo(ValueNode_Composite::Handle::cast_dynamic(value_desc.get_parent_value_node()));

--- a/synfig-studio/src/synfigapp/actions/valuenodedynamiclistunloop.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuenodedynamiclistunloop.cpp
@@ -125,7 +125,7 @@ Action::ValueNodeDynamicListUnLoop::set_param(const synfig::String& name, const 
 		value_node=ValueNode_DynamicList::Handle::cast_dynamic(value_desc.get_parent_value_node());
 		if (!value_node)
 		{
-			// we didn't found a dynamic list, let's check wheter the parent is a composite
+			// we didn't found a dynamic list, let's check whether the parent is a composite
 			if(ValueNode_Composite::Handle::cast_dynamic(value_desc.get_parent_value_node()))
 			{
 				ValueNode_Composite::Handle compo(ValueNode_Composite::Handle::cast_dynamic(value_desc.get_parent_value_node()));

--- a/synfig-studio/src/synfigapp/blineconvert.cpp
+++ b/synfig-studio/src/synfigapp/blineconvert.cpp
@@ -330,7 +330,7 @@ int tessellate_curves(const std::vector<cpindex> &inds, const std::vector<Point>
 		if(j->error < 0)
 		{
 			//get the stepsize etc. for the number of points in here
-			unsigned int n = j->curind - j2->curind + 1; //thats the number of points in the span
+			unsigned int n = j->curind - j2->curind + 1; //that's the number of points in the span
 			unsigned int k, kend, i0, i3;
 			//so reset the right chunk
 
@@ -488,7 +488,7 @@ synfigapp::BLineConverter::operator()(std::list<synfig::BLinePoint>  &blinepoint
 		break_tangents.push_back(0);
 
 		// loop through the curvatures; in each continuous run of
-		// curvatures that exceed the tolerence, find the one with the
+		// curvatures that exceed the tolerance, find the one with the
 		// sharpest curvature and add its index to the list of indices
 		// at which to split tangents
 		for (i = 1; i < curvature.size()-1; ++i)

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -532,7 +532,7 @@ CanvasInterface::generate_param_list(const ValueDesc &value_desc)
 		// into the param_list and then export the canvas, the handle
 		// will miss out of having its reference count reduced,
 		// because by the time the handle is destructed the canvas
-		// will no longer be inline.  So let's not propogate that
+		// will no longer be inline.  So let's not propagate that
 		// ValueBase any further than here.
 		if (value_desc.get_value_type() == type_canvas)
 			param_list.add("value",Canvas::LooseHandle(value_desc.get_value().get(Canvas::LooseHandle())));

--- a/synfig-studio/src/synfigapp/canvasinterface.h
+++ b/synfig-studio/src/synfigapp/canvasinterface.h
@@ -279,7 +279,7 @@ public:
 
 	//! Stage 1/4 of add_layer_to. Create new layer and assign canvas
 	synfig::Layer::Handle layer_create(const synfig::String &id, const synfig::Canvas::Handle &canvas);
-	//! Stage 2/4 of add_layer_to. Apply defaut parameters (canvas should be assigned before)
+	//! Stage 2/4 of add_layer_to. Apply default parameters (canvas should be assigned before)
 	void layer_set_defaults(const synfig::Layer::Handle &layer);
 	//! Stage 3/4 of add_layer_to. Perform action to add the layer
 	bool layer_add_action(const synfig::Layer::Handle &layer);

--- a/synfig-studio/src/synfigapp/inputdevice.h
+++ b/synfig-studio/src/synfigapp/inputdevice.h
@@ -52,7 +52,7 @@ class Settings;
 **  \see  studio::DeviceTracker
 **  \see  synfigapp::Settings
 **
-**   The represenation includes both the GDK state (e.g., mode) and synfigstudio
+**   The representation includes both the GDK state (e.g., mode) and synfigstudio
 **   state (e.g., outline color). An object of this class can be saved and
 **   restored using its Settings object, provided by the settings method.
 */

--- a/synfig-studio/src/synfigapp/pluginmanager.cpp
+++ b/synfig-studio/src/synfigapp/pluginmanager.cpp
@@ -133,7 +133,7 @@ PluginLauncher::execute( std::string script_path, const std::string& /* synfig_r
 {
 	String command = "";
 	
-	// Path to python binary can be overriden
+	// Path to python binary can be overridden
 	// with SYNFIG_PYTHON_BINARY env variable:
 	char* custom_python_binary=getenv("SYNFIG_PYTHON_BINARY");
 	if(custom_python_binary) {

--- a/synfig-studio/src/synfigapp/wplistconverter.cpp
+++ b/synfig-studio/src/synfigapp/wplistconverter.cpp
@@ -109,7 +109,7 @@ WPListConverter::operator()(std::list<synfig::WidthPoint> &wp_out, const std::li
 	ek2.resize(n);
 	// Initially I insert all widthpoints with a dash set to true
 	// Why?: dash=true means that the widthpoint has to be discarded later
-	// Only setting dash to false will validate the widhtpoint based on the
+	// Only setting dash to false will validate the widthpoint based on the
 	// error rules.
 	for(i=0; i<n; i++)
 		work_out[i]=WidthPoint(norm_distances[i], widths[i], WidthPoint::TYPE_INTERPOLATE, WidthPoint::TYPE_INTERPOLATE, true);


### PR DESCRIPTION
Found via `codespell -q 3 -L ,ang,ba,childs,eiter,forse,objext,pevent,shouldbe,thru,uint,unselect,vertexes --skip="./synfig-studio/po,./synfig-core/po,/synfig-core/m4,./synfig-osx/,./gtkmm-osx,./bugs,.*.eps,*.sif"`