### PR TITLE
fixes: #830 Entry filename extension now corresponds to the selected target

### DIFF
--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -223,13 +223,11 @@ RenderSettings::set_entry_filename()
 		else
 			filename+=" ("+canvas->get_name()+')';
 	}
-
-	filename += ".avi";
-
+	
 	try
 	{
 		if(!comboboxtext_target.get_active_row_number())
-			entry_filename.set_text((filename));
+			entry_filename.set_text((filename +".avi"));
 		// in case the file was saved and loaded again then .ext should be according to target
 		else on_comboboxtext_target_changed();
 	}

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -100,7 +100,7 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 		target_names.push_back(iter->first);
 	}
 	comboboxtext_target.set_active(0);
-	comboboxtext_target.signal_changed().connect(sigc::mem_fun(this, &RenderSettings::set_entry_filename));
+	comboboxtext_target.signal_changed().connect(sigc::mem_fun(this, &RenderSettings::on_comboboxtext_target_changed));
 
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
 	dialogPadding->set_padding(12, 12, 12, 12);
@@ -213,11 +213,7 @@ void
 RenderSettings::set_entry_filename()
 {
 	String filename(filename_sans_extension(canvas_interface_->get_canvas()->get_file_name()));
-	//a map containing (target and corresponding .ext)
-	std::map<std::string,std::string> ext = {{"bmp",".bmp"}, {"cairo_png",".png"},{"dv",".dv"},
-					{"ffmpeg",".avi"},{"gif",".gif"},{"imagemagick",".png"}, {"jpeg",".jpg"},
-					{"magick++",".gif"},{"mng",".mng"},{"openexr",".exr"},{"png",".png"},
-					{"png-spritesheet",".png"},{"ppm",".ppm"}, {"yuv420p",".yuv"}, {"libav",".avi"}};
+
 	// if this isn't the root canvas, append (<canvasname>) to the filename
 	etl::handle<synfig::Canvas> canvas = canvas_interface_->get_canvas();
 	if (!canvas->is_root())
@@ -227,35 +223,41 @@ RenderSettings::set_entry_filename()
 		else
 			filename+=" ("+canvas->get_name()+')';
 	}
-	
-	int i = comboboxtext_target.get_active_row_number();
-	//if auto is selected then append .avi and function will return at next if
-	if(!i)
-	{
-		filename += ".avi";
 
-		try
-		{
+	filename += ".avi";
+
+	try
+	{
+		if(!comboboxtext_target.get_active_row_number())
 			entry_filename.set_text((filename));
-		}
-		catch(...)
-		{
-			synfig::warning("Averted crash!");
-			entry_filename.set_text("output.avi");
-		}
+		// in case the file was saved and loaded again then .ext should be according to target
+		else on_comboboxtext_target_changed();
 	}
-	
-	//if it was auto function will return else proceed to append corresponding filename .ext
+	catch(...)
+	{
+		synfig::warning("Averted crash!");
+		entry_filename.set_text("output.avi");
+	}
+}
+
+void
+RenderSettings::on_comboboxtext_target_changed()
+{
+	std::map<std::string,std::string> ext = {{"bmp",".bmp"}, {"cairo_png",".png"},{"dv",".dv"},
+					{"ffmpeg",".avi"},{"gif",".gif"},{"imagemagick",".png"}, {"jpeg",".jpg"},
+					{"magick++",".gif"},{"mng",".mng"},{"openexr",".exr"},{"png",".png"},
+					{"png-spritesheet",".png"},{"ppm",".ppm"}, {"yuv420p",".yuv"}, {"libav",".avi"}};
+	int i = comboboxtext_target.get_active_row_number();
 	if (i < 0 || i >= (int)target_names.size()) return;
 	if (target_name == target_names[i]) return;
 	auto itr = ext.find(target_names[i]); 
     // check if target_name is there in map
     if(itr != ext.end())
 	{
-		filename = filename.substr(0,filename.find_last_of('.'))+itr->second;
-		entry_filename.set_text(filename);
+		String filename = entry_filename.get_text();
+		entry_filename.set_text(filename.substr(0,filename.find_last_of('.'))+itr->second);
 	}
-	set_target(target_names[i]);	
+	set_target(target_names[i]);
 }
 
 void


### PR DESCRIPTION
Fixes #830 
I merged the two function as per the https://github.com/synfig/synfig/issues/830#issuecomment-494469045
@morevnaproject please review the changes and suggest any possible improvements