### PR TITLE
Update autotools files

### DIFF
--- a/ETL/bootstrap.sh
+++ b/ETL/bootstrap.sh
@@ -1,13 +1,17 @@
-#! /bin/sh
+#!/bin/sh
 
 set -e
 
-AUTORECONF=`command -v autoreconf || true`
-if test -z $AUTORECONF; then
+AUTORECONF=`command -v autoreconf || true` #if don't set true, script fails with no messages
+if [ -z $AUTORECONF ]; then
         echo "*** No autoreconf found, please install it ***"
         exit 1
 fi
 
 
 rm -f aclocal.m4
+
+echo "running autoreconf..."
 autoreconf --install --force
+
+echo "Done! Please run ./configure now."

--- a/ETL/configure.ac
+++ b/ETL/configure.ac
@@ -1,7 +1,7 @@
 # $Id$
 
 # -- I N I T --------------------------------------------------
-AC_PREREQ(2.59)
+AC_PREREQ(2.60)
 AC_INIT([Extended Template Library],[1.3.11],[https://github.com/synfig/synfig/issues],[ETL])
 AC_REVISION
 

--- a/synfig-core/bootstrap.sh
+++ b/synfig-core/bootstrap.sh
@@ -50,5 +50,4 @@ sed 's/itlocaledir = $(prefix)\/$(DATADIRNAME)\/locale/itlocaledir = $(datarootd
 # -- force didn't work under MacOS
 mv -f po/Makefile.in.in.tmp po/Makefile.in.in
 
-
 echo "Done! Please run ./configure now."

--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -2,7 +2,7 @@
 
 # -- I N I T --------------------------------------------------
 
-AC_PREREQ([2.59])
+AC_PREREQ([2.60])
 AC_INIT([Synfig Core],[1.3.11],[https://github.com/synfig/synfig/issues],[synfig])
 AC_REVISION()
 
@@ -13,11 +13,16 @@ AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([nostdinc subdir-objects])
 AM_MAINTAINER_MODE
 
-AC_LIBLTDL_CONVENIENCE
-AC_SUBST(INCLTDL)
-AC_SUBST(LIBLTDL)
+LT_CONFIG_LTDL_DIR([libltdl])
+
+LT_INIT([dlopen, win32-dll, disable-static])
+AC_SUBST(LIBTOOL_DEPS)
+
+LTDL_INIT([convenience])
 
 AC_DEFINE(LT_SCOPE,[extern],[LibLTDL is linked statically])
+
+AC_CONFIG_MACRO_DIRS([m4])
 
 # -- V A R I A B L E S ----------------------------------------
 
@@ -28,7 +33,6 @@ SYNFIGLIB_DIR=${libdir}/synfig
 # -- P R O G R A M S ------------------------------------------
 
 AC_PROG_CC
-AC_GNU_SOURCE
 AC_PROG_CXX
 AC_PROG_CPP
 AC_PROG_CXXCPP
@@ -59,14 +63,6 @@ AC_ARG_ENABLE(g5opt,
 ])
 
 AC_WIN32_QUIRKS
-
-AC_LIBTOOL_WIN32_DLL
-AC_LIBTOOL_DLOPEN
-AC_DISABLE_STATIC
-AC_ENABLE_SHARED
-AC_PROG_LIBTOOL
-AC_SUBST(LIBTOOL_DEPS)
-AC_LIBTOOL_PATCH
 
 dnl
 dnl dynamic linker

--- a/synfig-core/m4/subs.m4
+++ b/synfig-core/m4/subs.m4
@@ -228,18 +228,3 @@ esac
 
 
 ])
-
-AC_DEFUN([AC_LIBTOOL_PATCH],
-[
-
-if [[ "$LIBTOOL_PATCH_SED""x" != "x" ]] ; then {
-    printf "Patching libtool... "
-    cat libtool | sed "$LIBTOOL_PATCH_SED" > libtool2
-    rm libtool
-    mv libtool2 libtool
-    chmod +x libtool
-    AC_MSG_RESULT([patched])
-} fi ;
-
-
-])

--- a/synfig-studio/bootstrap.sh
+++ b/synfig-studio/bootstrap.sh
@@ -2,19 +2,22 @@
 
 set -e
 
-AUTORECONF=`command -v autoreconf || true`
-if test -z $AUTORECONF; then
+AUTORECONF=`command -v autoreconf || true` #if don't set true, script fails with no messages
+if [ -z $AUTORECONF ]; then
         echo "*** No autoreconf found, please install it ***"
         exit 1
 fi
 
 INTLTOOLIZE=`command -v intltoolize || true`
-if test -z $INTLTOOLIZE; then
+if [ -z $INTLTOOLIZE ]; then
         echo "*** No intltoolize found, please install the intltool package ***"
         exit 1
 fi
 
+echo "running autopoint..."
 autopoint --force
+
+echo "running autoreconf..."
 AUTOPOINT='intltoolize --automake --copy' autoreconf --force --install --verbose
 
 # WORKAROUND 2013-08-15:
@@ -26,7 +29,9 @@ AUTOPOINT='intltoolize --automake --copy' autoreconf --force --install --verbose
 # TODO: Drop this hack, and bump our intltool version requiement once the issue
 #       is fixed in intltool
 
+echo "patching po/Makefile.in.in..."
 sed 's/itlocaledir = $(prefix)\/$(DATADIRNAME)\/locale/itlocaledir = $(datarootdir)\/locale/' < po/Makefile.in.in > po/Makefile.in.in.tmp
+# -- force didn't work under MacOS
 mv -f po/Makefile.in.in.tmp po/Makefile.in.in
 
 echo "Done! Please run ./configure now."

--- a/synfig-studio/configure.ac
+++ b/synfig-studio/configure.ac
@@ -2,7 +2,7 @@
 
 # -- I N I T --------------------------------------------------
 
-AC_PREREQ([2.59])
+AC_PREREQ([2.60])
 AC_INIT([Synfig Studio],[1.3.11],[https://github.com/synfig/synfig/issues],[synfigstudio])
 AC_REVISION()
 
@@ -14,6 +14,11 @@ AC_CANONICAL_HOST
 
 AM_INIT_AUTOMAKE([subdir-objects])
 AM_MAINTAINER_MODE
+
+LT_INIT([dlopen, win32-dll, disable-static])
+AC_SUBST(LIBTOOL_DEPS)
+
+AC_CONFIG_MACRO_DIRS([m4])
 
 # -- V A R I A B L E S ----------------------------------------
 
@@ -30,7 +35,6 @@ LOCALEDIR=[${prefix}/${DATADIRNAME}/locale]
 # -- P R O G R A M S ------------------------------------------
 
 AC_PROG_CC
-AC_GNU_SOURCE
 AC_PROG_CXX
 AC_PROG_CPP
 AC_PROG_CXXCPP
@@ -59,14 +63,6 @@ AC_ARG_ENABLE(g5opt,[
 ])
 
 AC_WIN32_QUIRKS
-
-AC_LIBTOOL_WIN32_DLL
-AC_LIBTOOL_DLOPEN
-AC_DISABLE_STATIC
-AC_ENABLE_SHARED
-AC_PROG_LIBTOOL
-AC_SUBST(LIBTOOL_DEPS)
-AC_LIBTOOL_PATCH
 
 ## AM_GLIB_GNU_GETTEXT([external])
 IT_PROG_INTLTOOL([0.35.0])

--- a/synfig-studio/m4/subs.m4
+++ b/synfig-studio/m4/subs.m4
@@ -225,18 +225,3 @@ esac
 
 
 ])
-
-AC_DEFUN([AC_LIBTOOL_PATCH],
-[
-
-if [[ "$LIBTOOL_PATCH_SED""x" != "x" ]] ; then {
-    printf "Patching libtool... "
-    cat libtool | sed "$LIBTOOL_PATCH_SED" > libtool2
-    rm libtool
-    mv libtool2 libtool
-    chmod +x libtool
-    AC_MSG_RESULT([patched])
-} fi ;
-
-
-])


### PR DESCRIPTION
Minor update to less warnings. Autoconf 2.60 is already 11 years old, so I think there is no problem here.
http://git.savannah.gnu.org/gitweb/?p=autoconf.git