### PR TITLE
Add incremental build for cmake autobuild

### DIFF
--- a/2-build-cmake.sh
+++ b/2-build-cmake.sh
@@ -8,6 +8,7 @@
 # -r = Release build
 # -n = Don't write the run-portable.sh to the out dir
 # -j NUMBER = Set parallel make jobs (1 <= NUMBER <= 999) (standard is 1)
+# -i = Enable incremental build (disables the clean_build_dir, gen_dir_structure and the build_images steps). Before using this option, you will have to build Synfig Studio on time without this option on the selected build mode
 # -p = Only print out the current active build settings and exit
 # --data-prefix = The installed Synfig Studio looks for it's data (icons, sounds, etc) in [DATA_PREFIX]/share/. This option sets a custom DATA_PREFIX. (Standard is the out directory)
 #


### PR DESCRIPTION
**Change description:**
Currently, the 2-build-cmake.sh script doesn't support incremental builds (that means to rebuild only the changed files).
This commit adds the option "-i" which disables the steps of deleting the old build path, creating the build folders and rendering the .sif icons with synfig. This option can be useful for developers, whose want to test Synfig Studio, after some code changes. With that option it's not necessary to rebuild the entire Synfig Studio. Only the changed files will be rebuild. That saves a lot off time.

**Limitations:**
The new "-i" option can only be used, if Synfig Studio is already build as a non incremental build (with 2-build-cmake.sh) at the selected build mode (build mode = debug or release).