### PR TITLE
Cov 308605

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_compselect.cpp
+++ b/synfig-studio/src/gui/widgets/widget_compselect.cpp
@@ -116,7 +116,7 @@ Widget_CompSelect::set_selected_instance(etl::loose_handle<studio::Instance> x)
 			set_active(i);
 		} else {
 			synfig::warning("Can't set selected instance! (already closed?)");
-			iter = studio::App::instance_list.begin();
+			return;
 		}
 	}
 	else

--- a/synfig-studio/src/gui/widgets/widget_compselect.cpp
+++ b/synfig-studio/src/gui/widgets/widget_compselect.cpp
@@ -111,7 +111,7 @@ Widget_CompSelect::set_selected_instance(etl::loose_handle<studio::Instance> x)
 		for(i=0,iter=studio::App::instance_list.begin();iter!=studio::App::instance_list.end() && ((*iter)!=x);iter++,i++)
 			;
 
-		if (*iter==x) 
+		if (iter != studio::App::instance_list.end())
 		{
 			set_active(i);
 		} else {

--- a/synfig-studio/src/gui/widgets/widget_compselect.cpp
+++ b/synfig-studio/src/gui/widgets/widget_compselect.cpp
@@ -116,7 +116,7 @@ Widget_CompSelect::set_selected_instance(etl::loose_handle<studio::Instance> x)
 			set_active(i);
 		} else {
 			synfig::warning("Can't set selected instance! (already closed?)");
-			return;
+			x.reset();
 		}
 	}
 	else


### PR DESCRIPTION
Fix Coverity issue cov#308605

Maybe we should just use `std::find()` instead of `for(i=0,iter=studio::App::instance_list.begin();iter!=studio::App::instance_list.end() && ((*iter)!=x);iter++,i++)`