### PR TITLE
remove an unneeded mutex wrapper

### DIFF
--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -101,18 +101,7 @@ using namespace synfig;
 static etl::reference_counter synfig_ref_count_(0);
 Main *Main::instance = NULL;
 
-class GeneralIOMutexHolder {
-private:
-	Mutex mutex;
-	bool initialized;
-public:
-	GeneralIOMutexHolder(): initialized(true) { }
-	~GeneralIOMutexHolder() { initialized = false; }
-	void lock() { if (initialized) mutex.lock(); }
-	void unlock() { if (initialized) mutex.unlock(); }
-};
-
-GeneralIOMutexHolder general_io_mutex;
+Mutex general_io_mutex;
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -101,7 +101,7 @@ using namespace synfig;
 static etl::reference_counter synfig_ref_count_(0);
 Main *Main::instance = NULL;
 
-Mutex general_io_mutex;
+static Mutex general_io_mutex;
 
 /* === P R O C E D U R E S ================================================= */
 


### PR DESCRIPTION
Its only "initialized" property is totally useless, so Mutex class can be used directly