### PR TITLE
applies/forces etl:: namespace for ETL library

### DIFF
--- a/ETL/ETL/_angle.h
+++ b/ETL/ETL/_angle.h
@@ -47,7 +47,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 // ========================================================================
 /*!	\class	angle	_angle.h	ETL/angle
@@ -473,7 +473,7 @@ public:
 }; // END of class angle::tan
 // inline angle::tan::operator angle::value_type()const { return get(); }
 
-_ETL_END_NAMESPACE
+};
 
 //#include <iostream>
 

--- a/ETL/ETL/_bezier.h
+++ b/ETL/ETL/_bezier.h
@@ -60,7 +60,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template<typename V,typename T> class bezier;
 
@@ -984,7 +984,7 @@ private:
 	}
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_bezier_angle.h
+++ b/ETL/ETL/_bezier_angle.h
@@ -38,7 +38,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 /*
 template <>
@@ -97,7 +97,7 @@ public:
 };
 */
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_boxblur.h
+++ b/ETL/ETL/_boxblur.h
@@ -37,7 +37,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template<typename T1,typename T2> void
 hbox_blur(T1 pen,int w, int h, int length, T2 outpen)
@@ -247,7 +247,7 @@ box_blur(T1 begin,T1 end, int blursize,T2 outpen)
 	hbox_blur(begin,size.x,size.y,blursize,outpen); vbox_blur(begin,size.x,size.y,blursize,outpen);
 }
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_bspline.h
+++ b/ETL/ETL/_bspline.h
@@ -40,7 +40,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template <class T, class K=float, class C=affine_combo<T,K>, class D=distance_func<T> >
 class bspline : public std::unary_function<K,T>
@@ -229,7 +229,7 @@ public:
 	}
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* -- F U N C T I O N S ----------------------------------------------------- */
 

--- a/ETL/ETL/_calculus.h
+++ b/ETL/ETL/_calculus.h
@@ -41,7 +41,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template <typename T>
 class derivative : public std::unary_function<typename T::argument_type,typename T::result_type>
@@ -95,7 +95,7 @@ public:
 	}
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_clock_base.h
+++ b/ETL/ETL/_clock_base.h
@@ -41,7 +41,7 @@ inline void sleep(int i) { Sleep(i*1000); }
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 inline void yield() { sleep(0); }
 
@@ -126,7 +126,7 @@ public:
 	}
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_clock_gettimeofday.h
+++ b/ETL/ETL/_clock_gettimeofday.h
@@ -38,7 +38,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class clock_desc_gettimeofday
 {
@@ -128,7 +128,7 @@ protected:
 	{ return timestamp((int)floor(x), (int)((x-floor(x))/precision()+0.5)); }
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_clock_system.h
+++ b/ETL/ETL/_clock_system.h
@@ -55,7 +55,7 @@ extern time_t _time(time_t *);
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class clock_desc_sys_clock
 {
@@ -140,7 +140,7 @@ protected:
 	{ return (timestamp)(x+(value_type)0.5f); }
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_clock_win32hpcount.h
+++ b/ETL/ETL/_clock_win32hpcount.h
@@ -43,7 +43,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class clock_desc_win32hpcount
 {
@@ -90,7 +90,7 @@ protected:
 	{ return (timestamp)(x/precision()); }
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_fastangle.h
+++ b/ETL/ETL/_fastangle.h
@@ -46,7 +46,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 /*! ========================================================================
 ** \class	fastangle
@@ -425,7 +425,7 @@ public:
 	value_type get()const { return (value_type)_fastangle_tan_table[v.data()&( (1<<ETL_FASTANGLE_LOOKUP_RES)-1)]; }
 }; // END of class fastangle::tan
 
-_ETL_END_NAMESPACE
+};
 
 template <>
 struct affine_combo<etl::fastangle,float>

--- a/ETL/ETL/_fixed.h
+++ b/ETL/ETL/_fixed.h
@@ -62,33 +62,33 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 // Forward declarations
 template<typename T, unsigned int FIXED_BITS> class fixed_base;
 //template<> class fixed_base<char>;
 
-_ETL_END_NAMESPACE
+};
 
-_STD_BEGIN_NAMESPACE
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> abs(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> cos(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> cosh(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> exp(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> log(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> log10(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> pow(const _ETL::fixed_base<T,FIXED_BITS>&, int);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> pow(const _ETL::fixed_base<T,FIXED_BITS>&, const T&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> pow(const _ETL::fixed_base<T,FIXED_BITS>&,
-					const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> pow(const _ETL::fixed_base<T,FIXED_BITS>&, const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> sin(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> sinh(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> sqrt(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> tan(const _ETL::fixed_base<T,FIXED_BITS>&);
-template<typename T, unsigned int FIXED_BITS> _ETL::fixed_base<T,FIXED_BITS> tanh(const _ETL::fixed_base<T,FIXED_BITS>&);
-_STD_END_NAMESPACE
-_ETL_BEGIN_NAMESPACE
+namespace std {
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> abs(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> cos(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> cosh(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> exp(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> log(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> log10(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> pow(const etl::fixed_base<T,FIXED_BITS>&, int);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> pow(const etl::fixed_base<T,FIXED_BITS>&, const T&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> pow(const etl::fixed_base<T,FIXED_BITS>&,
+					const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> pow(const etl::fixed_base<T,FIXED_BITS>&, const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> sin(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> sinh(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> sqrt(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> tan(const etl::fixed_base<T,FIXED_BITS>&);
+template<typename T, unsigned int FIXED_BITS> etl::fixed_base<T,FIXED_BITS> tanh(const etl::fixed_base<T,FIXED_BITS>&);
+};
+namespace etl {
 
 /*! ========================================================================
 ** \class	fixed_base
@@ -548,92 +548,92 @@ fixed_base<T,FIXED_BITS>::round()const
 
 typedef fixed_base<ETL_FIXED_TYPE,ETL_FIXED_BITS> fixed;
 
-_ETL_END_NAMESPACE
+};
 
-_STD_BEGIN_NAMESPACE
+namespace std {
 
 template <class T,unsigned int FIXED_BITS>
-inline _ETL::fixed_base<T,FIXED_BITS>
-ceil(const _ETL::fixed_base<T,FIXED_BITS> &rhs)
+inline etl::fixed_base<T,FIXED_BITS>
+ceil(const etl::fixed_base<T,FIXED_BITS> &rhs)
 { return rhs.ceil(); }
 
 template <class T,unsigned int FIXED_BITS>
-_ETL::fixed_base<T,FIXED_BITS>
-floor(const _ETL::fixed_base<T,FIXED_BITS> &rhs)
+etl::fixed_base<T,FIXED_BITS>
+floor(const etl::fixed_base<T,FIXED_BITS> &rhs)
 { return rhs.floor(); }
 
 template <class T,unsigned int FIXED_BITS>
-_ETL::fixed_base<T,FIXED_BITS>
-round(const _ETL::fixed_base<T,FIXED_BITS> &rhs)
+etl::fixed_base<T,FIXED_BITS>
+round(const etl::fixed_base<T,FIXED_BITS> &rhs)
 { return rhs.round(); }
 
 template <class T,unsigned int FIXED_BITS>
-_ETL::fixed_base<T,FIXED_BITS>
-abs(const _ETL::fixed_base<T,FIXED_BITS> &rhs)
-{ return rhs<_ETL::fixed_base<T,FIXED_BITS>(0)?-rhs:rhs; }
+etl::fixed_base<T,FIXED_BITS>
+abs(const etl::fixed_base<T,FIXED_BITS> &rhs)
+{ return rhs<etl::fixed_base<T,FIXED_BITS>(0)?-rhs:rhs; }
 
-_STD_END_NAMESPACE
+};
 
 /*
 template <class T,unsigned int FIXED_BITS, typename U> bool
-operator==(const _ETL::fixed_base<T,FIXED_BITS>& lhs, const _ETL::fixed_base<T,FIXED_BITS>& rhs)
+operator==(const etl::fixed_base<T,FIXED_BITS>& lhs, const etl::fixed_base<T,FIXED_BITS>& rhs)
 { return lhs.data()==rhs.data(); }
 
 template <class T,unsigned int FIXED_BITS, typename U> bool
-operator!=(const _ETL::fixed_base<T,FIXED_BITS>& lhs, const _ETL::fixed_base<T,FIXED_BITS>& rhs)
+operator!=(const etl::fixed_base<T,FIXED_BITS>& lhs, const etl::fixed_base<T,FIXED_BITS>& rhs)
 { return lhs.data()!=rhs.data(); }
 
 template <class T,unsigned int FIXED_BITS, typename U> bool
-operator>(const _ETL::fixed_base<T,FIXED_BITS>& lhs, const _ETL::fixed_base<T,FIXED_BITS>& rhs)
+operator>(const etl::fixed_base<T,FIXED_BITS>& lhs, const etl::fixed_base<T,FIXED_BITS>& rhs)
 { return lhs.data()>rhs.data(); }
 
 template <class T,unsigned int FIXED_BITS, typename U> bool
-operator<(const _ETL::fixed_base<T,FIXED_BITS>& lhs, const _ETL::fixed_base<T,FIXED_BITS>& rhs)
+operator<(const etl::fixed_base<T,FIXED_BITS>& lhs, const etl::fixed_base<T,FIXED_BITS>& rhs)
 { return lhs.data()<rhs.data(); }
 
 template <class T,unsigned int FIXED_BITS, typename U> bool
-operator>=(const _ETL::fixed_base<T,FIXED_BITS>& lhs, const _ETL::fixed_base<T,FIXED_BITS>& rhs)
+operator>=(const etl::fixed_base<T,FIXED_BITS>& lhs, const etl::fixed_base<T,FIXED_BITS>& rhs)
 { return lhs.data()>=rhs.data(); }
 
 template <class T,unsigned int FIXED_BITS, typename U> bool
-operator<=(const _ETL::fixed_base<T,FIXED_BITS>& lhs, const _ETL::fixed_base<T,FIXED_BITS>& rhs)
+operator<=(const etl::fixed_base<T,FIXED_BITS>& lhs, const etl::fixed_base<T,FIXED_BITS>& rhs)
 { return lhs.data()<=rhs.data(); }
 */
 
 
 #if defined(__GNUC__) && __GNUC__ == 3
 template <class T,unsigned int FIXED_BITS, typename U> U
-operator*(const U &a,const _ETL::fixed_base<T,FIXED_BITS> &b)
+operator*(const U &a,const etl::fixed_base<T,FIXED_BITS> &b)
 	{ return a*static_cast<double>(b); }
 
 template <class T,unsigned int FIXED_BITS, typename U> U
-operator/(const U &a,const _ETL::fixed_base<T,FIXED_BITS> &b)
+operator/(const U &a,const etl::fixed_base<T,FIXED_BITS> &b)
 	{ return a/static_cast<double>(b); }
 
 template <class T,unsigned int FIXED_BITS, typename U> U
-operator+(const U &a,const _ETL::fixed_base<T,FIXED_BITS> &b)
+operator+(const U &a,const etl::fixed_base<T,FIXED_BITS> &b)
 	{ return a+static_cast<double>(b); }
 
 template <class T,unsigned int FIXED_BITS, typename U> U
-operator-(const U &a,const _ETL::fixed_base<T,FIXED_BITS> &b)
+operator-(const U &a,const etl::fixed_base<T,FIXED_BITS> &b)
 	{ return a-static_cast<double>(b); }
 
 
 /*
 inline const float &
-operator*=(float &a,const _ETL::fixed &b)
+operator*=(float &a,const etl::fixed &b)
 	{ a*=(float)b; return a; }
 
 inline const float &
-operator/=(float &a,const _ETL::fixed &b)
+operator/=(float &a,const etl::fixed &b)
 	{ a/=(float)b; return a; }
 
 inline const float &
-operator-=(float &a,const _ETL::fixed &b)
+operator-=(float &a,const etl::fixed &b)
 	{ a-=(float)b; return a; }
 
 inline const float &
-operator+=(float &a,const _ETL::fixed &b)
+operator+=(float &a,const etl::fixed &b)
 	{ a+=(float)b; return a; }
 */
 #endif

--- a/ETL/ETL/_gaussian.h
+++ b/ETL/ETL/_gaussian.h
@@ -38,7 +38,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template<typename T> void
 gaussian_blur_5x5_(T pen,int w, int h,
@@ -309,7 +309,7 @@ gaussian_blur(T begin, T end,int w)
 	gaussian_blur(begin,size.x,size.y,w,w);
 }
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_handle.h
+++ b/ETL/ETL/_handle.h
@@ -51,7 +51,7 @@
 #endif
 
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 // Forward Declarations
 template <class T> class handle;
@@ -831,7 +831,7 @@ template <class T>		   bool operator<(const loose_handle<T>&  lhs,const T*				 r
 template <class T>		   bool operator<(const T*				  lhs,const handle<T>&		 rhs) { return (lhs		 <rhs.get());  }
 template <class T>		   bool operator<(const T*				  lhs,const loose_handle<T>& rhs) { return (lhs		 <rhs.get());  }
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_hermite.h
+++ b/ETL/ETL/_hermite.h
@@ -37,7 +37,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 /*
 template <typename T>
@@ -165,7 +165,7 @@ public:
 	}
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_misc.h
+++ b/ETL/ETL/_misc.h
@@ -34,7 +34,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template<typename I, typename T> inline I
 binary_find(I begin, I end, const T& value)
@@ -92,7 +92,7 @@ inline int ceil_to_int(const double x) { return static_cast<int>(ceil(x)); }
 inline int floor_to_int(const float x) { return static_cast<int>(floor(x)); }
 inline int floor_to_int(const double x) { return static_cast<int>(floor(x)); }
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_mutex_null.h
+++ b/ETL/ETL/_mutex_null.h
@@ -32,7 +32,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class mutex_null
 {
@@ -62,7 +62,7 @@ public:
 	void unlock_mutex(){}
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_mutex_pthreads.h
+++ b/ETL/ETL/_mutex_pthreads.h
@@ -41,7 +41,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class mutex
 {
@@ -107,7 +107,7 @@ public:
 	}
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_mutex_pthreads_simple.h
+++ b/ETL/ETL/_mutex_pthreads_simple.h
@@ -36,7 +36,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class mutex
 {
@@ -57,7 +57,7 @@ public:
 	};
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_mutex_win32.h
+++ b/ETL/ETL/_mutex_win32.h
@@ -40,7 +40,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class mutex
 {
@@ -73,7 +73,7 @@ public:
 	{ ReleaseMutex(handle); }
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_pen.h
+++ b/ETL/ETL/_pen.h
@@ -40,7 +40,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template<typename T>
 class generic_pen_row_iterator
@@ -403,7 +403,7 @@ public:
 	}
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_rect.h
+++ b/ETL/ETL/_rect.h
@@ -39,7 +39,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template<typename T>
 class rect
@@ -270,7 +270,7 @@ void rects_merge(List &list)
 	rects_merge(list, std::less<T>());
 }
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_ref_count.h
+++ b/ETL/ETL/_ref_count.h
@@ -38,7 +38,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class weak_reference_counter;
 
@@ -149,7 +149,7 @@ inline reference_counter::reference_counter(const weak_reference_counter &x):
 	if(counter_) (*counter_)++;
 }
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_rwlock.h
+++ b/ETL/ETL/_rwlock.h
@@ -33,7 +33,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class read_write_lock : private Mutex
 {
@@ -84,7 +84,7 @@ public:
 	{ unlock_mutex(); }
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_smach.h
+++ b/ETL/ETL/_smach.h
@@ -49,7 +49,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 /*! ========================================================================
 ** \class	smach
@@ -588,7 +588,7 @@ public:
 
 }; // END of template class smach
 
-_ETL_END_NAMESPACE
+};
 
 /* === E X T E R N S ======================================================= */
 

--- a/ETL/ETL/_smart_ptr.h
+++ b/ETL/ETL/_smart_ptr.h
@@ -38,7 +38,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template <class T>
 struct generic_deleter
@@ -356,7 +356,7 @@ template <class T> bool
 operator<(const T *lhs,const loose_smart_ptr<T> &rhs)
 	{ return (lhs<rhs.get()); }
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -101,7 +101,7 @@ extern "C" {
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 inline std::string
 vstrprintf(const char *format, va_list args)
@@ -492,7 +492,7 @@ solve_relative_path(std::string curr_path,std::string dest_path)
 }
 
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/_surface.h
+++ b/ETL/ETL/_surface.h
@@ -39,7 +39,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 class clamping
 {
@@ -539,7 +539,7 @@ public:
 	}
 
 	template<typename ReaderType, ReaderType reader(const void*, int, int)>
-	class sampler: public _ETL::sampler<accumulator_type, float, ReaderType, reader> { };
+	class sampler: public etl::sampler<accumulator_type, float, ReaderType, reader> { };
 
 	typedef sampler<accumulator_type, surface::reader_cook> sampler_cook;
 	typedef sampler<value_type, surface::reader> sampler_nocook;
@@ -577,7 +577,7 @@ public:
 		{ return (value_type)(sampler_nocook::cubic_sample(this, x, y)); }
 };
 
-_ETL_END_NAMESPACE
+};
 
 /* === T Y P E D E F S ===================================================== */
 

--- a/ETL/ETL/_trivial.h
+++ b/ETL/ETL/_trivial.h
@@ -35,7 +35,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 /*! ========================================================================
 ** \class	Trivial
@@ -133,7 +133,7 @@ public:
 	{ return !get(); }
 }; // END of template class trivial
 
-_ETL_END_NAMESPACE
+};
 
 //#include <iostream>
 

--- a/ETL/ETL/_value.h
+++ b/ETL/ETL/_value.h
@@ -55,7 +55,7 @@ public:
 	typedef	T						value_type;
 };
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 /*!	\class	value	_value.h	ETL/value
 	\brief	Abstraction of the concept of a generic value
@@ -231,7 +231,7 @@ ValueType value_cast(const value &v)
 	return *result;
 }
 
-_ETL_END_NAMESPACE
+};
 
 /* === E N D =============================================================== */
 

--- a/ETL/ETL/angle
+++ b/ETL/ETL/angle
@@ -32,9 +32,9 @@
 
 #ifdef ETL_FASTANGLE
 #include "_fastangle.h"
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 typedef fastangle angle;
-_ETL_END_NAMESPACE
+};
 #else
 # include "_angle.h"
 #endif

--- a/ETL/ETL/clock
+++ b/ETL/ETL/clock
@@ -32,20 +32,20 @@
 #ifdef HAVE_GETTIMEOFDAY
 #include "_clock_gettimeofday.h"
 #ifndef ETL_CLOCK_DEFAULT_DESC_CLASS
-#define ETL_CLOCK_DEFAULT_DESC_CLASS	_ETL::clock_desc_gettimeofday
+#define ETL_CLOCK_DEFAULT_DESC_CLASS	etl::clock_desc_gettimeofday
 #endif
 #ifndef ETL_CLOCK_REALTIME_DESC_CLASS
-#define ETL_CLOCK_REALTIME_DESC_CLASS	_ETL::clock_desc_gettimeofday
+#define ETL_CLOCK_REALTIME_DESC_CLASS	etl::clock_desc_gettimeofday
 #endif
 #endif
 
 #ifdef _WIN32
 #include "_clock_win32hpcount.h"
 #ifndef ETL_CLOCK_DEFAULT_DESC_CLASS
-#define ETL_CLOCK_DEFAULT_DESC_CLASS	_ETL::clock_desc_win32hpcount
+#define ETL_CLOCK_DEFAULT_DESC_CLASS	etl::clock_desc_win32hpcount
 #endif
 #ifndef ETL_CLOCK_REALTIME_DESC_CLASS
-#define ETL_CLOCK_REALTIME_DESC_CLASS	_ETL::clock_desc_win32hpcount
+#define ETL_CLOCK_REALTIME_DESC_CLASS	etl::clock_desc_win32hpcount
 #endif
 #endif
 
@@ -55,21 +55,21 @@
 // (Better than nothing...)
 #include "_clock_system.h"
 #ifndef ETL_CLOCK_DEFAULT_DESC_CLASS
-#define ETL_CLOCK_DEFAULT_DESC_CLASS	_ETL::clock_desc_sys_clock
+#define ETL_CLOCK_DEFAULT_DESC_CLASS	etl::clock_desc_sys_clock
 #endif
 #ifndef ETL_CLOCK_PROCTIME_DESC_CLASS
-#define ETL_CLOCK_PROCTIME_DESC_CLASS	_ETL::clock_desc_sys_clock
+#define ETL_CLOCK_PROCTIME_DESC_CLASS	etl::clock_desc_sys_clock
 #endif
 #ifndef ETL_CLOCK_REALTIME_DESC_CLASS
-#define ETL_CLOCK_REALTIME_DESC_CLASS	_ETL::clock_desc_sys_time
+#define ETL_CLOCK_REALTIME_DESC_CLASS	etl::clock_desc_sys_time
 #endif
 
 #include "_clock_base.h"
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 #if 0
-	typedef _ETL::clock_base<ETL_CLOCK_DEFAULT_DESC_CLASS> clock;
+	typedef etl::clock_base<ETL_CLOCK_DEFAULT_DESC_CLASS> clock;
 	#ifdef ETL_CLOCK_PROCTIME_DESC_CLASS
 		#define ETL_CLOCK_PROCTIME
 		typedef clock_base<ETL_CLOCK_PROCTIME_DESC_CLASS> clock_proctime;
@@ -82,20 +82,20 @@ _ETL_BEGIN_NAMESPACE
 	#endif
 
 #else
-	class clock : public _ETL::clock_base<ETL_CLOCK_DEFAULT_DESC_CLASS> { };
+	class clock : public etl::clock_base<ETL_CLOCK_DEFAULT_DESC_CLASS> { };
 	#ifdef ETL_CLOCK_PROCTIME_DESC_CLASS
 		#define ETL_CLOCK_PROCTIME
-		class clock_proctime : public _ETL::clock_base<ETL_CLOCK_PROCTIME_DESC_CLASS> { };
+		class clock_proctime : public etl::clock_base<ETL_CLOCK_PROCTIME_DESC_CLASS> { };
 	#endif
 	#ifdef ETL_CLOCK_REALTIME_DESC_CLASS
 		#define ETL_CLOCK_REALTIME
-		class clock_realtime : public _ETL::clock_base<ETL_CLOCK_REALTIME_DESC_CLASS> { };
+		class clock_realtime : public etl::clock_base<ETL_CLOCK_REALTIME_DESC_CLASS> { };
 	#else
 		#warning No realtime clock description found.
 	#endif
 #endif
 
-_ETL_END_NAMESPACE
+};
 
 //using etl::clock;
 

--- a/ETL/ETL/etl_config.h
+++ b/ETL/ETL/etl_config.h
@@ -4,29 +4,11 @@
 #include <ETL/etl_profile.h>
 #include <utility>
 
-#ifndef ETL_NAMESPACE
-# define ETL_NAMESPACE 			etl
-#endif
-
 #define ETL_DIRECTORY_SEPARATORS	"/\\"
 #define ETL_DIRECTORY_SEPARATOR0	'/'
 #define ETL_DIRECTORY_SEPARATOR1	'\\'
 
 #define ETL_DIRECTORY_SEPARATOR		ETL_DIRECTORY_SEPARATOR0
-
-#ifndef ETL_FLAG_NONAMESPACE
-# define _ETL					ETL_NAMESPACE
-# define _ETL_BEGIN_NAMESPACE	namespace _ETL {
-# define _ETL_END_NAMESPACE		};
-# define _STD_BEGIN_NAMESPACE	namespace std {
-# define _STD_END_NAMESPACE		};
-#else
-# define _ETL
-# define _ETL_BEGIN_NAMESPACE
-# define _ETL_END_NAMESPACE
-# define _STD_BEGIN_NAMESPACE
-# define _STD_END_NAMESPACE
-#endif
 
 /* If __FUNC__ is not defined,
 ** try to define it. If we cannot,

--- a/synfig-core/src/synfig/vector.h
+++ b/synfig-core/src/synfig/vector.h
@@ -475,7 +475,7 @@ abs(const synfig::Vector &rhs)
 
 #include <ETL/bezier>
 
-_ETL_BEGIN_NAMESPACE
+namespace etl {
 
 template <>
 class bezier_base<synfig::Vector,float> : public std::unary_function<float,synfig::Vector>
@@ -554,7 +554,7 @@ public:
 	}
 };
 
-_ETL_END_NAMESPACE
+};
 
 
 /* === E N D =============================================================== */


### PR DESCRIPTION
The Synfig-core makes use of “etl::” namespace directly
almost everywhere.
so I think this kind of macro useless.

'Discussed' here:
https://forums.synfig.org/t/forcing-etl-namespace/9938