### PR TITLE
remove redundant and unused function RendDesc::apply()

### DIFF
--- a/synfig-core/src/synfig/renddesc.cpp
+++ b/synfig-core/src/synfig/renddesc.cpp
@@ -51,13 +51,6 @@ using namespace synfig;
 
 /* === M E T H O D S ======================================================= */
 
-RendDesc &
-RendDesc::apply(const RendDesc &x)
-{
-	operator=(x);
-	return *this;
-}
-
 const Color &
 RendDesc::get_bg_color()const
 {

--- a/synfig-core/src/synfig/renddesc.h
+++ b/synfig-core/src/synfig/renddesc.h
@@ -152,9 +152,6 @@ public:
 	bool is_zero() const
 		{ return get_w() <= 0 || get_h() <= 0; }
 
-	//! Applies the given Render Description \x to the current one
-	RendDesc &apply(const RendDesc &x);
-
 	//! Gets the background color
 	const Color &get_bg_color()const;
 


### PR DESCRIPTION
One could simply use assignment operator;
the "apply" method implementation is just a wrapper
for the former.