### PR TITLE
Fix mem leaks in Studio

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2349,6 +2349,8 @@ App::apply_gtk_settings()
 	g_object_get (G_OBJECT (gtk_settings), "gtk-theme-name", &theme_name, NULL);
 	if ( String(theme_name) == "Adwaita" )
 		data += ".window-frame, .window-frame:backdrop { box-shadow: none; margin: 0; }\n";
+	g_free(theme_name);
+
 	if (!data.empty()) {
 		Glib::RefPtr<Gtk::CssProvider> css = Gtk::CssProvider::create();
 		try {

--- a/synfig-studio/src/gui/dialogs/about.cpp
+++ b/synfig-studio/src/gui/dialogs/about.cpp
@@ -198,6 +198,7 @@ About::About()
 
 	Gtk::Image *Logo = manage(new class Gtk::Image());
 	Logo->set(imagepath+"synfig_icon." IMAGE_EXT);
+	Logo->set_parent(*this);
 	set_logo(Logo->get_pixbuf());
 
 #ifdef SHOW_EXTRA_INFO

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -173,7 +173,6 @@ Dialog_Setup::create_system_page(PageInfo pi)
 	// System _ Units section
 	attach_label_section(pi.grid, _("Units"), row);
 	// System - 0 Timestamp
-	timestamp_menu=manage(new class Gtk::Menu());
 	attach_label(pi.grid, _("Timestamp"), ++row);
 	pi.grid->attach(timestamp_comboboxtext, 1, row, 1, 1);
 	timestamp_comboboxtext.set_hexpand(true);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -180,7 +180,6 @@ class Dialog_Setup : public Dialog_Template
 
 	synfig::Time::Format time_format;
 
-	Gtk::Menu *timestamp_menu;
 	Widget_Enum *widget_enum;
 
 	Widget_Time auto_backup_interval;

--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -98,8 +98,6 @@ Dock_Toolbox::Dock_Toolbox():
 	scrolled_window->set_border_width(2);
 	scrolled_window->show();
 
-	separator = manage(new class Gtk::HSeparator());
-
 	Widget_Defaults* widget_defaults(manage(new Widget_Defaults()));
 
 	// pack tools and default widgets

--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -100,17 +100,7 @@ Dock_Toolbox::Dock_Toolbox():
 
 	Widget_Defaults* widget_defaults(manage(new Widget_Defaults()));
 
-	// pack tools and default widgets
-	//tool_box = manage(new class Gtk::VBox(false, 2));
-	//tool_box->pack_start(*scrolled_window, Gtk::PACK_EXPAND_WIDGET|Gtk::PACK_SHRINK, 3);
-	//tool_box->pack_start(*separator, Gtk::PACK_SHRINK, 3);
-	//tool_box->pack_start(*widget_defaults, Gtk::PACK_EXPAND_WIDGET|Gtk::PACK_SHRINK, 3);
-	//tool_box->set_border_width(2);
-	//tool_box->show_all();
-
-	//add(*tool_box);
-	
-	Gtk::VPaned *tool_box_paned = manage(new class Gtk::VPaned());
+	Gtk::Paned *tool_box_paned = manage(new Gtk::Paned(Gtk::ORIENTATION_VERTICAL));
 	tool_box_paned->pack1(*scrolled_window, Gtk::PACK_EXPAND_WIDGET|Gtk::PACK_SHRINK, 3);
 	tool_box_paned->pack2(*widget_defaults, Gtk::PACK_EXPAND_WIDGET|Gtk::PACK_SHRINK, 3);
 	tool_box_paned->set_position(200);

--- a/synfig-studio/src/gui/docks/dock_toolbox.h
+++ b/synfig-studio/src/gui/docks/dock_toolbox.h
@@ -47,11 +47,6 @@
 
 /* === M A C R O S ========================================================= */
 
-// uncomment to enable the blend method selector in the tool options
-// panel for the circle and gradient tools
-//
-// #define BLEND_METHOD_IN_TOOL_OPTIONS
-
 /* === T Y P E D E F S ===================================================== */
 
 /* === C L A S S E S & S T R U C T S ======================================= */

--- a/synfig-studio/src/gui/docks/dock_toolbox.h
+++ b/synfig-studio/src/gui/docks/dock_toolbox.h
@@ -38,7 +38,6 @@
 #include <gtkmm/toolpalette.h>
 #include <gtkmm/toolitemgroup.h>
 #include <gtkmm/alignment.h>
-#include <gtkmm/separator.h>
 #include <gtkmm/table.h>
 #include <gtkmm/box.h>
 #include <synfig/string.h>
@@ -66,7 +65,6 @@ class Dock_Toolbox : public Dockable
 	friend class studio::StateManager;
 
 	Gtk::ToolItemGroup *tool_item_group;
-	Gtk::HSeparator *separator;
 	Gtk::VBox *tool_box;
 
 	std::map<synfig::String,Gtk::ToggleToolButton *> state_button_map;

--- a/synfig-studio/src/gui/docks/dockable.h
+++ b/synfig-studio/src/gui/docks/dockable.h
@@ -59,6 +59,7 @@ private:
 
 	synfig::String name_;
 	synfig::String local_name_;
+
 	Gtk::StockID stock_id_;
 	bool use_scrolled;
 

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -238,7 +238,7 @@ LayerTree::~LayerTree()
 		synfig::info("LayerTree::~LayerTree(): Deleted");
 }
 
-Gtk::Widget*
+void
 LayerTree::create_layer_tree()
 {
 	const LayerTreeStore::Model model;
@@ -312,18 +312,9 @@ LayerTree::create_layer_tree()
 	get_layer_tree_view().signal_event().connect(sigc::mem_fun(*this, &studio::LayerTree::on_layer_tree_event));
 	get_layer_tree_view().signal_query_tooltip().connect(sigc::mem_fun(*this, &studio::LayerTree::on_layer_tree_view_query_tooltip));
 	get_layer_tree_view().show();
-
-	Gtk::ScrolledWindow *scroll = manage(new class Gtk::ScrolledWindow());
-	scroll->set_can_focus(true);
-	scroll->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
-	//scroll->add(get_layer_tree_view());
-	scroll->set_shadow_type(Gtk::SHADOW_ETCHED_IN);
-	scroll->show();
-
-	return scroll;
 }
 
-Gtk::Widget*
+void
 LayerTree::create_param_tree()
 {
 	//Text attributes must be the same that TimeTrackView tree's to have aligned rows
@@ -486,20 +477,11 @@ LayerTree::create_param_tree()
 	columnzero_label->signal_draw().connect(sigc::mem_fun(*this, &studio::LayerTree::on_param_column_label_tree_draw));
 	get_param_tree_view().show();
 
-	Gtk::ScrolledWindow *scroll = manage(new class Gtk::ScrolledWindow());
-	scroll->set_can_focus(true);
-	scroll->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
-	//scroll->add(get_param_tree_view());
-	scroll->set_shadow_type(Gtk::SHADOW_ETCHED_IN);
-	scroll->show();
-
 	// To get the initial style
 	param_tree_style_changed = true;
 	param_tree_header_height = 0;
 
 	//column_time_track->set_visible(false);
-
-	return scroll;
 }
 
 void

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -156,17 +156,9 @@ LayerTree::LayerTree():
 
 	layer_tree_view_->signal_key_press_event().connect(sigc::mem_fun(*this, &LayerTree::onKeyPress));
 
-	//Gtk::HPaned* hpaned(manage(new Gtk::HPaned()));
-	//hpaned->show();
-	//attach(*hpaned, 0, 3, 0, 1, Gtk::EXPAND|Gtk::FILL,Gtk::EXPAND|Gtk::FILL, 0, 0);
-	//attach(*create_layer_tree(), 0, 3, 0, 1, Gtk::EXPAND|Gtk::FILL,Gtk::EXPAND|Gtk::FILL, 0, 0);
-
 	create_layer_tree();
 	create_param_tree();
 
-	//hpaned->pack1(*create_layer_tree(),false,false);
-	//hpaned->pack2(*create_param_tree(),true,false);
-	//hpaned->set_position(200);
 	hbox=manage(new Gtk::HBox());
 
 	attach(*hbox, 0, 1, 1, 2, Gtk::FILL|Gtk::SHRINK, Gtk::SHRINK, 0, 0);
@@ -180,7 +172,6 @@ LayerTree::LayerTree():
 	layer_amount_adjustment_->signal_value_changed().connect(sigc::mem_fun(*this, &studio::LayerTree::on_amount_value_changed));
 
 	Gtk::Image *icon;
-	//Gtk::IconSize iconsize(Gtk::IconSize::from_name("synfig-small_icon"));
 	Gtk::IconSize iconsize(Gtk::ICON_SIZE_SMALL_TOOLBAR);
 
 	SMALL_BUTTON(button_raise,"gtk-go-up","Raise");

--- a/synfig-studio/src/gui/trees/layertree.h
+++ b/synfig-studio/src/gui/trees/layertree.h
@@ -165,8 +165,8 @@ private:
 
 private:
 
-	Gtk::Widget* create_layer_tree();
-	Gtk::Widget* create_param_tree();
+	void create_layer_tree();
+	void create_param_tree();
 	//! Update the param_tree_view header height.
 	/*! \return true if param_tree_header_height updated, else false
 	*/

--- a/synfig-studio/src/gui/widgets/widget_link.cpp
+++ b/synfig-studio/src/gui/widgets/widget_link.cpp
@@ -60,11 +60,13 @@ Widget_Link::Widget_Link(const std::string &tlt_inactive, const std::string &tlt
 	Glib::RefPtr<Gtk::IconSet> chain_icon = Gtk::IconSet::lookup_default(Gtk::StockID("synfig-utils_chain_link_off"));
 	Glib::RefPtr<Gdk::Pixbuf> chain_icon_pixbuff = chain_icon->render_icon_pixbuf(context, (Gtk::IconSize)-1);
 	Glib::RefPtr<Gdk::Pixbuf> chain_icon_pixbuff_scaled = chain_icon_pixbuff->scale_simple(16, 32, Gdk::INTERP_BILINEAR);
-	icon_off_ = manage(new Gtk::Image(chain_icon_pixbuff_scaled));
+	// not use manage() otherwise the not-shown icon at exit wouldn't be deleted...
+	icon_off_ = new Gtk::Image(chain_icon_pixbuff_scaled);
 
 	chain_icon = Gtk::IconSet::lookup_default(Gtk::StockID("synfig-utils_chain_link_on"));
 	chain_icon_pixbuff_scaled = chain_icon->render_icon_pixbuf(context, (Gtk::IconSize)-1)->scale_simple(16, 32, Gdk::INTERP_BILINEAR);
-	icon_on_ = manage(new Gtk::Image(chain_icon_pixbuff_scaled));
+	// not use manage() otherwise the not-shown icon at exit wouldn't be deleted...
+	icon_on_ = new Gtk::Image(chain_icon_pixbuff_scaled);
 
 	icon_off_->set_padding(0,0);
 	icon_on_->set_padding(0,0);
@@ -79,6 +81,8 @@ Widget_Link::Widget_Link(const std::string &tlt_inactive, const std::string &tlt
 }
 
 Widget_Link::~Widget_Link() {
+	delete icon_on_;
+	delete icon_off_;
 }
 
 }

--- a/synfig-studio/src/gui/widgets/widget_vector.cpp
+++ b/synfig-studio/src/gui/widgets/widget_vector.cpp
@@ -61,13 +61,8 @@ Widget_Vector::Widget_Vector():
 	x_adjustment(Gtk::Adjustment::create(0,-100000000,100000000,0.05,0.05,0)),
 	y_adjustment(Gtk::Adjustment::create(0,-100000000,100000000,0.05,0.05,0))
 {
-	Gtk::Label *label;
 	int width_chars = 5;
 
-	label=manage(new class Gtk::Label("X:"));
-	label->set_alignment(0, 0.5);
-	//pack_start(*label, Gtk::PACK_SHRINK);
-	
 	entry_x=manage(new class Gtk::Entry());
 	entry_x->set_width_chars(width_chars);
 	entry_x->signal_changed().connect(sigc::mem_fun(*this,&studio::Widget_Vector::on_entry_x_changed));
@@ -86,11 +81,6 @@ Widget_Vector::Widget_Vector():
 	distance_x->signal_value_changed().connect(sigc::mem_fun(*this,&studio::Widget_Vector::on_value_changed));
 	pack_start(*distance_x, Gtk::PACK_EXPAND_WIDGET);
 
-	label=manage(new class Gtk::Label("Y:"));
-	label->set_alignment(0, 0.5);
-	label->show();
-	//pack_start(*label, Gtk::PACK_SHRINK);
-	
 	entry_y=manage(new class Gtk::Entry());
 	entry_y->set_width_chars(width_chars);
 	entry_y->signal_changed().connect(sigc::mem_fun(*this,&studio::Widget_Vector::on_entry_y_changed));


### PR DESCRIPTION
In my journey to convert coded-dialogs to GtkBuilder ones, I am testing for memory leaks with Valgrind.
I found these memory leaks and fixed them.
