### PR TITLE
fix #257 let Gtk::Entry & TextView key handlers have priority

### DIFF
--- a/synfig-studio/src/gui/mainwindow.cpp
+++ b/synfig-studio/src/gui/mainwindow.cpp
@@ -46,6 +46,8 @@
 #include <gtkmm/menubar.h>
 #include <gtkmm/box.h>
 
+#include <gtkmm/textview.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -225,6 +227,18 @@ MainWindow::toggle_show_menubar()
 		toggling_show_menubar = true;
 	}
 	App::enable_mainwin_menubar = toggling_show_menubar;
+}
+
+bool
+MainWindow::on_key_press_event(GdkEventKey* key_event)
+{
+	Gtk::Widget * widget = get_focus();
+	if (widget && (dynamic_cast<Gtk::Editable*>(widget) || dynamic_cast<Gtk::TextView*>(widget))) {
+		bool handled = gtk_window_propagate_key_event(this->gobj(), key_event);
+		if (handled)
+			return true;
+	}
+	return Gtk::Window::on_key_press_event(key_event);
 }
 
 void

--- a/synfig-studio/src/gui/mainwindow.h
+++ b/synfig-studio/src/gui/mainwindow.h
@@ -63,6 +63,8 @@ namespace studio {
 		Glib::RefPtr<Gtk::ToggleAction> toggle_menubar;
 		bool toggling_show_menubar;
 
+	protected:
+		virtual bool on_key_press_event(GdkEventKey *key_event);
 
 	public:
 		MainWindow();


### PR DESCRIPTION
over Accel keys.

Inspired by :
https://github.com/GNOME/gimp/blob/732852a471f466fb0e19ab30a11710f060700c06/app/widgets/gimpwindow.c#L159

Thanks to Jehan and mitch from #gimp IRC channel