### PR TITLE
remove unused/unneeded localization function

### DIFF
--- a/synfig-studio/src/gui/localization.h
+++ b/synfig-studio/src/gui/localization.h
@@ -46,9 +46,6 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-inline const char* synfiggui_localize(const char *x)
-	{ return _(x); }
-
 /* === E N D =============================================================== */
 
 #endif


### PR DESCRIPTION
just using _() / gettext() already defined in this header file