### PR TITLE
Don't load modules for trivial operations in cli

### DIFF
--- a/synfig-core/src/tool/main.cpp
+++ b/synfig-core/src/tool/main.cpp
@@ -267,15 +267,17 @@ int main(int argc, char* argv[])
 		parser.process_debug_options();
 #endif
 
-		// TODO: Optional load of main only if needed. i.e. not needed to display help
+		// Trivial info options -----------------------------------------------
+		parser.process_trivial_info_options();
+
 		// Synfig Main initialization needs to be after verbose and
 		// before any other where it's used
 		Progress p(binary_path.c_str());
 		//synfig::Main synfig_main(binary_path.parent_path().string(), &p);
 		synfig::Main synfig_main(get_absolute_path(binary_path + "/.."), &p);
 
-        // Info options -----------------------------------------------
-        parser.process_info_options();
+		// Info options -----------------------------------------------
+		parser.process_info_options();
 
 		std::list<Job> job_list;
 

--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -365,8 +365,7 @@ void SynfigCommandLineParser::process_settings_options()
 				   << SynfigToolGeneralOptions::instance()->get_threads() << std::endl;
 }
 
-//void OptionsProcessor::process_info_options()
-void SynfigCommandLineParser::process_info_options()
+void SynfigCommandLineParser::process_trivial_info_options()
 {
 	if (show_help)
 	{
@@ -425,6 +424,11 @@ void SynfigCommandLineParser::process_info_options()
 		throw (SynfigToolException(SYNFIGTOOL_HELP));
 	}
 
+}
+
+//void OptionsProcessor::process_info_options()
+void SynfigCommandLineParser::process_info_options()
+{
 	if (show_layers_list)
 	{
 		synfig::Layer::Book::iterator iter =

--- a/synfig-core/src/tool/optionsprocessor.h
+++ b/synfig-core/src/tool/optionsprocessor.h
@@ -96,6 +96,11 @@ public:
 	/// verbose, quiet, threads, benchmarks
 	void process_settings_options();
 
+	/// Trivial information options
+	/// Options that will only display information
+	/// and don't need to load modules
+	void process_trivial_info_options();
+
 	/// Information options
 	/// Options that will only display information
 	void process_info_options();


### PR DESCRIPTION
Create a new method SynfigCommandLineParser::process_trivial_info_options
specifically for process trivial operations from command line that don't need
synfig::Main
This new method is called before synfig::Main instantiation

Fix #281