### PR TITLE
Fix regressions tests

### DIFF
--- a/autobuild/synfigrenderer-regression-test.sh
+++ b/autobuild/synfigrenderer-regression-test.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-set -x 
+set -x
 
-ls
+export PATH="${TRAVIS_BUILD_DIR}/_production/build/bin:$PATH"
+which synfig
 
 ccache -s # show ccache stats
 git clone --depth 1 https://github.com/synfig/synfig-tests-regressions.git

--- a/autobuild/synfigrenderer-regression-test.sh
+++ b/autobuild/synfigrenderer-regression-test.sh
@@ -2,6 +2,8 @@
 
 set -x 
 
+ls
+
 ccache -s # show ccache stats
 git clone --depth 1 https://github.com/synfig/synfig-tests-regressions.git
 bash ./synfig-tests-regressions/test-rendering.sh results

--- a/autobuild/synfigrenderer-regression-test.sh
+++ b/autobuild/synfigrenderer-regression-test.sh
@@ -5,5 +5,5 @@ set -x
 export PATH="${TRAVIS_BUILD_DIR}/_production/build/bin:$PATH"
 
 ccache -s # show ccache stats
-git clone https://github.com/synfig/synfig-tests-regressions.git
-bash ./synfig-tests-regressions/test-rendering.sh results
+git clone https://gitlab.com/synfig/synfig-tests.git
+bash ./synfig-tests/test-rendering.sh results

--- a/autobuild/synfigrenderer-regression-test.sh
+++ b/autobuild/synfigrenderer-regression-test.sh
@@ -3,8 +3,7 @@
 set -x
 
 export PATH="${TRAVIS_BUILD_DIR}/_production/build/bin:$PATH"
-which synfig
 
 ccache -s # show ccache stats
-git clone --depth 1 https://github.com/synfig/synfig-tests-regressions.git
+git clone https://github.com/synfig/synfig-tests-regressions.git
 bash ./synfig-tests-regressions/test-rendering.sh results


### PR DESCRIPTION
- Now using tests repository hosted on GitLab - https://gitlab.com/synfig/synfig-tests/
- The script now providing actual information about failed tests against **current** code