### PR TITLE
fix mod_ffmpeg with cmake build

### DIFF
--- a/synfig-core/src/modules/mod_ffmpeg/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_ffmpeg/CMakeLists.txt
@@ -1,5 +1,10 @@
 add_library(mod_ffmpeg MODULE "")
 
+if (UNIX)
+	add_definitions(-DHAVE_FORK -DHAVE_PIPE -DHAVE_WAITPID)
+	add_definitions(-DHAVE_SYS_WAIT_H)
+endif (UNIX)
+
 target_sources(mod_ffmpeg
     PUBLIC
         "${CMAKE_CURRENT_LIST_DIR}/main.cpp"


### PR DESCRIPTION
With cmake, the autotools definitions are not implicitly defined. This led to
the windows codepath being used everywhere, causing breakage on unix.

The necessary definitions have been manually added to the cmake build.