### PR TITLE
Fix source comment typos and some comment formatting

### DIFF
--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -1020,7 +1020,7 @@ Svg_parser::build_linearGradient(xmlpp::Element* root,LinearGradient* data,SVGMa
 				mtx2=data->transform;
 			}
 			//matrix transforms the gradient as a whole
-			//it does not preserve angles, so we cant' simply transform both points
+			//it does not preserve angles, so we can't simply transform both points
 			float x3, y3, k;
 			//set point (x3,y3) on the same gradient line as (x2,y2)
 			//the gradient line is perpendicular to (x1,y1)(x2,y2)

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -1055,7 +1055,7 @@ ValueNode_BLine::get_blinepoint(std::vector<ListEntry>::const_iterator current, 
 	vns=bpnext.get_vertex_setup();
 	beta01=t1.angle();
 	beta02=t2.angle();
-	// New aproaching: I calculate the needed relative change of the tangents
+	// New approach: I calculate the needed relative change of the tangents
 	// in relation to the segment that joins the next and previous vertices.
 	// Then add a compensation due to the modification relative to the mid point.
 	// If the blinepoint tangent is not split it is not needed the compensation

--- a/synfig-osx/launcher/darwin.c
+++ b/synfig-osx/launcher/darwin.c
@@ -842,7 +842,7 @@ ddxProcessArgument (int argc, char *argv[], int i)
 
     if (!strcmp( argv[i], "-fakemouse2" ) ) {
         if ( i == argc-1 ) {
-            FatalError( "-fakemouse2 must be followed by a modifer list\n" );
+            FatalError( "-fakemouse2 must be followed by a modifier list\n" );
         }
 	darwinFakeMouse2Mask = DarwinParseModifierList(argv[i+1]);
         return 2;
@@ -850,7 +850,7 @@ ddxProcessArgument (int argc, char *argv[], int i)
 
     if (!strcmp( argv[i], "-fakemouse3" ) ) {
         if ( i == argc-1 ) {
-            FatalError( "-fakemouse3 must be followed by a modifer list\n" );
+            FatalError( "-fakemouse3 must be followed by a modifier list\n" );
         }
 	darwinFakeMouse3Mask = DarwinParseModifierList(argv[i+1]);
         return 2;

--- a/synfig-studio/config/package
+++ b/synfig-studio/config/package
@@ -1,5 +1,5 @@
 #! /bin/csh -ef
-# this file was orignally distributed by Apple in the Developer Tools package 
+# this file was originally distributed by Apple in the Developer Tools package 
 #it is distributed under the Apple Open Source License
 set version=0.2
 set prog = `/usr/bin/basename $0`
@@ -76,7 +76,7 @@ while ( $#argv > 0 )
 		breaksw
 	    endif
 	case -traditional:
-            echo useing standard tar
+            echo using standard tar
 	    set usetar
             unset usegnutar
 	    unset usepax

--- a/synfig-studio/plugins/lottie-exporter/common/Canvas.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Canvas.py
@@ -72,7 +72,7 @@ class Canvas:
 
     def get_def(self, key):
         """
-        Given a key, returns the corresponding child definded in the canvas
+        Given a key, returns the corresponding child defined in the canvas
         """
         if key in self.defs.keys():
             return self.defs[key]

--- a/synfig-studio/plugins/lottie-exporter/common/Param.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Param.py
@@ -54,7 +54,7 @@ class Param:
         
     def reset(self):
         """
-        This function will be called when any of the entities of the paramter
+        This function will be called when any of the entities of the parameter
         are changed. This should be internally called, but for now compromising
         """
         self.PATH_GENERATED = 0
@@ -566,7 +566,7 @@ class Param:
 
     def get_value(self, frame):
         """
-        Public method to get the value of the paramter at a given frame
+        Public method to get the value of the parameter at a given frame
         """
         ret = self.__get_value(frame)
         # Convert into Lottie format

--- a/synfig-studio/plugins/lottie-exporter/common/misc.py
+++ b/synfig-studio/plugins/lottie-exporter/common/misc.py
@@ -332,7 +332,7 @@ def parse_time(time_in_str):
 def get_vector(waypoint):
     """
     Given a waypoint, it parses the string vector into Vector class defined in
-    this convertor
+    this converter
 
     Args:
         waypoint (lxml.etree._Element) : Synfig format waypoint

--- a/synfig-studio/plugins/lottie-exporter/layers/group.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/group.py
@@ -296,7 +296,7 @@ def flip_time(time):
 def gen_hold_waypoints(deactive_time, layer, anim_type):
     """
     Will only be used to modify opacity waypoints, and set zero values where the
-    layer is deactive
+    layer is deactivated
 
     Args:
         deactive_time (set) : Range of time when the layer will be deactive

--- a/synfig-studio/plugins/lottie-exporter/layers/rotate_layer.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/rotate_layer.py
@@ -17,7 +17,7 @@ def gen_layer_rotate(lottie, layer):
 
     Args:
         lottie (dict) : Will store the transform properties in lottie format
-        layer  (common.Layer.Layer) : Tranform properties in Synfig format
+        layer  (common.Layer.Layer) : Transform properties in Synfig format
 
     Returns:
         (None)

--- a/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
@@ -289,7 +289,7 @@ def calc_tangent(animated, lottie, i):
         # See properties/multiDimenstionalKeyframed.py for more details
         # del lottie["e"]
 
-        # If the number of points is decresing, then hold interpolation should
+        # If the number of points is decreasing, then hold interpolation should
         # have reverse effect. The value should instantly decrease and remain
         # same for the rest of the interval
         if animated.attrib["type"] == "points":

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/outline.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/outline.py
@@ -96,7 +96,7 @@ def gen_bline_outline(lottie, bline_point):
     r_tip1.update_frame_window(window)
     r_tip1.animate_without_path("bool")
 
-    # Animaing the homogenous width
+    # Animating the homogeneous width
     homo_width.update_frame_window(window)
     homo_width.animate_without_path("bool")
 
@@ -334,7 +334,7 @@ def synfig_outline(bline, st_val, origin_p, outer_width_p, sharp_cusps_p, expand
         if length > EPSILON:
             div_length = 1.0 / length
 
-        # Might not need /3 for the tangents genereated finally - VERY IMPORTANT
+        # Might not need /3 for the tangents generated finally - VERY IMPORTANT
         # Make the outline
         pt = curve.derivative(CUSP_TANGENT_ADJUST) / 3
         n = 0.0

--- a/synfig-studio/plugins/lottie-exporter/settings.py
+++ b/synfig-studio/plugins/lottie-exporter/settings.py
@@ -95,11 +95,11 @@ def init():
     file_name = {}
     global num_precomp
     num_precomp = Count()
-    global OUTLINE_GROW     # outline grow param of group layer
+    global OUTLINE_GROW    # outline grow param of group layer
     OUTLINE_GROW = [0]
-    global layer_count  # Will only count the layers which do not have there desc set
+    global layer_count  # will only count the layers which do not have there desc set
     layer_count = Count()
-    global canvas_count # will only cound the canvas which do not have any names
+    global canvas_count # will only count the canvas which do not have any names
     canvas_count = Count()
     global controller_count # counts the slider and point effects controller
     controller_count = Count()

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3114,9 +3114,9 @@ App::dialog_save_file(const std::string &title, std::string &filename, std::stri
 			set_file_version(synfig::ReleaseVersion(file_type_enum->get_value()));
 
 		// add file extension according to file filter selected by user if he doesn't type file extension in
-		// file name entry. Right now it still detetes file extension from file name entry, if extension is one
+		// file name entry. Right now it still detects file extension from file name entry, if extension is one
 		// of .sif, sifz and sfg, it will be used otherwise, saved file format will depend on selected file filter.
-		// It should be improved by changing file extension according to selted file type filter, such as:
+		// It should be improved by changing file extension according to set file type filter, such as:
 		// dialog->property_filter().signal_changed().connect(sigc::mem_fun(*this, &App::on_save_dialog_filter_changed));
 		filename = dialog->get_filename();
 

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -207,7 +207,7 @@ class studio::StateDraw_Context : public sigc::trackable
 	Gtk::SpinButton localthres_spin;
 	Gtk::HBox localthres_box;
 
-	// golbal threshold
+	// global threshold
 	Gtk::RadioButton globalthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> globalthres_adj;
 	Gtk::SpinButton globalthres_spin;
@@ -2112,7 +2112,7 @@ StateDraw_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real 
 
 		debug_show_vertex_list(0, vertex_list, "continuous vertices", -1);
 
-		// \todo reenable or delete this section
+		// \todo re-enable or delete this section
 		int i=100;
 		for(bool done=false;!done && i<30;i++)
 		{

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -209,7 +209,7 @@ class studio::StateLasso_Context : public sigc::trackable
 	Gtk::SpinButton localthres_spin;
 	Gtk::HBox localthres_box;
 
-	// golbal threshold
+	// global threshold
 	Gtk::RadioButton globalthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> globalthres_adj;
 	Gtk::SpinButton globalthres_spin;
@@ -2125,7 +2125,7 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 
 		debug_show_vertex_list(0, vertex_list, "continuous vertices", -1);
 
-		// \todo reenable or delete this section
+		// \todo re-enable or delete this section
 		int i=100;
 		for(bool done=false;!done && i<30;i++)
 		{

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -473,7 +473,7 @@ StateWidth_Context::AdjustWidth(handle<Duckmatic::Bezier> c, float t, Real mult,
 					if(wplist)
 					{
 						// ... has a bline valid and is the same as the bline
-						// we found for the bezier previously catched...
+						// we found for the bezier previously caught...
 						ValueNode::Handle bline(wplist->get_bline());
 						if(bline && (bline==bezier_bline))
 						{

--- a/synfig-studio/src/synfigapp/vectorizer/centerlineadjustments.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlineadjustments.cpp
@@ -52,7 +52,7 @@ ContourFamily *currContourFamily;
 //--------------------------------------
 
 // EXPLANATION:  The raw skeleton data obtained from StraightSkeletonizer
-// class need to be grouped in joints and sequences before proceding with
+// class need to be grouped in joints and sequences before proceeding with
 // conversion in quadratics - which works on single sequences.
 
 // NOTE: Due to maxHeight, we have to assume that a single SkeletonGraph can

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinecolors.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinecolors.cpp
@@ -109,28 +109,21 @@ static synfig::Point3 firstInkChangePosition(
 // Currently in use only on colormaps
 
 // Summary: It is better to test the color to be assigned to the strokes
-// to check
-// sequences * before * convert them to TStroke (since you lose part
-// of the original grip
-// to the line). You specify a number of 'taste points' of the broken line
-// equidistant from each other,
-// on which the value of the corresponding pixel input is taken. If
-// identifies a change
-// of color, the sequence breaking procedure is launched: yes
-// identifies the point
-// of breaking, and the sequence s is blocked there; a new one is built
+// to check sequences *before* converting them to TStroke (since you lose part
+// of the original grip to the line). You specify a number of 'taste points'
+// of the broken line equidistant from each other, on which the value of
+// the corresponding pixel input is taken. If it identifies a change of
+// color, the sequence breaking procedure is launched: 'yes'
+// identifies the point of breaking, and the sequence 's' is blocked there;
+// a new one is built
 // sequence newSeq e
-// sampleColor is re-launched (ras, newSeq, sOpposite). Sequences between two points
-// of breaking up
-// are inserted into the vector 'globals-> singleSequences'.
+// sampleColor is re-launched (ras, newSeq, sOpposite). Sequences between two
+// points of breaking up are inserted into the vector 'globals-> singleSequences'.
 // In the case of circular sequences there is a small change: the first point of
-// splitting
-// * only redefines * the s-node, without introducing new sequences.
-// The sequence sOpposite, 'inverse' of s, remains and becomes 'forward-oriented'
-// after updating
-// of the tail.
-// Notice that the break nodes are entered with the signature
-// 'SAMPLECOLOR_SIGN'.
+// splitting *only redefines* the s-node, without introducing new sequences.
+// The sequence sOpposite, 'inverse' of 's', remains and becomes 'forward-oriented'
+// after updating of the tail.
+// Notice that the break nodes are entered with the signature 'SAMPLECOLOR_SIGN'.
 // NOTE: The J-S 'upper' graph structure is not altered in here.
 // Eventualm. to do outside.
 
@@ -149,9 +142,10 @@ static void sampleColor(
   std::vector<double> params;
 
   // Meanwhile, ensure each point belong to ras. Otherwise, typically an error
-  // occured in the thinning process and it's better avoid sampling procedure. Only
-  // exception, when
-  // a point has x==rsurface.get_w() || y==rsurface.get_h(); that is accepted.
+  // occurred in the thinning process and it's better avoid sampling procedure.
+  // Only exception, when a point has:
+  // x==rsurface.get_w() || y==rsurface.get_h();
+  // That is accepted.
   synfig::rendering::SurfaceResource::LockRead<synfig::rendering::SurfaceSW> lock( ras->rendering_surface ); 
 	const Surface &rsurface = lock->get_surface(); 
   {
@@ -231,9 +225,8 @@ static void sampleColor(
   }
 
   // NOTE: Extremities of a sequence are considered unreliable: they typically
-  // happen
-  //       to be junction points shared between possibly different-colored
-  //       strokes.
+  // happen to be junction points shared between possibly different-colored
+  // strokes.
 
   // Find first and last extremity-free sampled points
   synfig::Point3 first(*currGraph->getNode(seq.m_head));

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinepolygonizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinepolygonizer.cpp
@@ -216,7 +216,7 @@ Signaturemap::Signaturemap(const Handle &ras, int threshold)
 
 //--------------------------------------------------------------------------
 
-// Minority check for amiguous turning directions
+// Minority check for ambiguous turning directions
 inline bool getMinorityCheck(const Signaturemap &ras, int x, int y) 
 {
   // Assumes (x,y) is ambiguous case: 2 immediate surrounding pixels are white

--- a/synfig-studio/src/synfigapp/vectorizer/centerlineskeletonizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlineskeletonizer.cpp
@@ -83,7 +83,7 @@ public:
   typedef std::list<ContourNode *> IndexColumn;
 
   std::vector<IndexColumn>
-      m_columns;  //!< Countours set by 'column identifier'.
+      m_columns;  //!< Contours set by 'column identifier'.
   std::vector<int>
       m_identifiers;  //!< Column identifiers by original contour index.
 
@@ -1428,7 +1428,7 @@ inline void Event::processVertexEvent() {
   m_generator->m_next->m_prev   = newLeftNode;
   newLeftNode->m_next           = m_generator->m_next;
 
-  // Assign and calculate the new nodes' informations
+  // Assign and calculate the new nodes' information
   newLeftNode->m_edge  = m_generator->m_edge;
   newRightNode->m_edge = m_coGenerator->m_edge;
 

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
@@ -542,7 +542,7 @@ void SequenceConverter::lengthOfTriplet(unsigned int i, Length &len)
   synfig::Point3 B = middleAddedSequence[i + 1];
   synfig::Point3 C = middleAddedSequence[i + 2];
 
-  // We assume that this convertion is faithful, avoiding length penalty
+  // We assume that this conversion is faithful, avoiding length penalty
   len.l = 0;
   double d = tdistance(B, C - A, A);
   
@@ -605,7 +605,7 @@ bool SequenceConverter::parametrize(unsigned int a, unsigned int b)
 //==========================================================================
 
 //------------------------
-//    CP construcion
+//    CP construction
 //------------------------
 
 // NOTE: Check my thesis for variable meanings (int_ stands for 'integral').

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinevectorizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinevectorizer.cpp
@@ -124,7 +124,7 @@ std::vector< etl::handle<synfig::Layer> > VectorizerCore::centerlineVectorize(et
 
   // step 4
   // The raw skeleton data obtained from StraightSkeletonizer
-  // class need to be grouped in joints and sequences before proceding further
+  // class need to be grouped in joints and sequences before proceeding further
   studio::organizeGraphs(skeletons, globals);
 
 //   // junctionRecovery(polygons);   //Da' problemi per maxThickness<inf...

--- a/synfig-studio/src/synfigapp/vectorizer/polygonizerclasses.h
+++ b/synfig-studio/src/synfigapp/vectorizer/polygonizerclasses.h
@@ -229,7 +229,7 @@ public:
   // Further node properties
   bool m_concave;             //!< Whether the node represents a concave angle.
   unsigned int m_attributes,  //!< Bitwise signatures of this node
-      m_updateTime,  //!< \a Algoritmic time in which the node was updated.
+      m_updateTime,  //!< \a Algorithmic time in which the node was updated.
       m_ancestor,  //!< Index of the original node from which this one evolved.
       m_ancestorContour;  //!< Contour index of the original node from which
                           //! this one evolved.
@@ -343,7 +343,7 @@ public:
   Sequence() : m_graphHolder(0) {}
   ~Sequence() {}
 
-  // Impose a property dependant only on the extremity we consider first
+  // Impose a property dependent only on the extremity we consider first
   // - so that the same sequence is not considered twice when head and tail
   // are exchanged
   bool isForward() const 

--- a/synfig-studio/src/synfigapp/vectorizer/vectorizerparameters.h
+++ b/synfig-studio/src/synfigapp/vectorizer/vectorizerparameters.h
@@ -43,12 +43,12 @@ namespace studio {
 /*!
   \brief    Provides a base container for vectorization options.
 
-  \details  All vectorization options and informations are passed from higher
+  \details  All vectorization options and information are passed from higher
             (like \p VectorizerPopup) to lower layers (\p VectorizerCore) of
             the vectorization process inside a \p VectorizerConfiguration
   variable.
             This typically includes vectorization modes, various sensitivity and
-            accuracy parameters, and post-processing informations. This class
+            accuracy parameters, and post-processing information. This class
             merely acts as a base parameters container (although no pure virtual
             method is present) - meaning that every vectorization method
   inherits


### PR DESCRIPTION
Found via `codespell -q 3 -L ,ang,ba,childs,eiter,forse,objext,pevent,shouldbe,thru,uint,unselect,vertexes --skip="./synfig-studio/po,./synfig-core/po,/synfig-core/m4,./synfig-osx/,./gtkmm-osx,./bugs,.*.eps,*.sif"`