### PR TITLE
Fixed CMake build errors and improved the automatical build tool

### DIFF
--- a/2-build-cmake.sh
+++ b/2-build-cmake.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # = Usage: =
-#    ./build-cmake.sh [OPTIONS]
+#    ./2-build-cmake.sh [OPTIONS]
 #
 # OPTIONS
 # -d = Debug build (standard)

--- a/2-build-cmake.sh
+++ b/2-build-cmake.sh
@@ -8,7 +8,8 @@
 # -r = Release build
 # -n = Don't write the run-portable.sh to the out dir
 # -j NUMBER = Set parallel make jobs (1 <= NUMBER <= 999) (standard is 1)
-# -i = Enable incremental build (disables the clean_build_dir, gen_dir_structure and the build_images steps). Before using this option, you will have to build Synfig Studio on time without this option on the selected build mode
+# -i = Enable incremental build (disables the clean_build_dir, gen_dir_structure and the build_images steps). Before using this option, you will have to build Synfig Studio on time without this option on the selected build mode (or use the --rerender option)
+# --rerender = Rerender the images (even if incremental build is activated)
 # -p = Only print out the current active build settings and exit
 # --data-prefix = The installed Synfig Studio looks for it's data (icons, sounds, etc) in [DATA_PREFIX]/share/. This option sets a custom DATA_PREFIX. (Standard is the out directory)
 #

--- a/autobuild/build-cmake-common.sh
+++ b/autobuild/build-cmake-common.sh
@@ -11,6 +11,7 @@ print_build_settings_and_exit="false"
 write_portable_run_code="true"
 synfigstudio_data_prefix=""
 incremental_build="false"
+rerender_images="false"
 
 # Define build dirs
 cmake_debug_build_dir="_debug"
@@ -87,12 +88,12 @@ build_synfig_studio() {
     synfig_studio_make_cmd="make build_images"
     
     # Don't rerender the images if incremental is activated
-    if [ "$incremental_build" == "true" ]
+    if [ "$incremental_build" == "true" ] || [ ! "$rerender_images" == "true" ]
         then
             synfig_studio_make_cmd="make synfigstudio"
     fi
     
-    # Configure, make and install
+    # Configure, make, render images and install
     cmake "$cmake_build_type_option" "$cmake_prefix_option" "$cmake_install_prefix_option" "$cmake_cxxflags_option" "$cmake_dataprefix_option" ../../synfig-studio/ && $make_build_command && run_command_in_outenv "$synfig_studio_make_cmd" && make install
     
     if [ $? -ne 0 ]
@@ -118,18 +119,15 @@ clean_build_dir() {
 }
 
 gen_dir_structure() {
-    if [ "$incremental_build" == "false" ]
-        then
-            echo "Construct directory structure"
+    echo "Construct directory structure"
 
-            cd ${absolute_base_dir}
-            mkdir -p "./${cmake_build_dir}/${etl_build_dir}"
-            mkdir -p "./${cmake_build_dir}/${synfig_build_dir}"
-            mkdir -p "./${cmake_build_dir}/${synfigstudio_build_dir}"
-            mkdir -p "./${cmake_build_dir}/${out_dir}"
-            
-            echo "Constructed directory structure"
-    fi
+    cd ${absolute_base_dir}
+    mkdir -p "./${cmake_build_dir}/${etl_build_dir}"
+    mkdir -p "./${cmake_build_dir}/${synfig_build_dir}"
+    mkdir -p "./${cmake_build_dir}/${synfigstudio_build_dir}"
+    mkdir -p "./${cmake_build_dir}/${out_dir}"
+    
+    echo "Constructed directory structure"
 }
 
 get_run_cmd_prefix() {
@@ -147,6 +145,7 @@ parse_build_arguments() {
             [ $1 == "-p" ] && print_build_settings_and_exit="true"
             [ $1 == "-n" ] && write_portable_run_code="false"
             [ $1 == "-i" ] && incremental_build="true"
+            [ $1 == "--rerender" ] && rerender_images="true"
             [ $1 == "-j" ] && make_jobs_parameter=$2 && shift
             [ $1 == "--data-prefix" ] && synfigstudio_data_prefix=$2 && shift
             shift

--- a/autobuild/build-cmake-common.sh
+++ b/autobuild/build-cmake-common.sh
@@ -88,7 +88,7 @@ build_synfig_studio() {
     synfig_studio_make_cmd="make build_images"
     
     # Don't rerender the images if incremental is activated
-    if [ "$incremental_build" == "true" ] || [ ! "$rerender_images" == "true" ]
+    if [ "$incremental_build" == "true" ] && [ "$rerender_images" == "false" ]
         then
             synfig_studio_make_cmd="make synfigstudio"
     fi

--- a/synfig-studio/src/CMakeLists.txt
+++ b/synfig-studio/src/CMakeLists.txt
@@ -38,10 +38,14 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 include_directories(
     SYSTEM
-#         ${synfig_INCLUDE_DIRS}
         ${SIGCPP_INCLUDE_DIRS}
         ${GTKMM_INCLUDE_DIRS}
 )
+
+##
+## Search path for libs (needed to link with libsynfig)
+##
+link_directories(${CMAKE_PREFIX_PATH}/lib)
 
 ##
 ## Sub-directories


### PR DESCRIPTION
In the latest commit (a570f15844060c60ed3d12c31f0ec986112fa97d) the build of Synfig Studio with 2-build-cmake.sh fails with the following error (testet on Manjaro Linux): 
In the step of building the libsynfigapp the linking process (linking to libsynfig) fails because the linker can't find the library.

This commit fixes the error. It adds the output path to the search path for the linker.