### PR TITLE
Move regressions testing to separate Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ matrix:
       - ccache -s
       - ccache --set-config=compression=true
     script: ./travis.sh
-    after_script:
-      - autobuild/synfigrenderer-regression-test.sh
-      - ccache -s
 
   - os: linux
     name: "Synfig Studio Ubuntu 16.04 Xenial (CMake/Ninja)"
@@ -38,6 +35,17 @@ matrix:
       - ccache --set-config=compression=true
     script: mkdir -p build && cd build && cmake .. -GNinja && ninja
     after_script: ccache -s # show ccache stats
+
+  - os: linux
+    name: "Test render engine for regressions"
+    sudo: required
+    dist: xenial
+    cache: ccache
+    before_install: ./1-setup-linux-native.sh
+    before_script:
+      - ccache -s
+      - ccache --set-config=compression=true
+    script: ./travis.sh core && autobuild/synfigrenderer-regression-test.sh
 
   - os: osx
     name: "Synfig Studio OS X 10.10 Yosemite (Clang/Autotools/Brew)"
@@ -76,3 +84,4 @@ matrix:
   #  - env: CMAKE=true
   #  - os: osx
     - osx_image: xcode10
+    - name: "Test render engine for regressions"

--- a/travis.sh
+++ b/travis.sh
@@ -31,7 +31,12 @@ PING_LOOP_PID=$!
 # My build is using bash script, but you could build anything with this, E.g.
 # your_build_command_1 >> $BUILD_OUTPUT 2>&1
 # your_build_command_2 >> $BUILD_OUTPUT 2>&1
+if [ ! -z "$1" ] && [ "$1" = "core" ]; then
+./2-build-production.sh etl >> $BUILD_OUTPUT 2>&1
+./2-build-production.sh core >> $BUILD_OUTPUT 2>&1
+else
 ./2-build-production.sh >> $BUILD_OUTPUT 2>&1
+fi
 
 # The build finished without returning an error so dump a tail of the output
 dump_output


### PR DESCRIPTION
Re-format regression testing as separate Travis job (which is allowed to fail for now).