### PR TITLE
Allow to edit waypoints using double-click. Fixes #262.

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
@@ -723,6 +723,7 @@ CellRenderer_TimeTrack::activate_vfunc(
 	case GDK_MOTION_NOTIFY:
 		actual_time = ((double)event->motion.x - (double)cell_area.get_x())*k + (double)lower;
 		break;
+	case GDK_2BUTTON_PRESS:
 	case GDK_BUTTON_PRESS:
 	case GDK_BUTTON_RELEASE:
 		actual_time = ((double)event->button.x - (double)cell_area.get_x())*k + (double)lower;
@@ -751,6 +752,7 @@ CellRenderer_TimeTrack::activate_vfunc(
     switch(event->type) {
 	case GDK_MOTION_NOTIFY:
 		return true;
+	case GDK_2BUTTON_PRESS:
 	case GDK_BUTTON_PRESS: {
 		//Deal with time point selection, but only if they aren't involved in the insanity...
 		Time stime;
@@ -799,6 +801,15 @@ CellRenderer_TimeTrack::activate_vfunc(
 				//otherwise look at adding it
 				//for replace the list was cleared earlier, and for add it wasn't so it works
 				sel_times.insert(stime);
+				if (sel_times.size() == 1 && event->type == GDK_2BUTTON_PRESS) {
+					ValueBase v = value_desc.get_value(stime);
+					etl::handle<Node> node = v.get_type() == type_canvas && !getenv("SYNFIG_SHOW_CANVAS_PARAM_WAYPOINTS")
+					               ? etl::handle<Node>(v.get(Canvas::Handle()))
+					               : etl::handle<Node>(value_desc.get_value_node());
+					if (node)
+						signal_waypoint_clicked_cellrenderer()(node, stime, time_offset, time_dilation, -1);
+				} 
+				
 			}
 
 			if (selected || !sel_times.empty()) {

--- a/synfig-studio/src/gui/docks/dock_timetrack.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack.cpp
@@ -159,6 +159,7 @@ public:
 	{
 		switch(event->type)
 		{
+		case GDK_2BUTTON_PRESS:
 		case GDK_BUTTON_PRESS:
 			{
 				Gtk::TreeModel::Path path;


### PR DESCRIPTION
This PR adds double-clik to edit waypoints in the timetrack dock. See gif below for example
![synfig-double-click-edit](https://user-images.githubusercontent.com/221446/67795615-46e7a700-fa5d-11e9-894d-a63be2cf227a.gif)
