### PR TITLE
Fix Current Time Widget behaviour

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -2283,14 +2283,12 @@ CanvasView::on_time_changed()
 	current_time_widget->set_value(time);
 	if (!is_playing())
 	{
-		try {
-			//get_canvas()->keyframe_list().find(time);
-			KeyframeList::iterator iter;
-			get_canvas()->keyframe_list().find(time, iter); // not sure this is needed? O_o
+		KeyframeList::iterator iter;
+		if (get_canvas()->keyframe_list().find(time, iter)) {
 			// Widget::override_color() is deprecated since Gtkmm 3.16: Use a custom style provider and style classes instead.
 			// This function is very slow!
 			current_time_widget->override_color(Gdk::RGBA("#FF0000"));
-		} catch(...) {
+		} else {
 			// Widget::override_color() is deprecated since Gtkmm 3.16: Use a custom style provider and style classes instead.
 			// This function is very slow!
 			current_time_widget->override_color(Gdk::RGBA(0));


### PR DESCRIPTION
Current Time Widget should display its text in red when there is a keyframe at current time. Otherwise its text should be black.

![screenshot_002](https://user-images.githubusercontent.com/332868/68583545-fede7080-04af-11ea-97a6-54d5742905b3.png)


This behaviour got broken in 0589a7d, fixed now.