### PR TITLE
Fix issue #997 Removed gamma slider to reduce render settings window height

### DIFF
--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -541,7 +541,7 @@ Widget_Preview::Widget_Preview():
 	zoom_preview.set_entry_text_column(factors.factor_value);
 
 	Gtk::Entry* entry = zoom_preview.get_entry();
-	entry->set_text("100%"); //default zoom level
+	entry->set_text(_("Fit")); //default zoom level
 	entry->set_icon_from_stock(Gtk::StockID("synfig-zoom"));
 	entry->signal_activate().connect(sigc::mem_fun(*this, &Widget_Preview::on_zoom_entry_activated));
 

--- a/synfig-studio/src/gui/renddesc.cpp
+++ b/synfig-studio/src/gui/renddesc.cpp
@@ -576,9 +576,9 @@ Widget_RendDesc::create_widgets()
 	entry_gamma_r=manage(new Gtk::SpinButton(adjustment_gamma_r,0.01,2));
 	entry_gamma_g=manage(new Gtk::SpinButton(adjustment_gamma_g,0.01,2));
 	entry_gamma_b=manage(new Gtk::SpinButton(adjustment_gamma_b,0.01,2));
-	scale_gamma_r=manage(new Gtk::Scale(adjustment_gamma_r));
-	scale_gamma_g=manage(new Gtk::Scale(adjustment_gamma_g));
-	scale_gamma_b=manage(new Gtk::Scale(adjustment_gamma_b));
+	//scale_gamma_r=manage(new Gtk::Scale(adjustment_gamma_r));
+	//scale_gamma_g=manage(new Gtk::Scale(adjustment_gamma_g));
+	//scale_gamma_b=manage(new Gtk::Scale(adjustment_gamma_b));
 	toggle_px_aspect=manage(new Gtk::CheckButton(_("_Pixel Aspect"), true));
 	toggle_px_aspect->set_alignment(0, 0.5);
 	toggle_px_width=manage(new Gtk::CheckButton(_("Pi_xel Width"), true));
@@ -841,8 +841,8 @@ Widget_RendDesc::create_gamma_tab()
 			frameGrid->attach(*label, 0, row, 1, 2);
 			entry_gamma_r->set_hexpand(true);
 			frameGrid->attach(*entry_gamma_r, 1, row++, 1, 1);
-			scale_gamma_r->set_hexpand(true);
-			frameGrid->attach(*scale_gamma_r, 1, row++, 1, 1);
+			//scale_gamma_r->set_hexpand(true);
+			//frameGrid->attach(*scale_gamma_r, 1, row++, 1, 1);
 		}
 		
 		{
@@ -851,8 +851,8 @@ Widget_RendDesc::create_gamma_tab()
 			frameGrid->attach(*label, 0, row, 1, 2);
 			entry_gamma_g->set_hexpand(true);
 			frameGrid->attach(*entry_gamma_g, 1, row++, 1, 1);
-			scale_gamma_g->set_hexpand(true);
-			frameGrid->attach(*scale_gamma_g, 1, row++, 1, 1);
+			//scale_gamma_g->set_hexpand(true);
+			//frameGrid->attach(*scale_gamma_g, 1, row++, 1, 1);
 		}
 		
 		{
@@ -861,8 +861,8 @@ Widget_RendDesc::create_gamma_tab()
 			frameGrid->attach(*label, 0, row, 1, 2);
 			entry_gamma_b->set_hexpand(true);
 			frameGrid->attach(*entry_gamma_b, 1, row++, 1, 1);
-			scale_gamma_b->set_hexpand(true);
-			frameGrid->attach(*scale_gamma_b, 1, row++, 1, 1);
+			//scale_gamma_b->set_hexpand(true);
+			//frameGrid->attach(*scale_gamma_b, 1, row++, 1, 1);
 		}
 	}
 	

--- a/synfig-studio/src/gui/renddesc.h
+++ b/synfig-studio/src/gui/renddesc.h
@@ -80,9 +80,9 @@ class Widget_RendDesc : public Gtk::Notebook
 	Gtk::SpinButton *entry_gamma_g;
 	Gtk::SpinButton *entry_gamma_b;
 
-	Gtk::Scale* scale_gamma_r;
-	Gtk::Scale* scale_gamma_g;
-	Gtk::Scale* scale_gamma_b;
+	//Gtk::Scale* scale_gamma_r;
+	//Gtk::Scale* scale_gamma_g;
+	//Gtk::Scale* scale_gamma_b;
 
 	Widget_Link *toggle_wh_ratio;
 	Widget_Link *toggle_res_ratio;


### PR DESCRIPTION
Below is a screenshot after building synfigstudio without the gamma slider.
Now the render settings window fit on my small 1366x768 display screen

![Screenshot_2019-11-11_18-00-26](https://user-images.githubusercontent.com/24214509/68588619-fd14ad00-04af-11ea-9042-00342c2cf65c.png)

The codes are actually commented out in case they're needed for future enhancement... someone could un-comment and keep the gamma slider feature ;)