### PR TITLE
ENTER finish ("run") spline tool; ESC do cancel it - fixes #492

### DIFF
--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -45,6 +45,7 @@
 #include <ETL/calculus>
 #include <utility>
 #include "event_mouse.h"
+#include "event_keyboard.h"
 #include "event_layerclick.h"
 #include "docks/dock_toolbox.h"
 #include "docks/dialog_tooloptions.h"
@@ -262,6 +263,8 @@ public:
 
 	Smach::event_result event_refresh_handler(const Smach::event& x);
 
+	Smach::event_result event_key_press_handler(const Smach::event& x);
+	Smach::event_result event_key_release_handler(const Smach::event& x);
 	Smach::event_result event_mouse_click_handler(const Smach::event& x);
 	Smach::event_result event_mouse_release_handler(const Smach::event& x);
 	Smach::event_result event_mouse_motion_handler(const Smach::event& x);
@@ -311,6 +314,8 @@ StateBLine::StateBLine():
 	insert(event_def(EVENT_STOP,						&StateBLine_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,						&StateBLine_Context::event_refresh_handler));
 	insert(event_def(EVENT_REFRESH_DUCKS,				&StateBLine_Context::event_hijack));
+	insert(event_def(EVENT_WORKAREA_KEY_DOWN,			&StateBLine_Context::event_key_press_handler));
+	insert(event_def(EVENT_WORKAREA_KEY_UP,				&StateBLine_Context::event_key_release_handler));
 	insert(event_def(EVENT_WORKAREA_MOUSE_BUTTON_DOWN,	&StateBLine_Context::event_mouse_click_handler));
 	insert(event_def(EVENT_WORKAREA_MOUSE_BUTTON_UP,	&StateBLine_Context::event_mouse_release_handler));
 	insert(event_def(EVENT_WORKAREA_MOUSE_MOTION,		&StateBLine_Context::event_mouse_motion_handler));
@@ -1263,6 +1268,33 @@ StateBLine_Context::run_()
 	reset();
 	increment_id();
 	return true;
+}
+
+Smach::event_result
+StateBLine_Context::event_key_press_handler(const Smach::event& x)
+{
+	const EventKeyboard& event(*reinterpret_cast<const EventKeyboard*>(&x));
+	switch(event.keyval)
+	{
+	case GDK_KEY_Return:
+		if (bline_point_list.size() > 1)
+			run();
+		return Smach::RESULT_ACCEPT;
+	}
+	return Smach::RESULT_REJECT;
+}
+
+Smach::event_result
+StateBLine_Context::event_key_release_handler(const Smach::event& x)
+{
+	const EventKeyboard& event(*reinterpret_cast<const EventKeyboard*>(&x));
+	switch(event.keyval)
+	{
+	case GDK_KEY_Escape:
+		reset();
+		return Smach::RESULT_ACCEPT;
+	}
+	return Smach::RESULT_REJECT;
 }
 
 Smach::event_result


### PR DESCRIPTION
partial fix #491

Besides the new key assignment, Escape now really cancels spline.
Before this commit, it just hid the spline drawing
(if you click 'run' toolbutton the spline appears).