### PR TITLE
Fix case where directory path has a space

### DIFF
--- a/2-build-production.sh
+++ b/2-build-production.sh
@@ -36,4 +36,4 @@ popd > /dev/null
 
 cd "${WORKDIR}/${TYPE}"
 
-bash ${WORKDIR}/autobuild/build.sh "$1" "$2"
+bash "${WORKDIR}/autobuild/build.sh" "$1" "$2"


### PR DESCRIPTION
If WORKDIR contains a path with a blank space, the path is wrongly interpreted. This patch adresses that issue.