### PR TITLE
Fix crash undoing layer deletion #1070

### DIFF
--- a/synfig-studio/src/synfigapp/actions/layerremove.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerremove.cpp
@@ -72,8 +72,8 @@ bool LayerRemove::is_child_of_another_layer_in_list(Layer::LooseHandle layer) co
 	}
 
 	for (const auto &some_parent : parent_list) {
-		for (const auto &layer_pair : layer_list) {
-			if (some_parent == layer_pair.first) {
+		for (const auto &layer_tuple : layer_list) {
+			if (some_parent == std::get<0>(layer_tuple)) {
 				return true;
 			}
 		}
@@ -83,10 +83,10 @@ bool LayerRemove::is_child_of_another_layer_in_list(Layer::LooseHandle layer) co
 
 void LayerRemove::filter_layer_list()
 {
-	std::list<std::pair<synfig::Layer::Handle,int> > filtered_layer_list;
-	for (auto layer_pair : layer_list) {
-		if (!is_child_of_another_layer_in_list(layer_pair.first))
-			filtered_layer_list.push_back(layer_pair);
+	std::list<std::tuple<synfig::Layer::Handle, int, synfig::Canvas::Handle> > filtered_layer_list;
+	for (auto layer_tuple : layer_list) {
+		if (!is_child_of_another_layer_in_list(std::get<0>(layer_tuple)))
+			filtered_layer_list.push_back(layer_tuple);
 	}
 	layer_list = filtered_layer_list;
 }
@@ -99,7 +99,12 @@ Action::LayerRemove::LayerRemove()
 synfig::String
 Action::LayerRemove::get_local_name()const
 {
-	return get_layer_descriptions(layer_list, _("Delete Layer"), _("Delete Layers"));
+	std::list< std::pair<synfig::Layer::Handle,int> > layer_pair_list;
+	for (const auto& tuple : layer_list) {
+		std::pair<synfig::Layer::Handle,int> layer_pair = std::make_pair(std::get<0>(tuple), std::get<1>(tuple));
+		layer_pair_list.push_back(layer_pair);
+	}
+	return get_layer_descriptions(layer_pair_list, _("Delete Layer"), _("Delete Layers"));
 }
 
 Action::ParamVocab
@@ -127,9 +132,10 @@ Action::LayerRemove::set_param(const synfig::String& name, const Action::Param &
 {
 	if(name=="layer" && param.get_type()==Param::TYPE_LAYER)
 	{
-		std::pair<synfig::Layer::Handle,int> layer_pair;
-		layer_pair.first=param.get_layer();
-		layer_list.push_back(layer_pair);
+		synfig::Layer::Handle layer = param.get_layer();
+		std::tuple<synfig::Layer::Handle,int,synfig::Canvas::Handle> layer_tuple;
+		layer_tuple = std::make_tuple(layer, -1, nullptr);
+		layer_list.push_back(layer_tuple);
 		is_filtered = false;
 		return true;
 	}
@@ -152,10 +158,10 @@ Action::LayerRemove::perform()
 		filter_layer_list();
 		is_filtered = true;
 	}
-	std::list<std::pair<synfig::Layer::Handle,int> >::iterator iter;
-	for(iter=layer_list.begin();iter!=layer_list.end();++iter)
+
+	for(auto iter=layer_list.begin();iter!=layer_list.end();++iter)
 	{
-		Layer::Handle layer(iter->first);
+		Layer::Handle layer(std::get<0>(*iter));
 		Canvas::Handle subcanvas(layer->get_canvas());
 
 		// Find the iterator for the layer
@@ -182,7 +188,8 @@ Action::LayerRemove::perform()
 		set_canvas(subcanvas);
 
 		// Calculate the depth that the layer was at (For the undo)
-		iter->second=layer->get_depth();
+		std::get<1>(*iter) = layer->get_depth();
+		std::get<2>(*iter) = layer->get_canvas();
 
 		// Mark ourselves as dirty if necessary
 		set_dirty(layer->active());
@@ -199,24 +206,26 @@ Action::LayerRemove::perform()
 void
 Action::LayerRemove::undo()
 {
-	std::list<std::pair<synfig::Layer::Handle,int> >::reverse_iterator iter;
+	std::list<std::tuple<synfig::Layer::Handle,int, synfig::Canvas::Handle> >::reverse_iterator iter;
 	for(iter=layer_list.rbegin();iter!=layer_list.rend();++iter)
 	{
-		Layer::Handle layer(iter->first);
-		int& depth(iter->second);
+		Layer::Handle layer(std::get<0>(*iter));
+		int& depth(std::get<1>(*iter));
+
+		const synfig::Canvas::Handle canvas = std::get<2>(*iter);
 
 		// Set the layer's canvas
-		layer->set_canvas(get_canvas());
+		layer->set_canvas(canvas);
 
 		// Make sure that the depth is valid
-		if(get_canvas()->size()<depth)
-			depth=get_canvas()->size();
+		if(canvas->size()<depth)
+			depth=canvas->size();
 
 		// Mark ourselves as dirty if necessary
 		set_dirty(layer->active());
 
 		// Insert the layer into the canvas at the desired depth
-		get_canvas()->insert(get_canvas()->byindex(depth), layer);
+		canvas->insert(canvas->byindex(depth), layer);
 
 		// Signal that a layer has been inserted
 		if(get_canvas_interface())

--- a/synfig-studio/src/synfigapp/actions/layerremove.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerremove.cpp
@@ -122,7 +122,6 @@ Action::LayerRemove::perform()
 	for(iter=layer_list.begin();iter!=layer_list.end();++iter)
 	{
 		Layer::Handle layer(iter->first);
-//		int& depth(iter->second);
 		Canvas::Handle subcanvas(layer->get_canvas());
 
 		// Find the iterator for the layer

--- a/synfig-studio/src/synfigapp/actions/layerremove.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerremove.cpp
@@ -192,7 +192,8 @@ Action::LayerRemove::perform()
 		std::get<2>(*iter) = layer->get_canvas();
 
 		// Mark ourselves as dirty if necessary
-		set_dirty(layer->active());
+		if (layer->active())
+			set_dirty(true);
 
 		// Remove the layer from the canvas
 		subcanvas->erase(iter2);

--- a/synfig-studio/src/synfigapp/actions/layerremove.h
+++ b/synfig-studio/src/synfigapp/actions/layerremove.h
@@ -51,6 +51,10 @@ private:
 
 	std::list<std::pair<synfig::Layer::Handle,int> > layer_list;
 
+	bool is_child_of_another_layer_in_list(synfig::Layer::LooseHandle layer) const;
+	void filter_layer_list();
+	bool is_filtered;
+
 public:
 
 	LayerRemove();

--- a/synfig-studio/src/synfigapp/actions/layerremove.h
+++ b/synfig-studio/src/synfigapp/actions/layerremove.h
@@ -29,7 +29,7 @@
 
 #include <synfig/layer.h>
 #include <synfigapp/action.h>
-#include <list>
+#include <tuple>
 
 /* === M A C R O S ========================================================= */
 
@@ -49,7 +49,7 @@ class LayerRemove :
 {
 private:
 
-	std::list<std::pair<synfig::Layer::Handle,int> > layer_list;
+	std::list<std::tuple<synfig::Layer::Handle,int, synfig::Canvas::Handle> > layer_list;
 
 	bool is_child_of_another_layer_in_list(synfig::Layer::LooseHandle layer) const;
 	void filter_layer_list();

--- a/synfig-studio/src/synfigapp/actions/layerremove.h
+++ b/synfig-studio/src/synfigapp/actions/layerremove.h
@@ -51,9 +51,6 @@ private:
 
 	std::list<std::pair<synfig::Layer::Handle,int> > layer_list;
 
-	//synfig::Layer::Handle layer;
-	//int depth;
-
 public:
 
 	LayerRemove();


### PR DESCRIPTION
Now it doesn't try to delete a layer that is inside a layer-group that will be deleted too.

And it should re-add them at their right place when undoing.

fix #1070 