### PR TITLE
remove trivial copy-constructors

### DIFF
--- a/synfig-core/src/synfig/color/cairocolor.h
+++ b/synfig-core/src/synfig/color/cairocolor.h
@@ -191,12 +191,12 @@ public:
 public:
 	CairoColor() :pixel(0x0) { }
 	CairoColor(const unsigned char u): pixel((u<<24)|(u<<16)|(u<<8)|(u)) { }
-	//CairoColor(int f) :a_(f),r_(f), g_(f), b_(f) { }
+
 	CairoColor(const unsigned char R, const unsigned char G, const unsigned char B, const unsigned char A=ceil):
 	pixel((A<<24)|(R<<16)|(G<<8)|(B)) { }
 	CairoColor(const CairoColor& c, const unsigned char A):
 	pixel(c.get_pixel()) { set_a(A); }
-	CairoColor(const CairoColor& c): pixel(c.get_pixel()) { }
+
 	// Conversor constructor
 	CairoColor(const Color& c)
 	{

--- a/synfig-core/src/synfig/color/cairocoloraccumulator.h
+++ b/synfig-core/src/synfig/color/cairocoloraccumulator.h
@@ -128,13 +128,6 @@ public:
 	g_(G),
 	b_(B) { }
 	
-	//!	Copy constructor
-	CairoColorAccumulator(const CairoColorAccumulator& c):
-	a_(c.a_),
-	r_(c.r_),
-	g_(c.g_),
-	b_(c.b_) { }
-	
 	//!	Converter
 	CairoColorAccumulator(const CairoColor& c):
 	a_(c.get_a()/CairoColor::range),

--- a/synfig-core/src/synfig/color/color.h
+++ b/synfig-core/src/synfig/color/color.h
@@ -92,9 +92,6 @@ public:
 	**	\param A Opacity(alpha) */
 	inline Color(const Color& c, const value_type& A);
 
-	//!	Copy constructor
-	inline Color(const Color& c);
-
 	//! Convert from CairoColor to Color
 	inline Color(const CairoColor& c);
 	

--- a/synfig-core/src/synfig/color/color.hpp
+++ b/synfig-core/src/synfig/color/color.hpp
@@ -156,12 +156,6 @@ Color::Color(const Color& c, const value_type& A):
 	b_(c.b_),
 	a_(A) { }
 
-Color::Color(const Color& c):
-	r_(c.r_),
-	g_(c.g_),
-	b_(c.b_),
-	a_(c.a_) { }
-
 const String Color::get_hex()const
 {
     return String(real2hex(r_) + real2hex(g_) + real2hex(b_));

--- a/synfig-core/src/synfig/guid.h
+++ b/synfig-core/src/synfig/guid.h
@@ -58,8 +58,6 @@ class GUID
 public:
 	GUID()
 		{ make_unique(); }
-	GUID(const GUID& x):data(x.data)
-		{ }
 	GUID(const int i __attribute__ ((unused))){assert(!i); data.u_64.a=0;data.u_64.b=0;}
 
 	GUID(const String& str);


### PR DESCRIPTION
If it is defined, assignment copy method (operator =()) should be defined too.
Trivial copy constructors are defined by default. ;)

It avoids compiler warnings.