### PR TITLE
Avoid ambiguity in translation of Set (verb x noun)

### DIFF
--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1274,10 +1274,12 @@ Instance::process_action(synfig::String name, synfigapp::Action::ParamList param
 				// export and rename value dialog
 				if (entry.name == "ValueNodeRename") button2 = _("Rename");
 				// set layer description dialog
-				if (entry.name == "LayerSetDesc")
+				else if (entry.name == "LayerSetDesc")
 				{
-					button2 = _("Set");
+					button2 = _("OK");
 					label = _("Description: ");
+				} else if (entry.name == "GroupAddLayers") {
+					button2 = _("Add");
 				}
 
 				if(!studio::App::dialog_entry(entry.local_name,


### PR DESCRIPTION
When setting layer "description" I found out that the "OK" button (labeled as "Set" in code) in my language is translated as if it mean (Layer) Set.