### PR TITLE
replace button label with open icon for widget_filename

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_filename.cpp
+++ b/synfig-studio/src/gui/widgets/widget_filename.cpp
@@ -64,18 +64,9 @@ using namespace studio;
 Widget_Filename::Widget_Filename()
 {
 	entry_filename=manage(new Gtk::Entry());
-	label_find= manage(new Gtk::Label(" . . . "));
+	icon_browse = manage(new Gtk::Image(Gtk::StockID("synfig-open"), Gtk::ICON_SIZE_SMALL_TOOLBAR));
 	button_choose=manage(new Gtk::Button());
-	Pango::AttrList attr_list;
-	{
-		Pango::AttrInt pango_size(Pango::Attribute::create_attr_size(Pango::SCALE*7));
-		pango_size.set_start_index(0);
-		pango_size.set_end_index(64);
-		attr_list.change(pango_size);
-	}
-	label_find->set_attributes(attr_list);
-	label_find->set_ellipsize(Pango::ELLIPSIZE_END);
-	button_choose->add(*label_find);
+	button_choose->add(*icon_browse);
 
 	set_hexpand(true);
 	entry_filename->set_hexpand(true);
@@ -85,7 +76,7 @@ Widget_Filename::Widget_Filename()
 
 	entry_filename->show();
 	button_choose->show();
-	label_find->show();
+	icon_browse->show();
 
 	button_choose->signal_clicked().connect(sigc::mem_fun(*this, &studio::Widget_Filename::on_button_choose_pressed));
 	//entry_filename->signal_value_changed().connect(sigc::mem_fun(*this, &studio::Widget_Filename::on_value_changed));

--- a/synfig-studio/src/gui/widgets/widget_filename.h
+++ b/synfig-studio/src/gui/widgets/widget_filename.h
@@ -49,7 +49,7 @@ class Widget_Filename : public Gtk::Grid
 {
 	Gtk::Entry *entry_filename;
 	Gtk::Button *button_choose;
-	Gtk::Label *label_find;
+	Gtk::Image *icon_browse;
 	etl::handle<synfig::Canvas> canvas;
 
 	void on_button_choose_pressed();


### PR DESCRIPTION
The label contents ". . ." is nearly visible, so I thought it would be good to change it.