### PR TITLE
remove unused action restore-defaults-settings

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -972,7 +972,6 @@ DEFINE_ACTION("select-all-layers",        _("Select All Layers"));
 DEFINE_ACTION("unselect-all-layers",      _("Unselect All Layers"));
 DEFINE_ACTION("input-devices",            _("Input Devices..."));
 DEFINE_ACTION("setup",                    _("Preferences..."));
-DEFINE_ACTION("restore-default-settings", _("Restore Defaults"));
 
 // actions in View menu
 DEFINE_ACTION("toggle-mainwin-menubar",   _("Menubar"));


### PR DESCRIPTION
It's not an menu item and Dialog_Setup calls
App::restore_default_settings() method directly