### PR TITLE
remove strange #include in Dialog_Setup

### DIFF
--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -558,7 +558,6 @@ Dialog_Setup::create_interface_page(PageInfo pi)
 
 	static const char* languages[][2] = {
 		#include <languages.inc.c>
-		#include <gdkmm-3.0/gdkmm/rgba.h>
 		{ NULL, NULL } // final entry without comma to avoid misunderstanding
 	};
 


### PR DESCRIPTION
It was inserted by 366b6582272b8657c1d37909cc4c845de746cc82 . I don't know if it was supposed to be in another place...