### PR TITLE
fix problem with uninitialized variable in ThreadPool

### DIFF
--- a/synfig-core/src/synfig/threadpool.cpp
+++ b/synfig-core/src/synfig/threadpool.cpp
@@ -137,6 +137,7 @@ ThreadPool::ThreadPool():
 	last_thread_id(0),
 	running_threads(0),
 	ready_threads(0),
+	queue_size(0),
 	stopped(false)
 {
 	max_running_threads = g_get_num_processors();
@@ -152,14 +153,6 @@ ThreadPool::ThreadPool():
 	info("ThreadPool created with max running threads: %d", max_running_threads - 1);
 	#endif
 }
-
-ThreadPool::ThreadPool(const ThreadPool&):
-	max_running_threads(0),
-	last_thread_id(0),
-	running_threads(0),
-	ready_threads(0),
-	queue_size(0),
-	stopped(false) { }
 
 ThreadPool::~ThreadPool() {
 	#ifdef DEBUG_PTHREAD_MEASURE

--- a/synfig-core/src/synfig/threadpool.h
+++ b/synfig-core/src/synfig/threadpool.h
@@ -88,7 +88,7 @@ private:
 	void wakeup();
 
 	ThreadPool();
-	ThreadPool(const ThreadPool&);
+	ThreadPool(const ThreadPool&) = delete;
 
 public:
 	~ThreadPool();


### PR DESCRIPTION
and delete copy constructor: unused, forbiden and mislead the proper initialization