### PR TITLE
make width depend on TL/BR

### DIFF
--- a/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
@@ -66,7 +66,7 @@ void PreProcessSegment(studio::PointList &segment)
   {
     segment[i][0] = w_factor *( multiplier * segment[i][0]/unit_size ) + bottomleft[0];
     segment[i][1] = h_factor *( multiplier * segment[i][1]/unit_size ) + bottomleft[1];
-    segment[i][2] = segment[i][2]/2.5;
+    segment[i][2] = (segment[i][2]/2.5)*max(w_factor,h_factor);
   }
   
 }


### PR DESCRIPTION
@morevnaproject I used  `width = (width/2.5)*max(w_factor,h_factor)` I also tried sqrt(w_factor*h_factor) and results were similar considering almost same transformation along width and height. Let me know if this logic can be futher improved. 
@ice0 @blackwarthog suggestions?

Closes: #1082 