### PR TITLE
Fix #1064: Crash when calling any plugin on Windows

### DIFF
--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -354,11 +354,6 @@ cleanup_path(std::string path)
     if (path.size() > 1u && is_separator(path[path.size() - 1]))
     	path.erase(path.size() - 1, 1);
 
-    // fix slashes
-    for(size_t i = 0; i < path.size(); ++i) {
-        if (path[i] == '\\') path[i] = '/';
-    }
-
     return path;
 }
 

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -159,6 +159,7 @@ static void _canvas_file_name_changed(Canvas *x)
 Canvas::Handle
 synfig::open_canvas_as(const FileSystem::Identifier &identifier,const String &as,String &errors,String &warnings)
 {
+	String filename = FileSystem::fix_slashes(as);
 	if (CanvasParser::loading_.count(identifier))
 	{
 		String warning(strprintf(_("cannot load '%s' recursively"), identifier.filename.c_str()));
@@ -166,7 +167,7 @@ synfig::open_canvas_as(const FileSystem::Identifier &identifier,const String &as
 		warnings = "  * " + warning + "\n";
 		Canvas::Handle canvas(Canvas::create());
 		canvas->set_identifier(identifier);
-		canvas->set_file_name(as);
+		canvas->set_file_name(filename);
 		Layer::Handle paste(Layer_Group::create());
 		canvas->push_back(paste);
 		paste->set_description(warning);
@@ -180,7 +181,7 @@ synfig::open_canvas_as(const FileSystem::Identifier &identifier,const String &as
 	try
 	{
 		CanvasParser::loading_.insert(identifier);
-		canvas=parser.parse_from_file_as(identifier,as,errors);
+		canvas=parser.parse_from_file_as(identifier,filename,errors);
 	}
 	catch (...)
 	{


### PR DESCRIPTION
This fixes crash on re-opening same file.