### PR TITLE
Fix opening files with non-lating characters from commandline on Windows

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1754,7 +1754,7 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 			{
 				studio_init_cb.task(_("Loading files..."));
 				splash_screen.hide();
-				open((*argv)[*argc]);
+				open(Glib::locale_to_utf8((*argv)[*argc]));
 				opened_any = true;
 				splash_screen.show();
 			}

--- a/synfig-studio/src/gui/ipc.cpp
+++ b/synfig-studio/src/gui/ipc.cpp
@@ -299,7 +299,7 @@ IPC::process_command(const synfig::String& command_line)
 			break;
 		case 'O': // Open <arg>
 			App::signal_present_all()();
-			App::open(args);
+			App::open(Glib::locale_to_utf8(args));
 			break;
 		case 'X': // Quit
 		case 'Q': // Quit


### PR DESCRIPTION
Closes #680.

How to check:
1. Ensure that Synfig is not launched (otherwise you will hit #1124).
2. Drag-n-drop any Synfig file with non-latin characters on `synfigstudio.exe` binary.
3. Application should run and open file properly.