### PR TITLE
Fixes #1118 Added PACKAGE_NAME macro

### DIFF
--- a/synfig-studio/src/gui/dialogs/about.cpp
+++ b/synfig-studio/src/gui/dialogs/about.cpp
@@ -59,6 +59,10 @@ using namespace studio;
 
 /* === M A C R O S ========================================================= */
 
+#ifndef PACKAGE_NAME
+#define  PACKAGE_NAME "Synfig Studio"
+#endif
+
 #ifndef VERSION
 #define VERSION	"unknown"
 #endif


### PR DESCRIPTION
This fixes the building error encountered using the CMake build system on NetBeans.

EDIT: Need more insight on how synfig build works. I'm curious why not just configure CMakeLists.txt at the root directory to do all the build stuff instead of the custom build-cmake.sh script file.