### PR TITLE
New timetrack

### DIFF
--- a/synfig-studio/po/POTFILES.in
+++ b/synfig-studio/po/POTFILES.in
@@ -91,6 +91,7 @@ src/gui/docks/dock_soundwave.h
 src/gui/docks/dock_soundwave.cpp
 src/gui/docks/dock_timetrack.cpp
 src/gui/docks/dock_timetrack.h
+src/gui/docks/dock_timetrack2.cpp
 src/gui/docks/dock_toolbox.cpp
 src/gui/docks/dock_toolbox.h
 src/gui/docks/dockable.cpp
@@ -210,6 +211,7 @@ src/gui/widgets/widget_time.cpp
 src/gui/widgets/widget_time.h
 src/gui/widgets/widget_timeslider.cpp
 src/gui/widgets/widget_timeslider.h
+src/gui/widgets/widget_timetrack.cpp
 src/gui/widgets/widget_value.cpp
 src/gui/widgets/widget_value.h
 src/gui/widgets/widget_vector.cpp

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -148,6 +148,7 @@
 #include "docks/dock_navigator.h"
 #include "docks/dock_soundwave.h"
 #include "docks/dock_timetrack.h"
+#include "docks/dock_timetrack2.h"
 #include "docks/dock_toolbox.h"
 
 #include "modules/module.h"
@@ -300,6 +301,7 @@ studio::Dock_LayerGroups   *dock_layer_groups;
 studio::Dock_Navigator     *dock_navigator;
 studio::Dock_SoundWave     *dock_soundwave;
 studio::Dock_Timetrack     *dock_timetrack;
+studio::Dock_Timetrack2    *dock_timetrack2;
 studio::Dock_Curves        *dock_curves;
 
 std::list< etl::handle< studio::Module > > module_list_;
@@ -1069,6 +1071,7 @@ DEFINE_ACTION("panel-curves",          _("Graphs"));
 DEFINE_ACTION("panel-groups",          _("Sets"));
 DEFINE_ACTION("panel-pal_edit",        _("Palette Editor"));
 DEFINE_ACTION("panel-soundwave",       _("Sound"));
+DEFINE_ACTION("panel-timetrack2",      _("Timetrack 2"));
 
 // actions in Help menu
 DEFINE_ACTION("help",           Gtk::Stock::HELP);
@@ -1239,6 +1242,7 @@ DEFINE_ACTION("keyframe-properties", _("Properties"));
 "		<menuitem action='panel-info' />"
 "		<menuitem action='panel-navigator' />"
 "		<menuitem action='panel-timetrack' />"
+"		<menuitem action='panel-timetrack2' />"
 "		<menuitem action='panel-curves' />"
 "		<menuitem action='panel-groups' />"
 "		<menuitem action='panel-pal_edit' />"
@@ -1618,6 +1622,10 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 		studio_init_cb.task(_("Init Timetrack..."));
 		dock_timetrack = new studio::Dock_Timetrack();
 		dock_manager->register_dockable(*dock_timetrack);
+
+		studio_init_cb.task(_("Init Timetrack 2..."));
+		dock_timetrack2 = new studio::Dock_Timetrack2();
+		dock_manager->register_dockable(*dock_timetrack2);
 
 		studio_init_cb.task(_("Init Curve Editor..."));
 		dock_curves = new studio::Dock_Curves();

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -300,7 +300,7 @@ studio::Dock_Info          *dock_info;
 studio::Dock_LayerGroups   *dock_layer_groups;
 studio::Dock_Navigator     *dock_navigator;
 studio::Dock_SoundWave     *dock_soundwave;
-studio::Dock_Timetrack     *dock_timetrack_old;
+studio::Dock_Timetrack_Old     *dock_timetrack_old;
 studio::Dock_Timetrack2    *dock_timetrack;
 studio::Dock_Curves        *dock_curves;
 
@@ -1620,7 +1620,7 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 		dock_manager->register_dockable(*dock_soundwave);
 
 		studio_init_cb.task(_("Init Timetrack (old)..."));
-		dock_timetrack_old = new studio::Dock_Timetrack();
+		dock_timetrack_old = new studio::Dock_Timetrack_Old();
 		dock_manager->register_dockable(*dock_timetrack_old);
 
 		studio_init_cb.task(_("Init Timetrack..."));

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -300,8 +300,8 @@ studio::Dock_Info          *dock_info;
 studio::Dock_LayerGroups   *dock_layer_groups;
 studio::Dock_Navigator     *dock_navigator;
 studio::Dock_SoundWave     *dock_soundwave;
-studio::Dock_Timetrack     *dock_timetrack;
-studio::Dock_Timetrack2    *dock_timetrack2;
+studio::Dock_Timetrack     *dock_timetrack_old;
+studio::Dock_Timetrack2    *dock_timetrack;
 studio::Dock_Curves        *dock_curves;
 
 std::list< etl::handle< studio::Module > > module_list_;
@@ -1066,12 +1066,12 @@ DEFINE_ACTION("panel-meta_data",       _("Canvas MetaData"));
 DEFINE_ACTION("panel-children",        _("Library"));
 DEFINE_ACTION("panel-info",            _("Info"));
 DEFINE_ACTION("panel-navigator",       _("Navigator"));
-DEFINE_ACTION("panel-timetrack",       _("Timetrack"));
+DEFINE_ACTION("panel-timetrack-old",   _("Timetrack (old)"));
 DEFINE_ACTION("panel-curves",          _("Graphs"));
 DEFINE_ACTION("panel-groups",          _("Sets"));
 DEFINE_ACTION("panel-pal_edit",        _("Palette Editor"));
 DEFINE_ACTION("panel-soundwave",       _("Sound"));
-DEFINE_ACTION("panel-timetrack2",      _("Timetrack 2"));
+DEFINE_ACTION("panel-timetrack",      _("Timetrack"));
 
 // actions in Help menu
 DEFINE_ACTION("help",           Gtk::Stock::HELP);
@@ -1241,8 +1241,8 @@ DEFINE_ACTION("keyframe-properties", _("Properties"));
 "		<menuitem action='panel-children' />"
 "		<menuitem action='panel-info' />"
 "		<menuitem action='panel-navigator' />"
+"		<menuitem action='panel-timetrack-old' />"
 "		<menuitem action='panel-timetrack' />"
-"		<menuitem action='panel-timetrack2' />"
 "		<menuitem action='panel-curves' />"
 "		<menuitem action='panel-groups' />"
 "		<menuitem action='panel-pal_edit' />"
@@ -1619,13 +1619,13 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 		dock_soundwave = new studio::Dock_SoundWave();
 		dock_manager->register_dockable(*dock_soundwave);
 
-		studio_init_cb.task(_("Init Timetrack..."));
-		dock_timetrack = new studio::Dock_Timetrack();
-		dock_manager->register_dockable(*dock_timetrack);
+		studio_init_cb.task(_("Init Timetrack (old)..."));
+		dock_timetrack_old = new studio::Dock_Timetrack();
+		dock_manager->register_dockable(*dock_timetrack_old);
 
-		studio_init_cb.task(_("Init Timetrack 2..."));
-		dock_timetrack2 = new studio::Dock_Timetrack2();
-		dock_manager->register_dockable(*dock_timetrack2);
+		studio_init_cb.task(_("Init Timetrack..."));
+		dock_timetrack = new studio::Dock_Timetrack2();
+		dock_manager->register_dockable(*dock_timetrack);
 
 		studio_init_cb.task(_("Init Curve Editor..."));
 		dock_curves = new studio::Dock_Curves();

--- a/synfig-studio/src/gui/docks/CMakeLists.txt
+++ b/synfig-studio/src/gui/docks/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(synfigstudio
         "${CMAKE_CURRENT_LIST_DIR}/dock_params.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dock_soundwave.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dock_timetrack.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/dock_timetrack2.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dock_toolbox.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dockable.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dockbook.cpp"

--- a/synfig-studio/src/gui/docks/Makefile_insert
+++ b/synfig-studio/src/gui/docks/Makefile_insert
@@ -14,6 +14,7 @@ DOCKS_HH = \
 	docks/dock_params.h \
 	docks/dock_soundwave.h \
 	docks/dock_timetrack.h \
+	docks/dock_timetrack2.h \
 	docks/dock_toolbox.h \
 	docks/dockable.h \
 	docks/dockbook.h \
@@ -37,6 +38,7 @@ DOCKS_CC = \
 	docks/dock_params.cpp \
 	docks/dock_soundwave.cpp \
 	docks/dock_timetrack.cpp \
+	docks/dock_timetrack2.cpp \
 	docks/dock_toolbox.cpp \
 	docks/dockable.cpp \
 	docks/dockbook.cpp \

--- a/synfig-studio/src/gui/docks/dock_timetrack.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack.cpp
@@ -350,7 +350,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 Dock_Timetrack::Dock_Timetrack():
-	Dock_CanvasSpecific("timetrack",_("Timetrack"),Gtk::StockID("synfig-timetrack")),
+	Dock_CanvasSpecific("timetrack-old",_("Timetrack (old)"),Gtk::StockID("synfig-timetrack")),
 	grid_()
 {
 	set_use_scrolled(false);

--- a/synfig-studio/src/gui/docks/dock_timetrack.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack.cpp
@@ -349,20 +349,20 @@ public:
 
 /* === M E T H O D S ======================================================= */
 
-Dock_Timetrack::Dock_Timetrack():
+Dock_Timetrack_Old::Dock_Timetrack_Old():
 	Dock_CanvasSpecific("timetrack-old",_("Timetrack (old)"),Gtk::StockID("synfig-timetrack")),
 	grid_()
 {
 	set_use_scrolled(false);
 }
 
-Dock_Timetrack::~Dock_Timetrack()
+Dock_Timetrack_Old::~Dock_Timetrack_Old()
 {
 	if (grid_) delete grid_;
 }
 
 void
-Dock_Timetrack::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
+Dock_Timetrack_Old::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 {
 	LayerParamTreeStore::Model model;
 
@@ -386,11 +386,11 @@ Dock_Timetrack::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view
 	studio::LayerTree *tree_layer = dynamic_cast<studio::LayerTree*>(canvas_view->get_ext_widget("layers_cmp") );
 	assert(tree_layer);
 	tree_layer->signal_param_tree_header_height_changed().connect(
-		sigc::mem_fun(*this, &studio::Dock_Timetrack::on_update_header_height) );
+		sigc::mem_fun(*this, &studio::Dock_Timetrack_Old::on_update_header_height) );
 }
 
 void
-Dock_Timetrack::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
+Dock_Timetrack_Old::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 {
 	if (grid_)
 	{
@@ -488,7 +488,7 @@ Dock_Timetrack::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_v
 }
 
 void
-Dock_Timetrack::on_update_header_height(int height)
+Dock_Timetrack_Old::on_update_header_height(int height)
 {
 	int w = 0, h = 0;
 	widget_kf_list_.get_size_request(w, h);

--- a/synfig-studio/src/gui/docks/dock_timetrack.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack.h
@@ -43,7 +43,7 @@
 
 namespace studio {
 
-class Dock_Timetrack : public Dock_CanvasSpecific
+class Dock_Timetrack_Old : public Dock_CanvasSpecific
 {
 	Gtk::HScrollbar hscrollbar_;
 	Gtk::VScrollbar vscrollbar_;
@@ -56,8 +56,8 @@ protected:
 	virtual void changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view);
 
 public:
-	Dock_Timetrack();
-	~Dock_Timetrack();
+	Dock_Timetrack_Old();
+	~Dock_Timetrack_Old();
 
 private:
 	//! Signal handler for studio::LayerTree::signal_param_tree_header_height_changed

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -35,6 +35,8 @@
 
 #include <synfig/general.h>
 
+#include <cstring>
+
 #endif
 
 using namespace studio;
@@ -171,7 +173,7 @@ void Dock_Timetrack2::setup_tool_palette()
 	Gtk::ToolItemGroup *tool_item_group = Gtk::manage(new Gtk::ToolItemGroup());
 	gtk_tool_item_group_set_label(tool_item_group->gobj(), nullptr);
 	std::vector<std::tuple<const char*, const char*, const char*, Widget_Timetrack::ActionState>> tools_info = {
-		{"synfig-smooth_move", _("Move waypoints\n\nSelect waypoints and drag them along the timetrack."), nullptr, Widget_Timetrack::ActionState::MOVE},
+		{"synfig-smooth_move", _("Move waypoints\n\nSelect waypoints and drag them along the timetrack."), "", Widget_Timetrack::ActionState::MOVE},
 		{"synfig-duplicate", _("Duplicate waypoints\n\nAfter selecting waypoints, drag to duplicate them and place them in another time point."), _("Shift"), Widget_Timetrack::ActionState::COPY},
 		{"synfig-scale", _("Scale waypoints\n\nAfter selecting more than one waypoint, drag them to change their timepoint regarding current time."), _("Alt"), Widget_Timetrack::ActionState::SCALE}
 	};
@@ -192,8 +194,11 @@ void Dock_Timetrack2::setup_tool_palette()
 																	Gtk::IconSize::from_name("synfig-small_icon_16x16") )),
 														stock_item.get_label() ));
 		tool_button->set_name(Widget_Timetrack::get_action_state_name(action_state));
-		std::string shortcut_text = etl::strprintf(_("Shortcut: %s"), shortcut);
-		tool_button->set_tooltip_text(tooltip + "\n\n" + shortcut_text );
+		if (strlen(shortcut) > 0) {
+			std::string shortcut_text = etl::strprintf(_("Shortcut: %s"), shortcut);
+			tooltip += "\n\n" + shortcut_text;
+		}
+		tool_button->set_tooltip_text(tooltip);
 		tool_button->set_group(button_group);
 		tool_button->signal_toggled().connect([this, tool_button, action_state](){
 			if (tool_button->get_active())

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -40,7 +40,7 @@
 using namespace studio;
 
 Dock_Timetrack2::Dock_Timetrack2()
-	: Dock_CanvasSpecific("timetrack2", _("Timetrack"), Gtk::StockID("synfig-timetrack")),
+	: Dock_CanvasSpecific("timetrack", _("Timetrack"), Gtk::StockID("synfig-timetrack")),
 	  current_widget_timetrack(nullptr)
 {
 	set_use_scrolled(false);

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -72,6 +72,7 @@ void Dock_Timetrack2::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canva
 	widget_timetrack->show();
 	widget_timetrack->set_hexpand(true);
 	widget_timetrack->set_vexpand(true);
+	widget_timetrack->set_valign(Gtk::ALIGN_FILL);
 
 	canvas_view->set_ext_widget(get_name(), widget_timetrack);
 

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -64,8 +64,7 @@ Dock_Timetrack2::Dock_Timetrack2()
 void Dock_Timetrack2::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 {
 	Widget_Timetrack *widget_timetrack = new Widget_Timetrack();
-	widget_timetrack->set_time_model(canvas_view->time_model());
-	widget_timetrack->set_canvas_interface(canvas_view->canvas_interface());
+	widget_timetrack->use_canvas_view(canvas_view);
 	widget_timetrack->show();
 	widget_timetrack->set_hexpand(true);
 	widget_timetrack->set_vexpand(true);

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -58,6 +58,10 @@ Dock_Timetrack2::Dock_Timetrack2()
 
 	grid.set_column_homogeneous(false);
 	grid.set_row_homogeneous(false);
+	// for letting user click/drag waypoint or keyframe mark of time zero
+	grid.set_margin_left(2);
+	grid.set_margin_right(2);
+
 	add(grid);
 }
 

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -1,0 +1,116 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file docks/dock_timetrack2.cpp
+**	\brief Dock to displaying layer parameters timetrack
+**
+**	$Id$
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**  ......... ... 2020 Rodolfo Ribeiro Gomes
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include "dock_timetrack2.h"
+
+#include <widgets/widget_timetrack.h>
+#include <gui/canvasview.h>
+#include <gui/localization.h>
+
+#include <synfig/general.h>
+
+#endif
+
+using namespace studio;
+
+Dock_Timetrack2::Dock_Timetrack2()
+	: Dock_CanvasSpecific("timetrack2", _("Timetrack"), Gtk::StockID("synfig-timetrack")),
+	  current_widget_timetrack(nullptr)
+{
+	set_use_scrolled(false);
+
+	widget_kf_list.set_hexpand();
+	widget_kf_list.show();
+	widget_timeslider.set_hexpand();
+	widget_timeslider.show();
+
+	vscrollbar.set_vexpand();
+	vscrollbar.set_hexpand(false);
+	vscrollbar.show();
+	hscrollbar.set_hexpand();
+	hscrollbar.show();
+
+	grid.set_column_homogeneous(false);
+	grid.set_row_homogeneous(false);
+	add(grid);
+}
+
+void Dock_Timetrack2::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
+{
+	Widget_Timetrack *widget_timetrack = new Widget_Timetrack();
+	widget_timetrack->set_time_model(canvas_view->time_model());
+	widget_timetrack->set_canvas_interface(canvas_view->canvas_interface());
+	widget_timetrack->show();
+	widget_timetrack->set_hexpand(true);
+	widget_timetrack->set_vexpand(true);
+
+	canvas_view->set_ext_widget(get_name(), widget_timetrack);
+}
+
+void Dock_Timetrack2::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
+{
+	const std::vector<Gtk::Widget*> children = grid.get_children();
+	for (Gtk::Widget * widget : children) {
+		// CanvasView and Dock_Timetrack2 will delete widgets when needed
+		grid.remove(*widget);
+	}
+
+	if( !canvas_view ) {
+		widget_kf_list.set_time_model( etl::handle<TimeModel>() );
+		widget_kf_list.set_canvas_interface( etl::loose_handle<synfigapp::CanvasInterface>() );
+
+		widget_timeslider.set_canvas_view( CanvasView::Handle() );
+
+		current_widget_timetrack = nullptr; // deleted by its studio::CanvasView::~CanvasView()
+
+		hscrollbar.unset_adjustment();
+		vscrollbar.unset_adjustment();
+	} else {
+		widget_kf_list.set_time_model(canvas_view->time_model());
+		widget_kf_list.set_canvas_interface(canvas_view->canvas_interface());
+
+		widget_timeslider.set_canvas_view(canvas_view);
+
+		current_widget_timetrack = dynamic_cast<Widget_Timetrack*>( canvas_view->get_ext_widget(get_name()) );
+		current_widget_timetrack->set_size_request(100, 100);
+		current_widget_timetrack->set_hexpand(true);
+		current_widget_timetrack->set_vexpand(true);
+
+		vscrollbar.set_adjustment(current_widget_timetrack->get_range_adjustment());
+		hscrollbar.set_adjustment(canvas_view->time_model()->scroll_time_adjustment());
+
+		grid.attach(widget_kf_list,            0, 0, 1, 1);
+		grid.attach(widget_timeslider,         0, 1, 1, 1);
+		grid.attach(*current_widget_timetrack, 0, 2, 1, 1);
+		grid.attach(hscrollbar,                0, 4, 2, 1);
+		grid.attach(vscrollbar,                1, 0, 1, 4);
+		grid.show();
+	}
+
+}

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -35,8 +35,6 @@
 
 #include <synfig/general.h>
 
-#include <cstring>
-
 #endif
 
 using namespace studio;
@@ -172,18 +170,34 @@ void Dock_Timetrack2::setup_tool_palette()
 {
 	Gtk::ToolItemGroup *tool_item_group = Gtk::manage(new Gtk::ToolItemGroup());
 	gtk_tool_item_group_set_label(tool_item_group->gobj(), nullptr);
-	std::vector<std::tuple<const char*, const char*, const char*, Widget_Timetrack::ActionState>> tools_info = {
-		{"synfig-smooth_move", _("Move waypoints\n\nSelect waypoints and drag them along the timetrack."), "", Widget_Timetrack::ActionState::MOVE},
-		{"synfig-duplicate", _("Duplicate waypoints\n\nAfter selecting waypoints, drag to duplicate them and place them in another time point."), _("Shift"), Widget_Timetrack::ActionState::COPY},
-		{"synfig-scale", _("Scale waypoints\n\nAfter selecting more than one waypoint, drag them to change their timepoint regarding current time."), _("Alt"), Widget_Timetrack::ActionState::SCALE}
+	struct ActionButtonInfo {
+		std::string name;
+		std::string tooltip;
+		std::string shortcut;
+		Widget_Timetrack::ActionState action_state ;
+	};
+
+	const std::vector<ActionButtonInfo> tools_info {
+		{"synfig-smooth_move", _("Move waypoints\n\nSelect waypoints and drag them along the timetrack."),
+					std::string(""), Widget_Timetrack::ActionState::MOVE},
+		{"synfig-duplicate", _("Duplicate waypoints\n\nAfter selecting waypoints, drag to duplicate them and place them in another time point."),
+					_("Shift"), Widget_Timetrack::ActionState::COPY},
+		{"synfig-scale", _("Scale waypoints\n\nAfter selecting more than one waypoint, drag them to change their timepoint regarding current time."),
+// This should be a function like get_key_name() to be reused
+#ifdef __APPLE__
+					_("Option"),
+#else
+					_("Alt"),
+#endif
+					Widget_Timetrack::ActionState::SCALE}
 	};
 
 	Gtk::RadioButtonGroup button_group;
 	for (const auto & tool_info : tools_info) {
-		std::string name = std::get<0>(tool_info);
-		std::string tooltip = std::get<1>(tool_info);
-		const char * shortcut = std::get<2>(tool_info);
-		Widget_Timetrack::ActionState action_state = std::get<3>(tool_info);
+		const std::string &name = tool_info.name;
+		std::string tooltip = tool_info.tooltip;
+		const std::string &shortcut = tool_info.shortcut;
+		Widget_Timetrack::ActionState action_state = tool_info.action_state;
 
 		Gtk::StockItem stock_item;
 		Gtk::Stock::lookup(Gtk::StockID(name),stock_item);
@@ -194,8 +208,8 @@ void Dock_Timetrack2::setup_tool_palette()
 																	Gtk::IconSize::from_name("synfig-small_icon_16x16") )),
 														stock_item.get_label() ));
 		tool_button->set_name(Widget_Timetrack::get_action_state_name(action_state));
-		if (strlen(shortcut) > 0) {
-			std::string shortcut_text = etl::strprintf(_("Shortcut: %s"), shortcut);
+		if (!shortcut.empty()) {
+			std::string shortcut_text = _("Shortcut: ") + shortcut;
 			tooltip += "\n\n" + shortcut_text;
 		}
 		tool_button->set_tooltip_text(tooltip);

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -86,6 +86,19 @@ void Dock_Timetrack2::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canva
 		sigc::mem_fun(*this, &studio::Dock_Timetrack2::on_update_header_height)
 	);
 
+	widget_timetrack->signal_waypoint_clicked().connect([=](synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button) {
+		if (button != 3)
+			return;
+		button = 2;
+		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
+	});
+
+	widget_timetrack->signal_waypoint_double_clicked().connect([=](synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button) {
+		if (button != 1)
+			return;
+		button = -1;
+		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
+	});
 }
 
 void Dock_Timetrack2::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)

--- a/synfig-studio/src/gui/docks/dock_timetrack2.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.h
@@ -53,6 +53,8 @@ private:
 	Widget_Timetrack *current_widget_timetrack;
 	Gtk::VScrollbar vscrollbar;
 	Gtk::HScrollbar hscrollbar;
+
+	void on_update_header_height(int height);
 };
 
 }

--- a/synfig-studio/src/gui/docks/dock_timetrack2.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.h
@@ -31,6 +31,8 @@
 #include <gtkmm/grid.h>
 #include <gtkmm/box.h>
 #include <gtkmm/scrollbar.h>
+#include <gtkmm/toolpalette.h>
+#include <gtkmm/radiotoolbutton.h>
 
 namespace studio {
 
@@ -53,8 +55,13 @@ private:
 	Widget_Timetrack *current_widget_timetrack;
 	Gtk::VScrollbar vscrollbar;
 	Gtk::HScrollbar hscrollbar;
+	Gtk::ToolPalette tool_palette;
 
 	void on_update_header_height(int height);
+
+	void setup_tool_palette();
+	void update_tool_palette_action();
+	std::map<std::string, Gtk::RadioToolButton*> action_button_map;
 };
 
 }

--- a/synfig-studio/src/gui/docks/dock_timetrack2.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.h
@@ -1,0 +1,60 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file docks/dock_timetrack2.h
+**	\brief Dock to displaying layer parameters timetrack
+**
+**	$Id$
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	......... ... 2020 Rodolfo Ribeiro Gomes
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+
+#ifndef SYNFIG_STUDIO_DOCK_TIMETRACK2_H
+#define SYNFIG_STUDIO_DOCK_TIMETRACK2_H
+
+#include "dock_canvasspecific.h"
+
+#include <widgets/widget_canvastimeslider.h>
+#include <widgets/widget_keyframe_list.h>
+
+#include <gtkmm/grid.h>
+#include <gtkmm/box.h>
+#include <gtkmm/scrollbar.h>
+
+namespace studio {
+
+class Widget_Timetrack;
+
+class Dock_Timetrack2 : public Dock_CanvasSpecific
+{
+public:
+	Dock_Timetrack2();
+
+protected:
+	virtual void init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view);
+	virtual void changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view);
+
+private:
+	Gtk::Grid grid;
+
+	Widget_Keyframe_List widget_kf_list;
+	Widget_CanvasTimeslider widget_timeslider;
+	Widget_Timetrack *current_widget_timetrack;
+	Gtk::VScrollbar vscrollbar;
+	Gtk::HScrollbar hscrollbar;
+};
+
+}
+
+#endif // SYNFIG_STUDIO_DOCK_TIMETRACK2_H

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -678,6 +678,22 @@ bool SelectDragHelper<T>::process_button_release_event(GdkEventButton* event)
 template<class T>
 bool SelectDragHelper<T>::process_motion_event(GdkEventMotion* event)
 {
+	{
+		// update modifiers when mouse/pointer moves:
+		//   useful if widget looses focus due to a shortcut
+		//   like Ctrl+Shift+S
+		Gdk::ModifierType previous_modifiers = modifiers;
+		modifiers = Gdk::ModifierType();
+		if (event->state & Gdk::SHIFT_MASK)
+			modifiers |= Gdk::SHIFT_MASK;
+		if (event->state & Gdk::CONTROL_MASK)
+			modifiers |= Gdk::CONTROL_MASK;
+		if (event->state & Gdk::MOD1_MASK)
+			modifiers |= Gdk::MOD1_MASK;
+		if (modifiers != previous_modifiers)
+			signal_modifier_keys_changed().emit();
+	}
+
 	bool processed = false;
 	auto previous_hovered_point = hovered_item;
 	bool was_hovered_item_valid = is_hovered_item_valid;

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -113,6 +113,9 @@ private:
 	bool pan_enabled = false;
 	bool drag_enabled = true;
 
+protected:
+	synfigapp::Action::PassiveGrouper *get_action_group_drag() const;
+
 public:
 	SelectDragHelper(const char *drag_action_name);
 	virtual ~SelectDragHelper() {delete action_group_drag;}
@@ -759,6 +762,12 @@ bool SelectDragHelper<T>::process_scroll_event(GdkEventScroll* event)
 			break;
 	}
 	return false;
+}
+
+template<class T>
+synfigapp::Action::PassiveGrouper* SelectDragHelper<T>::get_action_group_drag() const
+{
+	return action_group_drag;
 }
 
 template <class T>

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -237,7 +237,8 @@ public:
 
 template <class T>
 SelectDragHelper<T>::SelectDragHelper(const char* drag_action_name)
-	: drag_action_name(drag_action_name), action_group_drag(nullptr), hovered_item(), is_hovered_item_valid(false), active_item(nullptr), pointer_state(POINTER_NONE)
+	: drag_action_name(drag_action_name), action_group_drag(nullptr), hovered_item(), is_hovered_item_valid(false), active_item(nullptr), pointer_state(POINTER_NONE),
+	  modifiers(Gdk::ModifierType())
 {
 }
 

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -464,8 +464,14 @@ bool SelectDragHelper<T>::process_button_press_event(GdkEventButton* event)
 				}
 				some_action_done = true;
 			} else {
-				if (box_selection_enabled && multiple_selection_enabled) {
-					pointer_state = POINTER_SELECTING;
+				if (multiple_selection_enabled) {
+					if (box_selection_enabled) {
+						pointer_state = POINTER_SELECTING;
+						some_action_done = true;
+					}
+				} else {
+					selected_items.clear();
+					signal_selection_changed().emit();
 					some_action_done = true;
 				}
 			}

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -123,6 +123,10 @@ public:
 	std::vector<T*> get_selected_items();
 	/// Check if an item is selected
 	bool is_selected(const T& item) const;
+	/// Add the provided item to selection
+	void select(const T& item);
+	/// Remove the provided item from selection: only if user isn't dragging
+	void deselect(const T& item);
 	/// The selected item user started to drag
 	const T* get_active_item() const;
 
@@ -261,6 +265,29 @@ std::vector<T*> SelectDragHelper<T>::get_selected_items()
 template<class T>
 bool SelectDragHelper<T>::is_selected(const T& item) const {
 	return std::find(selected_items.begin(), selected_items.end(), item) != selected_items.end();
+}
+
+template<class T>
+void SelectDragHelper<T>::select(const T& item)
+{
+	if (is_selected(item))
+		return;
+	selected_items.push_back(item);
+	signal_selection_changed().emit();
+}
+
+template<class T>
+void SelectDragHelper<T>::deselect(const T& item)
+{
+	if (pointer_state == POINTER_DRAGGING)
+		return;
+
+	auto iter = std::find(selected_items.begin(), selected_items.end(), item);
+	if (iter == selected_items.end())
+		return;
+
+	selected_items.erase(iter);
+	signal_selection_changed().emit();
 }
 
 template<class T>

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -99,7 +99,7 @@ private:
 
 	sigc::signal<void> signal_drag_started_;
 	sigc::signal<void> signal_drag_canceled_;
-	sigc::signal<void> signal_drag_finished_;
+	sigc::signal<void, bool> signal_drag_finished_;
 
 	sigc::signal<void, const T&, unsigned int, Gdk::Point> signal_item_clicked_;
 	sigc::signal<void, const T&, unsigned int, Gdk::Point> signal_item_double_clicked_;
@@ -223,7 +223,9 @@ public:
 
 	sigc::signal<void>& signal_drag_started() { return signal_drag_started_; }
 	sigc::signal<void>& signal_drag_canceled() { return signal_drag_canceled_; }
-	sigc::signal<void>& signal_drag_finished() { return signal_drag_finished_; }
+	/// emitted when user finishes drag
+	/// \param started_by_key
+	sigc::signal<void, bool>& signal_drag_finished() { return signal_drag_finished_; }
 
 	sigc::signal<void, const T&, unsigned int, Gdk::Point>& signal_item_clicked() { return signal_item_clicked_; }
 	sigc::signal<void, const T&, unsigned int, Gdk::Point>& signal_item_double_clicked() { return signal_item_double_clicked_; }
@@ -830,7 +832,7 @@ void SelectDragHelper<T>::finish_dragging()
 
 	pointer_state = POINTER_NONE;
 
-	signal_drag_finished().emit();
+	signal_drag_finished().emit(dragging_started_by_key);
 }
 
 template <class T>

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -115,6 +115,7 @@ private:
 
 protected:
 	synfigapp::Action::PassiveGrouper *get_action_group_drag() const;
+	bool is_dragging_started_by_keys() const;
 
 public:
 	SelectDragHelper(const char *drag_action_name);
@@ -770,6 +771,12 @@ template<class T>
 synfigapp::Action::PassiveGrouper* SelectDragHelper<T>::get_action_group_drag() const
 {
 	return action_group_drag;
+}
+
+template<class T>
+bool SelectDragHelper<T>::is_dragging_started_by_keys() const
+{
+	return dragging_started_by_key;
 }
 
 template <class T>

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -132,7 +132,8 @@ public:
 	/// The point where active item was initially placed
 	void get_active_item_initial_point(int &px, int &py) const;
 
-	//! Retrieve the position of a given item
+	//! @brief Retrieve the position of a given item
+	//! Implementation only needed if item dragging is enabled.
 	//! @param[out] position the location the provided item
 	virtual void get_item_position(const T &item, Gdk::Point &position) = 0;
 
@@ -141,7 +142,8 @@ public:
 	//! @return true if an item was found, false otherwise
 	virtual bool find_item_at_position(int pos_x, int pos_y, T & item) = 0;
 
-	//! Retrieve all items inside a rectangular area
+	//! @brief Retrieve all items inside a rectangular area.
+	//! Implementation only needed if multiple selection is enabled.
 	//! @param rect the rectangle area
 	//! @param[out] the list of items contained inside rect
 	//! @return true if any item was found, false otherwise
@@ -152,7 +154,8 @@ public:
 	virtual void get_all_items(std::vector<T> & items) = 0;
 
 	void drag_to(int pointer_x, int pointer_y);
-	//! Do drag selected items
+	//! @brief Do drag selected items
+	//! Implementation only needed if dragging is enabled.
 	/*!
 	 * @param total_dx total pointer/mouse displacement along x-axis since drag start
 	 * @param total_dy total pointer/mouse displacement along y-axis since drag start

--- a/synfig-studio/src/gui/widgets/CMakeLists.txt
+++ b/synfig-studio/src/gui/widgets/CMakeLists.txt
@@ -24,4 +24,5 @@ target_sources(synfigstudio
         "${CMAKE_CURRENT_LIST_DIR}/widget_ruler.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/widget_soundwave.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/widget_timegraphbase.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/widget_timetrack.cpp"
 )

--- a/synfig-studio/src/gui/widgets/Makefile_insert
+++ b/synfig-studio/src/gui/widgets/Makefile_insert
@@ -22,7 +22,8 @@ WIDGETS_HH = \
 	widgets/widget_bonechooser.h \
 	widgets/widget_ruler.h \
 	widgets/widget_soundwave.h \
-	widgets/widget_timegraphbase.h
+	widgets/widget_timegraphbase.h \
+	widgets/widget_timetrack.h
 
 WIDGETS_CC = \
 	widgets/widget_canvaschooser.cpp \
@@ -48,7 +49,8 @@ WIDGETS_CC = \
 	widgets/widget_bonechooser.cpp \
 	widgets/widget_ruler.cpp \
 	widgets/widget_soundwave.cpp \
-	widgets/widget_timegraphbase.cpp
+	widgets/widget_timegraphbase.cpp \
+	widgets/widget_timetrack.cpp
 
 synfigstudio_src += \
 	$(WIDGETS_HH) \

--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -510,7 +510,7 @@ Widget_Curves::Widget_Curves()
 	channel_point_sd.signal_drag_canceled().connect([&]() {
 		overlapped_waypoints.clear();
 	});
-	channel_point_sd.signal_drag_finished().connect([&]() {
+	channel_point_sd.signal_drag_finished().connect([&](bool /*started_by_keys*/) {
 //		overlapped_waypoints.clear();
 	});
 	channel_point_sd.signal_redraw_needed().connect(sigc::mem_fun(*this, &Gtk::Widget::queue_draw));

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
@@ -144,7 +144,15 @@ etl::handle<synfigapp::CanvasInterface> Widget_TimeGraphBase::get_canvas_interfa
 
 void Widget_TimeGraphBase::set_canvas_interface(const etl::handle<synfigapp::CanvasInterface>& value)
 {
+	if (canvas_interface.get() == value.get())
+		return;
 	canvas_interface = value;
+	on_canvas_interface_changed();
+}
+
+void Widget_TimeGraphBase::on_canvas_interface_changed()
+{
+
 }
 
 void Widget_TimeGraphBase::set_default_page_size(double new_value)

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
@@ -140,6 +140,16 @@ void Widget_TimeGraphBase::pan(int dx, int dy, int /*total_dx*/, int /*total_dy*
 			.finish();
 }
 
+etl::handle<synfigapp::CanvasInterface> Widget_TimeGraphBase::get_canvas_interface() const
+{
+	return canvas_interface;
+}
+
+void Widget_TimeGraphBase::set_canvas_interface(const etl::handle<synfigapp::CanvasInterface>& value)
+{
+	canvas_interface = value;
+}
+
 void Widget_TimeGraphBase::set_default_page_size(double new_value)
 {
 	if (new_value < 0 || synfig::approximate_zero(new_value))
@@ -176,12 +186,22 @@ void Widget_TimeGraphBase::on_time_model_changed()
 
 }
 
-void Widget_TimeGraphBase::draw_current_time(const Cairo::RefPtr<Cairo::Context>& cr)
+void Widget_TimeGraphBase::draw_current_time(const Cairo::RefPtr<Cairo::Context>& cr) const
 {
 	cr->save();
 	cr->set_line_width(1.0);
 	cr->set_source_rgb(0, 0, 1);
 	cr->rectangle(time_plot_data->get_pixel_t_coord(time_plot_data->time), 0, 0, get_height());
 	cr->stroke();
+	cr->restore();
+}
+
+void Widget_TimeGraphBase::draw_keyframe_line(const Cairo::RefPtr<Cairo::Context>& cr, const synfig::Keyframe& keyframe) const
+{
+	const Gdk::Color keyframe_color("#a07f7f");
+	cr->save();
+	Gdk::Cairo::set_source_color(cr, keyframe_color);
+	cr->rectangle(time_plot_data->get_pixel_t_coord(keyframe.get_time()), 0, 1.0, get_height());
+	cr->fill();
 	cr->restore();
 }

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
@@ -1,5 +1,5 @@
 /* === S Y N F I G ========================================================= */
-/*!	\file widgets/widget_timegraphbase.h
+/*!	\file widgets/widget_timegraphbase.cpp
 **	\brief Base class for widgets that are graph-like representations with time axis
 **
 **	$Id$
@@ -29,11 +29,8 @@
 
 #include "widget_timegraphbase.h"
 
-#include <canvasview.h>
+#include <gui/canvasview.h>
 #include <gui/timeplotdata.h>
-
-#include <Mlt.h>
-#include <gui/selectdraghelper.h>
 
 #include <cairomm/cairomm.h>
 #include <gdkmm.h>

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
@@ -204,10 +204,13 @@ void Widget_TimeGraphBase::draw_current_time(const Cairo::RefPtr<Cairo::Context>
 
 void Widget_TimeGraphBase::draw_keyframe_line(const Cairo::RefPtr<Cairo::Context>& cr, const synfig::Keyframe& keyframe) const
 {
+	const synfig::Time &keyframe_time = keyframe.get_time();
+	if (keyframe_time < time_plot_data->lower_ex || keyframe_time >= time_plot_data->upper_ex)
+		return;
 	const Gdk::Color keyframe_color("#a07f7f");
 	cr->save();
 	Gdk::Cairo::set_source_color(cr, keyframe_color);
-	cr->rectangle(time_plot_data->get_pixel_t_coord(keyframe.get_time()), 0, 1.0, get_height());
+	cr->rectangle(time_plot_data->get_pixel_t_coord(keyframe_time), 0, 1.0, get_height());
 	cr->fill();
 	cr->restore();
 }

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
@@ -151,8 +151,9 @@ void Widget_TimeGraphBase::set_default_page_size(double new_value)
 {
 	if (new_value < 0 || synfig::approximate_zero(new_value))
 		return;
+	double current_zoom = get_zoom();
 	default_page_size = new_value;
-	set_zoom(get_zoom());
+	set_zoom(current_zoom);
 }
 
 double Widget_TimeGraphBase::get_default_page_size() const

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.h
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.h
@@ -84,6 +84,7 @@ public:
 
 protected:
 	etl::handle<synfigapp::CanvasInterface> canvas_interface;
+	virtual void on_canvas_interface_changed();
 
 	Glib::RefPtr<Gtk::Adjustment> range_adjustment;
 	TimePlotData * time_plot_data;

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.h
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.h
@@ -33,6 +33,26 @@ namespace studio {
 
 class TimePlotData;
 
+/**
+ * \brief Base class for widgets that are graph-like representations with time axis
+ *
+ * Derive this class in order to create graph-like widgets that must be in sync
+ * with the time set for the animation: it allows to easily react to time-line
+ * zooming and panning/scrolling.
+ *
+ * It also supports a vertical adjustment, allowing to zoom and pan/scroll in
+ * Y-axis too. It can be set for an external Gtk::ScrollBar to control this widget.
+ * Retrieve it by Widget_TimeGraphBase::get_range_adjustment().
+ *
+ * A derived class can support the zoom/pan/scroll actions by checking Widget_TimeGraphBase#time_plot_data
+ * methods that provide conversion between (horizontal) pixels <-> time values
+ * as well between (vertical) pixels <-> real Y values (the meaning of Y depends on each case).
+ *
+ * The effects of those three actions are automatically mapped in Widget_TimeGraphBase#time_plot_data.
+ *
+ * After class instancing, it is mandatory to set a TimeModel via Widget_TimeGraphBase::set_time_model(),
+ * otherwise it is impossible to do the pixel coordinates <-> time value conversions.
+ */
 class Widget_TimeGraphBase : public Gtk::DrawingArea
 {
 public:
@@ -44,12 +64,16 @@ public:
 	virtual const etl::handle<TimeModel>& get_time_model() const;
 	virtual void set_time_model(const etl::handle<TimeModel> &x);
 
+	//! Zoom in along vertical-axis. \sa Widget_TimeGraphBase#zoom_changing_factor
 	virtual void zoom_in();
+	//! Zoom out along vertical-axis. \sa Widget_TimeGraphBase#zoom_changing_factor
 	virtual void zoom_out();
+	//! Alias for set_zoom(1.0);
 	virtual void zoom_100();
 	virtual void set_zoom(double new_zoom_factor);
 	virtual double get_zoom() const;
 
+	//! Scroll vertically by step_increment units of Widget_TimeGraphBase#range_adjustment
 	virtual void scroll_up();
 	virtual void scroll_down();
 
@@ -64,15 +88,22 @@ protected:
 	Glib::RefPtr<Gtk::Adjustment> range_adjustment;
 	TimePlotData * time_plot_data;
 
+	//! Multiplier zoom factor for Widget_TimeGraphBase::zoom_in() and Widget_TimeGraphBase::zoom_out()
+	//! Example: if it equals to 2.0, zoom_in() doubles current zoom value, whereas zoom_out() reduces by half
 	double zoom_changing_factor;
 
+	//! Set the page size of Widget_TimeGraphBase#range_adjustment when zoom is set to 100%
 	void set_default_page_size(double new_value);
 	double get_default_page_size() const;
 
 	virtual bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr);
 	virtual void on_time_model_changed();
 
+	//! Draw a vertical line representing the current time in Synfig Studio
+	//! To be used in Widget_TimeGraphBase::on_draw() override implementation.
 	void draw_current_time(const Cairo::RefPtr<Cairo::Context> &cr) const;
+	//! Draw a vertical line marking the keyframe time
+	//! To be used in Widget_TimeGraphBase::on_draw() override implementation.
 	void draw_keyframe_line(const Cairo::RefPtr<Cairo::Context> &cr, const synfig::Keyframe& keyframe) const;
 
 private:

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.h
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.h
@@ -55,6 +55,9 @@ public:
 
 	virtual void pan(int dx, int dy, int /*total_dx*/, int /*total_dy*/);
 
+	etl::handle<synfigapp::CanvasInterface> get_canvas_interface() const;
+	void set_canvas_interface(const etl::handle<synfigapp::CanvasInterface>& value);
+
 protected:
 	etl::handle<synfigapp::CanvasInterface> canvas_interface;
 
@@ -69,7 +72,8 @@ protected:
 	virtual bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr);
 	virtual void on_time_model_changed();
 
-	void draw_current_time(const Cairo::RefPtr<Cairo::Context> &cr);
+	void draw_current_time(const Cairo::RefPtr<Cairo::Context> &cr) const;
+	void draw_keyframe_line(const Cairo::RefPtr<Cairo::Context> &cr, const synfig::Keyframe& keyframe) const;
 
 private:
 	double default_page_size;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -736,6 +736,10 @@ Widget_Timetrack::WaypointSD::WaypointSD(Widget_Timetrack& widget)
 	signal_drag_started().connect([&]() {deltatime = 0;});
 	signal_drag_canceled().connect([&]() {deltatime = 0;});
 	signal_drag_finished().connect([&]() {on_drag_finish();});
+	signal_modifier_keys_changed().connect([&]() {
+		if (get_state() == POINTER_DRAGGING)
+			widget.queue_draw();
+	});
 }
 
 Widget_Timetrack::WaypointSD::~WaypointSD()

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -376,7 +376,8 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 		});
 
 		// Draw static intervals
-		draw_static_intervals_for_row(cr, row_info, visible_waypoints);
+		if (value_desc.get_value_type() != synfig::type_canvas)
+			draw_static_intervals_for_row(cr, row_info, visible_waypoints);
 
 		draw_waypoints(cr, path, row_info, visible_waypoints);
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -826,5 +826,5 @@ void Widget_Timetrack::WaypointSD::delta_drag(int total_dx, int /*total_dy*/, bo
 
 	// now we update cached values in select-drag handler
 	for (auto pair : timepoints_to_update)
-		pair.first->time_point = synfig::TimePoint(pair.second);
+		pair.first->time_point.set_time(pair.second);
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -1087,8 +1087,10 @@ void Widget_Timetrack::WaypointSD::on_drag_canceled()
 
 void Widget_Timetrack::WaypointSD::on_drag_finish(bool /*started_by_keys*/)
 {
-	if (deltatime == 0)
+	if (deltatime == 0) {
+		update_action();
 		return;
+	}
 
 	if (action == MOVE)
 		widget.move_selected(deltatime);

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -742,15 +742,19 @@ void Widget_Timetrack::on_waypoint_clicked(const Widget_Timetrack::WaypointItem&
 {
 	std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoint_set;
 	const synfigapp::ValueDesc &value_desc = param_info_map[wi.path.to_string()]->get_value_desc();
-	synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), value_desc.get_value_node());
-	signal_waypoint_clicked().emit(value_desc, waypoint_set, button);
+	if (value_desc.is_value_node())
+		synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), value_desc.get_value_node());
+	if (waypoint_set.size() > 0)
+		signal_waypoint_clicked().emit(value_desc, waypoint_set, button);
 }
 
 void Widget_Timetrack::on_waypoint_double_clicked(const Widget_Timetrack::WaypointItem& wi, unsigned int button, Gdk::Point)
 {
 	std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoint_set;
 	const synfigapp::ValueDesc &value_desc = param_info_map[wi.path.to_string()]->get_value_desc();
-	synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), value_desc.get_value_node());
+	if (value_desc.is_value_node())
+		synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), value_desc.get_value_node());
+	if (waypoint_set.size() > 0)
 	signal_waypoint_double_clicked().emit(value_desc, waypoint_set, button);
 }
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -399,7 +399,7 @@ void Widget_Timetrack::rebuild_param_info_list()
 	}
 
 	Gtk::TreeViewColumn *col = params_treeview->get_column(0);
-	params_store.get()->foreach([&](const Gtk::TreeModel::Path &path, const Gtk::TreeModel::iterator &iter) -> bool {
+	params_store->foreach([&](const Gtk::TreeModel::Path &path, const Gtk::TreeModel::iterator &iter) -> bool {
 		Gdk::Rectangle rect;
 		params_treeview->get_cell_area(path, *col, rect);
 		Geometry geometry;
@@ -439,7 +439,7 @@ void Widget_Timetrack::update_param_list_geometries()
 	}
 
 	Gtk::TreeViewColumn *col = params_treeview->get_column(0);
-	params_store.get()->foreach([&](const Gtk::TreeModel::Path &path, const Gtk::TreeModel::iterator &/*iter*/) -> bool {
+	params_store->foreach_path([&](const Gtk::TreeModel::Path &path) -> bool {
 		Gdk::Rectangle rect;
 		params_treeview->get_cell_area(path, *col, rect);
 		Geometry geometry;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -81,7 +81,7 @@ bool Widget_Timetrack::set_params_view(Gtk::TreeView* treeview)
 
 	Glib::RefPtr<LayerParamTreeStore> treestore = Glib::RefPtr<LayerParamTreeStore>::cast_dynamic( treeview->get_model() );
 	if (!treestore) {
-		synfig::error("TreeView must use model based on LayerParamTreeStore");
+		synfig::error(_("TreeView must use model based on LayerParamTreeStore"));
 		return false;
 	}
 	params_store = treestore;
@@ -107,12 +107,12 @@ Glib::RefPtr<LayerParamTreeStore> Widget_Timetrack::get_params_model() const
 bool Widget_Timetrack::use_canvas_view(etl::loose_handle<CanvasView> canvas_view)
 {
 	if (!canvas_view) {
-		synfig::error("No canvas_view for timetrack");
+		synfig::error(_("No canvas_view for timetrack"));
 		return false;
 	}
 	Gtk::TreeView* params_treeview = dynamic_cast<Gtk::TreeView*>(canvas_view->get_ext_widget("params"));
 	if (!params_treeview) {
-		synfig::error("Params treeview widget doesn't exist");
+		synfig::error(_("Params treeview widget doesn't exist"));
 		return false;
 	}
 
@@ -712,7 +712,7 @@ void Widget_Timetrack::RowInfo::set_geometry(const Widget_Timetrack::Geometry& v
 void Widget_Timetrack::RowInfo::refresh()
 {
 	if (!value_desc) {
-		synfig::error("ValueDesc invalid! Internal error");
+		synfig::error(_("ValueDesc invalid! Internal error"));
 		return;
 	}
 
@@ -730,7 +730,7 @@ bool Widget_Timetrack::WaypointItem::operator ==(const Widget_Timetrack::Waypoin
 }
 
 Widget_Timetrack::WaypointSD::WaypointSD(Widget_Timetrack& widget)
-	: SelectDragHelper<WaypointItem>("Move waypoints"),
+	: SelectDragHelper<WaypointItem>(_("Move waypoints")),
 	  widget(widget)
 {
 	signal_drag_started().connect([&]() {deltatime = 0;});
@@ -751,7 +751,7 @@ void Widget_Timetrack::WaypointSD::get_item_position(const Widget_Timetrack::Way
 	p.set_x(widget.time_plot_data->get_pixel_t_coord(item.time_point.get_time()));
 	RowInfo * row_info = widget.param_info_map[item.path.to_string()];
 	if (!row_info) {
-		synfig::warning("invalid item");
+		synfig::warning(_("invalid item"));
 		return;
 	}
 	Geometry geometry = row_info->get_geometry();
@@ -769,7 +769,7 @@ bool Widget_Timetrack::WaypointSD::find_item_at_position(int pos_x, int pos_y, W
 
 	RowInfo *row_info = widget.param_info_map[path.to_string()];
 	if (!row_info) {
-		synfig::warning("couldn't find row info for path: internal error");
+		synfig::warning(_("couldn't find row info for path: internal error"));
 		return false;
 	}
 	const synfigapp::ValueDesc &value_desc = row_info->get_value_desc();
@@ -818,7 +818,7 @@ bool Widget_Timetrack::WaypointSD::find_items_in_rect(Gdk::Rectangle rect, std::
 
 		const RowInfo *row_info = widget.param_info_map[path.to_string()];
 		if (!row_info) {
-			synfig::warning("%s :\n\tcouldn't find row info for path: internal error", __PRETTY_FUNCTION__);
+			synfig::warning(_("%s :\n\tcouldn't find row info for path: internal error"), __PRETTY_FUNCTION__);
 			continue;
 		}
 		path_list.push_back(path);

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -146,13 +146,6 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 void Widget_Timetrack::on_size_allocate(Gtk::Allocation& allocation)
 {
 	double upper = range_adjustment->get_upper();
-	{
-		std::lock_guard<std::mutex> lock(param_list_mutex);
-		if (param_info_map.size() > 0) {
-			Geometry geometry = param_info_map.end()->second->get_geometry();
-			upper = geometry.y + geometry.h;
-		}
-	}
 	Widget_TimeGraphBase::on_size_allocate(allocation);
 	set_default_page_size(allocation.get_height());
 	ConfigureAdjustment(range_adjustment)

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -422,7 +422,7 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 						waypoint_edge_length - 2*margin);
 
 			bool hover = false;
-			bool selected = false;
+			bool selected = true;
 			WaypointRenderer::render_time_point_to_window(cr, area, tp, selected, hover);
 		}
 	}

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -736,10 +736,7 @@ Widget_Timetrack::WaypointSD::WaypointSD(Widget_Timetrack& widget)
 	signal_drag_started().connect([&]() {deltatime = 0;});
 	signal_drag_canceled().connect([&]() {deltatime = 0;});
 	signal_drag_finished().connect([&]() {on_drag_finish();});
-	signal_modifier_keys_changed().connect([&]() {
-		if (get_state() == POINTER_DRAGGING)
-			widget.queue_draw();
-	});
+	signal_modifier_keys_changed().connect([&]() {on_modifier_keys_changed();});
 }
 
 Widget_Timetrack::WaypointSD::~WaypointSD()
@@ -909,4 +906,21 @@ void Widget_Timetrack::WaypointSD::on_drag_finish()
 	}
 
 	deltatime = 0;
+}
+
+void Widget_Timetrack::WaypointSD::on_modifier_keys_changed()
+{
+	if (get_state() == POINTER_DRAGGING) {
+		synfigapp::Action::PassiveGrouper * action = get_action_group_drag();
+		if (action) {
+			std::string action_name;
+			if (!get_modifiers())
+				action_name = _("Move waypoints");
+			else if (has_modifier(Gdk::SHIFT_MASK))
+				action_name = _("Copy waypoints");
+			action->set_name(action_name);
+		}
+
+		widget.queue_draw();
+	}
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -858,22 +858,16 @@ void Widget_Timetrack::WaypointSD::on_drag_finish()
 	if (deltatime == 0)
 		return;
 
+	widget.move_selected(deltatime);
+
 	const float fps = widget.canvas_interface->get_canvas()->rend_desc().get_frame_rate();
-	std::vector<std::pair<WaypointItem*, synfig::Time> > timepoints_to_update;
 	std::vector<WaypointItem*> selection = get_selected_items();
 	for (WaypointItem * point : selection) {
 		const synfig::Time &time = point->time_point.get_time();
 		const synfig::Time new_time = synfig::Time(time+deltatime).round(fps);
 
-		timepoints_to_update.push_back(std::pair<WaypointItem*, synfig::Time>(point, new_time));
+		point->time_point.set_time(new_time);
 	}
-
-	// first we move waypoints
-	widget.move_selected(deltatime);
-
-	// now we update cached values in select-drag handler
-	for (auto pair : timepoints_to_update)
-		pair.first->time_point.set_time(pair.second);
 
 	deltatime = 0;
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -735,7 +735,7 @@ Widget_Timetrack::WaypointSD::WaypointSD(Widget_Timetrack& widget)
 {
 	signal_drag_started().connect([&]() {deltatime = 0;});
 	signal_drag_canceled().connect([&]() {deltatime = 0;});
-	signal_drag_finished().connect([&]() {on_drag_finish();});
+	signal_drag_finished().connect([&](bool started_by_keys) {on_drag_finish(started_by_keys);});
 	signal_modifier_keys_changed().connect([&]() {on_modifier_keys_changed();});
 }
 
@@ -885,16 +885,15 @@ const synfig::Time& Widget_Timetrack::WaypointSD::get_deltatime()
 	return deltatime;
 }
 
-void Widget_Timetrack::WaypointSD::on_drag_finish()
+void Widget_Timetrack::WaypointSD::on_drag_finish(bool started_by_keys)
 {
 	if (deltatime == 0)
 		return;
 
-	if (!get_modifiers())
+	if (started_by_keys || !get_modifiers())
 		widget.move_selected(deltatime);
-	else if (has_modifier(Gdk::SHIFT_MASK)) {
+	else if (has_modifier(Gdk::SHIFT_MASK))
 		widget.copy_selected(deltatime);
-	}
 
 	const float fps = widget.canvas_interface->get_canvas()->rend_desc().get_frame_rate();
 	std::vector<WaypointItem*> selection = get_selected_items();

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -1,0 +1,67 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file widgets/widget_timetrack.cpp
+**	\brief Widget to displaying layer parameter waypoints along time
+**
+**	$Id$
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	......... ... 2020 Rodolfo Ribeiro Gomes
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include "widget_timetrack.h"
+
+#include <gui/canvasview.h>
+#include <gui/timeplotdata.h>
+
+#include <gui/localization.h>
+
+#include <cairomm/cairomm.h>
+#include <gdkmm.h>
+#endif
+
+using namespace studio;
+
+Widget_Timetrack::Widget_Timetrack()
+{
+
+}
+
+Widget_Timetrack::~Widget_Timetrack()
+{
+
+}
+
+bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
+{
+	if (Widget_TimeGraphBase::on_draw(cr))
+		return true;
+
+	if (canvas_interface) {
+		synfig::Canvas::Handle canvas = canvas_interface->get_canvas();
+
+		if (canvas)
+			for(synfig::KeyframeList::const_iterator i = canvas->keyframe_list().begin(); i != canvas->keyframe_list().end(); ++i)
+				draw_keyframe_line(cr, *i);
+	}
+	draw_current_time(cr);
+	return true;
+}

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -194,11 +194,15 @@ void Widget_Timetrack::goto_next_waypoint(long n)
 	auto item = std::find(time_vector.begin(), time_vector.end(), wi.time_point);
 
 	if (n > 0) {
-		n = std::min(n, std::distance(item, time_vector.end()-1));
+		long max = std::distance(item, time_vector.end()-1);
+		if (n > max)
+			n = max;
 		if (n <= 0)
 			return;
 	} else {
-		n = std::max(n, std::distance(item, time_vector.begin()));
+		long min = std::distance(item, time_vector.begin());
+		if (n < min)
+			n = min;
 		if (n == 0)
 			return;
 	}

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -867,8 +867,10 @@ void Widget_Timetrack::WaypointSD::delta_drag(int total_dx, int /*total_dy*/, bo
 	}
 
 	// Move along time
-	if (dx == 0)
+	if (dx == 0) {
+		deltatime = 0;
 		return;
+	}
 
 	const float fps = widget.canvas_interface->get_canvas()->rend_desc().get_frame_rate();
 	int x0, y0;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -309,6 +309,7 @@ void Widget_Timetrack::setup_mouse_handler()
 	waypoint_sd.signal_scroll_down_requested().connect(sigc::mem_fun(*this, &Widget_Timetrack::scroll_down));
 	waypoint_sd.signal_panning_requested().connect(sigc::mem_fun(*this, &Widget_Timetrack::pan));
 
+	waypoint_sd.signal_selection_changed().connect(sigc::mem_fun(*this, &Gtk::Widget::queue_draw));
 	waypoint_sd.signal_item_clicked().connect(sigc::mem_fun(*this, &Widget_Timetrack::on_waypoint_clicked));
 	waypoint_sd.signal_item_double_clicked().connect(sigc::mem_fun(*this, &Widget_Timetrack::on_waypoint_double_clicked));
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -39,6 +39,7 @@
 #include <gdkmm.h>
 
 #include <synfig/general.h>
+#include <synfig/timepointcollect.h>
 #endif
 
 using namespace studio;
@@ -233,6 +234,9 @@ void Widget_Timetrack::setup_mouse_handler()
 	waypoint_sd.signal_scroll_up_requested().connect(sigc::mem_fun(*this, &Widget_Timetrack::scroll_up));
 	waypoint_sd.signal_scroll_down_requested().connect(sigc::mem_fun(*this, &Widget_Timetrack::scroll_down));
 	waypoint_sd.signal_panning_requested().connect(sigc::mem_fun(*this, &Widget_Timetrack::pan));
+
+	waypoint_sd.signal_item_clicked().connect(sigc::mem_fun(*this, &Widget_Timetrack::on_waypoint_clicked));
+	waypoint_sd.signal_item_double_clicked().connect(sigc::mem_fun(*this, &Widget_Timetrack::on_waypoint_double_clicked));
 }
 
 void Widget_Timetrack::setup_params_store()
@@ -424,6 +428,22 @@ void Widget_Timetrack::draw_waypoints(const Cairo::RefPtr<Cairo::Context>& cr, c
 		bool selected = waypoint_sd.is_selected(WaypointItem(tp, path));
 		WaypointRenderer::render_time_point_to_window(cr, area, tp, selected, hover);
 	}
+}
+
+void Widget_Timetrack::on_waypoint_clicked(const Widget_Timetrack::WaypointItem& wi, unsigned int button, Gdk::Point)
+{
+	std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoint_set;
+	const synfigapp::ValueDesc &value_desc = param_info_map[wi.path.to_string()]->get_value_desc();
+	synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), value_desc.get_value_node());
+	signal_waypoint_clicked().emit(value_desc, waypoint_set, button);
+}
+
+void Widget_Timetrack::on_waypoint_double_clicked(const Widget_Timetrack::WaypointItem& wi, unsigned int button, Gdk::Point)
+{
+	std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoint_set;
+	const synfigapp::ValueDesc &value_desc = param_info_map[wi.path.to_string()]->get_value_desc();
+	synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), value_desc.get_value_node());
+	signal_waypoint_double_clicked().emit(value_desc, waypoint_set, button);
 }
 
 Widget_Timetrack::RowInfo::RowInfo()

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -322,10 +322,6 @@ Widget_Timetrack::RowInfo::RowInfo(synfigapp::ValueDesc value_desc_, Widget_Time
 			value_desc_connections.push_back(
 						value_desc.get_parent_value_node()->signal_changed().connect(
 							sigc::mem_fun(*this, &RowInfo::refresh )));
-		if (value_desc.parent_is_layer())
-			value_desc_connections.push_back(
-						value_desc.get_layer()->signal_changed().connect(
-							sigc::mem_fun(*this, &RowInfo::refresh )));
 		refresh();
 	}
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -274,7 +274,11 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 			return true;
 		}
 
-		if (row_info->get_geometry().h == 0)
+		const Geometry& geometry = row_info->get_geometry();
+		if (geometry.h == 0)
+			return false;
+
+		if (geometry.y + geometry.h < 0 || geometry.y > get_height())
 			return false;
 
 		// is param selected?

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -442,13 +442,25 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 		cr->stroke();
 	}
 
+	synfig::Canvas::Handle canvas;
+	if (params_treeview && param_info_map.size() > 0) {
+		const RowInfo * row_info = param_info_map.begin()->second;
+//		If Parameters Panel shows data of more than one layer, maybe we should do something like:
+//		Gtk::TreeIter selected_iter = params_treeview->get_selection()->get_selected();
+//		Gtk::TreePath path = params_treeview->get_model()->get_path(selected_iter);
+//		const RowInfo *row_info = param_info_map[path.to_string()];
+		if (row_info) {
+			// A different canvas? (eg. imported layer)
+			canvas = row_info->get_value_desc().get_canvas();
+		}
+	}
 
-	if (canvas_interface) {
-		synfig::Canvas::Handle canvas = canvas_interface->get_canvas();
+	if (!canvas && canvas_interface)
+		canvas = canvas_interface->get_canvas();
 
-		if (canvas)
-			for(synfig::KeyframeList::const_iterator i = canvas->keyframe_list().begin(); i != canvas->keyframe_list().end(); ++i)
-				draw_keyframe_line(cr, *i);
+	if (canvas) {
+		for(synfig::KeyframeList::const_iterator i = canvas->keyframe_list().begin(); i != canvas->keyframe_list().end(); ++i)
+	        draw_keyframe_line(cr, *i);
 	}
 	draw_current_time(cr);
 	return true;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -36,21 +36,82 @@
 
 #include <cairomm/cairomm.h>
 #include <gdkmm.h>
+
+#include <synfig/general.h>
 #endif
 
 using namespace studio;
 
 Widget_Timetrack::Widget_Timetrack()
+	: params_treeview(nullptr),
+	  update_param_tree_queued(false),
+	  update_param_height_queued(false)
 {
 	add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK | Gdk::SCROLL_MASK | Gdk::POINTER_MOTION_MASK | Gdk::KEY_PRESS_MASK | Gdk::KEY_RELEASE_MASK);
 	set_can_focus(true);
 	time_plot_data->set_extra_time_margin(16/2);
 	setup_mouse_handler();
+
+	setup_adjustment();
 }
 
 Widget_Timetrack::~Widget_Timetrack()
 {
+	teardown_params_view();
+	teardown_params_store();
+}
 
+bool Widget_Timetrack::set_params_view(Gtk::TreeView* treeview)
+{
+	teardown_params_view();
+	teardown_params_store();
+
+	params_treeview = nullptr;
+	params_store.reset();
+
+	if (!treeview)
+		return true;
+
+	Glib::RefPtr<LayerParamTreeStore> treestore = Glib::RefPtr<LayerParamTreeStore>::cast_dynamic( treeview->get_model() );
+	if (!treestore) {
+		synfig::error("TreeView must use model based on LayerParamTreeStore");
+		return false;
+	}
+	params_store = treestore;
+	params_treeview = treeview;
+	setup_params_store();
+	setup_params_view();
+
+	update_param_tree();
+
+	return true;
+}
+
+Gtk::TreeView* Widget_Timetrack::get_params_view() const
+{
+	return params_treeview;
+}
+
+Glib::RefPtr<LayerParamTreeStore> Widget_Timetrack::get_params_model() const
+{
+	return params_store;
+}
+
+bool Widget_Timetrack::use_canvas_view(etl::loose_handle<CanvasView> canvas_view)
+{
+	if (!canvas_view) {
+		synfig::error("No canvas_view for timetrack");
+		return false;
+	}
+	Gtk::TreeView* params_treeview = dynamic_cast<Gtk::TreeView*>(canvas_view->get_ext_widget("params"));
+	if (!params_treeview) {
+		synfig::error("Params treeview widget doesn't exist");
+		return false;
+	}
+
+	set_time_model(canvas_view->time_model());
+	set_canvas_interface(canvas_view->canvas_interface());
+	return set_params_view(params_treeview);
 }
 
 bool Widget_Timetrack::on_event(GdkEvent* event)
@@ -62,6 +123,8 @@ bool Widget_Timetrack::on_event(GdkEvent* event)
 
 bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 {
+	std::lock_guard<std::mutex> lock(param_list_mutex);
+
 	if (Widget_TimeGraphBase::on_draw(cr))
 		return true;
 
@@ -78,14 +141,20 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 
 void Widget_Timetrack::on_size_allocate(Gtk::Allocation& allocation)
 {
+	double upper = range_adjustment->get_upper();
+	{
+		std::lock_guard<std::mutex> lock(param_list_mutex);
+		if (params_info_list.size() > 0) {
+			upper = params_info_list.back().second.y + params_info_list.back().second.h;
+		}
+	}
 	Widget_TimeGraphBase::on_size_allocate(allocation);
 	set_default_page_size(allocation.get_height());
-	range_adjustment->set_page_size(allocation.get_height());
-	range_adjustment->set_step_increment(allocation.get_height()/10);
 	ConfigureAdjustment(range_adjustment)
 			.set_page_size(allocation.get_height())
 			.set_step_increment(allocation.get_height()/10)
 			.set_lower(0)
+			.set_upper(upper)
 			.finish();
 }
 
@@ -101,3 +170,142 @@ void Widget_Timetrack::setup_mouse_handler()
 	waypoint_sd.signal_scroll_down_requested().connect(sigc::mem_fun(*this, &Widget_Timetrack::scroll_down));
 	waypoint_sd.signal_panning_requested().connect(sigc::mem_fun(*this, &Widget_Timetrack::pan));
 }
+
+void Widget_Timetrack::setup_params_store()
+{
+	sigc::connection conn;
+
+	conn = params_store->signal_row_inserted().connect([&](const Gtk::TreeModel::Path&, const Gtk::TreeModel::iterator&){
+		queue_update_param_tree();
+	});
+	treestore_connections.push_back(conn);
+
+	conn = params_store->signal_row_deleted().connect([&](const Gtk::TreeModel::Path&){
+		queue_update_param_tree();
+	});
+	treestore_connections.push_back(conn);
+
+	conn = params_store->signal_rows_reordered().connect([&](const Gtk::TreeModel::Path&, const Gtk::TreeModel::iterator&, int*){
+		queue_update_param_tree();
+	});
+	treestore_connections.push_back(conn);
+}
+
+void Widget_Timetrack::teardown_params_store()
+{
+	for (sigc::connection &conn : treestore_connections)
+		conn.disconnect();
+	treestore_connections.clear();
+}
+
+void Widget_Timetrack::setup_params_view()
+{
+	sigc::connection conn;
+	conn = params_treeview->signal_row_expanded().connect([&](const Gtk::TreeModel::iterator&,const Gtk::TreeModel::Path&) {
+		queue_update_param_heights();
+	});
+	treeview_connections.push_back(conn);
+
+	conn = params_treeview->signal_row_collapsed().connect([&](const Gtk::TreeModel::iterator&,const Gtk::TreeModel::Path&) {
+		queue_update_param_heights();
+	});
+	treeview_connections.push_back(conn);
+
+	conn = params_treeview->signal_style_updated().connect(sigc::mem_fun(*this, &Widget_Timetrack::queue_update_param_heights));
+	treeview_connections.push_back(conn);
+}
+
+void Widget_Timetrack::teardown_params_view()
+{
+	for (sigc::connection &conn : treeview_connections)
+		conn.disconnect();
+	treeview_connections.clear();
+}
+
+void Widget_Timetrack::setup_adjustment()
+{
+	range_adjustment->signal_value_changed().connect([&](){
+		// wait for all members of Adjustment group to synchronize
+		queue_update_param_heights();
+	});
+	range_adjustment->signal_changed().connect([&](){
+		set_default_page_size(range_adjustment->get_page_size());
+		queue_update_param_heights();
+	});
+}
+
+void Widget_Timetrack::queue_update_param_tree()
+{
+	if (update_param_tree_queued)
+		return;
+	update_param_tree_queued = true;
+	Glib::signal_idle().connect_once(sigc::mem_fun(*this, &Widget_Timetrack::update_param_tree));
+}
+
+void Widget_Timetrack::update_param_tree()
+{
+	std::lock_guard<std::mutex> lock(param_list_mutex);
+
+	update_param_tree_queued = false;
+
+	params_info_list.clear();
+
+	if (!params_treeview || !params_treeview->get_realized() || !params_store) {
+		queue_draw();
+		return;
+	}
+
+	Gtk::TreeViewColumn *col = params_treeview->get_column(0);
+	params_store.get()->foreach([&](const Gtk::TreeModel::Path &path, const Gtk::TreeModel::iterator &iter) -> bool {
+		Gdk::Rectangle rect;
+		params_treeview->get_cell_area(path, *col, rect);
+		Geometry geometry;
+		geometry.y = rect.get_y();
+		geometry.h = rect.get_height();
+		synfigapp::ValueDesc value_desc = iter->get_value(params_store->model.value_desc);
+		params_info_list.push_back(std::pair<synfigapp::ValueDesc, Geometry>(value_desc, geometry));
+
+		return false;
+	});
+
+	queue_draw();
+}
+
+void Widget_Timetrack::queue_update_param_heights()
+{
+	if (update_param_height_queued)
+		return;
+	update_param_height_queued = true;
+	Glib::signal_idle().connect_once(sigc::mem_fun(*this, &Widget_Timetrack::update_param_heights));
+}
+
+void Widget_Timetrack::update_param_heights()
+{
+	std::lock_guard<std::mutex> lock(param_list_mutex);
+	update_param_height_queued = false;
+
+	if (params_info_list.size() == 0 ||
+		!params_treeview ||
+		!params_treeview->get_realized() ||
+		!params_store)
+	{
+		queue_draw();
+		return;
+	}
+
+	size_t idx = 0;
+	Gtk::TreeViewColumn *col = params_treeview->get_column(0);
+	params_store.get()->foreach([&](const Gtk::TreeModel::Path &path, const Gtk::TreeModel::iterator &/*iter*/) -> bool {
+		Gdk::Rectangle rect;
+		params_treeview->get_cell_area(path, *col, rect);
+		Geometry geometry;
+		geometry.y = rect.get_y();
+		geometry.h = rect.get_height();
+		params_info_list[idx++].second = geometry;
+
+		return false;
+	});
+
+	queue_draw();
+}
+

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -280,8 +280,9 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 		// is param selected?
 		draw_selected_background(cr, path, row_info);
 
-		bool is_draggable = row_info->get_value_desc().is_animated() || row_info->get_value_desc().parent_is_linkable_value_node();
-		if (!is_draggable) {
+		const synfigapp::ValueDesc &value_desc = row_info->get_value_desc();
+		bool is_static_value_node = (value_desc.is_value_node() && !synfig::ValueNode_Animated::Handle::cast_dynamic(value_desc.get_value_node()));
+		if (is_static_value_node) {
 			cr->push_group();
 		}
 
@@ -298,7 +299,7 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 
 		draw_waypoints(cr, path, row_info, visible_waypoints);
 
-		if (!is_draggable) {
+		if (is_static_value_node) {
 			cr->pop_group_to_source();
 			cr->paint_with_alpha(0.5);
 		}

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -70,6 +70,8 @@ public:
 
 	void delete_selected();
 	void move_selected(synfig::Time delta_time);
+	//! Duplicate selected waypoints and move them delta_time
+	void copy_selected(synfig::Time delta_time);
 	//! \param n : how many waypoints to skip
 	void goto_next_waypoint(long n);
 	//! \param n : how many waypoints to skip back

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -142,6 +142,7 @@ private:
 		int h;
 	};
 
+	/// Tracks a parameter item : its value and its y-position and height in parameters list view
 	struct RowInfo {
 		RowInfo();
 		RowInfo(synfigapp::ValueDesc value_desc, Geometry geometry);

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -187,6 +187,7 @@ private:
 	};
 
 	std::map<std::string, RowInfo*> param_info_map;
+	int param_list_height;
 
 	std::mutex param_list_mutex;
 	bool is_rebuild_param_info_list_queued;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -107,7 +107,29 @@ private:
 		int h;
 	};
 
-	std::vector< std::pair<synfigapp::ValueDesc, Geometry> > params_info_list;
+	struct RowInfo {
+		RowInfo();
+		RowInfo(synfigapp::ValueDesc value_desc, Geometry geometry);
+		~RowInfo();
+
+		sigc::signal<void> signal_changed() {return signal_changed_;}
+
+		synfigapp::ValueDesc get_value_desc() const;
+
+		Geometry get_geometry() const;
+		void set_geometry(const Geometry& value);
+
+	protected:
+		synfigapp::ValueDesc value_desc;
+		Geometry geometry;
+		sigc::signal<void> signal_changed_;
+
+		void refresh();
+	private:
+		std::vector<sigc::connection> value_desc_connections;
+	};
+
+	std::map<std::string, RowInfo*> param_info_map;
 
 	std::mutex param_list_mutex;
 	bool is_rebuild_param_info_list_queued;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -68,6 +68,9 @@ public:
 
 	bool use_canvas_view(etl::loose_handle<CanvasView> canvas_view);
 
+	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_clicked() { return signal_waypoint_clicked_; }
+	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_double_clicked() { return signal_waypoint_double_clicked_; }
+
 protected:
 	virtual bool on_event(GdkEvent* event) override;
 	virtual bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr) override;
@@ -155,6 +158,12 @@ private:
 
 	void draw_static_intervals_for_row(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo *row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
 	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath& path, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
+
+	void on_waypoint_clicked(const WaypointItem &wi, unsigned int button, Gdk::Point /*point*/);
+	void on_waypoint_double_clicked(const WaypointItem &wi, unsigned int button, Gdk::Point /*point*/);
+
+	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int> signal_waypoint_clicked_;
+	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int> signal_waypoint_double_clicked_;
 };
 
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -172,6 +172,8 @@ private:
 		Geometry get_geometry() const;
 		void set_geometry(const Geometry& value);
 
+		void recheck_for_value_nodes();
+
 	protected:
 		synfigapp::ValueDesc value_desc;
 		Geometry geometry;
@@ -179,7 +181,9 @@ private:
 
 		void refresh();
 	private:
-		std::vector<sigc::connection> value_desc_connections;
+		sigc::connection value_node_connection;
+		sigc::connection parent_value_node_connection;
+		void clear_connections();
 	};
 
 	std::map<std::string, RowInfo*> param_info_map;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -68,6 +68,8 @@ public:
 
 	bool use_canvas_view(etl::loose_handle<CanvasView> canvas_view);
 
+	void delete_selected();
+
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_clicked() { return signal_waypoint_clicked_; }
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_double_clicked() { return signal_waypoint_double_clicked_; }
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -82,6 +82,17 @@ public:
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_clicked() { return signal_waypoint_clicked_; }
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_double_clicked() { return signal_waypoint_double_clicked_; }
 
+	enum ActionState {
+		NONE,
+		MOVE,
+		COPY,
+		SCALE
+	};
+	static std::string get_action_state_name(ActionState action_state);
+	ActionState get_action_state() const;
+	void set_action_state(ActionState action_state);
+	sigc::signal<void>& signal_action_state_changed() { return signal_action_state_changed_; }
+
 protected:
 	virtual bool on_event(GdkEvent* event) override;
 	virtual bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr) override;
@@ -109,15 +120,9 @@ private:
 	//! Handle mouse actions for panning/zooming/scrolling and waypoint selection
 	struct WaypointSD : SelectDragHelper<WaypointItem>
 	{
-		enum Action {
-			NONE,
-			MOVE,
-			COPY,
-			SCALE
-		};
 	protected:
 		Widget_Timetrack &widget;
-		Action action;
+		ActionState action;
 
 	public:
 		WaypointSD(Widget_Timetrack &widget);
@@ -129,10 +134,12 @@ private:
 		virtual void delta_drag(int total_dx, int total_dy, bool by_keys) override;
 
 		const synfig::Time& get_deltatime() const;
-		Action get_action() const;
+		ActionState get_action() const;
+		void set_action(ActionState action_state);
 		sigc::signal<void>& signal_action_changed();
 	protected:
 		synfig::Time deltatime;
+		bool is_action_set_before_drag;
 
 		void on_drag_started();
 		void on_drag_canceled();
@@ -210,6 +217,10 @@ private:
 
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int> signal_waypoint_clicked_;
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int> signal_waypoint_double_clicked_;
+
+	sigc::signal<void> signal_action_state_changed_;
+
+	ActionState action_state;
 
 	struct WaypointScaleInfo {
 		double scale;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -72,6 +72,8 @@ public:
 	void move_selected(synfig::Time delta_time);
 	//! Duplicate selected waypoints and move them delta_time
 	void copy_selected(synfig::Time delta_time);
+	//! Scale selected waypoints based on current time
+	void scale_selected();
 	//! \param n : how many waypoints to skip
 	void goto_next_waypoint(long n);
 	//! \param n : how many waypoints to skip back
@@ -198,6 +200,15 @@ private:
 
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int> signal_waypoint_clicked_;
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int> signal_waypoint_double_clicked_;
+
+	struct WaypointScaleInfo {
+		double scale;
+		double ref_time;
+		double base_offset;
+	};
+
+	WaypointScaleInfo compute_scale_params() const;
+	synfig::Time compute_scaled_time(const WaypointItem &item, const WaypointScaleInfo &scale_info) const;
 };
 
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -104,7 +104,7 @@ private:
 		virtual ~WaypointSD() override;
 		virtual void get_item_position(const WaypointItem& item, Gdk::Point& p) override;
 		virtual bool find_item_at_position(int pos_x, int pos_y, WaypointItem& item) override;
-		virtual bool find_items_in_rect(Gdk::Rectangle, std::vector<WaypointItem>&) override { return false; }
+		virtual bool find_items_in_rect(Gdk::Rectangle rect, std::vector<WaypointItem>&list) override;
 		virtual void get_all_items(std::vector<WaypointItem>&) override {}
 		virtual void delta_drag(int total_dx, int total_dy, bool by_keys) override;
 	} waypoint_sd;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -104,7 +104,16 @@ private:
 	//! Handle mouse actions for panning/zooming/scrolling and waypoint selection
 	struct WaypointSD : SelectDragHelper<WaypointItem>
 	{
+		enum Action {
+			NONE,
+			MOVE,
+			COPY,
+			SCALE
+		};
+	protected:
 		Widget_Timetrack &widget;
+		Action action;
+
 	public:
 		WaypointSD(Widget_Timetrack &widget);
 		virtual ~WaypointSD() override;
@@ -114,13 +123,18 @@ private:
 		virtual void get_all_items(std::vector<WaypointItem>&) override {}
 		virtual void delta_drag(int total_dx, int total_dy, bool by_keys) override;
 
-		const synfig::Time& get_deltatime();
+		const synfig::Time& get_deltatime() const;
+		Action get_action() const;
 	protected:
 		synfig::Time deltatime;
 
+		void on_drag_started();
+		void on_drag_canceled();
 		void on_drag_finish(bool started_by_keys);
 
 		void on_modifier_keys_changed();
+
+		void update_action();
 	} waypoint_sd;
 	void setup_mouse_handler();
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -1,0 +1,61 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file widgets/widget_timetrack.h
+**	\brief Widget to displaying layer parameter waypoints along time
+**
+**	$Id$
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	......... ... 2020 Rodolfo Ribeiro Gomes
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+
+#ifndef SYNFIG_STUDIO_WIDGET_TIMETRACK_H
+#define SYNFIG_STUDIO_WIDGET_TIMETRACK_H
+
+
+#include <gui/widgets/widget_timegraphbase.h>
+#include <gui/selectdraghelper.h>
+
+namespace studio {
+
+class Widget_Timetrack : public Widget_TimeGraphBase
+{
+public:
+	Widget_Timetrack();
+	virtual ~Widget_Timetrack() override;
+
+protected:
+	bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr) override;
+
+private:
+
+	// Handle mouse actions for panning/zooming/scrolling and waypoint selection
+	struct WaypointSD : SelectDragHelper<int>
+	{
+		// SelectDragHelper interface
+	public:
+		WaypointSD() : SelectDragHelper<int>("Move waypoints") {}
+		virtual ~WaypointSD() override {}
+		virtual void get_item_position(const int& , Gdk::Point& ) override {}
+		virtual bool find_item_at_position(int, int, int&) override { return false; }
+		virtual bool find_items_in_rect(Gdk::Rectangle, std::vector<int>&) override { return false; }
+		virtual void get_all_items(std::vector<int>&) override {}
+		virtual void delta_drag(int, int, bool) override {}
+	} waypoint_sd;
+
+};
+
+}
+
+#endif // SYNFIG_STUDIO_WIDGET_TIMETRACK_H

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -70,6 +70,10 @@ public:
 
 	void delete_selected();
 	void move_selected(synfig::Time delta_time);
+	//! \param n : how many waypoints to skip
+	void goto_next_waypoint(long n);
+	//! \param n : how many waypoints to skip back
+	void goto_previous_waypoint(long n);
 
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_clicked() { return signal_waypoint_clicked_; }
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_double_clicked() { return signal_waypoint_double_clicked_; }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -91,6 +91,8 @@ protected:
 private:
 	void displace_selected_waypoint_items(const synfig::Time &offset);
 
+	void update_cursor();
+
 	struct WaypointItem {
 		synfig::TimePoint time_point;
 		Gtk::TreePath path;
@@ -128,6 +130,7 @@ private:
 
 		const synfig::Time& get_deltatime() const;
 		Action get_action() const;
+		sigc::signal<void>& signal_action_changed();
 	protected:
 		synfig::Time deltatime;
 
@@ -138,6 +141,7 @@ private:
 		void on_modifier_keys_changed();
 
 		void update_action();
+		sigc::signal<void> signal_action_changed_;
 	} waypoint_sd;
 	void setup_mouse_handler();
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -118,7 +118,7 @@ private:
 	protected:
 		synfig::Time deltatime;
 
-		void on_drag_finish();
+		void on_drag_finish(bool started_by_keys);
 
 		void on_modifier_keys_changed();
 	} waypoint_sd;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -69,6 +69,7 @@ public:
 	bool use_canvas_view(etl::loose_handle<CanvasView> canvas_view);
 
 	void delete_selected();
+	void move_selected(synfig::Time delta_time);
 
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_clicked() { return signal_waypoint_clicked_; }
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int>& signal_waypoint_double_clicked() { return signal_waypoint_double_clicked_; }
@@ -78,6 +79,7 @@ protected:
 	virtual bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr) override;
 	virtual void on_size_allocate(Gtk::Allocation &allocation) override;
 
+	virtual void on_canvas_interface_changed() override;
 private:
 
 	struct WaypointItem {
@@ -93,11 +95,10 @@ private:
 		bool operator !=(const WaypointItem &b) const {return !operator==(b);}
 	};
 
-	// Handle mouse actions for panning/zooming/scrolling and waypoint selection
+	//! Handle mouse actions for panning/zooming/scrolling and waypoint selection
 	struct WaypointSD : SelectDragHelper<WaypointItem>
 	{
 		Widget_Timetrack &widget;
-		// SelectDragHelper interface
 	public:
 		WaypointSD(Widget_Timetrack &widget);
 		virtual ~WaypointSD() override;
@@ -105,10 +106,11 @@ private:
 		virtual bool find_item_at_position(int pos_x, int pos_y, WaypointItem& item) override;
 		virtual bool find_items_in_rect(Gdk::Rectangle, std::vector<WaypointItem>&) override { return false; }
 		virtual void get_all_items(std::vector<WaypointItem>&) override {}
-		virtual void delta_drag(int, int, bool) override {}
+		virtual void delta_drag(int total_dx, int total_dy, bool by_keys) override;
 	} waypoint_sd;
 	void setup_mouse_handler();
 
+	//! the treeview to synch with
 	Gtk::TreeView *params_treeview;
 	Glib::RefPtr<LayerParamTreeStore> params_store;
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -69,9 +69,9 @@ public:
 	bool use_canvas_view(etl::loose_handle<CanvasView> canvas_view);
 
 	void delete_selected();
-	void move_selected(synfig::Time delta_time);
+	bool move_selected(synfig::Time delta_time);
 	//! Duplicate selected waypoints and move them delta_time
-	void copy_selected(synfig::Time delta_time);
+	bool copy_selected(synfig::Time delta_time);
 	//! Scale selected waypoints based on current time
 	void scale_selected();
 	//! \param n : how many waypoints to skip
@@ -89,6 +89,7 @@ protected:
 
 	virtual void on_canvas_interface_changed() override;
 private:
+	void displace_selected_waypoint_items(const synfig::Time &offset);
 
 	struct WaypointItem {
 		synfig::TimePoint time_point;

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -75,17 +75,31 @@ protected:
 
 private:
 
+	struct WaypointItem {
+		synfig::TimePoint time_point;
+		Gtk::TreePath path;
+
+		WaypointItem() {}
+		WaypointItem(const synfig::TimePoint time_point, const Gtk::TreePath &path);
+
+		bool is_draggable() const;
+
+		bool operator ==(const WaypointItem &b) const;
+		bool operator !=(const WaypointItem &b) const {return !operator==(b);}
+	};
+
 	// Handle mouse actions for panning/zooming/scrolling and waypoint selection
-	struct WaypointSD : SelectDragHelper<int>
+	struct WaypointSD : SelectDragHelper<WaypointItem>
 	{
+		Widget_Timetrack &widget;
 		// SelectDragHelper interface
 	public:
-		WaypointSD() : SelectDragHelper<int>("Move waypoints") {}
-		virtual ~WaypointSD() override {}
-		virtual void get_item_position(const int& , Gdk::Point& ) override {}
-		virtual bool find_item_at_position(int, int, int&) override { return false; }
-		virtual bool find_items_in_rect(Gdk::Rectangle, std::vector<int>&) override { return false; }
-		virtual void get_all_items(std::vector<int>&) override {}
+		WaypointSD(Widget_Timetrack &widget);
+		virtual ~WaypointSD() override;
+		virtual void get_item_position(const WaypointItem& item, Gdk::Point& p) override;
+		virtual bool find_item_at_position(int pos_x, int pos_y, WaypointItem& item) override;
+		virtual bool find_items_in_rect(Gdk::Rectangle, std::vector<WaypointItem>&) override { return false; }
+		virtual void get_all_items(std::vector<WaypointItem>&) override {}
 		virtual void delta_drag(int, int, bool) override {}
 	} waypoint_sd;
 	void setup_mouse_handler();
@@ -114,7 +128,7 @@ private:
 
 		sigc::signal<void> signal_changed() {return signal_changed_;}
 
-		synfigapp::ValueDesc get_value_desc() const;
+		const synfigapp::ValueDesc& get_value_desc() const;
 
 		Geometry get_geometry() const;
 		void set_geometry(const Geometry& value);
@@ -140,7 +154,7 @@ private:
 	void update_param_list_geometries();
 
 	void draw_static_intervals_for_row(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo *row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
-	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo *row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
+	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath& path, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
 };
 
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -110,12 +110,12 @@ private:
 	std::vector< std::pair<synfigapp::ValueDesc, Geometry> > params_info_list;
 
 	std::mutex param_list_mutex;
-	bool update_param_tree_queued;
-	void queue_update_param_tree();
-	void update_param_tree();
-	bool update_param_height_queued;
-	void queue_update_param_heights();
-	void update_param_heights();
+	bool is_rebuild_param_info_list_queued;
+	void queue_rebuild_param_info_list();
+	void rebuild_param_info_list();
+	bool is_update_param_list_geometries_queued;
+	void queue_update_param_list_geometries();
+	void update_param_list_geometries();
 };
 
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -138,6 +138,9 @@ private:
 	bool is_update_param_list_geometries_queued;
 	void queue_update_param_list_geometries();
 	void update_param_list_geometries();
+
+	void draw_static_intervals_for_row(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo *row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
+	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo *row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
 };
 
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -36,7 +36,9 @@ public:
 	virtual ~Widget_Timetrack() override;
 
 protected:
-	bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr) override;
+	virtual bool on_event(GdkEvent* event) override;
+	virtual bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr) override;
+	virtual void on_size_allocate(Gtk::Allocation &allocation) override;
 
 private:
 
@@ -53,7 +55,7 @@ private:
 		virtual void get_all_items(std::vector<int>&) override {}
 		virtual void delta_drag(int, int, bool) override {}
 	} waypoint_sd;
-
+	void setup_mouse_handler();
 };
 
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -119,6 +119,8 @@ private:
 		synfig::Time deltatime;
 
 		void on_drag_finish();
+
+		void on_modifier_keys_changed();
 	} waypoint_sd;
 	void setup_mouse_handler();
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -164,8 +164,9 @@ private:
 	void queue_update_param_list_geometries();
 	void update_param_list_geometries();
 
-	void draw_static_intervals_for_row(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo *row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
-	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath& path, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints);
+	void draw_static_intervals_for_row(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo *row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints) const;
+	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath& path, const RowInfo *row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints) const;
+	void draw_selected_background(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath& path, const RowInfo* row_info) const;
 
 	void on_waypoint_clicked(const WaypointItem &wi, unsigned int button, Gdk::Point /*point*/);
 	void on_waypoint_double_clicked(const WaypointItem &wi, unsigned int button, Gdk::Point /*point*/);

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -111,6 +111,12 @@ private:
 		virtual bool find_items_in_rect(Gdk::Rectangle rect, std::vector<WaypointItem>&list) override;
 		virtual void get_all_items(std::vector<WaypointItem>&) override {}
 		virtual void delta_drag(int total_dx, int total_dy, bool by_keys) override;
+
+		const synfig::Time& get_deltatime();
+	protected:
+		synfig::Time deltatime;
+
+		void on_drag_finish();
 	} waypoint_sd;
 	void setup_mouse_handler();
 


### PR DESCRIPTION
I don't know all features of current TimeTrack, please let me know if something is missing:

- [x] Sync with Parameters dock (it has issues with two timetracks enabled. It works fine with only the new timetrack.

- [x] context/popup menu via right-click in waypoint (for single waypoint)

- [x] move selected waypoint (mouse drag and arrow keys)

- [x] shift + drag : copy selected waypoint
- [x] waypoint deletion via Delete key (**novelty**)

- [x] double-click opens Waypoint editor dialog

- [x] multiple selection - including across parameters (**novelty**) (#761 #762)

- [x] display static interval (**novelty**) (#790)

- [x] allow to scale waypoints (**novelty**) (#266 https://github.com/synfig/synfig/issues/266#issuecomment-480610390 )

- [x] parameters and Timeline panels show the same row selected. (**novelty**) (#246)

- [x] waypoint navigation  (**novelty**)
  key `n` and `b` to go to next or previous waypoint. By holding `shift`, user skips 5 waypoints.
(by design, it only works when only one waypoint is selected.)

- [ ] #529  fixed?