### PR TITLE
Do not require to explicitly call FileSystemTemporary::discard_changes()

### DIFF
--- a/synfig-core/src/synfig/filesystemtemporary.cpp
+++ b/synfig-core/src/synfig/filesystemtemporary.cpp
@@ -60,6 +60,7 @@ FileSystemTemporary::FileSystemTemporary(const String &tag, const String &tempor
 	tag(tag),
 	temporary_directory(temporary_directory.empty() ? get_system_temporary_directory() : temporary_directory),
 	temporary_filename_base(generate_temporary_filename_base(tag)),
+	keep_files_when_destroyed(false),
 	autosave(true)
 {
 	set_sub_file_system(sub_file_system);
@@ -67,7 +68,9 @@ FileSystemTemporary::FileSystemTemporary(const String &tag, const String &tempor
 
 FileSystemTemporary::~FileSystemTemporary()
 {
-
+	if (!keep_files_when_destroyed) {
+		discard_changes();
+	}
 }
 
 String

--- a/synfig-core/src/synfig/filesystemtemporary.h
+++ b/synfig-core/src/synfig/filesystemtemporary.h
@@ -72,6 +72,7 @@ namespace synfig
 
 		std::map<String, String> meta;
 
+		bool keep_files_when_destroyed;
 		bool autosave;
 
 		static bool save_changes(
@@ -125,6 +126,8 @@ namespace synfig
 		const std::map<String, String>& get_metadata() const;
 		void set_metadata(const std::map<String, String> &data);
 
+		void set_keep_files_when_destroyed(bool value)
+			{ keep_files_when_destroyed = value; }
 		bool get_autosave() const
 			{ return autosave; }
 		void set_autosave(bool value)

--- a/synfig-studio/src/gui/autorecover.cpp
+++ b/synfig-studio/src/gui/autorecover.cpp
@@ -164,11 +164,9 @@ AutoRecover::clear_backups()
 			// FileSystemTemporary will clear opened temporary files in destructor
 			String filename = App::get_temporary_directory() + ETL_DIRECTORY_SEPARATOR + *i;
 			bool s = false;
-			try {
-				FileSystemTemporary temporary_filesystem = FileSystemTemporary("");
-				s = temporary_filesystem.open_temporary(filename);
-				temporary_filesystem.discard_changes();
-			} catch (...) {
+			try { s = FileSystemTemporary("").open_temporary(filename); }
+			catch (...)
+			{
 				synfig::warning("Autobackup file is not recoverable. Forcing to remove.");
 			}
 			if (!s)

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -701,9 +701,9 @@ Instance::close(bool remove_temporary_files)
 		studio::App::instance_list.front()->canvas_view_list().front()->present();
 	}
 
-	if (remove_temporary_files) {
+	if (!remove_temporary_files) {
 		FileSystemTemporary::Handle temporary_filesystem = FileSystemTemporary::Handle::cast_dynamic(get_canvas()->get_file_system());
-		temporary_filesystem->discard_changes();
+		temporary_filesystem->set_keep_files_when_destroyed(true);
 	}
 }
 

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -638,7 +638,6 @@ Instance::save_as(const synfig::String &file_name)
 			new_temporary_filesystem->set_meta("as", new_canvas_filename);
 			new_temporary_filesystem->set_meta("truncate", "0");
 			new_canvas_filesystem = new_temporary_filesystem;
-			previous_temporary_filesystem->discard_changes();
 		}
 
 		new_canvas_identifier = new_canvas_filesystem->get_identifier(CanvasFileNaming::project_file(new_canvas_filename));


### PR DESCRIPTION
This is a better approach for 93f25328c15 and 28db040026 (partially reverts their changes).
It does not requires to explicitly call `FileSystemTemporary::discard_changes()`.

Instead, I just added a flag to FileSystemTemporary class (keep_files_when_destroyed),
which defines how to deal with temporary files after class instance is destroyed.