### PR TITLE
Fix crash when removing a list item of a parameter

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
@@ -832,6 +832,11 @@ const synfig::Node::time_set	& ValueNode_DynamicList::ListEntry::get_times() con
 											end = timing_info.end();
 
 	//must remerge with all the other values because we don't know if we've changed...
+	if (!value_node) {
+		static const synfig::Node::time_set empty_set;
+		synfig::error("ValueNode Dynamic List invalid");
+		return empty_set;
+	}
 	times = value_node->get_times();
 
 	for(; j != end; ++j)

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
@@ -833,7 +833,7 @@ const synfig::Node::time_set	& ValueNode_DynamicList::ListEntry::get_times() con
 
 	//must remerge with all the other values because we don't know if we've changed...
 	if (!value_node) {
-		static const synfig::Node::time_set empty_set;
+		static const synfig::Node::time_set empty_set {};
 		synfig::error("ValueNode Dynamic List invalid");
 		return empty_set;
 	}

--- a/synfig-studio/src/gui/trees/canvastreestore.cpp
+++ b/synfig-studio/src/gui/trees/canvastreestore.cpp
@@ -268,8 +268,15 @@ CanvasTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int colum
 		else
 		{
 			stype=value_desc.get_value_type().description.local_name;
-			if(!value_desc.is_const())
-				stype+=" (" + value_desc.get_value_node()->get_local_name() + ")";
+			if(!value_desc.is_const()) {
+				const ValueNode::LooseHandle value_node = value_desc.get_value_node();
+				if (value_node) {
+					stype+=" (" + value_node->get_local_name() + ")";
+				} else {
+					stype+=" (> " + string(_("Invalid ValueNode")) + " <)";
+					synfig::error(_("Invalid ValueNode"));
+				}
+			}
 		}
 		x.set(stype.c_str());
 		g_value_init(value.gobj(),x.value_type());
@@ -305,12 +312,17 @@ CanvasTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int colum
 			ValueNode::Handle value_node=value_desc.get_value_node();
 
 			// Setup the row's label
-			if(value_node->get_id().empty())
-				x.set(Glib::ustring((*iter)[model.name]));
-			else if(Glib::ustring((*iter)[model.name]).empty())
-				x.set(value_node->get_id());
-			else
-				x.set(Glib::ustring((*iter)[model.name])+" ("+value_node->get_id()+')');
+			if (value_node) {
+				if(value_node->get_id().empty())
+					x.set(Glib::ustring((*iter)[model.name]));
+				else if(Glib::ustring((*iter)[model.name]).empty())
+					x.set(value_node->get_id());
+				else
+					x.set(Glib::ustring((*iter)[model.name])+" ("+value_node->get_id()+')');
+			} else {
+				x.set(" (> " + string(_("Invalid ValueNode")) + " <)");
+				synfig::error(_("Invalid ValueNode"));
+			}
 		}
 
 		g_value_init(value.gobj(),x.value_type());

--- a/synfig-studio/src/gui/trees/layerparamtreestore.cpp
+++ b/synfig-studio/src/gui/trees/layerparamtreestore.cpp
@@ -569,8 +569,20 @@ LayerParamTreeStore::on_value_node_child_added(synfig::ValueNode::Handle /*value
 }
 
 void
-LayerParamTreeStore::on_value_node_child_removed(synfig::ValueNode::Handle /*value_node*/,synfig::ValueNode::Handle /*child*/)
+LayerParamTreeStore::on_value_node_child_removed(synfig::ValueNode::Handle value_node, synfig::ValueNode::Handle /*child*/)
 {
+	TreeModel::iterator iter_to_remove;
+	foreach_iter([&](const TreeModel::iterator &iter) -> bool {
+		Gtk::TreeRow row = *iter;
+		synfig::ValueNode::Handle row_value_node = row[model.value_node];
+		if (row_value_node == value_node) {
+			iter_to_remove = iter;
+			return true;
+		}
+		return false;
+	});
+
+	erase(iter_to_remove);
 	rebuild();
 }
 


### PR DESCRIPTION
If you select a vertex item of Spline parameter list and then right-click on it and choose `Remove item (Smart)`, app crashes.
Not anymore. Simple, but not the best, solution.