### PR TITLE
upgrade minimum version of libav/FFmpeg

### DIFF
--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -166,7 +166,7 @@ AC_ARG_WITH(libavcodec,
 ])
 
 if test $with_libavcodec != "no" ; then {
-	PKG_CHECK_MODULES(LIBAVCODEC, [libavcodec >= 51.42 libavformat >= 54.0 libavutil >= 52.9 libswscale >= 2.1.2],
+	PKG_CHECK_MODULES(LIBAVCODEC, [libavcodec >= 57.0 libavformat >= 57.0 libavutil >= 55.0 libswscale >= 4.0],
 		[CONFIG_DEPS="$CONFIG_DEPS libavcodec libavformat libswscale"],
 		[echo no; with_libavcodec="no"])
 } ; fi


### PR DESCRIPTION
fix #744

According to:
https://github.com/synfig/synfig/issues/744#issuecomment-469157746
"Looks like build files if FFmpeg version is older than 3.0."

And FFmpeg site says:
https://www.ffmpeg.org/olddownload.html
"FFmpeg 3.0.12 "Einstein"
It includes the following library versions:

libavutil      55. 17.103
libavcodec     57. 24.102
libavformat    57. 25.100
libavdevice    57.  0.101
libavfilter     6. 31.100
libavresample   3.  0.  0
libswscale      4.  0.100
libswresample   2.  0.101
libpostproc    54.  0.100