### PR TITLE
fix renaming a "layer set" - it affected other ones with certain names - #1146

### DIFF
--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -1609,14 +1609,19 @@ Canvas::rename_group(const String&old_name,const String&new_name)
 		return parent_->rename_group(old_name,new_name);
 
 	{
+		const char GROUP_NEST_CHAR = '.';
+		const string old_name_prefix = old_name + GROUP_NEST_CHAR;
+
 		std::map<String,std::set<etl::handle<Layer> > >::iterator iter;
+
 		iter=group_db_.find(old_name);
-		if(iter!=group_db_.end())
-		for(++iter;iter!=group_db_.end() && iter->first.find(old_name)==0;iter=group_db_.find(old_name),++iter)
-		{
-			String name(iter->first,old_name.size(),String::npos);
-			name=new_name+name;
-			rename_group(iter->first,name);
+		if(iter!=group_db_.end()) {
+			for(++iter;iter!=group_db_.end() && iter->first.find(old_name_prefix)==0;iter=group_db_.find(old_name),++iter)
+			{
+				String name(iter->first,old_name_prefix.size(),String::npos);
+				name=new_name+GROUP_NEST_CHAR+name;
+				rename_group(iter->first,name);
+			}
 		}
 	}
 


### PR DESCRIPTION
fix #1146

And if user renames a set forcing to a nested one, it avoids forbidden renaming of higher hierarchies.

Example:
Sets
-A
-AB
-AC

by renaming A -> D:
-AB
-AC
-D
(issue 1146 fixed)

by renaming AB -> F.G.H
-AC
-D
-F
\\-G
 .   \\-H

and F, F.G can be renamed too thanks commit ef57befe08f6f52cc19b2676c6313db8b4fabb88