### PR TITLE
[Lottie exporter] Convert methods working with radius of simple circle layer

### DIFF
--- a/synfig-studio/plugins/lottie-exporter/common/Param.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Param.py
@@ -172,7 +172,7 @@ class Param:
         If this parameter is not animated, it generates dummy waypoints and
         animates this parameter
         """
-        if anim_type in {"vector", "group_layer_scale", "stretch_layer_scale"}:   # This will never happen, can remove this latter
+        if anim_type in {"vector", "group_layer_scale", "stretch_layer_scale", "circle_radius"}:   # This will never happen, can remove this latter
             self.dimension = 2
 
         # Check if we are dealing with convert methods
@@ -206,7 +206,7 @@ class Param:
         """
         Internal private method for animating
         """
-        if anim_type in {"vector", "group_layer_scale", "stretch_layer_scale"}:
+        if anim_type in {"vector", "group_layer_scale", "stretch_layer_scale", "circle_radius"}:
             self.dimension = 2
 
         # Check if we are dealing with convert methods

--- a/synfig-studio/plugins/lottie-exporter/effects/controller.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/controller.py
@@ -23,7 +23,7 @@ def gen_effects_controller(lottie, value, anim_type):
 
     lottie["ef"] = []
     lottie["ef"].append({})
-    if anim_type in {"vector", "group_layer_scale", "stretch_layer_scale"}:
+    if anim_type in {"vector", "group_layer_scale", "stretch_layer_scale", "circle_radius"}:
         gen_effects_point(lottie["ef"][-1], value, idx)
     else:
         gen_effects_slider(lottie["ef"][-1], value, idx)


### PR DESCRIPTION
Fixes: #1101 
@AnishGG , I looked at #1018 which had similar issue as this one and was able to resolve this.
Please have a look at this.