### PR TITLE
[Lottie Exporter] Code cleanup for Lottie exporter plugin

### DIFF
--- a/synfig-studio/plugins/lottie-exporter/common/Bline.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Bline.py
@@ -4,7 +4,6 @@ Will store the Parameters class for Bline
 """
 
 import sys
-import settings
 import common
 sys.path.append("..")
 

--- a/synfig-studio/plugins/lottie-exporter/common/Param.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Param.py
@@ -11,7 +11,7 @@ from lxml import etree
 import settings
 import common
 import synfig.group
-from synfig.animation import modify_bool_animation, to_Synfig_axis, is_animated, get_bool_at_frame, get_vector_at_frame, print_animation
+from synfig.animation import modify_bool_animation, to_Synfig_axis, is_animated, get_bool_at_frame, get_vector_at_frame
 from properties.multiDimensionalKeyframed import gen_properties_multi_dimensional_keyframed
 from properties.valueKeyframed import gen_value_Keyframed
 from properties.value import gen_properties_value

--- a/synfig-studio/plugins/lottie-exporter/effects/color.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/color.py
@@ -3,7 +3,6 @@ This module will store all the functions required for color property of lottie
 """
 
 import sys
-import copy
 import settings
 from common.Count import Count
 sys.path.append("../")

--- a/synfig-studio/plugins/lottie-exporter/effects/controller.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/controller.py
@@ -3,7 +3,6 @@ This module will store the expression controllers of lottie/AE
 """
 
 import sys
-import copy
 import settings
 from common.Count import Count
 from effects.slider import gen_effects_slider

--- a/synfig-studio/plugins/lottie-exporter/effects/fill.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/fill.py
@@ -5,7 +5,6 @@ This module will store all the functions required for fill effects of lottie
 import sys
 import settings
 from common.Count import Count
-from common.Layer import Layer
 from effects.fillmask import gen_effects_fillmask
 from effects.allmask import gen_effects_allmask
 from effects.color import gen_effects_color

--- a/synfig-studio/plugins/lottie-exporter/effects/opacity.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/opacity.py
@@ -3,7 +3,6 @@ This module will store all the functions required for opacity property of lottie
 """
 
 import sys
-import copy
 import settings
 from common.Count import Count
 sys.path.append("../")

--- a/synfig-studio/plugins/lottie-exporter/effects/point.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/point.py
@@ -3,7 +3,6 @@ Store all functions necessary for effect/point.json
 """
 
 import sys
-import copy
 import settings
 from common.Count import Count
 sys.path.append("../")

--- a/synfig-studio/plugins/lottie-exporter/effects/slider.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/slider.py
@@ -3,7 +3,6 @@ This module will store the expression controllers of lottie/AE
 """
 
 import sys
-import copy
 import settings
 from common.Count import Count
 sys.path.append("../")

--- a/synfig-studio/plugins/lottie-exporter/helpers/transform.py
+++ b/synfig-studio/plugins/lottie-exporter/helpers/transform.py
@@ -5,15 +5,9 @@ corresponding to lottie
 """
 
 import sys
-import math
-import copy
 import settings
 from common.Count import Count
-from common.misc import is_animated, change_axis
 from properties.value import gen_properties_value
-from properties.valueKeyframed import gen_value_Keyframed
-from properties.multiDimensionalKeyframed import gen_properties_multi_dimensional_keyframed
-from synfig.animation import print_animation
 sys.path.append("../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/layers/group.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/group.py
@@ -5,7 +5,6 @@ Store all functions corresponding to group layer in Synfig
 
 import sys
 import math
-import copy
 import settings
 from common.Param import Param
 from common.Canvas import Canvas
@@ -14,7 +13,7 @@ from common.misc import get_frame, approximate_equal, get_time
 from sources.precomp import add_precomp_asset
 from helpers.transform import gen_helpers_transform
 from helpers.blendMode import get_blend
-from synfig.animation import print_animation, insert_waypoint_at_frame, to_Synfig_axis
+from synfig.animation import insert_waypoint_at_frame, to_Synfig_axis
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/layers/image.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/image.py
@@ -9,13 +9,9 @@ from lxml import etree
 import settings
 from helpers.transform import gen_helpers_transform
 from helpers.blendMode import get_blend
-from common.misc import is_animated, get_frame
-from common.Layer import Layer
 from common.Param import Param
 from sources.image import add_image_asset
 from shapes.rectangle import to_Synfig_axis
-from properties.multiDimensionalKeyframed import gen_properties_multi_dimensional_keyframed
-from synfig.animation import print_animation
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/layers/preComp.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/preComp.py
@@ -5,7 +5,6 @@ Store all functions corresponding to pre composition in lottie
 
 import sys
 import settings
-from common.Layer import Layer
 from sources.precomp import add_precomp_asset
 from layers.rotate_layer import gen_layer_rotate
 from layers.scale_layer import gen_layer_scale

--- a/synfig-studio/plugins/lottie-exporter/layers/rotate_layer.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/rotate_layer.py
@@ -6,8 +6,6 @@ import sys
 import copy
 import settings
 from helpers.transform import gen_helpers_transform
-from common.Param import Param
-import synfig.group as group
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/layers/shape.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/shape.py
@@ -5,7 +5,6 @@ Will store all the functions corresponding to shapes in lottie
 import sys
 import settings
 from common.Count import Count
-from common.Layer import Layer
 from shapes.star import gen_shapes_star
 from shapes.circle import gen_shapes_circle
 from shapes.fill import gen_shapes_fill

--- a/synfig-studio/plugins/lottie-exporter/layers/shape_solid.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/shape_solid.py
@@ -10,7 +10,6 @@ from helpers.blendMode import get_blend
 from helpers.mask import gen_mask
 from common.misc import get_color_hex, is_animated
 from common.Count import Count
-from common.Layer import Layer
 from effects.fill import gen_effects_fill
 from synfig.group import get_additional_width, get_additional_height
 sys.path.append("..")

--- a/synfig-studio/plugins/lottie-exporter/layers/solid.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/solid.py
@@ -6,7 +6,6 @@ import sys
 import settings
 from common.misc import get_color_hex
 from common.Count import Count
-from common.Layer import Layer
 from helpers.blendMode import get_blend
 from helpers.transform import gen_helpers_transform
 from effects.fill import gen_effects_fill

--- a/synfig-studio/plugins/lottie-exporter/layers/translate_layer.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/translate_layer.py
@@ -4,11 +4,9 @@ Will store all the functions needed to export the translate layer
 
 import sys
 from lxml import etree
-import copy
 import settings
 from common.Param import Param
 from helpers.transform import gen_helpers_transform
-from synfig.animation import print_animation
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/properties/multiDimensionalKeyframed.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/multiDimensionalKeyframed.py
@@ -4,7 +4,6 @@ multiDimensionalKeyframed file in lottie
 """
 
 import sys
-import settings
 from properties.offsetKeyframe import gen_properties_offset_keyframe
 from properties.timeAdjust import time_adjust
 from common.misc import get_frame

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/circle.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/circle.py
@@ -8,9 +8,8 @@ import sys
 import math
 from common.Matrix2 import Matrix2
 from common.Vector import Vector
-from common.Layer import Layer
-from synfig.animation import print_animation, to_Synfig_axis
-from properties.shapePropKeyframe.helper import add, insert_dict_at, update_child_at_parent, quadratic_to_cubic
+from synfig.animation import to_Synfig_axis
+from properties.shapePropKeyframe.helper import add, insert_dict_at, quadratic_to_cubic
 sys.path.append("../../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
@@ -5,15 +5,10 @@ in Lottie format
 """
 
 import sys
-import ast
-from lxml import etree
 import settings
-from common.misc import change_axis, get_frame, is_animated, radial_to_tangent
+from common.misc import change_axis, radial_to_tangent
 from common.Vector import Vector
 from common.Param import Param
-from properties.multiDimensionalKeyframed import gen_properties_multi_dimensional_keyframed
-from properties.valueKeyframed import gen_value_Keyframed
-from synfig.animation import print_animation, get_vector_at_frame, get_bool_at_frame
 sys.path.append("../../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/outline.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/outline.py
@@ -8,7 +8,6 @@ import sys
 import math
 import settings
 from common.Bline import Bline
-from common.Param import Param
 from common.Vector import Vector
 from common.Hermite import Hermite
 from synfig.animation import to_Synfig_axis

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/rectangle.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/rectangle.py
@@ -8,10 +8,8 @@ import sys
 from lxml import etree
 from common.misc import approximate_equal
 from common.Vector import Vector
-from common.Layer import Layer
-from common.Param import Param
 from synfig.animation import to_Synfig_axis
-from properties.shapePropKeyframe.helper import add, insert_dict_at, update_child_at_parent, quadratic_to_cubic
+from properties.shapePropKeyframe.helper import add, insert_dict_at, quadratic_to_cubic
 sys.path.append("../../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/region.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/region.py
@@ -5,10 +5,7 @@ in Lottie format
 """
 
 import sys
-import copy
 from common.Bline import Bline
-from common.Param import Param
-from properties.multiDimensionalKeyframed import gen_properties_multi_dimensional_keyframed
 from properties.shapePropKeyframe.helper import insert_dict_at, animate_tangents, get_tangent_at_frame, convert_tangent_to_lottie
 sys.path.append("../../")
 

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/star.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/star.py
@@ -7,9 +7,8 @@ in Lottie format
 import sys
 import math
 from common.Vector import Vector
-from common.Layer import Layer
 from synfig.animation import to_Synfig_axis
-from properties.shapePropKeyframe.helper import add, insert_dict_at, update_child_at_parent
+from properties.shapePropKeyframe.helper import add, insert_dict_at
 sys.path.append("../../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/properties/valueKeyframed.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/valueKeyframed.py
@@ -3,7 +3,6 @@ Stores all the functions required for generating value key frames in lottie
 """
 
 import sys
-import settings
 from properties.timeAdjust import time_adjust
 from properties.valueKeyframe import gen_value_Keyframe
 from common.misc import get_frame

--- a/synfig-studio/plugins/lottie-exporter/shapes/circle.py
+++ b/synfig-studio/plugins/lottie-exporter/shapes/circle.py
@@ -4,14 +4,8 @@ This will also support the simple_circle layer of Synfig
 """
 
 import sys
-import copy
 import settings
-from properties.value import gen_properties_value
-from common.misc import is_animated
 from common.Count import Count
-from properties.multiDimensionalKeyframed import gen_properties_multi_dimensional_keyframed
-from properties.valueKeyframed import gen_value_Keyframed
-from synfig.animation import print_animation
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/shapes/fill.py
+++ b/synfig-studio/plugins/lottie-exporter/shapes/fill.py
@@ -8,7 +8,6 @@ from properties.value import gen_properties_value
 from properties.valueKeyframed import gen_value_Keyframed
 from common.misc import is_animated
 from common.Count import Count
-from common.Layer import Layer
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/shapes/rectangle.py
+++ b/synfig-studio/plugins/lottie-exporter/shapes/rectangle.py
@@ -8,12 +8,11 @@ import copy
 from lxml import etree
 import settings
 from common.Count import Count
-from common.Vector import Vector
 from common.misc import is_animated, get_frame, get_vector, set_vector
 from properties.value import gen_properties_value
 from properties.multiDimensionalKeyframed import gen_properties_multi_dimensional_keyframed
 from properties.valueKeyframed import gen_value_Keyframed
-from synfig.animation import gen_dummy_waypoint, insert_waypoint_at_frame, print_animation, to_Synfig_axis, get_vector_at_frame, get_animated_time_list, copy_tcb_average, copy_tcb
+from synfig.animation import gen_dummy_waypoint, insert_waypoint_at_frame, to_Synfig_axis, get_vector_at_frame, get_animated_time_list, copy_tcb_average, copy_tcb
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/shapes/star.py
+++ b/synfig-studio/plugins/lottie-exporter/shapes/star.py
@@ -5,7 +5,7 @@ Will store all functions needed to generate the star layer in lottie
 import sys
 import settings
 from properties.value import gen_properties_value
-from common.misc import get_frame, get_angle, change_axis, is_animated
+from common.misc import get_angle, change_axis, is_animated
 from common.Count import Count
 from properties.multiDimensionalKeyframed import gen_properties_multi_dimensional_keyframed
 from properties.valueKeyframed import gen_value_Keyframed

--- a/synfig-studio/plugins/lottie-exporter/sources/precomp.py
+++ b/synfig-studio/plugins/lottie-exporter/sources/precomp.py
@@ -5,7 +5,6 @@ Will store all the functions corresponding to Image Assets in lottie
 import sys
 import settings
 import layers.driver
-from common.Canvas import Canvas
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/synfig/group.py
+++ b/synfig-studio/plugins/lottie-exporter/synfig/group.py
@@ -9,7 +9,6 @@ import settings
 from common.misc import is_animated
 from common.Vector import Vector
 import common
-from synfig.animation import print_animation
 sys.path.append("..")
 
 


### PR DESCRIPTION
Cleaned up the code for Lottie Exporter plugin according to the LGTM active alerts. 
Link for the alerts : [LGTM alerts for the Lottie Exporter plugin](https://lgtm.com/projects/g/synfig/synfig/?mode=list&lang=python&severity=recommendation)