### PR TITLE
fix i18n for Set Keyframe Description dialog

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3311,12 +3311,12 @@ CanvasView::on_keyframe_description_set()
 			return;
 
 		String str(keyframe.get_description ());
-		if(!App::dialog_entry((action->get_local_name() + _(" Description")),
+		if(!App::dialog_entry(_("Set Keyframe Description"),
 					_("Description: "),
 					//action->get_local_name(),
 					str,
 					_("Cancel"),
-					_("Set")))
+					_("Ok")))
 			return;
 
 		keyframe.set_description(str);


### PR DESCRIPTION
* "Set" button -> "Ok", because it would be translated as "group" meaning otherwise

* Don't concatenate strings, because several languages don't follow genitive case ordering like Noun (owner) + Noun like English and German do.
Eg., in Portuguese, we use Noun + " de " + Noun(owner). So we need full text for i18n.