### PR TITLE
Fixed wrong filename in plugins dialog box

### DIFF
--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -558,6 +558,7 @@ studio::Instance::dialog_save_as()
 		if (filename_extension(filename) == "")
 			filename+=".sifz";
 
+		canvas->set_name(base_filename);
 		// forced to .sifz, the below code is not need anymore
 		try
 		{


### PR DESCRIPTION
Fixes: #1204 
@AnishGG , @ice0 , I fixed it by adding canvas->set_name() to the Save dialog box.
Please have a look at this.