### PR TITLE
[CMake] Updated CMake script to change layout of build files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,9 @@ synfig-studio/doc
 /ETL/nbproject/
 /synfig-core/nbproject/
 /synfig-studio/nbproject/
+
+# ------------------------------------------------------------------------
+# CLion projects
+# ------------------------------------------------------------------------
+/.idea
+cmake-build-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 2.8)
 
 project(synfig-studio)
 
+set(SYNFIG_BUILD_ROOT ${CMAKE_BINARY_DIR}/output)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/bin)
+
 add_subdirectory(ETL)
 include_directories(ETL)
 include_directories(${PROJECT_BINARY_DIR}/ETL) # to find the generated etl_profile.h

--- a/synfig-core/src/modules/CMakeLists.txt
+++ b/synfig-core/src/modules/CMakeLists.txt
@@ -43,6 +43,9 @@ set(MODS_ENABLED
 #    mptr_mplayer # - "This code has vulnerabilities"
 )
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/lib/synfig/modules)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/lib/synfig/modules)
+
 ## Magick++ support
 option(WITH_MAGICPP "Enable Magic++ module (output format support)" OFF)
 option(WITHOUT_MAGICPP "Disable Magic++ module (output format support)" OFF)


### PR DESCRIPTION
Fixes on #1131. 

Changes:
- Updated `CMakeLists.txt`. Inside the build folder, it makes `bin` and `lib` (~~ETL~~, ~~include~~). Execution still require [these commands](https://github.com/synfig/synfig/issues/1131#issuecomment-586873899).
- Updated `.gitignore`.

