### PR TITLE
[Lottie Exporter] Code cleanup for Lottie exporter plugin

### DIFF
--- a/synfig-studio/plugins/lottie-exporter/common/Param.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Param.py
@@ -672,7 +672,7 @@ class Param:
                 if isinstance(ret, list):
                     ret[0], ret[1] = ret[0] / len(lst), ret[1] / len(lst)
                 else:
-                    ret /= len(lst)
+                    ret /= float(len(lst))
 
             elif self.param[0].tag == "weighted_average":
                 self.subparams["weighted_average"].extract_subparams()
@@ -695,7 +695,7 @@ class Param:
                 if isinstance(ret, list):
                     ret[0], ret[1] = ret[0] / den, ret[1] / den
                 else:
-                    ret /= den
+                    ret /= float(den)
 
             elif self.param[0].tag == "composite":  # Only available for vectors
                 x = self.subparams["composite"].subparams["x"].__get_value(frame)

--- a/synfig-studio/plugins/lottie-exporter/effects/color.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/color.py
@@ -21,7 +21,6 @@ def gen_effects_color(lottie, layer, idx):
         (None)
 
     """
-    index = Count()
     lottie["ty"] = settings.EFFECTS_COLOR   # Effect type
     lottie["nm"] = "Color"                  # Name
     lottie["ix"] = idx                      # Index

--- a/synfig-studio/plugins/lottie-exporter/effects/color.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/color.py
@@ -4,7 +4,6 @@ This module will store all the functions required for color property of lottie
 
 import sys
 import settings
-from common.Count import Count
 sys.path.append("../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/effects/controller.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/controller.py
@@ -4,7 +4,6 @@ This module will store the expression controllers of lottie/AE
 
 import sys
 import settings
-from common.Count import Count
 from effects.slider import gen_effects_slider
 from effects.point import gen_effects_point
 sys.path.append("../")

--- a/synfig-studio/plugins/lottie-exporter/effects/controller.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/controller.py
@@ -14,7 +14,6 @@ def gen_effects_controller(lottie, value, anim_type):
     """
     Generates the dictionary correspondingt to effects/controller.json
     """
-    index = Count()
     lottie["ty"] = settings.EFFECTS_CONTROLLER  # Effect type
     idx = settings.controller_count.inc()
     lottie["nm"] = "Controller" + str(idx)

--- a/synfig-studio/plugins/lottie-exporter/effects/opacity.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/opacity.py
@@ -20,7 +20,6 @@ def gen_effects_opacity(lottie, layer, idx):
     Returns:
         (None)
     """
-    index = Count()
     lottie["ty"] = settings.EFFECTS_OPACITY     # Effect type
     lottie["nm"] = "Opacity"                    # Name
     lottie["ix"] = idx                          # Index

--- a/synfig-studio/plugins/lottie-exporter/effects/opacity.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/opacity.py
@@ -4,7 +4,6 @@ This module will store all the functions required for opacity property of lottie
 
 import sys
 import settings
-from common.Count import Count
 sys.path.append("../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/effects/point.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/point.py
@@ -4,7 +4,6 @@ Store all functions necessary for effect/point.json
 
 import sys
 import settings
-from common.Count import Count
 sys.path.append("../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/effects/point.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/point.py
@@ -12,7 +12,6 @@ def gen_effects_point(lottie, value, idx):
     """
     Generates the dictionary corresponding to effects/point.json
     """
-    index = Count()
     lottie["ty"] = settings.EFFECTS_POINT      # Effect type
     lottie["nm"] = "Point" + str(idx)
     lottie["ix"] = idx

--- a/synfig-studio/plugins/lottie-exporter/effects/slider.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/slider.py
@@ -4,7 +4,6 @@ This module will store the expression controllers of lottie/AE
 
 import sys
 import settings
-from common.Count import Count
 sys.path.append("../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/effects/slider.py
+++ b/synfig-studio/plugins/lottie-exporter/effects/slider.py
@@ -12,7 +12,6 @@ def gen_effects_slider(lottie, value, idx):
     """
     Generates the dictionary corresponding to effects/slider.json
     """
-    index = Count()
     lottie["ty"] = settings.EFFECTS_SLIDER      # Effect type
     lottie["nm"] = "Slider" + str(idx)
     lottie["ix"] = idx

--- a/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
@@ -63,7 +63,7 @@ def clamped_tangent(p1, p2, p3, animated, i):
                 bias = 0.0
             tangent = (p2 - p1) * (1.0 + bias) / 2.0 + (p3 - p2) * (1.0 - bias) / 2.0
     elif p1 > p2:
-        if p2 >= p1 or p2 <= p3:
+        if p2 <= p3:
             tangent = tangent * 0.0
         else:
             if p2 > pm:

--- a/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
@@ -63,7 +63,7 @@ def clamped_tangent(p1, p2, p3, animated, i):
                 bias = 0.0
             tangent = (p2 - p1) * (1.0 + bias) / 2.0 + (p3 - p2) * (1.0 - bias) / 2.0
     elif p1 > p2:
-        if p2 <= p3:
+        if p2 >= p1 or p2 <= p3:
             tangent = tangent * 0.0
         else:
             if p2 > pm:

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
@@ -275,6 +275,6 @@ def quadratic_to_cubic(qp0, qp1, qp2):
     """
     cp0 = qp0
     cp3 = qp2
-    cp1 = qp0 + 2/float(3)*(qp1 - qp0)
-    cp2 = qp2 + 2/float(3)*(qp1 - qp2)
+    cp1 = qp0 + 2/3.0*(qp1 - qp0)
+    cp2 = qp2 + 2/3.0*(qp1 - qp2)
     return cp1, cp2

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
@@ -275,6 +275,6 @@ def quadratic_to_cubic(qp0, qp1, qp2):
     """
     cp0 = qp0
     cp3 = qp2
-    cp1 = qp0 + 2/3*(qp1 - qp0)
-    cp2 = qp2 + 2/3*(qp1 - qp2)
+    cp1 = qp0 + 2/float(3)*(qp1 - qp0)
+    cp2 = qp2 + 2/float(3)*(qp1 - qp2)
     return cp1, cp2

--- a/synfig-studio/plugins/lottie-exporter/shapes/circle.py
+++ b/synfig-studio/plugins/lottie-exporter/shapes/circle.py
@@ -22,7 +22,6 @@ def gen_shapes_circle(lottie, layer, idx):
     Returns:
         (None)
     """
-    index = Count()
     lottie["ty"] = "el"     # Type: circle
     lottie["p"] = {}        # Position of circle
     lottie["d"] = settings.DEFAULT_DIRECTION

--- a/synfig-studio/plugins/lottie-exporter/shapes/circle.py
+++ b/synfig-studio/plugins/lottie-exporter/shapes/circle.py
@@ -5,7 +5,6 @@ This will also support the simple_circle layer of Synfig
 
 import sys
 import settings
-from common.Count import Count
 sys.path.append("..")
 
 

--- a/synfig-studio/plugins/lottie-exporter/synfig/animation.py
+++ b/synfig-studio/plugins/lottie-exporter/synfig/animation.py
@@ -412,7 +412,7 @@ def copy_tcb_average(new_waypoint, waypoint, next_waypoint):
         cont1 = float(next_waypoint.attrib["continuity"])
     if "bias" in next_waypoint.keys():
         bias1 = float(next_waypoint.attrib["bias"])
-    f_tens, f_bias, f_cont = (tens + tens1) / float(2), (bias + bias1) / float(2), (cont + cont1) / float(2)
+    f_tens, f_bias, f_cont = (tens + tens1) / 2.0, (bias + bias1) / 2.0, (cont + cont1) / 2.0
     new_waypoint.attrib["tension"] = str(f_tens)
     new_waypoint.attrib["continuity"] = str(f_cont)
     new_waypoint.attrib["bias"] = str(f_bias)

--- a/synfig-studio/plugins/lottie-exporter/synfig/animation.py
+++ b/synfig-studio/plugins/lottie-exporter/synfig/animation.py
@@ -412,7 +412,7 @@ def copy_tcb_average(new_waypoint, waypoint, next_waypoint):
         cont1 = float(next_waypoint.attrib["continuity"])
     if "bias" in next_waypoint.keys():
         bias1 = float(next_waypoint.attrib["bias"])
-    f_tens, f_bias, f_cont = (tens + tens1) / 2, (bias + bias1) / 2, (cont + cont1) / 2
+    f_tens, f_bias, f_cont = (tens + tens1) / float(2), (bias + bias1) / float(2), (cont + cont1) / float(2)
     new_waypoint.attrib["tension"] = str(f_tens)
     new_waypoint.attrib["continuity"] = str(f_cont)
     new_waypoint.attrib["bias"] = str(f_bias)


### PR DESCRIPTION
Cleaned up the code for Lottie Exporter plugin and removed LGTM warning alerts. In #1199 I had focussed only on adding changes tagged as recommendations.
Link for the alerts : [LGTM warning alerts for the Lottie Exporter plugin](https://lgtm.com/projects/g/synfig/synfig/?mode=list&lang=python&severity=warning)


@AnishGG , @ice0 Please have a look at this