### PR TITLE
[Lottie Exporter] Changes made to offsetKeyframe file

### DIFF
--- a/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
@@ -62,7 +62,7 @@ def clamped_tangent(p1, p2, p3, animated, i):
             else:
                 bias = 0.0
             tangent = (p2 - p1) * (1.0 + bias) / 2.0 + (p3 - p2) * (1.0 - bias) / 2.0
-    elif p1 > p2:
+    elif p1 > p3:
         if p2 >= p1 or p2 <= p3:
             tangent = tangent * 0.0
         else:


### PR DESCRIPTION
There was a mistake in the file offsetKeyframe.py .

https://github.com/synfig/synfig/blob/b380d8a35d882f5d5d839b396a7d3912b8488c9f/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py#L65-L67

The above lines should be changed according to : https://github.com/synfig/synfig/blob/b380d8a35d882f5d5d839b396a7d3912b8488c9f/synfig-core/src/synfig/valuenodes/valuenode_animatedinterface.cpp#L148-L151