### PR TITLE
Fixes for CMake build_images target.

### DIFF
--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -230,8 +230,15 @@ set(IMAGES
     ${ICONS}
 )
 
+set(PIXMAPS_DIR ${SYNFIG_BUILD_ROOT}/share/pixmaps/synfigstudio)
+
+file(MAKE_DIRECTORY ${PIXMAPS_DIR})
+
 ## TODO: don't run this if files are up to date
-add_custom_target(build_images)
+add_custom_target(
+    build_images
+    DEPENDS synfig_bin
+    )
 
 ## TODO: configure icon size
 foreach (ICON IN ITEMS ${ICONS})
@@ -255,13 +262,12 @@ foreach (IMAGE IN ITEMS ${IMAGES})
     endif()
     add_custom_command(
         TARGET build_images POST_BUILD
-        COMMAND synfig ${SRC}.sif --time ${TIME}f -w ${W} -h ${H} --quiet
-        COMMAND mv ${SRC}.png ${CMAKE_CURRENT_BINARY_DIR}/${IMAGE}.png
+        COMMAND synfig_bin ${SRC}.sif -o ${PIXMAPS_DIR}/${IMAGE}.png --time ${TIME}f -w ${W} -h ${H} --quiet
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${SRC}.sif
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${SRC}.sif synfig_bin
     )
     install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/${IMAGE}.png
-        DESTINATION share/pixmaps
+        FILES ${PIXMAPS_DIR}/${IMAGE}.png
+        DESTINATION share/pixmaps/synfigstudio
     )
 endforeach()


### PR DESCRIPTION
Fixes: #1132 

I've made these changes on top of changes proposed in #1232 (I'll rebase these changes onto master once it's merged).

This will reduce the cmake building commands to:
```
mkdir build-cmake && cd build-cmake
cmake ../
make -j4
make build_images -j4
./output/bin/synfigstudio 
```

Existing issues:
- Rebuilding of images everytime (#1229).
- ~~Running binaries after running `make install` doesn't seem to run, it throws~~

Once these are fixed, we can even update [documentations](https://github.com/synfig/synfig/blob/master/README-CMake.md).