### PR TITLE
fixes "local time" of Time Loop layer - fix #479

### DIFF
--- a/synfig-core/src/modules/lyr_std/timeloop.cpp
+++ b/synfig-core/src/modules/lyr_std/timeloop.cpp
@@ -261,11 +261,12 @@ Layer_TimeLoop::set_time_vfunc(IndependentContext context, Time t)const
 		if (duration == 0)
 			t = link_time;
 		else {
+			float local_time_frames = round(local_time*document_fps);
 			float t_frames = round(t*document_fps);
 			float duration_frames = round(duration*document_fps);
 			if (duration > 0)
 			{
-				t -= local_time;
+				t_frames -= local_time_frames;
 				// Simple formula looks like this:
 				// t -= floor(t / duration) * duration;
 				// but we should make all calculations in frames to avoid round errors
@@ -276,7 +277,7 @@ Layer_TimeLoop::set_time_vfunc(IndependentContext context, Time t)const
 			}
 			else
 			{
-				t -= local_time;
+				t_frames -= local_time_frames;
 				// Simple formula looks like this:
 				// t -= floor(t / -duration) * -duration;
 				// but we should make all calculations in frames to avoid round errors


### PR DESCRIPTION
Now this example works as described:
https://wiki.synfig.org/Time_Loop_Layer#Contrived_Example