### PR TITLE
DashItem Offset and Length variables are not consistent when editing them

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
@@ -763,12 +763,10 @@ ValueNode_Composite::get_children_vocab_vfunc()const
 		ret.push_back(ParamDesc(ValueBase(),"offset")
 			.set_local_name(_("Offset"))
 			.set_description(_("The offset length of the Dash Item over the Spline"))
-			.set_is_distance()
 		);
 		ret.push_back(ParamDesc(ValueBase(),"length")
 			.set_local_name(_("Length"))
 			.set_description(_("The length of the Dash Item"))
-			.set_is_distance()
 		);
 		ret.push_back(ParamDesc(ValueBase(),"side_before")
 			.set_local_name(_("Side Type Before"))


### PR DESCRIPTION
Fixes #1265 