### PR TITLE
[MSYS2] Enable building of images (Autotools)

### DIFF
--- a/1-setup-osx-brew.sh
+++ b/1-setup-osx-brew.sh
@@ -23,7 +23,7 @@ pushd "${WORKDIR}" > /dev/null
 WORKDIR=`pwd`
 popd > /dev/null
 
-PACKAGES="adwaita-icon-theme autoconf automake ccache libtool intltool imagemagick gettext pkg-config glibmm libxml++ cairo fftw pango mlt boost gtkmm3 sdl2 sdl2_mixer libxml2 libxslt"
+PACKAGES="coreutils adwaita-icon-theme autoconf automake ccache libtool intltool imagemagick gettext pkg-config glibmm libxml++ cairo fftw pango mlt boost gtkmm3 sdl2 sdl2_mixer libxml2 libxslt"
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1

--- a/1-setup-windows-msys2.sh
+++ b/1-setup-windows-msys2.sh
@@ -41,6 +41,7 @@ $ARCH-boost \
 $ARCH-cairomm \
 $ARCH-fftw \
 $ARCH-glibmm \
+$ARCH-imagemagick \
 $ARCH-libxml++2.6 \
 $ARCH-pango \
 $ARCH-gtkmm3

--- a/autobuild/build.sh
+++ b/autobuild/build.sh
@@ -205,13 +205,19 @@ if [ -e /etc/debian_version ] && [ -z "$BOOST_CONFIGURE_OPTIONS" ]; then
 		export BOOST_CONFIGURE_OPTIONS="--with-boost-libdir=$MULTIARCH_LIBDIR"
 	fi
 fi
+if [[ `uname -o` == "Msys" ]]; then
+	# Currently there is an error when building with Magick++ on MSYS2
+	export CONFIGURE_OPTIONS="--without-magickpp"
+else
+	export CONFIGURE_OPTIONS="--with-magickpp"
+fi
 /bin/bash "${REPO_DIR}/synfig-core/configure" --prefix="${PREFIX}" \
 	--includedir="${PREFIX}/include" \
 	--disable-static --enable-shared \
-	--with-magickpp \
 	--without-libavcodec \
 	--without-included-ltdl \
 	$BOOST_CONFIGURE_OPTIONS \
+	$CONFIGURE_OPTIONS \
 	$DEBUG
 cd ..
 }
@@ -259,10 +265,6 @@ pushd "${REPO_DIR}/synfig-studio/" >/dev/null
 popd >/dev/null
 if [[ `uname` == "Linux" ]]; then
 	export CONFIGURE_OPTIONS="--enable-jack"
-elif [[ `uname -o` == "Msys" ]]; then
-	# currently where is a bug in synfig-core (in MinGW build) which causes 
-	# synfig-core to halt before exit, so we skip image generation
-	export CONFIGURE_OPTIONS="--without-images"
 else
 	export CONFIGURE_OPTIONS=""
 fi

--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -108,6 +108,7 @@ AC_ARG_WITH(magickpp,
 ],[
 	with_magickpp="yes"
 ])
+AM_CONDITIONAL(HAVE_LIBMAGICKPP,false)
 if test $with_magickpp = "yes" ; then {
 	PKG_CHECK_MODULES(MAGICKPP, Magick++ >= 6.4.2,[
 		with_magickpp="yes"
@@ -115,8 +116,7 @@ if test $with_magickpp = "yes" ; then {
 		CONFIG_DEPS="$CONFIG_DEPS Magick++"
 	],[
 		with_magickpp="no"
-		AC_MSG_RESULT([ *** Magick++ Output target disabled])
-		AM_CONDITIONAL(HAVE_LIBMAGICKPP,false)
+		AC_MSG_ERROR([ *** Unable to find Magick++])
 	])
 } ; fi
 

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -420,12 +420,12 @@ SUFFIXES = .sif .tif .png .sifz .bmp
 #.SUFFIXES: $(SUFFIXES)
 
 .sifz.ico:
-	bash ../build_tools/sif2ico.sh $<
+	bash $(srcdir)/../build_tools/sif2ico.sh $<
 	echo "  File \"images\\$@\"" >>./icons.nsh
 	echo "  Delete \"\$$INSTDIR\\share\\pixmaps\\$@\"" >>./unicons.nsh
 
 .sif.ico:
-	bash ../build_tools/sif2ico.sh $<
+	bash $(srcdir)/../build_tools/sif2ico.sh $<
 	echo "  File \"images\\$@\"" >>./icons.nsh
 	echo "  Delete \"\$$INSTDIR\\share\\pixmaps\\$@\"" >>./unicons.nsh
 

--- a/synfig-studio/images/splash_screen_development.sh
+++ b/synfig-studio/images/splash_screen_development.sh
@@ -2,9 +2,12 @@
 
 set -x
 
+
+SRCDIR_RELATIVE=`realpath --relative-to="$PWD" "$2"`
+
 export commit_id=`git log --no-color -1 | head -n 1 | cut -f 2 -d ' ' | cut -c -6`
 export commit_date=`git show --pretty=format:%ci HEAD |  head -c 10`
 export branch=`git branch -a --no-color --contains HEAD | sed -e s/\*\ // | sed -e s/\(no\ branch\)// | head -n 1 | sed s/^' '//`
 export branch=`echo $branch | egrep origin/master > /dev/null && echo master || echo $branch | cut -d ' ' -f 1 | sed -e 's/.*\///'`
-sed "s|%branch%|$branch|" "$2/splash_screen_development.sif.in" | sed "s|%commit_date%|$commit_date|" | sed "s|%commit_id%|$commit_id|" | sed "s|synfig_icon.sif#|$2/synfig_icon.sif#|" > "$1"
+sed "s|%branch%|$branch|" "$2/splash_screen_development.sif.in" | sed "s|%commit_date%|$commit_date|" | sed "s|%commit_id%|$commit_id|" | sed "s|synfig_icon.sif#|$SRCDIR_RELATIVE/synfig_icon.sif#|" > "$1"
 

--- a/synfig-studio/src/gui/resourcehelper.cpp
+++ b/synfig-studio/src/gui/resourcehelper.cpp
@@ -37,6 +37,7 @@
 
 synfig::String studio::ResourceHelper::get_image_path()
 {
+
 #ifndef IMAGE_DIR
 #	define IMAGE_DIR "/usr/local/share/pixmaps/synfigstudio"
 #endif
@@ -52,10 +53,8 @@ synfig::String studio::ResourceHelper::get_image_path()
 		imagepath=std::string(synfig_root)+"/share/pixmaps/synfigstudio";
 	}
 	else {
-#if defined CMAKE_BUILD
+#if defined CMAKE_BUILD || defined _WIN32
         imagepath=App::get_base_path()+"/share/pixmaps/synfigstudio";
-#elif defined _WIN32
-        imagepath=App::get_base_path()+"/share/pixmaps";
 #else
         imagepath=IMAGE_DIR;
 #endif


### PR DESCRIPTION
This enables building image with Autotools on Windows.

I've been forced to disable Magick++, because it failed to build for me.
At the same time, ImageMagick is mandatory requirement to build images with Autotools (it is used to convert some icon files).