### PR TITLE
fix uninitialized row info geometry

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -847,6 +847,7 @@ synfig::Time Widget_Timetrack::compute_scaled_time(const Widget_Timetrack::Waypo
 }
 
 Widget_Timetrack::RowInfo::RowInfo()
+	: geometry{0,0}
 {
 }
 


### PR DESCRIPTION
coverity report