### PR TITLE
Export plugins

### DIFF
--- a/autobuild/lottie_test.sh
+++ b/autobuild/lottie_test.sh
@@ -29,7 +29,7 @@ failing_files=(070-skeleton.sif 075-skeleton-group.sif 076-skeleton-group-animat
 for filename in $test_files;
 do 
     pass=1      # 0 -> File is failing to export unexpectedly, 1 -> File is exporting, 2 -> File is allowed to fail
-    python3 $LOTTIE $filename || { # This line catches errors in python script
+    python3 $LOTTIE $filename "${filename%.sif}.json" || { # This line catches errors in python script
 
         # Check if the program is allowed to fail
         for i in ${failing_files[@]}

--- a/synfig-studio/plugins/lottie-exporter/common/Param.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Param.py
@@ -433,6 +433,7 @@ class Param:
                 return ret, self.expression_controllers
 
             elif self.param[0].tag == "bone_link":
+                import pdb; pdb.set_trace(); pass
                 self.subparams["bone_link"].extract_subparams()
                 guid = self.subparams["bone_link"].subparams["bone"][0].attrib["guid"]
                 bone = self.get_bone_from_canvas(guid)
@@ -800,6 +801,7 @@ class Param:
                     ret = link_on * switch + link_off * (1 - switch)
 
             elif self.param[0].tag == "bone_link":
+                import pdb; pdb.set_trace(); pass
                 guid = self.subparams["bone_link"].subparams["bone"][0].attrib["guid"]
                 bone = self.get_bone_from_canvas(guid)
                 ret_origin, ret_angle, lls, rls = bone.__get_value(frame)
@@ -986,6 +988,7 @@ class Param:
                 self.subparams["scale"].subparams["scalar"].update_frame_window(window)
 
             elif node.tag == "bone_link":
+                import pdb; pdb.set_trace(); pass
                 self.subparams["bone_link"].extract_subparams()
                 guid = self.subparams["bone_link"].subparams["bone"][0].attrib["guid"]
                 bone = self.get_bone_from_canvas(guid)

--- a/synfig-studio/plugins/lottie-exporter/common/Param.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Param.py
@@ -433,7 +433,6 @@ class Param:
                 return ret, self.expression_controllers
 
             elif self.param[0].tag == "bone_link":
-                import pdb; pdb.set_trace(); pass
                 self.subparams["bone_link"].extract_subparams()
                 guid = self.subparams["bone_link"].subparams["bone"][0].attrib["guid"]
                 bone = self.get_bone_from_canvas(guid)
@@ -801,7 +800,6 @@ class Param:
                     ret = link_on * switch + link_off * (1 - switch)
 
             elif self.param[0].tag == "bone_link":
-                import pdb; pdb.set_trace(); pass
                 guid = self.subparams["bone_link"].subparams["bone"][0].attrib["guid"]
                 bone = self.get_bone_from_canvas(guid)
                 ret_origin, ret_angle, lls, rls = bone.__get_value(frame)
@@ -988,7 +986,6 @@ class Param:
                 self.subparams["scale"].subparams["scalar"].update_frame_window(window)
 
             elif node.tag == "bone_link":
-                import pdb; pdb.set_trace(); pass
                 self.subparams["bone_link"].extract_subparams()
                 guid = self.subparams["bone_link"].subparams["bone"][0].attrib["guid"]
                 bone = self.get_bone_from_canvas(guid)

--- a/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
+++ b/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
@@ -18,29 +18,25 @@ from layers.driver import gen_layers
 from common.misc import modify_final_dump
 from common.Canvas import Canvas
 import settings
+import argparse
 
 
-def write_to(filename, extension, data):
+def write_to(filename, data):
     """
     Helps in writing data to a specified file name
 
     Args:
         filename  (str) : Original file name
-        extension (str) : original file name needs to be converted to this
         data      (str) : Data that needs to be written
 
     Returns:
         (str) : changed file name according to the extension specified
     """
-    new_name = filename.split(".")
-    new_name[-1] = extension
-    new_name = ".".join(new_name)
-    with open(new_name, "w") as fil:
+    with open(filename, "w") as fil:
         fil.write(data)
-    return new_name
 
 
-def parse(file_name):
+def parse(file_name, new_file_name):
     """
     Driver function for parsing .sif to lottie(.json) format
 
@@ -68,7 +64,7 @@ def parse(file_name):
     gen_layers(settings.lottie_format["layers"], canvas, canvas.get_num_layers() - 1)
 
     lottie_string = json.dumps(modify_final_dump(settings.lottie_format))
-    return write_to(file_name, "json", lottie_string)
+    write_to(new_file_name, lottie_string)
 
 
 def gen_html(file_name):
@@ -135,7 +131,7 @@ def gen_html(file_name):
 </html>
 """
 
-    write_to(file_name, "html", html_text.format(bodymovin_script=bodymovin_script, file_name_data=json.dumps(modify_final_dump(settings.lottie_format))))
+    write_to(os.path.splitext(file_name)[0]+".html", html_text.format(bodymovin_script=bodymovin_script, file_name_data=json.dumps(modify_final_dump(settings.lottie_format))))
 
 
 def init_logs():
@@ -155,10 +151,13 @@ def init_logs():
     logging.getLogger().setLevel(logging.DEBUG)
 
 
-if len(sys.argv) < 2:
-    sys.exit()
-else:
-    settings.init()
-    FILE_NAME = sys.argv[1]
-    new_file_name = parse(FILE_NAME)
-    gen_html(new_file_name)
+parser = argparse.ArgumentParser()
+parser.add_argument("infile")
+parser.add_argument("outfile")
+ns = parser.parse_args()
+
+settings.init()
+FILE_NAME = ns.infile
+new_file_name = ns.outfile
+parse(FILE_NAME, new_file_name)
+gen_html(new_file_name)

--- a/synfig-studio/plugins/lottie-exporter/plugin.xml.in
+++ b/synfig-studio/plugins/lottie-exporter/plugin.xml.in
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin>
+<plugin type="exporter">
    <_name>Export to Lottie format</_name>
    <exec>lottie-exporter.py</exec>
-   <type>exporter</type>
    <extension>.json</extension>
    <description>Lottie Animation (*.json)</description>
 </plugin> 

--- a/synfig-studio/plugins/lottie-exporter/plugin.xml.in
+++ b/synfig-studio/plugins/lottie-exporter/plugin.xml.in
@@ -2,4 +2,7 @@
 <plugin>
    <_name>Export to Lottie format</_name>
    <exec>lottie-exporter.py</exec>
+   <type>exporter</type>
+   <extension>.json</extension>
+   <description>Lottie Animation (*.json)</description>
 </plugin> 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3273,7 +3273,7 @@ App::dialog_export_file(const std::string &title, std::string &filename, std::st
 
         _preferences.set_value(preference, dirname(filename));
 
-        auto filter = dialog->get_filter().get();
+        auto filter = dialog->get_filter();
         for ( const auto& plugin : exporters )
         {
             if (  filter->get_name() == plugin.description )

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -410,6 +410,7 @@ public:
 	static bool dialog_open_file_with_history_button(const std::string &title, std::string &filename, bool &show_history, std::string preference);
 	static bool dialog_open_folder(const std::string &title, std::string &filename, std::string preference, Gtk::Window& transientwind=*App::main_window);
 	static bool dialog_save_file(const std::string &title, std::string &filename, std::string preference);
+	static std::string dialog_export_file(const std::string &title, std::string &filename, std::string preference);
 	static bool dialog_save_file_spal(const std::string &title, std::string &filename, std::string preference);
 	static bool dialog_save_file_sketch(const std::string &title, std::string &filename, std::string preference);
 	static bool dialog_save_file_render(const std::string &title, std::string &filename, std::string preference);

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1439,6 +1439,9 @@ CanvasView::init_menus()
 	action_group->add( Gtk::Action::create("save-as", Gtk::StockID("synfig-save_as"), _("Save As..."), _("Save As")),
 		sigc::hide_return(sigc::mem_fun(*get_instance().get(), &Instance::dialog_save_as))
 	);
+	action_group->add( Gtk::Action::create("export", Gtk::StockID("synfig-export"), _("Export..."), _("Export")),
+		sigc::hide_return(sigc::mem_fun(*get_instance().get(), &Instance::dialog_export))
+	);
 	action_group->add( Gtk::Action::create("save-all", Gtk::StockID("synfig-save_all"), _("Save All"), _("Save all opened documents")),
 		sigc::ptr_fun(save_all)
 	);
@@ -1515,10 +1518,15 @@ CanvasView::init_menus()
 	);
 
 	std::list<PluginManager::plugin> plugin_list = App::plugin_manager.get_list();
+    auto instance = get_instance().get();
 	for(std::list<PluginManager::plugin>::const_iterator p = plugin_list.begin(); p != plugin_list.end(); ++p)
+    {
+        std::string path = p->path;
 		action_group->add(
 			Gtk::Action::create(p->id, p->name),
-			sigc::bind( sigc::mem_fun(*get_instance().get(), &Instance::run_plugin), p->path ) );
+			[instance, path](){instance->run_plugin(path, true);}
+        );
+    }
 
 	// Low-Res Quality Menu
 	for(std::list<int>::iterator i = get_pixel_sizes().begin(); i != get_pixel_sizes().end(); ++i) {

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -177,6 +177,7 @@ IconController::init_icons(const synfig::String& path_to_icons)
 	INIT_STOCK_ICON(open, "action_doc_open_icon." IMAGE_EXT, _("Open"));
 	INIT_STOCK_ICON(save, "action_doc_save_icon." IMAGE_EXT, _("Save"));
 	INIT_STOCK_ICON(save_as, "action_doc_saveas_icon." IMAGE_EXT, _("Save As"));
+	INIT_STOCK_ICON(export, "action_doc_saveas_icon." IMAGE_EXT, _("Export"));
 	INIT_STOCK_ICON(save_all, "action_doc_saveall_icon." IMAGE_EXT, _("Save All"));
 	INIT_STOCK_ICON(redo, "action_doc_redo_icon." IMAGE_EXT, _("Redo"));
 	INIT_STOCK_ICON(undo, "action_doc_undo_icon." IMAGE_EXT, _("Undo"));

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -230,7 +230,7 @@ studio::Instance::run_plugin_with_arguments(std::string plugin_path, const std::
 
 	bool result = false;
 	String output;
-	String command = "";
+	String command;
 
 	// Path to python binary can be overridden
 	// with SYNFIG_PYTHON_BINARY env variable:
@@ -238,7 +238,6 @@ studio::Instance::run_plugin_with_arguments(std::string plugin_path, const std::
 	if(custom_python_binary) {
 		command=custom_python_binary;
 		if (!App::check_python_version(command)) {
-			output=_("Error: You need to have Python 3 installed.");
 			command="";
 		}
 	} else {
@@ -275,10 +274,10 @@ studio::Instance::run_plugin_with_arguments(std::string plugin_path, const std::
 
 		// Construct the full command:
 		command = command+" \""+plugin_path+"\"";
-        for ( const auto& arg : args )
-        {
-            command += " \"" + arg + "\"";
-        }
+		for ( const auto& arg : args )
+		{
+			command += " \"" + arg + "\"";
+		}
         command += " 2>&1";
 #ifdef _WIN32
 		// This covers the dumb cmd.exe behavior.
@@ -288,7 +287,7 @@ studio::Instance::run_plugin_with_arguments(std::string plugin_path, const std::
 
 		FILE* pipe = popen(command.c_str(), "r");
 		if (!pipe) {
-			output = "ERROR: pipe failed!";
+			output = _("ERROR: pipe failed!");
 		} else {
 			char buffer[128];
 			while(!feof(pipe)) {
@@ -309,16 +308,16 @@ studio::Instance::run_plugin_with_arguments(std::string plugin_path, const std::
 	}
 
 
-    if (!result){
-        one_moment.hide();
-        App::dialog_message_1b(
-                "Error",
-                output,
-                "details",
-                _("Close"));
+	if (!result){
+		one_moment.hide();
+		App::dialog_message_1b(
+				"Error",
+				output,
+				"details",
+				_("Close"));
 
-        one_moment.show();
-    }
+		one_moment.show();
+	}
 
     return result;
 }
@@ -328,23 +327,23 @@ studio::Instance::run_plugin(std::string plugin_path, bool modify_canvas, std::v
 {
 	handle<synfigapp::UIInterface> uim = this->find_canvas_view(this->get_canvas())->get_ui_interface();
 
-    if ( modify_canvas )
-    {
-        String message = strprintf(_("Do you really want to run plugin for file \"%s\"?" ),
-                    this->get_canvas()->get_name().c_str());
+	if ( modify_canvas )
+	{
+		String message = strprintf(_("Do you really want to run plugin for file \"%s\"?" ),
+					this->get_canvas()->get_name().c_str());
 
-        String details = strprintf(_("This operation cannot be undone and all undo history will be cleared."));
+		String details = _("This operation cannot be undone and all undo history will be cleared.");
 
-        int answer = uim->confirmation(
-                    message,
-                    details,
-                    _("Cancel"),
-                    _("Proceed"),
-                    synfigapp::UIInterface::RESPONSE_OK);
+		int answer = uim->confirmation(
+					message,
+					details,
+					_("Cancel"),
+					_("Proceed"),
+					synfigapp::UIInterface::RESPONSE_OK);
 
-        if(answer != synfigapp::UIInterface::RESPONSE_OK)
-            return;
-    }
+		if(answer != synfigapp::UIInterface::RESPONSE_OK)
+			return;
+	}
 
 	OneMoment one_moment;
 
@@ -426,28 +425,28 @@ studio::Instance::run_plugin(std::string plugin_path, bool modify_canvas, std::v
 	canvas=0;
 
 
-    if ( modify_canvas ) {
-        one_moment.show();
-        bool ok = App::open_from_temporary_filesystem(tmp_filename);
-        if (!ok) {
-            synfig::error("run_plugin(): Cannot reopen file");
-            return;
-        }
+	if ( modify_canvas ) {
+		one_moment.show();
+		bool ok = App::open_from_temporary_filesystem(tmp_filename);
+		if (!ok) {
+			synfig::error("run_plugin(): Cannot reopen file");
+			return;
+		}
 
-        etl::handle<Instance> new_instance = App::instance_list.back();
-        if (!new_instance) {
-            synfig::error("run_plugin(): Cannot retrieve new instance");
-        } else {
-            // Restore time cursor position
-            canvas = new_instance->get_canvas();
-            etl::handle<synfigapp::CanvasInterface> new_canvas_interface(new_instance->find_canvas_interface(canvas));
-            if (!new_canvas_interface) {
-                synfig::error("run_plugin(): Cannot retrieve canvas interface");
-            } else {
-                new_canvas_interface->set_time(cur_time);
-            }
-        }
-    }
+		etl::handle<Instance> new_instance = App::instance_list.back();
+		if (!new_instance) {
+			synfig::error("run_plugin(): Cannot retrieve new instance");
+		} else {
+			// Restore time cursor position
+			canvas = new_instance->get_canvas();
+			etl::handle<synfigapp::CanvasInterface> new_canvas_interface(new_instance->find_canvas_interface(canvas));
+			if (!new_canvas_interface) {
+				synfig::error("run_plugin(): Cannot retrieve canvas interface");
+			} else {
+				new_canvas_interface->set_time(cur_time);
+			}
+		}
+	}
 }
 
 bool

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -292,7 +292,7 @@ studio::Instance::run_plugin_with_arguments(std::string plugin_path, const std::
 			char buffer[128];
 			while(!feof(pipe)) {
 				if(fgets(buffer, 128, pipe) != NULL)
-						output += buffer;
+					output += buffer;
 			}
 
 			if (output != "" ){

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -278,7 +278,7 @@ studio::Instance::run_plugin_with_arguments(std::string plugin_path, const std::
 		{
 			command += " \"" + arg + "\"";
 		}
-        command += " 2>&1";
+		command += " 2>&1";
 #ifdef _WIN32
 		// This covers the dumb cmd.exe behavior.
 		// See: http://eli.thegreenplace.net/2011/01/28/on-spaces-in-the-paths-of-programs-and-files-on-windows/
@@ -319,7 +319,7 @@ studio::Instance::run_plugin_with_arguments(std::string plugin_path, const std::
 		one_moment.show();
 	}
 
-    return result;
+	return result;
 }
 
 void
@@ -365,8 +365,8 @@ studio::Instance::run_plugin(std::string plugin_path, bool modify_canvas, std::v
 		filename_processed = filename_original+"."+guid.get_string().substr(0,8)+".sif";
 	} while (stat(filename_processed.c_str(), &buf) != -1);
 
-    if ( modify_canvas )
-        close(false);
+	if ( modify_canvas )
+		close(false);
 
 	if(canvas->count() != 1 && modify_canvas)
 	{
@@ -399,8 +399,8 @@ studio::Instance::run_plugin(std::string plugin_path, bool modify_canvas, std::v
 		outfile.close();
 		stream_in.reset();
 
-        one_moment.hide();
-        extra_args.insert(extra_args.begin(), filename_processed);
+		one_moment.hide();
+		extra_args.insert(extra_args.begin(), filename_processed);
 		bool result = run_plugin_with_arguments(plugin_path, extra_args);
 
 		if (result && modify_canvas){
@@ -669,17 +669,17 @@ studio::Instance::dialog_export()
 		filename = absolute_path(filename);
 
 	// show the canvas' name if it has one, else its ID
-    std::string plugin = App::dialog_export_file(
-        (_("Please choose a file name") +
-        String(" (") +
-        (canvas->get_name().empty() ? canvas->get_id() : canvas->get_name()) +
-        ")"),
-        filename, ANIMATION_DIR_PREFERENCE
-    );
+	std::string plugin = App::dialog_export_file(
+		(_("Please choose a file name") +
+		String(" (") +
+		(canvas->get_name().empty() ? canvas->get_id() : canvas->get_name()) +
+		")"),
+		filename, ANIMATION_DIR_PREFERENCE
+	);
 	if ( !plugin.empty() )
 	{
-        run_plugin(plugin, false, {filename});
-        return true;
+		run_plugin(plugin, false, {filename});
+		return true;
 	}
 
 	return false;

--- a/synfig-studio/src/gui/instance.h
+++ b/synfig-studio/src/gui/instance.h
@@ -180,7 +180,9 @@ public:
 
 	const CanvasViewList & canvas_view_list()const { return canvas_view_list_; }
 
-	void run_plugin(std::string plugin_path);
+	void run_plugin(std::string plugin_path, bool modify_canvas, std::vector<std::string> extra_args = {});
+
+	bool run_plugin_with_arguments(std::string plugin_path, const std::vector<std::string>& args);
 
 	bool save_as(const synfig::String &filename);
 
@@ -190,6 +192,8 @@ public:
 	//! Opens a "Save As" dialog, and then saves the composition to that file
 	//! returns true if the save was successful
 	bool dialog_save_as();
+
+	bool dialog_export();
 
 	void open();
 

--- a/synfig-studio/src/gui/pluginmanager.cpp
+++ b/synfig-studio/src/gui/pluginmanager.cpp
@@ -138,7 +138,7 @@ PluginManager::load_plugin( const std::string &path )
 	std::string plugindir = dirname(path);
 	p.id=plugindir;
 
-    std::list<plugin>* target_list = &list_;
+	std::list<plugin>* target_list = &list_;
 	
 	// parse xml file
 	try

--- a/synfig-studio/src/gui/pluginmanager.h
+++ b/synfig-studio/src/gui/pluginmanager.h
@@ -51,6 +51,8 @@ public:
 		std::string id;
 		std::string name;
 		std::string path;
+		std::string extension;
+		std::string description;
 	};
 
 	/*
@@ -66,6 +68,7 @@ public:
 private:
 
 	std::list< plugin > list_;
+	std::list< plugin > exporters_;
 
 protected:
 	
@@ -81,6 +84,8 @@ public:
 	void load_plugin( const std::string &path );
 
 	std::list< plugin > get_list() { return list_; };
+
+	std::list< plugin > get_exporters() { return exporters_; };
 
 }; // END class PluginManager
 


### PR DESCRIPTION
Adds more metadata to the plugins to support a proper export system.

I've also updated the lottie exporter to use this system.

This is said plugin description as an example:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<plugin type="exporter">
   <_name>Export to Lottie format</_name>
   <exec>lottie-exporter.py</exec>
   <extension>.json</extension>
   <description>Lottie Animation (*.json)</description>
</plugin> 
```

if the `type` attribute is present and its value is "exporter", the plugin will be added to a list of exporters. The `<extension>` and `<description>` elements are used by the new "Export" dialog to set up the file filters.

Such plugins no longer show in the Plugins menu, they are only accessible through File > Export...