### PR TITLE
fix outline vertex order for older files - again :)

### DIFF
--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -2343,14 +2343,10 @@ CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 			bool loop = is_true(loop_str);
 			bline_value_node->set_loop(loop);
 
-			xmlpp::Element *parent = element->get_parent();
-			if (loop && parent->get_name() == "param") {
-				xmlpp::Element *gran_parent = parent->get_parent();
-				if (gran_parent) {
-					string version = gran_parent->get_attribute_value("version");
-					if (version == "0.2" || version == "0.1")
-						must_rotate_point_list = true;
-				}
+			if (loop) {
+				string version = canvas->get_version();
+				if (version == "1.0" || (version[0] == '0' && version[1] == '.'))
+					must_rotate_point_list = true;
 			}
 		}
 	}


### PR DESCRIPTION
This way files from version <= 1.3.11 can be correctly opened in
new version as well for those created in current Studio version.

More info:
https://github.com/synfig/synfig/issues/1284
https://github.com/synfig/synfig/issues/314#issuecomment-603703084