### PR TITLE
remove useless Importer::get_frame overloaded method

### DIFF
--- a/synfig-core/src/synfig/importer.cpp
+++ b/synfig-core/src/synfig/importer.cpp
@@ -166,9 +166,7 @@ Importer::get_frame(const RendDesc & /* renddesc */, const Time &time)
 		return last_surface_;
 
 	Surface surface;
-	bool trimmed = false;
-	unsigned int width = 0, height = 0, top = 0, left = 0;
-	if(!get_frame(surface, RendDesc(), time, trimmed, width, height, top, left))
+	if(!get_frame(surface, RendDesc(), time))
 		warning(strprintf("Unable to get frame from \"%s\"", identifier.filename.c_str()));
 
 	const char *s = getenv("SYNFIG_PACK_IMAGES");

--- a/synfig-core/src/synfig/importer.cpp
+++ b/synfig-core/src/synfig/importer.cpp
@@ -98,7 +98,7 @@ Importer::open(const FileSystem::Identifier &identifier, bool force)
 	if(identifier.filename.empty())
 	{
 		synfig::error(_("Importer::open(): Cannot open empty filename"));
-		return 0;
+		return nullptr;
 	}
 
 	// If we already have an importer open under that filename,
@@ -112,7 +112,7 @@ Importer::open(const FileSystem::Identifier &identifier, bool force)
 	if(filename_extension(identifier.filename) == "")
 	{
 		synfig::error(_("Importer::open(): Couldn't find extension"));
-		return 0;
+		return nullptr;
 	}
 
 	String ext(filename_extension(identifier.filename));
@@ -123,7 +123,7 @@ Importer::open(const FileSystem::Identifier &identifier, bool force)
 	if(!Importer::book().count(ext))
 	{
 		synfig::error(_("Importer::open(): Unknown file type -- ")+ext);
-		return 0;
+		return nullptr;
 	}
 
 	try {
@@ -136,7 +136,7 @@ Importer::open(const FileSystem::Identifier &identifier, bool force)
 	{
 		synfig::error(str);
 	}
-	return 0;
+	return nullptr;
 }
 
 void Importer::forget(const FileSystem::Identifier &identifier)
@@ -170,7 +170,7 @@ Importer::get_frame(const RendDesc & /* renddesc */, const Time &time)
 		warning(strprintf("Unable to get frame from \"%s\"", identifier.filename.c_str()));
 
 	const char *s = getenv("SYNFIG_PACK_IMAGES");
-	if (s == NULL || atoi(s) != 0)
+	if (s == nullptr || atoi(s) != 0)
 		last_surface_ = new rendering::SurfaceSWPacked();
 	else
 		last_surface_ = new rendering::SurfaceSW();

--- a/synfig-core/src/synfig/importer.h
+++ b/synfig-core/src/synfig/importer.h
@@ -166,16 +166,6 @@ public:
 	**	\see ProgressCallback, Surface
 	*/
 	virtual bool get_frame(Surface &surface, const RendDesc &renddesc, Time time, ProgressCallback *callback=NULL)=0;
-	virtual bool get_frame(Surface &surface, const RendDesc &renddesc,Time time,
-						   bool &trimmed,
-						   unsigned int &width,
-						   unsigned int &height,
-						   unsigned int &top,
-						   unsigned int &left,
-						   ProgressCallback *callback=NULL)
-	{
-		return get_frame(surface,renddesc,time,callback);
-	}
 
 	virtual rendering::Surface::Handle get_frame(const RendDesc &renddesc, const Time &time);
 

--- a/synfig-core/src/synfig/importer.h
+++ b/synfig-core/src/synfig/importer.h
@@ -123,7 +123,7 @@ public:
 		Factory factory;
 		bool supports_file_system_wrapper;
 
-		BookEntry(): factory(NULL), supports_file_system_wrapper(false) { }
+		BookEntry(): factory(nullptr), supports_file_system_wrapper(false) { }
 		BookEntry(Factory factory, bool supports_file_system_wrapper):
 		factory(factory), supports_file_system_wrapper(supports_file_system_wrapper)
 		{ }
@@ -165,7 +165,7 @@ public:
 	**	\return \c true on success, \c false on error
 	**	\see ProgressCallback, Surface
 	*/
-	virtual bool get_frame(Surface &surface, const RendDesc &renddesc, Time time, ProgressCallback *callback=NULL)=0;
+	virtual bool get_frame(Surface &surface, const RendDesc &renddesc, Time time, ProgressCallback *callback=nullptr) = 0;
 
 	virtual rendering::Surface::Handle get_frame(const RendDesc &renddesc, const Time &time);
 


### PR DESCRIPTION
This version with rectangle parameters aren't used anywhere