### PR TITLE
Fix for no icon in Import Image Layer for CMake Build.

### DIFF
--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -18,6 +18,7 @@ set(IMG_SOURCE_action_doc_undo_icon action_doc_icons 6)
 set(IMG_SOURCE_action_doc_redo_icon action_doc_icons 7)
 
 set(IMG_SOURCE_canvas_icon canvas_and_importimage_icons 2)
+set(IMG_SOURCE_layer_other_importimage_icon canvas_and_importimage_icons 1)
 
 set(IMG_SOURCE_animate_seek_next_keyframe_icon framedial_icons 0)
 set(IMG_SOURCE_animate_seek_prev_keyframe_icon framedial_icons 1)
@@ -148,6 +149,7 @@ set(ICONS
     layer_icon
     layer_other_duplicate_icon
     layer_other_group_icon
+    layer_other_importimage_icon
     layer_other_plant_icon
     layer_other_skeleton_icon
     layer_other_sound_icon


### PR DESCRIPTION
Fixes: #959

![image](https://user-images.githubusercontent.com/34449856/78418388-5052ec00-7659-11ea-940a-82e95cbdc6b3.png)
