### PR TITLE
allow enum parameter be edited with a double click instead of triple click

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -73,8 +73,6 @@ using namespace studio;
 
 /* === M A C R O S ========================================================= */
 
-#define DIGITS		15
-
 /* === G L O B A L S ======================================================= */
 
 class studio::ValueBase_Entry : public Gtk::CellEditable, public Gtk::EventBox

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -78,17 +78,7 @@ public:
 	{
 		parent           = nullptr;
 		edit_done_called = false;
-/*
-		  Gtk::HBox *const hbox = new Gtk::HBox(false, 0);
-		  add(*Gtk::manage(hbox));
 
-		  Gtk::Entry *entry_ = new Gtk::Entry();
-			entry_->set_text("bleh");
-		  hbox->pack_start(*Gtk::manage(entry_), Gtk::PACK_EXPAND_WIDGET);
-		  entry_->set_has_frame(false);
-		  entry_->gobj()->is_cell_renderer = true; // XXX
-
-*/
 		valuewidget = manage(new class Widget_ValueBase());
 		valuewidget->inside_cellrenderer();
 		add(*valuewidget);
@@ -97,27 +87,8 @@ public:
 		//set_can_focus(true);
 		//set_events(Gdk::KEY_PRESS_MASK | Gdk::KEY_RELEASE_MASK);
 
-		/*
-		set_events(//(Gdk::ALL_EVENTS_MASK)
-		~(	Gdk::EXPOSURE_MASK
-			| Gdk::ENTER_NOTIFY_MASK
-			| Gdk::LEAVE_NOTIFY_MASK
-			| Gdk::FOCUS_CHANGE_MASK
-			| Gdk::STRUCTURE_MASK
-			| Gdk::PROPERTY_CHANGE_MASK
-			| Gdk::VISIBILITY_NOTIFY_MASK
-			| Gdk::PROXIMITY_IN_MASK
-			| Gdk::PROXIMITY_OUT_MASK
-			| Gdk::SUBSTRUCTURE_MASK
-		)
-		);
-		*/
-		//signal_editing_done().connect(sigc::mem_fun(*this, &studio::ValueBase_Entry::hide));
-		//signal_remove_widget().connect(sigc::mem_fun(*this, &studio::ValueBase_Entry::hide));
-
 		show_all_children();
 
-		//signal_show().connect(sigc::mem_fun(*this, &ValueBase_Entry::grab_focus));
 	}
 	~ValueBase_Entry()
 	{
@@ -478,7 +449,6 @@ CellRenderer_ValueBase::render_vfunc(
 	else
 	if (type == type_nil)
 	{
-		//property_text()=(Glib::ustring)" ";
 		return;
 	}
 	else

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -608,7 +608,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 	else
 	{
 		assert(get_canvas());
-		//delete value_entry;
+
 		saved_data = data;
 
 		value_entry = manage(new ValueBase_Entry());
@@ -639,15 +639,9 @@ CellRenderer_ValueBase::on_value_editing_done()
 
 	if (value_entry)
 	{
+		ValueBase value(value_entry->get_value());
 
-		//ValueBase old_value(property_value_.get_value());
-		ValueBase     value(value_entry->get_value());
-
-		//if (old_value != value)
 		if (saved_data != value)
 			signal_edited_(value_entry->get_path(), value);
-
-		//delete value_entry;
-		//value_entry=0;
 	}
 }

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -550,12 +550,12 @@ CellRenderer_ValueBase::color_edited(synfig::Color color, Glib::ustring path)
 
 Gtk::CellEditable*
 CellRenderer_ValueBase::start_editing_vfunc(
-	GdkEvent*              event,
+	GdkEvent*              /*event*/,
 	Gtk::Widget&           widget,
 	const Glib::ustring&   path,
-	const Gdk::Rectangle&  background_area,
-	const Gdk::Rectangle&  cell_area,
-	Gtk::CellRendererState flags)
+	const Gdk::Rectangle&  /*background_area*/,
+	const Gdk::Rectangle&  /*cell_area*/,
+	Gtk::CellRendererState /*flags*/)
 {
 	edit_value_done_called = false;
 	// If we aren't editable, then there is nothing to do

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -287,10 +287,10 @@ CellRenderer_ValueBase::string_edited_(const Glib::ustring& path, const Glib::us
 
 	if (old_value.get_type() == type_time)
 	{
-		value = ValueBase( Time( (String)str, get_canvas()->rend_desc().get_frame_rate() ) );
+		value = ValueBase( Time(str, get_canvas()->rend_desc().get_frame_rate() ) );
 	}
 	else
-		value = ValueBase( (String)str );
+		value = ValueBase( str );
 
 	if (old_value != value)
 		signal_edited_(path, value);

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -33,21 +33,13 @@
 
 #include <synfig/general.h>
 
-#include <gtkmm/label.h>
 #include <ETL/stringf>
 #include <gtkmm/celleditable.h>
 #include <gtkmm/editable.h>
-#include <gtkmm/entry.h>
 #include <gtkmm/eventbox.h>
 
 #include "app.h"
 #include "widgets/widget_value.h"
-#include "widgets/widget_vector.h"
-#include "widgets/widget_filename.h"
-#include "widgets/widget_enum.h"
-#include "widgets/widget_color.h"
-#include "widgets/widget_canvaschooser.h"
-#include "widgets/widget_time.h"
 
 #include "cellrenderer_gradient.h"
 #include "cellrenderer_value.h"
@@ -58,7 +50,6 @@
 #include "widgets/widget_gradient.h"
 #include "dialogs/dialog_gradient.h"
 #include "dialogs/dialog_color.h"
-#include <gtkmm/textview.h>
 
 #include <gdkmm/general.h>
 

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -85,7 +85,7 @@ public:
 	ValueBase_Entry():
 		Glib::ObjectBase(typeid(ValueBase_Entry))
 	{
-		parent           = 0;
+		parent           = nullptr;
 		edit_done_called = false;
 /*
 		  Gtk::HBox *const hbox = new Gtk::HBox(false, 0);
@@ -586,7 +586,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 	edit_value_done_called = false;
 	// If we aren't editable, then there is nothing to do
 	if (!property_editable())
-		return 0;
+		return nullptr;
 
 	ValueBase data = property_value_.get_value();
 
@@ -595,7 +595,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 	if (type == type_bool)
 	{
 		signal_edited_( path, ValueBase(!data.get(bool())) );
-		return NULL;
+		return nullptr;
 	}
 	//else
 	//if (type == type_time)
@@ -616,7 +616,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 		);
 		App::dialog_gradient->set_default_button_set_sensitive(true);
 		App::dialog_gradient->present();
-		return NULL;
+		return nullptr;
 	}
 	else
 	if (type == type_color)
@@ -630,7 +630,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 			)
 		);
 		App::dialog_color->present();
-		return NULL;
+		return nullptr;
 	}
 	else
 	if (type == type_string
@@ -640,7 +640,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 		string = data.get(string);
 		if (get_paragraph(string))
 			signal_edited_(path, ValueBase(string));
-		return NULL;
+		return nullptr;
 	}
 	// if (type == type_string) && (get_param_desc().get_hint()!="filename")
 		// return CellRendererText::start_editing_vfunc(event,widget,path,background_area,cell_area,flags);
@@ -662,7 +662,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 		return value_entry;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -70,8 +70,8 @@ class studio::ValueBase_Entry : public Gtk::CellEditable, public Gtk::EventBox
 {
 	Glib::ustring     path;
 	Widget_ValueBase *valuewidget;
-	bool              edit_done_called;
 	Gtk::Widget      *parent;
+	bool              edit_done_called;
 public:
 	ValueBase_Entry():
 		Glib::ObjectBase(typeid(ValueBase_Entry))

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -119,10 +119,23 @@ public:
 		Gtk::CellEditable::on_remove_widget();
 	}
 
-	void start_editing_vfunc(GdkEvent */*event*/)
+	void start_editing_vfunc(GdkEvent *event)
 	{
 		valuewidget->signal_activate().connect(sigc::mem_fun(*this,
 			&studio::ValueBase_Entry::editing_done));
+
+		// popup combobox menu if its is a enum editor
+		if (event && event->type == GDK_BUTTON_PRESS && valuewidget) {
+			Type &type(valuewidget->get_value().get_type());
+			if (type == type_integer)
+			{
+				string param_hint = valuewidget->get_param_desc().get_hint();
+				string child_param_hint = valuewidget->get_child_param_desc().get_hint();
+				if ( param_hint == "enum" || child_param_hint == "enum" )
+					valuewidget->popup_enum_combobox();
+			}
+		}
+
 		show();
 		//valuewidget->grab_focus();
 		//get_window()->set_focus(*valuewidget);
@@ -619,6 +632,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 		value_entry->set_child_param_desc(get_child_param_desc());
 		value_entry->set_value(data);
 		value_entry->set_parent(&widget);
+		value_entry->show(); // in order to enable "instant"/"single-click" pop-up for enum comboboxes
 		value_entry->signal_editing_done().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_done));
 		return value_entry;
 	}

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
@@ -27,32 +27,12 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <gtk/gtk.h>
-
 #include <glibmm/property.h>
 
-#include <gtkmm/arrow.h>
-#include <gtkmm/image.h>
-#include <gdkmm/pixbufloader.h>
-#include <gtkmm/viewport.h>
-#include <gtkmm/adjustment.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/table.h>
-#include <gtkmm/statusbar.h>
-#include <gtkmm/button.h>
-#include <gtkmm/label.h>
-#include <gtkmm/paned.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/treestore.h>
-#include <gtkmm/box.h>
-#include <gtkmm/spinbutton.h>
-#include <gtkmm/cellrenderer.h>
-#include <gtkmm/checkbutton.h>
+#include <gtkmm/cellrenderertext.h>
 
-#include <gtkmm/colorselection.h>
-
-//#include <synfig/synfig.h>
 #include <synfig/paramdesc.h>
+#include <synfigapp/value_desc.h>
 #include <synfig/value.h>
 
 

--- a/synfig-studio/src/gui/widgets/widget_value.cpp
+++ b/synfig-studio/src/gui/widgets/widget_value.cpp
@@ -210,6 +210,19 @@ Widget_ValueBase::set_sensitive(bool x)
 	distance_widget->set_sensitive(x);
 }
 
+void Widget_ValueBase::popup_enum_combobox()
+{
+	Type &type(get_value().get_type());
+	if (type == type_integer)
+	{
+		string param_hint = get_param_desc().get_hint();
+		string child_param_hint = get_child_param_desc().get_hint();
+		if ( param_hint == "enum" || child_param_hint == "enum" ) {
+			enum_widget->popup();
+		}
+	}
+}
+
 void
 Widget_ValueBase::set_value(const synfig::ValueBase &data)
 {

--- a/synfig-studio/src/gui/widgets/widget_value.cpp
+++ b/synfig-studio/src/gui/widgets/widget_value.cpp
@@ -348,15 +348,6 @@ Widget_ValueBase::set_value(const synfig::ValueBase &data)
 		{
 			color_widget->set_value(value.get(synfig::Color()));
 			color_widget->show();
-	/*
-				Gdk::Color gdkcolor;
-				synfig::Color color=value.get(synfig::Color());
-				gdkcolor.set_rgb_p(color.get_r(),color.get_g(),color.get_b());
-				color_widget->set_current_color(gdkcolor);
-				color_widget->set_has_opacity_control(true);
-				color_widget->set_current_alpha((unsigned short)(color.get_a()*65535.0));
-				color_widget->show();
-	*/
 		}
 		else
 		{
@@ -433,17 +424,6 @@ Widget_ValueBase::get_value()
 	if (type == type_color)
 	{
 		value=color_widget->get_value();
-/*
-		Gdk::Color gdkcolor;
-		synfig::Color color;
-		gdkcolor=color_widget->get_current_color();
-		color.set_r(gdkcolor.get_red_p());
-		color.set_g(gdkcolor.get_green_p());
-		color.set_b(gdkcolor.get_blue_p());
-		color.set_a(color_widget->get_current_alpha()/65535.0);
-
-		value=color;
-*/
 	}
 
 	return value;
@@ -510,61 +490,3 @@ Widget_ValueBase::on_grab_focus()
 	if (type == type_color)
 		color_widget->grab_focus();
 }
-
-/*
-Glib::SignalProxy0<void>
-Widget_ValueBase::signal_activate()
-{
-	Type &type(value.get_type());
-	if (type == type_vector)
-		return vector_widget->signal_activate();
-	else
-	if (type == type_real)
-	{
-		if(param_desc.get_is_distance()&& canvas)
-			return distance_widget->signal_activate();
-		else
-			return real_widget->signal_activate();
-	}
-	else
-	if (type == type_time)
-		return time_widget->signal_activate();
-	else
-	if (type == type_angle)
-		return angle_widget->signal_activate();
-	else
-	if (type == type_bone_valuenode)
-		return bone_widget->signal_activate();
-	else
-	if (type == type_canvas)
-		return canvas_widget->signal_activate();
-	else
-	if (type == type_integer)
-	{
-		if(param_desc.get_hint()!="enum")
-			return integer_widget->signal_activate();
-		else
-			return enum_widget->signal_activate();
-	}
-	else
-	if (type == type_bool)
-		return string_widget->signal_activate();
-	else
-	if (type == type_string)
-	{
-		if(param_desc.get_hint()!="filename")
-		{
-			return string_widget->signal_activate();
-		}
-		else
-		{
-			return filename_widget->signal_activate();
-		}
-	}
-	else
-	if (type == type_color)
-		return color_widget->signal_activate();
-
-	return string_widget->signal_activate();
-}
-*/

--- a/synfig-studio/src/gui/widgets/widget_value.h
+++ b/synfig-studio/src/gui/widgets/widget_value.h
@@ -131,6 +131,9 @@ public:
 
 	void set_sensitive(bool x);
 
+	/// popup combobox menu if it is an enum entry
+	void popup_enum_combobox();
+
 	//void set_hint(std::string x) { hint=x; }
 //	std::string get_hint() { return hint; }
 


### PR DESCRIPTION
Previously, to select a new value for a enum parameter (like "Blend method"), user had to:

1. click to select the desired parameter row
2. click on parameter value cell to start editor, i.e.  to show a combobox
3. click once more on the same place, now on the combobox to popup the menu
4. click (again) on the desired new value

This PR removes the step 3.