### PR TITLE
avoid duplicated dynamic_cast (other cases)

### DIFF
--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -1692,17 +1692,15 @@ Canvas::invoke_signal_value_node_child_removed(etl::handle<ValueNode> container,
 #endif
 	for (std::set<Node*>::iterator iter = canvas->parent_set.begin(); iter != canvas->parent_set.end(); iter++)
 	{
-		if (dynamic_cast<Layer*>(*iter))
+		if (Layer* layer = dynamic_cast<Layer*>(*iter))
 		{
-			Layer* layer(dynamic_cast<Layer*>(*iter));
 #ifdef DEBUG_INVOKE_SVNCR
 			printf("it's a layer %lx\n", uintptr_t(layer));
 			printf("%s:%d it's a layer with %zd parents\n", __FILE__, __LINE__, layer->parent_set.size());
 #endif
 			for (std::set<Node*>::iterator iter = layer->parent_set.begin(); iter != layer->parent_set.end(); iter++)
-				if (dynamic_cast<Canvas*>(*iter))
+				if (Canvas* canvas = dynamic_cast<Canvas*>(*iter))
 				{
-					Canvas* canvas(dynamic_cast<Canvas*>(*iter));
 #ifdef DEBUG_INVOKE_SVNCR
 					printf("it's a canvas %lx\n", uintptr_t(canvas));
 #endif

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -128,7 +128,7 @@ Canvas::~Canvas()
 		Layer_PasteCanvas* paste_canvas = dynamic_cast<Layer_PasteCanvas*>(*iter);
 		iter++;
 		if(paste_canvas)
-			paste_canvas->set_sub_canvas(0);
+			paste_canvas->set_sub_canvas(nullptr);
 		else
 			warning("destroyed canvas has a parent that is not a pastecanvas - please report if repeatable");
 	}
@@ -1115,7 +1115,7 @@ Canvas::remove_child_canvas(Canvas::Handle child_canvas)
 		throw Exception::IDNotFound(child_canvas->get_id());
 
 	children().remove(child_canvas);
-	child_canvas->set_parent(0);
+	child_canvas->set_parent(nullptr);
 }
 
 void
@@ -1331,7 +1331,7 @@ synfig::optimize_layers(Time time, Context context, Canvas::Handle op_canvas, bo
 		// note: this used to include "&& paste_canvas->get_time_offset()==0", but then
 		//		 time-shifted layers weren't being sorted by z-depth (bug #1806852)
 		Layer_PasteCanvas* paste_canvas(dynamic_cast<Layer_PasteCanvas*>(layer.get()));
-		if(paste_canvas!=NULL)
+		if(paste_canvas)
 		{
 			// we need to blur the sub canvas if:
 			// our parent is blurred,

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -1431,7 +1431,7 @@ synfig::optimize_layers(Time time, Context context, Canvas::Handle op_canvas, bo
 			 */
 
 			// \todo: this code probably needs modification to work properly with motionblur and duplicate
-			etl::handle<Layer_Composite> composite = etl::handle<Layer_Composite>::cast_dynamic(layer);
+//			etl::handle<Layer_Composite> composite = etl::handle<Layer_Composite>::cast_dynamic(layer);
 
 			/* some layers (such as circle) don't touch pixels that aren't
 			 * part of the circle, so they don't get blended correctly when

--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -461,9 +461,9 @@ xmlpp::Element* encode_animated(xmlpp::Element* root,ValueNode_Animated::ConstHa
 			waypoint_node->set_attribute("use",iter->get_value_node()->get_relative_id(canvas));
 		else {
 			ValueNode::ConstHandle value_node = iter->get_value_node();
-			if(ValueNode_Const::ConstHandle::cast_dynamic(value_node))
+			if(ValueNode_Const::ConstHandle value_node_const = ValueNode_Const::ConstHandle::cast_dynamic(value_node))
 			{
-				const ValueBase data = ValueNode_Const::ConstHandle::cast_dynamic(value_node)->get_value();
+				const ValueBase data = value_node_const->get_value();
 				if (data.get_type() == type_canvas)
 					waypoint_node->set_attribute("use",data.get(Canvas::Handle()).get()->get_relative_id(canvas));
 				else
@@ -717,35 +717,35 @@ xmlpp::Element* encode_value_node(xmlpp::Element* root,ValueNode::ConstHandle va
 	if(value_node->rcount()>1)
 		root->set_attribute("guid",(value_node->get_guid()^canvas->get_root()->get_guid()).get_string());
 
-	if(ValueNode_Bone::ConstHandle::cast_dynamic(value_node))
+	if(ValueNode_Bone::ConstHandle value_node_bone = ValueNode_Bone::ConstHandle::cast_dynamic(value_node))
 	{
 		if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d shortcutting for valuenode_bone\n", __FILE__, __LINE__);
-		encode_value_node_bone_id(root,ValueNode_Bone::ConstHandle::cast_dynamic(value_node),canvas);
+		encode_value_node_bone_id(root, value_node_bone,canvas);
 	}
 	else
-	if(ValueNode_Animated::ConstHandle::cast_dynamic(value_node))
-		encode_animated(root,ValueNode_Animated::ConstHandle::cast_dynamic(value_node),canvas);
+	if (ValueNode_Animated::ConstHandle animated_value_node = ValueNode_Animated::ConstHandle::cast_dynamic(value_node))
+		encode_animated(root,animated_value_node,canvas);
 	else
-	if(ValueNode_Subtract::ConstHandle::cast_dynamic(value_node))
-		encode_subtract(root,ValueNode_Subtract::ConstHandle::cast_dynamic(value_node),canvas);
+	if (ValueNode_Subtract::ConstHandle subtract_value_node = ValueNode_Subtract::ConstHandle::cast_dynamic(value_node))
+		encode_subtract(root,subtract_value_node,canvas);
 	else
-	if(ValueNode_StaticList::ConstHandle::cast_dynamic(value_node))
-		encode_static_list(root,ValueNode_StaticList::ConstHandle::cast_dynamic(value_node),canvas);
+	if (ValueNode_StaticList::ConstHandle static_list_value_node = ValueNode_StaticList::ConstHandle::cast_dynamic(value_node))
+		encode_static_list(root,static_list_value_node,canvas);
 	else
-	if(ValueNode_DynamicList::ConstHandle::cast_dynamic(value_node))
+	if (ValueNode_DynamicList::ConstHandle dynamic_list_value_node = ValueNode_DynamicList::ConstHandle::cast_dynamic(value_node))
 	{
-		encode_dynamic_list(root,ValueNode_DynamicList::ConstHandle::cast_dynamic(value_node),canvas);
+		encode_dynamic_list(root,dynamic_list_value_node,canvas);
 	}
 	// if it's a ValueNode_Const
-	else if(ValueNode_Const::ConstHandle::cast_dynamic(value_node))
+	else if (ValueNode_Const::ConstHandle const_value_node = ValueNode_Const::ConstHandle::cast_dynamic(value_node))
 	{
 		if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d got ValueNode_Const encoding value\n", __FILE__, __LINE__);
 		// encode its get_value()
-		encode_value(root,ValueNode_Const::ConstHandle::cast_dynamic(value_node)->get_value(),canvas);
+		encode_value(root,const_value_node->get_value(),canvas);
 	}
 	else
-	if(LinkableValueNode::ConstHandle::cast_dynamic(value_node))
-		encode_linkable_value_node(root,LinkableValueNode::ConstHandle::cast_dynamic(value_node),canvas);
+	if (LinkableValueNode::ConstHandle linkable_value_node = LinkableValueNode::ConstHandle::cast_dynamic(value_node))
+		encode_linkable_value_node(root,linkable_value_node,canvas);
 	else
 	{
 		error(_("Unknown ValueNode Type (%s), cannot create an XML representation"),value_node->get_local_name().c_str());
@@ -769,8 +769,8 @@ xmlpp::Element* encode_value_node_bone(xmlpp::Element* root,ValueNode::ConstHand
 	assert(value_node);
 	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_value_node_bone %s %s\n", __FILE__, __LINE__, value_node->get_string().c_str(), value_node->get_guid().get_string().c_str());
 
-	if(ValueNode_Bone::ConstHandle::cast_dynamic(value_node))
-		encode_linkable_value_node(root,LinkableValueNode::ConstHandle::cast_dynamic(value_node),canvas);
+	if (ValueNode_Bone::ConstHandle bone_value_node = ValueNode_Bone::ConstHandle::cast_dynamic(value_node))
+		encode_linkable_value_node(root,bone_value_node,canvas);
 	else
 	{
 		error(_("Unknown ValueNode Type (%s), cannot create an XML representation"),value_node->get_local_name().c_str());
@@ -1043,9 +1043,8 @@ xmlpp::Element* encode_canvas(xmlpp::Element* root,Canvas::ConstHandle canvas)
 		for(ValueNodeList::const_iterator iter=value_node_list.begin();iter!=value_node_list.end();++iter)
 		{
 			// If the value_node is a constant, then use the shorthand
-			if(handle<ValueNode_Const>::cast_dynamic(*iter))
+			if (ValueNode_Const::Handle value_node = ValueNode_Const::Handle::cast_dynamic(*iter))
 			{
-				ValueNode_Const::Handle value_node(ValueNode_Const::Handle::cast_dynamic(*iter));
 				reinterpret_cast<xmlpp::Element*>(encode_value(node->add_child("value"),value_node->get_value(),canvas))->set_attribute("id",value_node->get_id());
 				continue;
 			}

--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -414,16 +414,16 @@ xmlpp::Element* encode_value(xmlpp::Element* root,const ValueBase &data,Canvas::
 		root->set_name("bone_valuenode");
 		return root;
 	}
-	if (dynamic_cast<types_namespace::TypeWeightedValueBase*>(&type) != NULL)
+	if (types_namespace::TypeWeightedValueBase* tw = dynamic_cast<types_namespace::TypeWeightedValueBase*>(&type))
 	{
-		encode_weighted_value(root, *dynamic_cast<types_namespace::TypeWeightedValueBase*>(&type), data, canvas);
+		encode_weighted_value(root, *tw, data, canvas);
 		encode_static(root, data.get_static());
 		encode_interpolation(root, data.get_interpolation(), "interpolation");
 		return root;
 	}
-	if (dynamic_cast<types_namespace::TypePairBase*>(&type) != NULL)
+	if (types_namespace::TypePairBase* tp = dynamic_cast<types_namespace::TypePairBase*>(&type))
 	{
-		encode_pair(root, *dynamic_cast<types_namespace::TypePairBase*>(&type), data, canvas);
+		encode_pair(root, *tp, data, canvas);
 		encode_static(root, data.get_static());
 		encode_interpolation(root, data.get_interpolation(), "interpolation");
 		return root;

--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -89,8 +89,8 @@ using namespace synfig;
 
 ReleaseVersion save_canvas_version = ReleaseVersion(RELEASE_VERSION_END-1);
 int valuenode_too_new_count;
-save_canvas_external_file_callback_t save_canvas_external_file_callback = NULL;
-void *save_canvas_external_file_user_data = NULL;
+save_canvas_external_file_callback_t save_canvas_external_file_callback = nullptr;
+void *save_canvas_external_file_user_data = nullptr;
 
 /* === P R O C E D U R E S ================================================= */
 
@@ -267,9 +267,9 @@ xmlpp::Element* encode_gradient(xmlpp::Element* root,Gradient x)
 }
 
 
-xmlpp::Element* encode_value(xmlpp::Element* root,const ValueBase &data,Canvas::ConstHandle canvas=0);
+xmlpp::Element* encode_value(xmlpp::Element* root,const ValueBase &data,Canvas::ConstHandle canvas=nullptr);
 
-xmlpp::Element* encode_list(xmlpp::Element* root,std::vector<ValueBase> list, Canvas::ConstHandle canvas=0)
+xmlpp::Element* encode_list(xmlpp::Element* root,std::vector<ValueBase> list, Canvas::ConstHandle canvas=nullptr)
 {
 	root->set_name("list");
 
@@ -440,7 +440,7 @@ xmlpp::Element* encode_value(xmlpp::Element* root,const ValueBase &data,Canvas::
 	return root;
 }
 
-xmlpp::Element* encode_animated(xmlpp::Element* root,ValueNode_Animated::ConstHandle value_node,Canvas::ConstHandle canvas=0)
+xmlpp::Element* encode_animated(xmlpp::Element* root,ValueNode_Animated::ConstHandle value_node,Canvas::ConstHandle canvas=nullptr)
 {
 	assert(value_node);
 	root->set_name("animated");
@@ -498,7 +498,7 @@ xmlpp::Element* encode_animated(xmlpp::Element* root,ValueNode_Animated::ConstHa
 }
 
 
-xmlpp::Element* encode_subtract(xmlpp::Element* root,ValueNode_Subtract::ConstHandle value_node,Canvas::ConstHandle canvas=0)
+xmlpp::Element* encode_subtract(xmlpp::Element* root,ValueNode_Subtract::ConstHandle value_node,Canvas::ConstHandle canvas=nullptr)
 {
 	assert(value_node);
 	root->set_name("subtract");
@@ -536,7 +536,7 @@ xmlpp::Element* encode_subtract(xmlpp::Element* root,ValueNode_Subtract::ConstHa
 	return root;
 }
 
-xmlpp::Element* encode_static_list(xmlpp::Element* root,ValueNode_StaticList::ConstHandle value_node,Canvas::ConstHandle canvas=0)
+xmlpp::Element* encode_static_list(xmlpp::Element* root,ValueNode_StaticList::ConstHandle value_node,Canvas::ConstHandle canvas=nullptr)
 {
 	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_static_list %s\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	assert(value_node);
@@ -564,7 +564,7 @@ xmlpp::Element* encode_static_list(xmlpp::Element* root,ValueNode_StaticList::Co
 	return root;
 }
 
-xmlpp::Element* encode_dynamic_list(xmlpp::Element* root,ValueNode_DynamicList::ConstHandle value_node,Canvas::ConstHandle canvas=0)
+xmlpp::Element* encode_dynamic_list(xmlpp::Element* root,ValueNode_DynamicList::ConstHandle value_node,Canvas::ConstHandle canvas=nullptr)
 {
 	assert(value_node);
 	const float fps(canvas?canvas->rend_desc().get_frame_rate():0);
@@ -660,7 +660,7 @@ xmlpp::Element* encode_dynamic_list(xmlpp::Element* root,ValueNode_DynamicList::
 }
 
 // Generic linkable data node entry
-xmlpp::Element* encode_linkable_value_node(xmlpp::Element* root,LinkableValueNode::ConstHandle value_node,Canvas::ConstHandle canvas=0)
+xmlpp::Element* encode_linkable_value_node(xmlpp::Element* root,LinkableValueNode::ConstHandle value_node,Canvas::ConstHandle canvas=nullptr)
 {
 	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_linkable_value_node %s\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	assert(value_node);
@@ -896,7 +896,7 @@ xmlpp::Element* encode_layer(xmlpp::Element* root,Layer::ConstHandle layer)
 			node->set_attribute("name",iter->get_name());
 
 			// remember filename param if need
-			if (save_canvas_external_file_callback != NULL
+			if (save_canvas_external_file_callback != nullptr
 			 && iter->get_name() == "filename"
 			 && value.get_type() == type_string)
 			{

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -752,7 +752,7 @@ LinkableValueNode::link_name(int i)const
 	Vocab vocab(get_children_vocab());
 	Vocab::iterator iter(vocab.begin());
 	int j=0;
-	for(;iter!=vocab.end() && j<i; iter++, j++) {};
+	for(;iter!=vocab.end() && j<i; iter++, j++) {}
 	return iter!=vocab.end()?iter->get_name():String();
 }
 
@@ -762,7 +762,7 @@ LinkableValueNode::link_local_name(int i)const
 	Vocab vocab(get_children_vocab());
 	Vocab::iterator iter(vocab.begin());
 	int j=0;
-	for(;iter!=vocab.end() && j<i; iter++, j++){};
+	for(;iter!=vocab.end() && j<i; iter++, j++) {}
 	return iter!=vocab.end()?iter->get_local_name():String();
 }
 

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -186,9 +186,6 @@ ValueNode::get_description(bool show_exported_name)const
 
 	String ret(_("ValueNode"));
 
-	if (dynamic_cast<const LinkableValueNode*>(this))
-		return (dynamic_cast<const LinkableValueNode*>(this))->get_description(-1, show_exported_name);
-
 	if (show_exported_name && !is_exported())
 		show_exported_name = false;
 

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -181,8 +181,8 @@ ValueNode::set_id(const String &x)
 String
 ValueNode::get_description(bool show_exported_name)const
 {
-	if (dynamic_cast<const LinkableValueNode*>(this))
-		return dynamic_cast<const LinkableValueNode*>(this)->get_description(-1, show_exported_name);
+	if (const LinkableValueNode* value_node = dynamic_cast<const LinkableValueNode*>(this))
+		return value_node->get_description(-1, show_exported_name);
 
 	String ret(_("ValueNode"));
 

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -208,7 +208,7 @@ ValueNode::is_descendant(ValueNode::Handle value_node_dest)
 
     //! loop through the parents of each node in current_nodes
     set<Node*> node_parents(value_node_dest->parent_set);
-    ValueNode::Handle value_node_parent = NULL;
+    ValueNode::Handle value_node_parent;
     for (set<Node*>::iterator iter = node_parents.begin(); iter != node_parents.end(); iter++)
     {
         value_node_parent = ValueNode::Handle::cast_dynamic(*iter);
@@ -699,7 +699,7 @@ LinkableValueNode::get_description(int index, bool show_exported_name)const
 	}
 
 	const synfig::Node* node = this;
-	LinkableValueNode::ConstHandle parent_linkable_vn = 0;
+	LinkableValueNode::ConstHandle parent_linkable_vn;
 
 	// walk up through the valuenodes trying to find the layer at the top
 	while (!node->parent_set.empty() && !dynamic_cast<const Layer*>(node))


### PR DESCRIPTION
Improves efficiency, readability maybe, and vanishes some Coverity reports
I've made some minor cleanup too