### PR TITLE
Detect duplicated frames when importing image sequence

### DIFF
--- a/synfig-core/src/synfig/rendering/surface.cpp
+++ b/synfig-core/src/synfig/rendering/surface.cpp
@@ -185,6 +185,20 @@ Surface::get_pixels(Color *dest) const
 }
 
 bool
+Surface::compare_with(synfig::rendering::Surface::Handle s) const
+{
+	if(!(get_width()==s->get_width() && get_height()==s->get_height())){
+		return false;
+	}else{
+		std::vector<Color> buffer1(get_pixels_count()),buffer2(s->get_pixels_count());
+		get_pixels(&buffer1.front());
+		s->get_pixels(&buffer2.front());
+		if(buffer1==buffer2) return true;
+		else return false;
+	}
+}
+
+bool
 Surface::touch()
 {
 	if (is_read_only() || !is_exists())

--- a/synfig-core/src/synfig/rendering/surface.h
+++ b/synfig-core/src/synfig/rendering/surface.h
@@ -147,6 +147,8 @@ public:
 	const Color* get_pixels_pointer() const;
 	bool get_pixels(Color *dest) const;
 
+	bool compare_with(synfig::rendering::Surface::Handle s) const;
+
 	int get_width() const
 		{ return width; }
 	int get_height() const

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3496,19 +3496,28 @@ CanvasView::squence_import()
 	String errors, warnings;
 	if(App::dialog_open_file_image_sequence(_("Please select a file"), filenames, IMAGE_DIR_PREFERENCE))
 	{
-		canvas_interface()->import_sequence(filenames, errors, warnings, App::resize_imported_images);
-		if (!errors.empty())
-			App::dialog_message_1b(
-				"ERROR",
-				etl::strprintf("%s:\n\n%s", _("Error"), errors.c_str()),
-				"details",
-				_("Close"));
-		if (!warnings.empty())
-			App::dialog_message_1b(
-				"WARNING",
-				etl::strprintf("%s:\n\n%s", _("Warning"), warnings.c_str()),
-				"details",
-				_("Close"));
+		int answer = get_ui_interface()->yes_no_cancel(
+				("Remove Duplicates while importing?"),
+				_("Synfig will detect and remove consecutive duplicates (if any)."),
+				_("No"),
+				_("Cancel"),
+				_("Yes"),
+				UIInterface::RESPONSE_NO);
+		if(answer!=UIInterface::RESPONSE_CANCEL){
+			canvas_interface()->import_sequence(filenames, errors, warnings, App::resize_imported_images,answer);
+			if (!errors.empty())
+				App::dialog_message_1b(
+						"ERROR",
+						etl::strprintf("%s:\n\n%s", _("Error"), errors.c_str()),
+						"details",
+						_("Close"));
+			if (!warnings.empty())
+				App::dialog_message_1b(
+						"WARNING",
+						etl::strprintf("%s:\n\n%s", _("Warning"), warnings.c_str()),
+						"details",
+						_("Close"));
+		}
 	}
 }
 

--- a/synfig-studio/src/synfigapp/canvasinterface.h
+++ b/synfig-studio/src/synfigapp/canvasinterface.h
@@ -312,7 +312,8 @@ public:
 		const std::set<synfig::String> &filenames,
 		synfig::String &errors,
 		synfig::String &warnings,
-		bool resize_image = false );
+		bool resize_image = false,
+		bool remove_dups=false);
 
 	void waypoint_set_value_node(synfig::ValueNode::Handle value_node, const synfig::Waypoint& waypoint);
 	void waypoint_move(const ValueDesc& value_desc, const synfig::Time& time, const synfig::Time& deltatime);


### PR DESCRIPTION
This PR is regarding issue #1138 

- Modified `import_sequence()` function so that it detects and removes duplicates in the sequence.
- User is asked if they want to remove duplicates before importing a sequence.