### PR TITLE
show workarea task messages as tooltip too

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -266,6 +266,7 @@ public:
 		{
 			view->statusbar->pop();
 			view->statusbar->push(task);
+			view->statusbar->set_tooltip_text(task);
 		}
 		//App::process_all_events();
 		if(view->cancel){return false;}


### PR DESCRIPTION
sometimes they don't fit in due to screen size vs. message length