### PR TITLE
Different look for indirect waypoints 

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
@@ -338,6 +338,9 @@ CellRenderer_TimeTrack::render_vfunc(
 		}
 	}
 
+	// if this valuedesc is not animated and has waypoints, those waypoints are probably from inner value nodes ( = converted)
+	const bool is_static_value_node = (value_desc.is_value_node() && !synfig::ValueNode_Animated::Handle::cast_dynamic(value_desc.get_value_node()));
+
 	// render all the time points that exist
 	if (const Node::time_set *tset = get_times_from_vdesc(value_desc)) {
 		bool valselected = sel_value.get_value_node() == base_value && !sel_times.empty();
@@ -386,7 +389,7 @@ CellRenderer_TimeTrack::render_vfunc(
 					cell_area.get_height() - 2 );
 				TimePoint tp_copy = *i;
 				tp_copy.set_time(t);
-				WaypointRenderer::render_time_point_to_window(cr, area, tp_copy, selected, false);
+				WaypointRenderer::render_time_point_to_window(cr, area, tp_copy, selected, false, is_static_value_node);
 			}
 		}
 
@@ -397,7 +400,7 @@ CellRenderer_TimeTrack::render_vfunc(
 				cell_area.get_y() + 1,
 				cell_area.get_height() - 2,
 				cell_area.get_height() - 2 );
-			WaypointRenderer::render_time_point_to_window(cr, area, *i, true, false);
+			WaypointRenderer::render_time_point_to_window(cr, area, *i, true, false, is_static_value_node);
 		}
 	}
 

--- a/synfig-studio/src/gui/waypointrenderer.cpp
+++ b/synfig-studio/src/gui/waypointrenderer.cpp
@@ -113,7 +113,7 @@ WaypointRenderer::render_time_point_to_window(
 	bool selected,
 	bool hover)
 {
-	const Gdk::RGBA black = get_black(hover);
+	const Gdk::RGBA outline_color = get_black(hover);
 
 	if(selected)
 		cr->set_line_width(2.0);
@@ -140,7 +140,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->arc(0.5, 0.5, 0.5, 90*M_PI/180.0, 270*M_PI/180.0);
 		cr->fill_preserve();
 		cr->restore();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		break;
 
@@ -153,10 +153,10 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill();
 		cr->arc(0.5, 0.5, 0.5, 180*M_PI/180.0, 270*M_PI/180.0);
 		cr->restore();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->move_to(area.get_x(),area.get_y()+area.get_height());
 		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
 		cr->stroke();
@@ -168,7 +168,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->line_to(area.get_x(),area.get_y()+area.get_height());
 		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
 		cr->fill_preserve();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		cr->restore();
 		break;
@@ -182,7 +182,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->line_to(area.get_x(),area.get_y()+area.get_height());
 		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
 		cr->fill_preserve();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		cr->restore();
 		break;
@@ -193,7 +193,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->line_to(area.get_x(),area.get_y()+area.get_height()/2);
 		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
 		cr->fill_preserve();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		cr->restore();
 		break;
@@ -207,7 +207,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->line_to(area.get_x()+area.get_width()/3.f,area.get_y()+area.get_height());
 		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
 		cr->fill_preserve();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		cr->restore();
 		break;
@@ -230,7 +230,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->arc(0.5, 0.5, 0.5, -90*M_PI/180.0, 90*M_PI/180.0);
 		cr->fill_preserve();
 		cr->restore();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		break;
 
@@ -243,10 +243,10 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill();
 		cr->arc(0.5, 0.0, 0.5, 0*M_PI / 180.0, 90*M_PI / 180.0);
 		cr->restore();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->stroke();
@@ -258,7 +258,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
 		cr->fill_preserve();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		cr->restore();
 		break;
@@ -272,7 +272,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->line_to(area.get_x()+area.get_width()-area.get_width()/4,area.get_y()+area.get_height());
 		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
 		cr->fill_preserve();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		cr->restore();
 		break;
@@ -283,7 +283,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/2);
 		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
 		cr->fill_preserve();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		cr->restore();
 		break;
@@ -297,7 +297,7 @@ WaypointRenderer::render_time_point_to_window(
 		cr->line_to(area.get_x()+area.get_width()-area.get_width()/3,area.get_y()+area.get_height());
 		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
 		cr->fill_preserve();
-		cr->set_source_rgb(black.get_red(),black.get_green(),black.get_blue());
+		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 		cr->restore();
 		break;

--- a/synfig-studio/src/gui/waypointrenderer.cpp
+++ b/synfig-studio/src/gui/waypointrenderer.cpp
@@ -185,9 +185,9 @@ WaypointRenderer::render_time_point_to_window(
 		break;
 
 	case INTERPOLATION_LINEAR:
-		cr->move_to(area.get_x()+area.get_width()/2.f,area.get_y());
+		cr->move_to(area.get_x()+area.get_width()/2.,area.get_y());
 		cr->line_to(area.get_x(),area.get_y()+area.get_height());
-		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
@@ -202,12 +202,12 @@ WaypointRenderer::render_time_point_to_window(
 		break;
 
 	case INTERPOLATION_CONSTANT:
-		cr->move_to(area.get_x()+area.get_width()/2.f,area.get_y());
-		cr->line_to(area.get_x()+area.get_width()/4.f,area.get_y());
-		cr->line_to(area.get_x()+area.get_width()/4.f,area.get_y()+area.get_height()/2);
-		cr->line_to(area.get_x(),area.get_y()+area.get_height()/2);
+		cr->move_to(area.get_x()+area.get_width()/2.,area.get_y());
+		cr->line_to(area.get_x()+area.get_width()/4.,area.get_y());
+		cr->line_to(area.get_x()+area.get_width()/4.,area.get_y()+area.get_height()/2.);
+		cr->line_to(area.get_x(),area.get_y()+area.get_height()/2.);
 		cr->line_to(area.get_x(),area.get_y()+area.get_height());
-		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
@@ -224,28 +224,28 @@ WaypointRenderer::render_time_point_to_window(
 		break;
 
 	case INTERPOLATION_CLAMPED:
-		cr->move_to(area.get_x()+area.get_width()/2.f,area.get_y());
-		cr->line_to(area.get_x(),area.get_y()+area.get_height()/2);
-		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
+		cr->move_to(area.get_x()+area.get_width()/2.,area.get_y());
+		cr->line_to(area.get_x(),area.get_y()+area.get_height()/2.);
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 
 		if (double_outline) {
 			cr->move_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
-			cr->line_to(area.get_x()-double_outline_margin_pixels,area.get_y()+area.get_height()/2);
+			cr->line_to(area.get_x()-double_outline_margin_pixels,area.get_y()+area.get_height()/2.);
 			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height()+double_outline_margin_pixels);
 			cr->stroke();
 		}
 		break;
 
 	default:
-		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y());
-		cr->line_to(area.get_x()+area.get_width()/3.f,area.get_y());
-		cr->line_to(area.get_x(),area.get_y()+area.get_height()/3);
-		cr->line_to(area.get_x(),area.get_y()+area.get_height()-area.get_height()/3);
-		cr->line_to(area.get_x()+area.get_width()/3.f,area.get_y()+area.get_height());
-		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y());
+		cr->line_to(area.get_x()+area.get_width()/3.,area.get_y());
+		cr->line_to(area.get_x(),area.get_y()+area.get_height()/3.);
+		cr->line_to(area.get_x(),area.get_y()+area.get_height()-area.get_height()/3.);
+		cr->line_to(area.get_x()+area.get_width()/3.,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
@@ -318,9 +318,9 @@ WaypointRenderer::render_time_point_to_window(
 		break;
 
 	case INTERPOLATION_LINEAR:
-		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
+		cr->move_to(area.get_x()+area.get_width()/2.,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y());
-		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
@@ -335,61 +335,61 @@ WaypointRenderer::render_time_point_to_window(
 		break;
 
 	case INTERPOLATION_CONSTANT:
-		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
+		cr->move_to(area.get_x()+area.get_width()/2.,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y());
-		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/2);
-		cr->line_to(area.get_x()+area.get_width()-area.get_width()/4,area.get_y()+area.get_height()/2);
-		cr->line_to(area.get_x()+area.get_width()-area.get_width()/4,area.get_y()+area.get_height());
-		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/2.);
+		cr->line_to(area.get_x()+area.get_width()-area.get_width()/4.,area.get_y()+area.get_height()/2.);
+		cr->line_to(area.get_x()+area.get_width()-area.get_width()/4.,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 
 		if (double_outline) {
-			cr->move_to(area.get_x()+area.get_width()/2,area.get_y()-double_outline_margin_pixels);
+			cr->move_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
 			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()-double_outline_margin_pixels);
-			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/2+double_outline_margin_pixels);
-			cr->line_to(area.get_x()+area.get_width()-area.get_width()/4+double_outline_margin_pixels,area.get_y()+area.get_height()/2+double_outline_margin_pixels);
-			cr->line_to(area.get_x()+area.get_width()-area.get_width()/4+double_outline_margin_pixels,area.get_y()+area.get_height()+double_outline_margin_pixels);
-			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/2.+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()-area.get_width()/4.+double_outline_margin_pixels,area.get_y()+area.get_height()/2.+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()-area.get_width()/4.+double_outline_margin_pixels,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height()+double_outline_margin_pixels);
 			cr->stroke();
 		}
 		break;
 
 	case INTERPOLATION_CLAMPED:
-		cr->line_to(area.get_x()+area.get_width()/2,area.get_y());
-		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/2);
-		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y());
+		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/2.);
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 
 		if (double_outline) {
-			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()-double_outline_margin_pixels);
-			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/2);
-			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/2.);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height()+double_outline_margin_pixels);
 			cr->stroke();
 		}
 		break;
 
 	default:
-		cr->line_to(area.get_x()+area.get_width()/2,area.get_y());
-		cr->line_to(area.get_x()+area.get_width()-area.get_width()/3,area.get_y());
-		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/3);
-		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()-area.get_height()/3);
-		cr->line_to(area.get_x()+area.get_width()-area.get_width()/3,area.get_y()+area.get_height());
-		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y());
+		cr->line_to(area.get_x()+area.get_width()-area.get_width()/3.,area.get_y());
+		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/3.);
+		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()-area.get_height()/3.);
+		cr->line_to(area.get_x()+area.get_width()-area.get_width()/3.,area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
 
 		if (double_outline) {
-			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()-double_outline_margin_pixels);
-			cr->line_to(area.get_x()+area.get_width()-area.get_width()/3+double_outline_margin_pixels/2,area.get_y()-double_outline_margin_pixels);
-			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/3-double_outline_margin_pixels/2);
-			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()-area.get_height()/3+double_outline_margin_pixels/2);
-			cr->line_to(area.get_x()+area.get_width()-area.get_width()/3+double_outline_margin_pixels/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
-			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()-area.get_width()/3.+double_outline_margin_pixels/2,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/3.-double_outline_margin_pixels/2);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()-area.get_height()/3.+double_outline_margin_pixels/2);
+			cr->line_to(area.get_x()+area.get_width()-area.get_width()/3.+double_outline_margin_pixels/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height()+double_outline_margin_pixels);
 			cr->stroke();
 		}
 		break;
@@ -475,7 +475,7 @@ WaypointRenderer::foreach_visible_waypoint(const synfigapp::ValueDesc &value_des
 	if (!tset.empty()) {
 		const Time time_offset = get_time_offset_from_vdesc(value_desc);
 		const Time time_dilation = get_time_dilation_from_vdesc(value_desc);
-		const double time_k = time_dilation == Time::zero() ? 1.0 : 1.0/(double)time_dilation;
+		const double time_k = time_dilation == Time::zero() ? 1.0 : 1.0/time_dilation;
 
 		for (const auto & timepoint : tset) {
 			Time t = (timepoint.get_time() - time_offset)*time_k;

--- a/synfig-studio/src/gui/waypointrenderer.cpp
+++ b/synfig-studio/src/gui/waypointrenderer.cpp
@@ -165,18 +165,15 @@ WaypointRenderer::render_time_point_to_window(
 		break;
 
 	case INTERPOLATION_LINEAR:
-		cr->save();
 		cr->move_to(area.get_x()+area.get_width()/2.f,area.get_y());
 		cr->line_to(area.get_x(),area.get_y()+area.get_height());
 		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
-		cr->restore();
 		break;
 
 	case INTERPOLATION_CONSTANT:
-		cr->save();
 		cr->move_to(area.get_x()+area.get_width()/2.f,area.get_y());
 		cr->line_to(area.get_x()+area.get_width()/4.f,area.get_y());
 		cr->line_to(area.get_x()+area.get_width()/4.f,area.get_y()+area.get_height()/2);
@@ -186,22 +183,18 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
-		cr->restore();
 		break;
 
 	case INTERPOLATION_CLAMPED:
-		cr->save();
 		cr->move_to(area.get_x()+area.get_width()/2.f,area.get_y());
 		cr->line_to(area.get_x(),area.get_y()+area.get_height()/2);
 		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
-		cr->restore();
 		break;
 
 	default:
-		cr->save();
 		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y());
 		cr->line_to(area.get_x()+area.get_width()/3.f,area.get_y());
 		cr->line_to(area.get_x(),area.get_y()+area.get_height()/3);
@@ -211,7 +204,6 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
-		cr->restore();
 		break;
 	}
 
@@ -252,18 +244,15 @@ WaypointRenderer::render_time_point_to_window(
 		break;
 
 	case INTERPOLATION_LINEAR:
-		cr->save();
 		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
-		cr->restore();
 		break;
 
 	case INTERPOLATION_CONSTANT:
-		cr->save();
 		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/2);
@@ -273,22 +262,18 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
-		cr->restore();
 		break;
 
 	case INTERPOLATION_CLAMPED:
-		cr->save();
 		cr->line_to(area.get_x()+area.get_width()/2,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/2);
 		cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height());
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
-		cr->restore();
 		break;
 
 	default:
-		cr->save();
 		cr->line_to(area.get_x()+area.get_width()/2,area.get_y());
 		cr->line_to(area.get_x()+area.get_width()-area.get_width()/3,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y()+area.get_height()/3);
@@ -298,7 +283,6 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
-		cr->restore();
 		break;
 	}
 }

--- a/synfig-studio/src/gui/waypointrenderer.cpp
+++ b/synfig-studio/src/gui/waypointrenderer.cpp
@@ -154,13 +154,8 @@ WaypointRenderer::render_time_point_to_window(
 		cr->restore();
 
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
-		cr->move_to(area.get_x(),area.get_y()+area.get_height());
-		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
-		cr->stroke();
-
-		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
-		cr->move_to(area.get_x(),area.get_y()+area.get_height());
-		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
+		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
+		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->stroke();
 		break;
 

--- a/synfig-studio/src/gui/waypointrenderer.cpp
+++ b/synfig-studio/src/gui/waypointrenderer.cpp
@@ -169,8 +169,6 @@ WaypointRenderer::render_time_point_to_window(
 		cr->restore();
 
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
-		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
-		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->stroke();
 
 		if (double_outline) {
@@ -304,8 +302,6 @@ WaypointRenderer::render_time_point_to_window(
 		cr->restore();
 
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
-		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
-		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->stroke();
 
 		if (double_outline) {

--- a/synfig-studio/src/gui/waypointrenderer.cpp
+++ b/synfig-studio/src/gui/waypointrenderer.cpp
@@ -111,7 +111,8 @@ WaypointRenderer::render_time_point_to_window(
 	const Gdk::Rectangle& area,
 	const TimePoint &tp,
 	bool selected,
-	bool hover)
+	bool hover,
+	bool double_outline)
 {
 	const Gdk::RGBA outline_color = get_black(hover);
 
@@ -130,6 +131,11 @@ WaypointRenderer::render_time_point_to_window(
 	if(hover) color = color_shift(color, 0.2);
 	cr->set_source_rgb(color.get_red(),color.get_green(),color.get_blue());
 
+	const double double_outline_margin_pixels = 2.5;
+	double double_outline_margin = double_outline_margin_pixels;
+	if (double_outline)
+		double_outline_margin /= std::max(area.get_width(), area.get_height());
+
 	switch(tp.get_before())
 	{
 	case INTERPOLATION_TCB:
@@ -142,6 +148,15 @@ WaypointRenderer::render_time_point_to_window(
 		cr->restore();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->save();
+			cr->translate(area.get_x(), area.get_y());
+			cr->scale(area.get_width(), area.get_height());
+			cr->arc(0.5, 0.5, 0.5+double_outline_margin, 90*M_PI/180.0, 270*M_PI/180.0);
+			cr->restore();
+			cr->stroke();
+		}
 		break;
 
 	case INTERPOLATION_HALT:
@@ -157,6 +172,18 @@ WaypointRenderer::render_time_point_to_window(
 		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->save();
+			cr->translate(area.get_x(), area.get_y());
+			cr->scale(area.get_width(), area.get_height()*2);
+			cr->move_to(0.5, 0.5+double_outline_margin/2);
+			cr->line_to(-double_outline_margin, 0.5+double_outline_margin/2);
+			cr->arc(0.5-double_outline_margin/2, 0.5, 0.5+double_outline_margin/2, 180*M_PI/180.0, 270*M_PI/180.0);
+			cr->line_to(0.5, -double_outline_margin/2);
+			cr->restore();
+			cr->stroke();
+		}
 		break;
 
 	case INTERPOLATION_LINEAR:
@@ -166,6 +193,14 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->move_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.-double_outline_margin_pixels/2,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()-double_outline_margin_pixels*1.5,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->stroke();
+		}
 		break;
 
 	case INTERPOLATION_CONSTANT:
@@ -178,6 +213,16 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->move_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/4.-double_outline_margin_pixels,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/4.-double_outline_margin_pixels,area.get_y()+area.get_height()/2.-double_outline_margin_pixels);
+			cr->line_to(area.get_x()-double_outline_margin_pixels,area.get_y()+area.get_height()/2.-double_outline_margin_pixels);
+			cr->line_to(area.get_x()-double_outline_margin_pixels,area.get_y()+area.get_height() + double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height() + double_outline_margin_pixels);
+			cr->stroke();
+		}
 		break;
 
 	case INTERPOLATION_CLAMPED:
@@ -187,6 +232,13 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->move_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()-double_outline_margin_pixels,area.get_y()+area.get_height()/2);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->stroke();
+		}
 		break;
 
 	default:
@@ -199,6 +251,16 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/3.-double_outline_margin_pixels/2,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()-double_outline_margin_pixels,area.get_y()+area.get_height()/3.-double_outline_margin_pixels/2);
+			cr->line_to(area.get_x()-double_outline_margin_pixels,area.get_y()+area.get_height()-area.get_height()/3.+double_outline_margin_pixels/2);
+			cr->line_to(area.get_x()+area.get_width()/3.-double_outline_margin_pixels/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->stroke();
+		}
 		break;
 	}
 
@@ -221,6 +283,15 @@ WaypointRenderer::render_time_point_to_window(
 		cr->restore();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->save();
+			cr->translate(area.get_x(), area.get_y());
+			cr->scale(area.get_width(), area.get_height());
+			cr->arc(0.5, 0.5, 0.5+double_outline_margin, -90*M_PI/180.0, 90*M_PI/180.0);
+			cr->restore();
+			cr->stroke();
+		}
 		break;
 
 	case INTERPOLATION_HALT:
@@ -236,6 +307,18 @@ WaypointRenderer::render_time_point_to_window(
 		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());
 		cr->line_to(area.get_x()+area.get_width(),area.get_y());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->save();
+			cr->translate(area.get_x(), area.get_y());
+			cr->scale(area.get_width(), area.get_height()*2);
+			cr->move_to(0.5, 0.0-double_outline_margin/2);
+			cr->line_to(1.0+double_outline_margin, 0.0-double_outline_margin/2);
+			cr->arc(0.5+double_outline_margin/2, 0.0, 0.5+double_outline_margin/2, 0*M_PI/180.0, 90*M_PI/180.0);
+			cr->line_to(0.5, 0.5+double_outline_margin/2);
+			cr->restore();
+			cr->stroke();
+		}
 		break;
 
 	case INTERPOLATION_LINEAR:
@@ -245,6 +328,14 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->move_to(area.get_x()+area.get_width()/2.,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()+1.5*double_outline_margin_pixels,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.+double_outline_margin_pixels/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2.,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->stroke();
+		}
 		break;
 
 	case INTERPOLATION_CONSTANT:
@@ -257,6 +348,16 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->move_to(area.get_x()+area.get_width()/2,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/2+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()-area.get_width()/4+double_outline_margin_pixels,area.get_y()+area.get_height()/2+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()-area.get_width()/4+double_outline_margin_pixels,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->stroke();
+		}
 		break;
 
 	case INTERPOLATION_CLAMPED:
@@ -266,6 +367,13 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/2);
+			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->stroke();
+		}
 		break;
 
 	default:
@@ -278,6 +386,16 @@ WaypointRenderer::render_time_point_to_window(
 		cr->fill_preserve();
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->stroke();
+
+		if (double_outline) {
+			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()-area.get_width()/3+double_outline_margin_pixels/2,area.get_y()-double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()/3-double_outline_margin_pixels/2);
+			cr->line_to(area.get_x()+area.get_width()+double_outline_margin_pixels,area.get_y()+area.get_height()-area.get_height()/3+double_outline_margin_pixels/2);
+			cr->line_to(area.get_x()+area.get_width()-area.get_width()/3+double_outline_margin_pixels/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->line_to(area.get_x()+area.get_width()/2,area.get_y()+area.get_height()+double_outline_margin_pixels);
+			cr->stroke();
+		}
 		break;
 	}
 }

--- a/synfig-studio/src/gui/waypointrenderer.cpp
+++ b/synfig-studio/src/gui/waypointrenderer.cpp
@@ -150,10 +150,12 @@ WaypointRenderer::render_time_point_to_window(
 		cr->scale(area.get_width(), area.get_height()*2);
 		cr->move_to(0.5, 0.5);
 		cr->arc(0.5, 0.5, 0.5, 180*M_PI/180.0, 270*M_PI/180.0);
-		cr->fill();
-		cr->arc(0.5, 0.5, 0.5, 180*M_PI/180.0, 270*M_PI/180.0);
+		cr->fill_preserve();
 		cr->restore();
+
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
+		cr->move_to(area.get_x(),area.get_y()+area.get_height());
+		cr->line_to(area.get_x()+area.get_width()/2.f,area.get_y()+area.get_height());
 		cr->stroke();
 
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
@@ -240,11 +242,8 @@ WaypointRenderer::render_time_point_to_window(
 		cr->scale(area.get_width(), area.get_height()*2);
 		cr->move_to(0.5, 0.0);
 		cr->arc(0.5, 0.0, 0.5, 0*M_PI/180.0, 90*M_PI/180.0);
-		cr->fill();
-		cr->arc(0.5, 0.0, 0.5, 0*M_PI / 180.0, 90*M_PI / 180.0);
+		cr->fill_preserve();
 		cr->restore();
-		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
-		cr->stroke();
 
 		cr->set_source_rgb(outline_color.get_red(),outline_color.get_green(),outline_color.get_blue());
 		cr->move_to(area.get_x()+area.get_width()/2,area.get_y());

--- a/synfig-studio/src/gui/waypointrenderer.h
+++ b/synfig-studio/src/gui/waypointrenderer.h
@@ -51,7 +51,7 @@ public:
 		const Gdk::Rectangle& area,
 		const synfig::TimePoint &tp,
 		bool selected,
-		bool hover);
+		bool hover, bool double_outline);
 
 	//! Callback called at every iteration of \ref foreach_visible_waypoint
 	//! \param tp A visible TimePoint

--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -792,7 +792,7 @@ Widget_Curves::on_draw(const Cairo::RefPtr<Cairo::Context> &cr)
 				area.set_y(0 - waypoint_edge_length/2 + 1 + py);
 
 				bool selected = channel_point_sd.is_selected(ChannelPoint(curve_it, tp, c));
-				WaypointRenderer::render_time_point_to_window(cr, area, tp, selected, hover);
+				WaypointRenderer::render_time_point_to_window(cr, area, tp, selected, hover, !is_draggable);
 			}
 			return false;
 		});


### PR DESCRIPTION
Case:
A given parameter P was converted, and its inner parameters were animated.
Timetrack panel shows a summary of those (inner parameter) waypoints in the row of parameter P.

Now it's uses double outline instead of misleading semi-transparency.

Fix #1266 