### PR TITLE
make first vertex selectable when creating spline - Fix #1281

### DIFF
--- a/synfig-studio/src/gui/duck.h
+++ b/synfig-studio/src/gui/duck.h
@@ -77,6 +77,7 @@ public:
 		TYPE_SCALE_X				=	(1 <<  9),	//  512
 		TYPE_SCALE_Y				=	(1 << 10),	// 1024
 		TYPE_SKEW					=	(1 << 11),	// 2048
+		TYPE_FIRST_VERTEX			=	(1 << 12),	// 4096
 
 		TYPE_ALL					=	(~0),
 

--- a/synfig-studio/src/gui/duckmatic.cpp
+++ b/synfig-studio/src/gui/duckmatic.cpp
@@ -422,11 +422,13 @@ Duckmatic::get_duck_list()const
 {
 	DuckList ret;
 	DuckMap::const_iterator iter;
+	for(iter=duck_map.begin();iter!=duck_map.end();++iter) if (iter->second->get_type()&Duck::TYPE_FIRST_VERTEX) ret.push_back(iter->second);
 	for(iter=duck_map.begin();iter!=duck_map.end();++iter) if (iter->second->get_type()&Duck::TYPE_POSITION) ret.push_back(iter->second);
 	for(iter=duck_map.begin();iter!=duck_map.end();++iter) if (iter->second->get_type()&Duck::TYPE_VERTEX  ) ret.push_back(iter->second);
 	for(iter=duck_map.begin();iter!=duck_map.end();++iter) if (iter->second->get_type()&Duck::TYPE_TANGENT ) ret.push_back(iter->second);
 	for(iter=duck_map.begin();iter!=duck_map.end();++iter)
 		if (!(iter->second->get_type()&Duck::TYPE_POSITION) &&
+			!(iter->second->get_type()&Duck::TYPE_FIRST_VERTEX) &&
 			!(iter->second->get_type()&Duck::TYPE_VERTEX) &&
 			!(iter->second->get_type()&Duck::TYPE_TANGENT))
 			ret.push_back(iter->second);
@@ -1376,6 +1378,14 @@ Duckmatic::find_duck(synfig::Point point, synfig::Real radius, Duck::Type type)
                     break;
                 }
         if(!found)
+            for(i=0; i<ret_vector.size();i++)
+                if(ret_vector[i]->get_type() & Duck::TYPE_FIRST_VERTEX)
+                {
+                    ret=ret_vector[i];
+                    found=true;
+                    break;
+                }
+		if(!found)
             for(i=0; i<ret_vector.size();i++)
                 if(ret_vector[i]->get_type() & Duck::TYPE_VERTEX)
                 {

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -1409,7 +1409,9 @@ StateBLine_Context::refresh_ducks(bool button_down)
 		duck=new WorkArea::Duck(bline_point.get_vertex());
 		duck->set_editable(true);
 #ifdef DISTINGUISH_FIRST_DUCK
-		if (iter!=bline_point_list.begin())
+		if (iter==bline_point_list.begin())
+			duck->set_type(Duck::TYPE_FIRST_VERTEX);
+		else
 			duck->set_type(Duck::TYPE_VERTEX);
 #else
 		duck->set_type(Duck::TYPE_VERTEX);

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -65,6 +65,8 @@ using namespace studio;
 
 /* === M A C R O S ========================================================= */
 
+#define DISTINGUISH_FIRST_DUCK
+
 #ifndef LAYER_CREATION
 #define LAYER_CREATION(button, stockid, tooltip)	\
 	{ \
@@ -1311,6 +1313,11 @@ StatePolygon_Context::refresh_ducks()
 	etl::handle<WorkArea::Duck> duck;
 	duck=new WorkArea::Duck(*iter);
 	duck->set_editable(true);
+#ifdef DISTINGUISH_FIRST_DUCK
+	duck->set_type(Duck::TYPE_FIRST_VERTEX);
+#else
+	duck->set_type(Duck::TYPE_VERTEX);
+#endif
 	duck->signal_edited().connect(
 		sigc::bind(sigc::mem_fun(*this,&studio::StatePolygon_Context::on_polygon_duck_change),iter)
 	);
@@ -1325,7 +1332,8 @@ StatePolygon_Context::refresh_ducks()
 
 		duck=new WorkArea::Duck(*iter);
 		duck->set_editable(true);
-		duck->set_name(strprintf("%x",&*iter));
+		duck->set_name(strprintf("%p",&*iter));
+		duck->set_type(Duck::TYPE_VERTEX);
 		duck->signal_edited().connect(
 			sigc::bind(sigc::mem_fun(*this,&studio::StatePolygon_Context::on_polygon_duck_change),iter)
 		);


### PR DESCRIPTION
It allows now to close Spline while creating it by clicking on
first vertex, even if the tangents ducks are at same place.

This bogus duck is only used while creating spline, not editing.