### PR TITLE
fix bline point order when saving for older canvas (part 2)

### DIFF
--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -950,7 +950,10 @@ xmlpp::Element* encode_canvas(xmlpp::Element* root,Canvas::ConstHandle canvas)
 	root->set_name("canvas");
 
 	if(canvas->is_root())
-		root->set_attribute("version",canvas->get_version());
+		if (save_canvas_version < RELEASE_VERSION_1_4_0)
+			root->set_attribute("version","1.0");
+		else
+			root->set_attribute("version",canvas->get_version());
 
 	if(!canvas->get_id().empty() && !canvas->is_root() && !canvas->is_inline())
 		root->set_attribute("id",canvas->get_id());


### PR DESCRIPTION
Complementary fix for #1347

It fixes following situation:
- user opens (creates) file in Synfig 1.4
- adds looped advanced outlines with widthpoints
- user saves file in older format
- user opens closes file and opens it again in Synfig 1.4 -> widthpoint positions are wrong.