### PR TITLE
Cmake fixes

### DIFF
--- a/ETL/ETL/CMakeLists.txt
+++ b/ETL/ETL/CMakeLists.txt
@@ -27,7 +27,6 @@ set(ETL_HEADERS
 #     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/_ref_count.h"
         "${CMAKE_CURRENT_LIST_DIR}/_trivial.h"
-        "${CMAKE_CURRENT_LIST_DIR}/_smach.h"
         "${CMAKE_CURRENT_LIST_DIR}/_surface.h"
         "${CMAKE_CURRENT_LIST_DIR}/_smart_ptr.h"
         "${CMAKE_CURRENT_LIST_DIR}/_pen.h"

--- a/synfig-core/src/CMakeLists.txt
+++ b/synfig-core/src/CMakeLists.txt
@@ -42,6 +42,26 @@ pkg_check_modules(MAGICKCORE REQUIRED MagickCore) # for Magick++
 ## TODO: move to module where it is actually required
 pkg_check_modules(PANGO REQUIRED pango)
 
+foreach(pkg_config_lib 
+  SIGCPP 
+  GLIBMM 
+  GIOMM 
+  CAIRO 
+  PANGOCAIRO 
+  LIBXML 
+  MLT 
+  FFTW 
+  FT 
+  LIBPNG
+  LIBMNG
+  LIBJPEG
+  OPENEXR
+  MAGICKCORE
+  PANGO)
+    include_directories(${${pkg_config_lib}_INCLUDE_DIRS})
+    link_directories(${${pkg_config_lib}_LIBRARY_DIRS})
+endforeach()
+
 ## TODO: should we keep it here?
 find_package(ImageMagick COMPONENTS Magick++)
 

--- a/synfig-studio/src/CMakeLists.txt
+++ b/synfig-studio/src/CMakeLists.txt
@@ -23,6 +23,11 @@ pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
 pkg_check_modules(LIBXML REQUIRED libxml++-2.6)
 pkg_check_modules(MLT REQUIRED mlt++) # required for widget_soundwave
 
+foreach(pkg_config_lib SIGCPP GTKMM LIBXML MLT)
+    include_directories(${${pkg_config_lib}_INCLUDE_DIRS})
+    link_directories(${${pkg_config_lib}_LIBRARY_DIRS})
+endforeach()
+
 ##
 ## Config
 ##


### PR DESCRIPTION
A few CMake related fixes that came up while creating a snap package (#1398)

All in all, basic stuff. To quote the commits:

> Add include & library dirs for each pkg_config module
> This allows building & linking with libraries in non-standard paths.

