### PR TITLE
hide GUID int constructor

### DIFF
--- a/synfig-core/src/synfig/guid.cpp
+++ b/synfig-core/src/synfig/guid.cpp
@@ -35,6 +35,8 @@
 #include <ETL/stringf>
 #include <functional>
 
+#include <cstring>
+
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -181,6 +183,12 @@ String
 synfig::GUID::get_string()const
 {
 	return strprintf("%08X%08X%08X%08X",data.u_32.a,data.u_32.b,data.u_32.c,data.u_32.d);
+}
+
+synfig::GUID::GUID(int i)
+{
+	assert(!i);
+	memset(&data, 0, sizeof (data));
 }
 
 synfig::GUID::GUID(const String &str)

--- a/synfig-core/src/synfig/guid.h
+++ b/synfig-core/src/synfig/guid.h
@@ -55,10 +55,11 @@ class GUID
 
 	} data;
 
+	GUID(int);
+
 public:
 	GUID()
 		{ make_unique(); }
-	GUID(const int i){assert(!i); data.u_64.a=0;data.u_64.b=0;}
 
 	GUID(const String& str);
 

--- a/synfig-core/src/synfig/layers/layer_bitmap.cpp
+++ b/synfig-core/src/synfig/layers/layer_bitmap.cpp
@@ -70,7 +70,7 @@ using namespace etl;
 
 synfig::Layer_Bitmap::Layer_Bitmap():
 	Layer_Composite	(1.0,Color::BLEND_COMPOSITE),
-	surface_modification_id (0),
+	surface_modification_id (GUID::zero()),
 	param_tl                (Point(-0.5,0.5)),
 	param_br                (Point(0.5,-0.5)),
 	param_c                 (int(1)),

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -340,7 +340,7 @@ CanvasParser::parse_guid(xmlpp::Element *element)
 	if(!element->get_attribute("value"))
 	{
 		error(element,strprintf(_("<%s> is missing \"value\" attribute"),"guid"));
-		return false;
+		return GUID::zero();
 	}
 
 	string val=element->get_attribute("value")->get_value();

--- a/synfig-core/src/synfig/node.cpp
+++ b/synfig-core/src/synfig/node.cpp
@@ -186,7 +186,7 @@ TimePointSet::insert(const TimePoint& x)
 
 
 Node::Node():
-	guid_(0),
+	guid_(GUID::zero()),
 	bchanged(true),
 	time_last_changed_(__sys_clock()),
 	deleting_(false)

--- a/synfig-core/src/synfig/node.h
+++ b/synfig-core/src/synfig/node.h
@@ -66,7 +66,7 @@ class TimePoint
 public:
 
 	TimePoint(const Time& x=Time::begin()):
-		guid(0),
+		guid(GUID::zero()),
 		time(x),
 		before(INTERPOLATION_NIL),
 		after(INTERPOLATION_NIL)

--- a/synfig-core/src/synfig/transform.cpp
+++ b/synfig-core/src/synfig/transform.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 synfig::GUID
 TransformStack::get_guid()const
 {
-	GUID ret(0);
+	GUID ret(GUID::zero());
 
 	for(const_iterator iter(begin());iter!=end();++iter)
 		ret%=(*iter)->get_guid();

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
@@ -59,7 +59,7 @@ using namespace synfig;
 #define GET_NODE_GUID_CSTR(node) GET_GUID_CSTR(node->get_guid())
 #define GET_NODE_NAME_CSTR(node,t) GET_NODE_NAME(node,t).c_str()
 #define GET_NODE_BONE_CSTR(node,t) GET_NODE_BONE(node,t).c_str()
-#define GET_NODE_DESC_CSTR(node,t) (node ? strprintf("%s (%s)", GET_NODE_GUID_CSTR(node), GET_NODE_NAME_CSTR(node,t)) : strprintf("%s <root>", GET_GUID_CSTR(GUID(0)))).c_str()
+#define GET_NODE_DESC_CSTR(node,t) (node ? strprintf("%s (%s)", GET_NODE_GUID_CSTR(node), GET_NODE_NAME_CSTR(node,t)) : strprintf("%s <root>", GET_GUID_CSTR(GUID::zero()))).c_str()
 #define GET_NODE_PARENT_CSTR(node,t) GET_GUID_CSTR(GET_NODE_PARENT(node,t))
 
 /* === G L O B A L S ======================================================= */

--- a/synfig-studio/src/gui/duck.cpp
+++ b/synfig-studio/src/gui/duck.cpp
@@ -78,7 +78,7 @@ int _DuckCounter::counter(0);
 /* === M E T H O D S ======================================================= */
 
 Duck::Duck():
-	guid_(0),
+	guid_(GUID::zero()),
 	type_(TYPE_NONE),
 	editable_(false),
 	alternative_editable_(false),


### PR DESCRIPTION
to avoid anybody to mess with its int parameter that could only be zero.

It fixes compiler warnings about unused parameter