### PR TITLE
Added toggleable option for thumbnail preview

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -283,6 +283,7 @@ std::list< etl::handle< studio::Module > > module_list_;
 
 bool   studio::App::restrict_radius_ducks        = true;
 bool   studio::App::resize_imported_images       = false;
+bool   studio::App::animation_thumbnail_preview  = true;
 bool   studio::App::enable_experimental_features = false;
 bool   studio::App::use_dark_theme               = false;
 bool   studio::App::show_file_toolbar            = true;
@@ -536,6 +537,11 @@ public:
 				value=strprintf("%i",(int)App::resize_imported_images);
 				return true;
 			}
+			if(key=="animation_thumbnail_preview")
+			{
+			        value=strprintf("%i",(int)App::animation_thumbnail_preview);
+			        return true;
+			}
 			if(key=="enable_experimental_features")
 			{
 				value=strprintf("%i",(int)App::enable_experimental_features);
@@ -709,6 +715,12 @@ public:
 				App::resize_imported_images=i;
 				return true;
 			}
+			if(key=="animation_thumbnail_preview")
+			{
+			        int i(atoi(value.c_str()));
+			        App::animation_thumbnail_preview=i;
+			        return true;
+			}
 			if(key=="enable_experimental_features")
 			{
 				int i(atoi(value.c_str()));
@@ -847,6 +859,7 @@ public:
 		ret.push_back("autosave_backup_interval");
 		ret.push_back("restrict_radius_ducks");
 		ret.push_back("resize_imported_images");
+		ret.push_back("animation_thumbnail_preview");
 		ret.push_back("enable_experimental_features");
 		ret.push_back("use_dark_theme");
 		ret.push_back("show_file_toolbar");
@@ -2240,6 +2253,7 @@ App::restore_default_settings()
 	synfigapp::Main::settings().set_value("pref.autosave_backup_interval",       "15000");
 	synfigapp::Main::settings().set_value("pref.restrict_radius_ducks",          "1");
 	synfigapp::Main::settings().set_value("pref.resize_imported_images",         "0");
+	synfigapp::Main::settings().set_value("pref.animation_thumbnail_preview",    "1");
 	synfigapp::Main::settings().set_value("pref.enable_experimental_features",   "0");
 	synfigapp::Main::settings().set_value("pref.use_dark_theme",                 "0");
 	synfigapp::Main::settings().set_value("pref.show_file_toolbar",              "1");

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -216,6 +216,7 @@ public:
 
 	static bool restrict_radius_ducks;
 	static bool resize_imported_images;
+	static bool animation_thumbnail_preview;
 	static bool enable_experimental_features;
 	static bool use_dark_theme;
 	static bool show_file_toolbar;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -397,6 +397,8 @@ Dialog_Setup::create_editing_page(PageInfo pi)
 	/*---------Editing------------------*\
 	 * IMPORTED IMAGE
 	 *  [x] Scale to fit
+	 * ANIMATION
+	 *  [x] Thumbnail preview
 	 * OTHER
 	 *  [x] Linear color
 	 *  [x] Restrict radius
@@ -415,6 +417,16 @@ Dialog_Setup::create_editing_page(PageInfo pi)
 	toggle_resize_imported_images.set_tooltip_text(_("When you import images, check this option if you want they fit the Canvas size."));
 	toggle_resize_imported_images.set_halign(Gtk::ALIGN_START);
 	toggle_resize_imported_images.set_hexpand(false);
+		
+	// Editing Animation section
+	attach_label_section(pi.grid, _("Animation"), ++row);
+
+	// Editing - Show animation thumbnail preview
+	attach_label(pi.grid, _("Thumbnail preview"), ++row);
+	pi.grid->attach(toggle_animation_thumbnail_preview, 1, row, 1, 1);
+	toggle_animation_thumbnail_preview.set_tooltip_text(_("Turn on/off animation thumbnail preview when you hover your mouse over the timetrack panel."));
+	toggle_animation_thumbnail_preview.set_halign(Gtk::ALIGN_START);
+	toggle_animation_thumbnail_preview.set_hexpand(false);
 
 	// Editing Other section
 	attach_label_section(pi.grid, _("Other"), ++row);
@@ -676,6 +688,9 @@ Dialog_Setup::on_apply_pressed()
 	// Set the resize_imported_images flag
 	App::resize_imported_images       = toggle_resize_imported_images.get_active();
 
+        // Set the animation_thumbnail_preview flag
+	App::animation_thumbnail_preview  = toggle_animation_thumbnail_preview.get_active();
+
 	// Set the experimental features flag
 	App::enable_experimental_features = toggle_enable_experimental_features.get_active();
 
@@ -913,6 +928,9 @@ Dialog_Setup::refresh()
 
 	// Refresh the status of the resize_imported_images flag
 	toggle_resize_imported_images.set_active(App::resize_imported_images);
+	
+	// Refresh the status of animation_thumbnail_preview flag
+	toggle_animation_thumbnail_preview.set_active(App::animation_thumbnail_preview);
 
 	// Refresh the status of the experimental features flag
 	toggle_enable_experimental_features.set_active(App::enable_experimental_features);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -141,6 +141,7 @@ class Dialog_Setup : public Dialog_Template
 
 	Gtk::Switch toggle_restrict_radius_ducks;
 	Gtk::Switch toggle_resize_imported_images;
+	Gtk::Switch toggle_animation_thumbnail_preview;
 	Gtk::Switch toggle_enable_experimental_features;
 	Gtk::Switch toggle_use_dark_theme;
 	Gtk::Switch toggle_show_file_toolbar;

--- a/synfig-studio/src/gui/widgets/widget_canvastimeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_canvastimeslider.cpp
@@ -196,7 +196,8 @@ Widget_CanvasTimeslider::on_motion_notify_event(GdkEventMotion* event)
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if ((event->state & (Gdk::BUTTON1_MASK | Gdk::BUTTON2_MASK)) == 0)
-		show_tooltip(Point(event->x, event->y), Point(event->x_root, event->y_root));
+	        if (App::animation_thumbnail_preview)
+        		show_tooltip(Point(event->x, event->y), Point(event->x_root, event->y_root));
 	return Widget_Timeslider::on_motion_notify_event(event);
 	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }


### PR DESCRIPTION
This fixes the keyboard input **Ctrl+,** & **Ctrl+.** not responding when
thumbnail is displayed under Wayland session

By default, thumbnail preview is turned on so it doesn't affect X11
users
Wayland users can turn it off in Preferences > Editing > Thumbnail
preview section

Fixes #1144