### PR TITLE
Fixed smach (state machine) compilation on MSVC

### DIFF
--- a/synfig-studio/src/gui/_smach.h
+++ b/synfig-studio/src/gui/_smach.h
@@ -217,10 +217,49 @@ public:
 
 	protected:
 
-		virtual void* enter_state(context_type* machine_context)const
+		/*
+		This part compiles differently in gcc/clang and MSVC compilers.
+		Since the behavior of the compiler is not specified for virtual methods
+		(C++11 standard says: § 14.7.1.10. "It is unspecified whether or not an
+		implementation implicitly instantiates a virtual member function of a
+		class template if the virtual member function would not otherwise be instantiated").
+
+		Unlike GCC/Clang, MSVC expects the template class to be fully defined
+		at the moment, so this code does not compile. Therefore, we move
+		the `enter_state` method to derived classes.
+
+		Minimal working example:
+		```
+		template <class T>
+		class A {
+		virtual void* Run() {
+			return new T();
+		}
+		};
+
+		class C;
+
+		class B : A<C> {
+		
+		};
+		```
+
+		MSVC fails with the error:
+		```
+		<source>(4): error C2027: use of undefined type 'C'
+		<source>(8): note: see declaration of 'C'
+		<source>(3): note: while compiling class template member function 'void *A<C>::Run(void)'
+		<source>(10): note: see reference to class template instantiation 'A<C>' being compiled
+		Compiler returned: 2
+		```
+
+		This code can be tested online at https://godbolt.org		
+		*/
+
+		/*virtual void* enter_state(context_type* machine_context)const
 		{
 			return new state_context_type(machine_context);
-		}
+		}*/
 
 		virtual bool leave_state(void* x)const
 		{

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -329,6 +329,11 @@ StateBLine::~StateBLine()
 {
 }
 
+void* StateBLine::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateBLine_Context(machine_context);
+}
+
 void
 StateBLine_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_bline.h
+++ b/synfig-studio/src/gui/states/state_bline.h
@@ -44,6 +44,7 @@ class StateBLine : public Smach::state<StateBLine_Context>
 public:
 	StateBLine();
 	~StateBLine();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateBLine
 
 extern StateBLine state_bline;

--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -259,6 +259,11 @@ StateBrush::~StateBrush()
 {
 }
 
+void* StateBrush::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateBrush_Context(machine_context);
+}
+
 void
 StateBrush_Context::BrushConfig::clear()
 {

--- a/synfig-studio/src/gui/states/state_brush.h
+++ b/synfig-studio/src/gui/states/state_brush.h
@@ -45,6 +45,7 @@ class StateBrush : public Smach::state<StateBrush_Context>
 public:
 	StateBrush();
 	~StateBrush();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateBrush
 
 extern StateBrush state_brush;

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -329,6 +329,11 @@ StateCircle::~StateCircle()
 {
 }
 
+void* StateCircle::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateCircle_Context(machine_context);
+}
+
 void
 StateCircle_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_circle.h
+++ b/synfig-studio/src/gui/states/state_circle.h
@@ -45,6 +45,7 @@ class StateCircle : public Smach::state<StateCircle_Context>
 public:
 	StateCircle();
 	~StateCircle();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateCircle
 
 extern StateCircle state_circle;

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -402,6 +402,10 @@ StateDraw::~StateDraw()
 {
 }
 
+void* StateDraw::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateDraw_Context(machine_context);
+}
 
 void
 StateDraw_Context::load_settings()

--- a/synfig-studio/src/gui/states/state_draw.h
+++ b/synfig-studio/src/gui/states/state_draw.h
@@ -45,6 +45,7 @@ class StateDraw : public Smach::state<StateDraw_Context>
 public:
 	StateDraw();
 	~StateDraw();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateDraw
 
 extern StateDraw state_draw;

--- a/synfig-studio/src/gui/states/state_eyedrop.cpp
+++ b/synfig-studio/src/gui/states/state_eyedrop.cpp
@@ -96,6 +96,11 @@ StateEyedrop::~StateEyedrop()
 {
 }
 
+void* StateEyedrop::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateEyedrop_Context(machine_context);
+}
+
 StateEyedrop_Context::StateEyedrop_Context(CanvasView *canvasView):
 	canvas_view(canvasView),
 	is_working(*canvasView)

--- a/synfig-studio/src/gui/states/state_eyedrop.h
+++ b/synfig-studio/src/gui/states/state_eyedrop.h
@@ -45,6 +45,7 @@ class StateEyedrop : public Smach::state<StateEyedrop_Context>
 public:
 	StateEyedrop();
 	~StateEyedrop();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateEyedrop
 
 extern StateEyedrop state_eyedrop;

--- a/synfig-studio/src/gui/states/state_fill.cpp
+++ b/synfig-studio/src/gui/states/state_fill.cpp
@@ -105,6 +105,11 @@ StateFill::~StateFill()
 {
 }
 
+void* StateFill::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateFill_Context(machine_context);
+}
+
 StateFill_Context::StateFill_Context(CanvasView *canvasView):
 	canvas_view(canvasView),
 	is_working(*canvasView),

--- a/synfig-studio/src/gui/states/state_fill.h
+++ b/synfig-studio/src/gui/states/state_fill.h
@@ -45,6 +45,7 @@ class StateFill : public Smach::state<StateFill_Context>
 public:
 	StateFill();
 	~StateFill();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateFill
 
 extern StateFill state_fill;

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -253,6 +253,11 @@ StateGradient::~StateGradient()
 {
 }
 
+void* StateGradient::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateGradient_Context(machine_context);
+}
+
 void
 StateGradient_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_gradient.h
+++ b/synfig-studio/src/gui/states/state_gradient.h
@@ -45,6 +45,7 @@ class StateGradient : public Smach::state<StateGradient_Context>
 public:
 	StateGradient();
 	~StateGradient();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateGradient
 
 extern StateGradient state_gradient;

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -392,6 +392,10 @@ StateLasso::~StateLasso()
 {
 }
 
+void* StateLasso::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateLasso_Context(machine_context);
+}
 
 void
 StateLasso_Context::load_settings()

--- a/synfig-studio/src/gui/states/state_lasso.h
+++ b/synfig-studio/src/gui/states/state_lasso.h
@@ -45,6 +45,7 @@ class StateLasso : public Smach::state<StateLasso_Context>
 public:
 	StateLasso();
 	~StateLasso();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateDraw
 
 extern StateLasso state_lasso;

--- a/synfig-studio/src/gui/states/state_mirror.cpp
+++ b/synfig-studio/src/gui/states/state_mirror.cpp
@@ -167,6 +167,11 @@ StateMirror::~StateMirror()
 {
 }
 
+void* StateMirror::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateMirror_Context(machine_context);
+}
+
 StateMirror_Context::StateMirror_Context(CanvasView* canvas_view):
 	canvas_view_(canvas_view),
 	is_working(*canvas_view),

--- a/synfig-studio/src/gui/states/state_mirror.h
+++ b/synfig-studio/src/gui/states/state_mirror.h
@@ -44,6 +44,7 @@ class StateMirror : public Smach::state<StateMirror_Context>
 public:
 	StateMirror();
 	~StateMirror();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateMirror
 
 extern StateMirror state_mirror;

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -235,6 +235,11 @@ StateNormal::~StateNormal()
 {
 }
 
+void* StateNormal::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateNormal_Context(machine_context);
+}
+
 void StateNormal_Context::refresh_cursor()
 {
 	// Check the current state and return when applicable

--- a/synfig-studio/src/gui/states/state_normal.h
+++ b/synfig-studio/src/gui/states/state_normal.h
@@ -46,6 +46,7 @@ class StateNormal : public Smach::state<StateNormal_Context>
 public:
 	StateNormal();
 	~StateNormal();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateNormal
 
 extern StateNormal state_normal;

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -292,6 +292,11 @@ StatePolygon::~StatePolygon()
 {
 }
 
+void* StatePolygon::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StatePolygon_Context(machine_context);
+}
+
 void
 StatePolygon_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_polygon.h
+++ b/synfig-studio/src/gui/states/state_polygon.h
@@ -44,6 +44,7 @@ class StatePolygon : public Smach::state<StatePolygon_Context>
 public:
 	StatePolygon();
 	~StatePolygon();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StatePolygon
 
 extern StatePolygon state_polygon;

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -299,6 +299,11 @@ StateRectangle::~StateRectangle()
 {
 }
 
+void* StateRectangle::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateRectangle_Context(machine_context);
+}
+
 void
 StateRectangle_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_rectangle.h
+++ b/synfig-studio/src/gui/states/state_rectangle.h
@@ -45,6 +45,7 @@ class StateRectangle : public Smach::state<StateRectangle_Context>
 public:
 	StateRectangle();
 	~StateRectangle();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateRectangle
 
 extern StateRectangle state_rectangle;

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -157,6 +157,11 @@ StateRotate::~StateRotate()
 {
 }
 
+void* StateRotate::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateRotate_Context(machine_context);
+}
+
 void
 StateRotate_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_rotate.h
+++ b/synfig-studio/src/gui/states/state_rotate.h
@@ -45,6 +45,7 @@ class StateRotate : public Smach::state<StateRotate_Context>
 public:
 	StateRotate();
 	~StateRotate();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateRotate
 
 extern StateRotate state_rotate;

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -146,6 +146,11 @@ StateScale::~StateScale()
 {
 }
 
+void* StateScale::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateScale_Context(machine_context);
+}
+
 void
 StateScale_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_scale.h
+++ b/synfig-studio/src/gui/states/state_scale.h
@@ -44,6 +44,7 @@ class StateScale : public Smach::state<StateScale_Context>
 public:
 	StateScale();
 	~StateScale();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateScale
 
 extern StateScale state_scale;

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -149,6 +149,11 @@ StateSketch::~StateSketch()
 {
 }
 
+void* StateSketch::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateSketch_Context(machine_context);
+}
+
 void
 StateSketch_Context::save_sketch()
 {

--- a/synfig-studio/src/gui/states/state_sketch.h
+++ b/synfig-studio/src/gui/states/state_sketch.h
@@ -44,6 +44,7 @@ class StateSketch : public Smach::state<StateSketch_Context>
 public:
 	StateSketch();
 	~StateSketch();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateSketch
 
 extern StateSketch state_sketch;

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -154,6 +154,11 @@ StateSmoothMove::~StateSmoothMove()
 {
 }
 
+void* StateSmoothMove::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateSmoothMove_Context(machine_context);
+}
+
 void
 StateSmoothMove_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_smoothmove.h
+++ b/synfig-studio/src/gui/states/state_smoothmove.h
@@ -45,6 +45,7 @@ class StateSmoothMove : public Smach::state<StateSmoothMove_Context>
 public:
 	StateSmoothMove();
 	~StateSmoothMove();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateSmoothMove
 
 extern StateSmoothMove state_smooth_move;

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -359,6 +359,11 @@ StateStar::~StateStar()
 {
 }
 
+void* StateStar::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateStar_Context(machine_context);
+}
+
 void
 StateStar_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_star.h
+++ b/synfig-studio/src/gui/states/state_star.h
@@ -46,6 +46,7 @@ class StateStar : public Smach::state<StateStar_Context>
 public:
 	StateStar();
 	~StateStar();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateStar
 
 extern StateStar state_star;

--- a/synfig-studio/src/gui/states/state_stroke.cpp
+++ b/synfig-studio/src/gui/states/state_stroke.cpp
@@ -122,6 +122,10 @@ StateStroke::~StateStroke()
 {
 }
 
+void* StateStroke::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateStroke_Context(machine_context);
+}
 
 StateStroke_Context::StateStroke_Context(CanvasView* canvas_view):
 	canvas_view_(canvas_view),

--- a/synfig-studio/src/gui/states/state_stroke.h
+++ b/synfig-studio/src/gui/states/state_stroke.h
@@ -52,6 +52,7 @@ class StateStroke : public Smach::state<StateStroke_Context>
 public:
 	StateStroke();
 	~StateStroke();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateStroke
 
 extern StateStroke state_stroke;

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -229,6 +229,11 @@ StateText::~StateText()
 {
 }
 
+void* StateText::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateText_Context(machine_context);
+}
+
 void
 StateText_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_text.h
+++ b/synfig-studio/src/gui/states/state_text.h
@@ -46,6 +46,7 @@ class StateText : public Smach::state<StateText_Context>
 public:
 	StateText();
 	~StateText();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateText
 
 extern StateText state_text;

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -172,6 +172,11 @@ StateWidth::~StateWidth()
 {
 }
 
+void* StateWidth::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateWidth_Context(machine_context);
+}
+
 void
 StateWidth_Context::load_settings()
 {

--- a/synfig-studio/src/gui/states/state_width.h
+++ b/synfig-studio/src/gui/states/state_width.h
@@ -45,6 +45,7 @@ class StateWidth : public Smach::state<StateWidth_Context>
 public:
 	StateWidth();
 	~StateWidth();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateWidth
 
 extern StateWidth state_width;

--- a/synfig-studio/src/gui/states/state_zoom.cpp
+++ b/synfig-studio/src/gui/states/state_zoom.cpp
@@ -112,6 +112,11 @@ StateZoom::~StateZoom()
 {
 }
 
+void* StateZoom::enter_state(studio::CanvasView* machine_context) const
+{
+	return new StateZoom_Context(machine_context);
+}
+
 StateZoom_Context::StateZoom_Context(CanvasView* canvas_view):
 	canvas_view_(canvas_view),
 	is_working(*canvas_view),

--- a/synfig-studio/src/gui/states/state_zoom.h
+++ b/synfig-studio/src/gui/states/state_zoom.h
@@ -44,6 +44,7 @@ class StateZoom : public Smach::state<StateZoom_Context>
 public:
 	StateZoom();
 	~StateZoom();
+	virtual void* enter_state(studio::CanvasView* machine_context) const;
 }; // END of class StateZoom
 
 extern StateZoom state_zoom;


### PR DESCRIPTION
This part compiles differently in gcc/clang and MSVC compilers. Since the behavior of the compiler is not specified for virtual methods (C++11 standard says: § 14.7.1.10. "It is unspecified whether or not an implementation implicitly instantiates a virtual member function of a class template if the virtual member function would not otherwise be instantiated").

Unlike GCC/Clang, MSVC expects the template class to be fully defined at the moment, so this code does not compile. Therefore, we move the `enter_state` method to derived classes.

Minimal working example:
```
template <class T>
class A {
  virtual void* Run() {
    return new T();
  }
};

class C;

class B : A<C> {
  
};
```

MSVC fails with the error:
```
<source>(4): error C2027: use of undefined type 'C'
<source>(8): note: see declaration of 'C'
<source>(3): note: while compiling class template member function 'void *A<C>::Run(void)'
<source>(10): note: see reference to class template instantiation 'A<C>' being compiled
Compiler returned: 2
```

This code can be tested online at https://godbolt.org