### PR TITLE
activate widget_filename when user chooses file via button/file dialog

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_filename.cpp
+++ b/synfig-studio/src/gui/widgets/widget_filename.cpp
@@ -151,6 +151,7 @@ Widget_Filename::on_button_choose_pressed()
 	{
 		filename = synfig::CanvasFileNaming::make_short_filename(canvas->get_file_name(), filename);
 		entry_filename->set_text(filename);
+		entry_filename->activate();
 	}
 }
 


### PR DESCRIPTION
otherwise the parameter value change is only propagated when widget looses focus or user explicitly activates (by pressing Enter/Return).

If it's a Sound layer, clicking on Play button right after choose a file (and the edit-widget not yet loosing focus), it would play the previous audio.