### PR TITLE
fix crashing when removing spline point too fast

### DIFF
--- a/synfig-studio/src/gui/trees/layerparamtreestore.cpp
+++ b/synfig-studio/src/gui/trees/layerparamtreestore.cpp
@@ -582,8 +582,10 @@ LayerParamTreeStore::on_value_node_child_removed(synfig::ValueNode::Handle value
 		return false;
 	});
 
-	erase(iter_to_remove);
-	rebuild();
+	if (iter_to_remove) {
+		erase(iter_to_remove);
+		rebuild();
+	}
 }
 
 void


### PR DESCRIPTION
repetitive quick undo/redo after insert-item-smart could be fatal