### PR TITLE
try to catch all exceptions thrown in GTK event callback/handlers

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -136,6 +136,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -1993,15 +1995,18 @@ CanvasView::create_tab_label()
 bool
 CanvasView::on_button_press_event(GdkEventButton * /* event */)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (this != App::get_selected_canvas_view())
 		App::set_selected_canvas_view(this);
 	return false;
 	//return Dockable::on_button_press_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 CanvasView::on_key_press_event(GdkEventKey* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	Gtk::Widget* focused_widget = App::main_window->get_focus();
 	if(focused_widget && focused_widget_has_priority(focused_widget))
 	{
@@ -2029,6 +2034,7 @@ CanvasView::on_key_press_event(GdkEventKey* event)
 		}
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_time.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_time.cpp
@@ -40,6 +40,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -108,6 +110,7 @@ CellRenderer_Time::start_editing_vfunc(
 	const Gdk::Rectangle& cell_area,
 	Gtk::CellRendererState flags)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	// If we aren't editable, then there is nothing to do
 	if(!property_editable())
 		return 0;
@@ -125,4 +128,5 @@ CellRenderer_Time::start_editing_vfunc(
 #else
 	return CellRendererText::start_editing_vfunc(event,widget,path,background_area,cell_area,flags);
 #endif
+	SYNFIG_EXCEPTION_GUARD_END_NULL(nullptr)
 }

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
@@ -47,6 +47,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #include "gui/waypointrenderer.h"
 
 #endif
@@ -482,6 +484,7 @@ CellRenderer_TimeTrack::activate_vfunc(
 	const Gdk::Rectangle& cell_area,
 	Gtk::CellRendererState /*flags*/)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	// Catch a null event received us a result of a keypress (only?)
 	if (!event)
 		return true; // On tab key press, Focus go to next panel. If return false, focus goes to canvas
@@ -658,4 +661,5 @@ CellRenderer_TimeTrack::activate_vfunc(
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.h
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.h
@@ -136,6 +136,7 @@ public:
 	bool is_selected(const synfig::Waypoint &waypoint) const
 		{ return selected == waypoint; }
 
+protected:
 	virtual void render_vfunc(
 		const ::Cairo::RefPtr< ::Cairo::Context>& cr,
 		Gtk::Widget& widget,

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -55,6 +55,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 using namespace synfig;
@@ -121,6 +123,7 @@ public:
 
 	void start_editing_vfunc(GdkEvent *event)
 	{
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		valuewidget->signal_activate().connect(sigc::mem_fun(*this,
 			&studio::ValueBase_Entry::editing_done));
 
@@ -150,10 +153,12 @@ public:
 		show();
 		//valuewidget->grab_focus();
 		//get_window()->set_focus(*valuewidget);
+		SYNFIG_EXCEPTION_GUARD_END()
 	}
 
 	bool on_event(GdkEvent *event)
 	{
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if (event->any.type == GDK_BUTTON_PRESS
 		 || event->any.type == GDK_2BUTTON_PRESS
 		 || event->any.type == GDK_KEY_PRESS
@@ -162,6 +167,7 @@ public:
 		 || event->any.type == GDK_3BUTTON_PRESS )
 			return true;
 		return Gtk::EventBox::on_event(event);
+		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 	}
 
 	void on_grab_focus()
@@ -568,6 +574,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 	const Gdk::Rectangle&  /*cell_area*/,
 	Gtk::CellRendererState /*flags*/)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	edit_value_done_called = false;
 	// If we aren't editable, then there is nothing to do
 	if (!property_editable())
@@ -649,6 +656,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 	}
 
 	return nullptr;
+	SYNFIG_EXCEPTION_GUARD_END_NULL(nullptr)
 }
 
 void

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
@@ -91,6 +91,7 @@ public:
 
 	void on_value_editing_done();
 
+protected:
 	virtual void
 	render_vfunc(
 		const ::Cairo::RefPtr< ::Cairo::Context>& cr,

--- a/synfig-studio/src/gui/dialogs/dialog_preview.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_preview.cpp
@@ -39,6 +39,8 @@
 #include <gui/widgets/widget_time.h>
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #include "gui/resourcehelper.h"
 #include <glibmm/fileutils.h>
 #include <glibmm/markup.h>
@@ -108,6 +110,7 @@ void Dialog_Preview::on_hide()
 //press escape key to close window
 bool Dialog_Preview::on_key_pressed(GdkEventKey *ev)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (ev->keyval == gdk_keyval_from_name("Escape") )
 	{
 		close_window_handler();
@@ -115,6 +118,7 @@ bool Dialog_Preview::on_key_pressed(GdkEventKey *ev)
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void Dialog_Preview::close_window_handler()

--- a/synfig-studio/src/gui/dials/zoomdial.cpp
+++ b/synfig-studio/src/gui/dials/zoomdial.cpp
@@ -40,6 +40,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -89,13 +91,16 @@ ZoomDial::ZoomDial(Gtk::IconSize & size):
 void
 ZoomDial::after_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (event->type == GDK_BUTTON_RELEASE)
 		current_zoom->select_region(0, current_zoom->get_text_length()-1);
+	SYNFIG_EXCEPTION_GUARD_END()
 }
 
 bool
 ZoomDial::current_zoom_event(GdkEvent* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (event->type == GDK_SCROLL)
 	{
 		if(event->scroll.direction==GDK_SCROLL_DOWN || event->scroll.direction==GDK_SCROLL_LEFT)
@@ -106,6 +111,7 @@ ZoomDial::current_zoom_event(GdkEvent* event)
 		return true;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 

--- a/synfig-studio/src/gui/docks/dock_history.cpp
+++ b/synfig-studio/src/gui/docks/dock_history.cpp
@@ -43,6 +43,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -396,6 +398,7 @@ Dock_History::delete_instance(etl::handle<studio::Instance> instance)
 bool
 Dock_History::on_action_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	studio::HistoryTreeStore::Model model;
     switch(event->type)
     {
@@ -446,6 +449,7 @@ Dock_History::on_action_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void

--- a/synfig-studio/src/gui/docks/dock_history.h
+++ b/synfig-studio/src/gui/docks/dock_history.h
@@ -71,15 +71,15 @@ public:
 	void clear_redo();
 	void clear_undo_and_redo();
 
-	bool on_action_event(GdkEvent *event);
-	void on_action_toggle(const Glib::ustring& path);
-
 	void update_undo_redo();
 
 	Dock_History();
 	~Dock_History();
 protected:
 	virtual void init_instance_vfunc(etl::loose_handle<Instance> instance);
+
+	bool on_action_event(GdkEvent *event);
+	void on_action_toggle(const Glib::ustring& path);
 
 }; // END of Dock_History
 

--- a/synfig-studio/src/gui/docks/dock_layers.cpp
+++ b/synfig-studio/src/gui/docks/dock_layers.cpp
@@ -46,6 +46,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -210,11 +212,13 @@ Dock_Layers::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 		)
 	);
 	layer_tree->signal_no_layer_user_click().connect([=](GdkEventButton *ev){
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if (ev->button == 3 && action_new_layer->is_sensitive()) {
 			popup_add_layer_menu();
 			return true;
 		}
 		return false;
+		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 	});
 
 	// (a) should be before (b), (b) should be before (c)

--- a/synfig-studio/src/gui/docks/dock_navigator.cpp
+++ b/synfig-studio/src/gui/docks/dock_navigator.cpp
@@ -47,6 +47,8 @@
 
 #include "dock_navigator.h"
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -257,6 +259,7 @@ Widget_NavView::on_rendering_tile_finished(synfig::Time time)
 bool
 studio::Widget_NavView::on_mouse_event(GdkEvent * e)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	int dw = drawto.get_width();
 	int dh = drawto.get_height();
 
@@ -290,6 +293,7 @@ studio::Widget_NavView::on_mouse_event(GdkEvent * e)
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 

--- a/synfig-studio/src/gui/docks/dock_timetrack.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack.cpp
@@ -52,6 +52,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -157,6 +159,7 @@ public:
 	bool
 	on_event(GdkEvent *event)
 	{
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		switch(event->type)
 		{
 		case GDK_2BUTTON_PRESS:
@@ -256,6 +259,7 @@ public:
 			break;
 		}
 		return Gtk::TreeView::on_event(event);
+		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 	}
 
 	void set_model(Glib::RefPtr<LayerParamTreeStore> store)

--- a/synfig-studio/src/gui/docks/dockbook.cpp
+++ b/synfig-studio/src/gui/docks/dockbook.cpp
@@ -46,6 +46,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #include "canvasview.h"
 
 #endif
@@ -264,6 +266,7 @@ DockBook::set_contents(const synfig::String& x)
 bool
 DockBook::tab_button_pressed(GdkEventButton* event, Dockable* dockable)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	CanvasView *canvas_view = dynamic_cast<CanvasView*>(dockable);
 	if (canvas_view && canvas_view != App::get_selected_canvas_view())
 		App::set_selected_canvas_view(canvas_view);
@@ -283,6 +286,7 @@ DockBook::tab_button_pressed(GdkEventButton* event, Dockable* dockable)
 	tabmenu->popup(event->button,gtk_get_current_event_time());
 
 	return true;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void

--- a/synfig-studio/src/gui/docks/dockbook.h
+++ b/synfig-studio/src/gui/docks/dockbook.h
@@ -79,6 +79,7 @@ public:
 
 	void refresh_tab(Dockable*);
 
+protected:
 	bool tab_button_pressed(GdkEventButton* event, Dockable* dockable);
 	void on_drag_data_received(const Glib::RefPtr<Gdk::DragContext>& context, int, int, const Gtk::SelectionData& selection_data, guint, guint time);
 	//! Override the default handler of the signal Gtk::Notebook::signal_switch_page().

--- a/synfig-studio/src/gui/docks/dockdialog.cpp
+++ b/synfig-studio/src/gui/docks/dockdialog.cpp
@@ -47,6 +47,7 @@
 #include <synfigapp/main.h>
 
 #include <gui/localization.h>
+#include <gui/exception_guard.h>
 
 #endif
 
@@ -140,6 +141,7 @@ DockDialog::~DockDialog()
 bool
 DockDialog::on_delete_event(GdkEventAny * /* event */)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	for(std::list<Dockable*>::iterator i = App::dock_manager->dockable_list_.begin(); i != App::dock_manager->dockable_list_.end(); i++)
 	{
 		if ((*i)->get_parent_window() == get_window())
@@ -153,6 +155,7 @@ DockDialog::on_delete_event(GdkEventAny * /* event */)
 	}
 	delete this;
 	return true;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool

--- a/synfig-studio/src/gui/exception_guard.h
+++ b/synfig-studio/src/gui/exception_guard.h
@@ -4,6 +4,13 @@
 #include <ETL/stringf>
 #include <synfig/general.h> // for synfig::error()
 
+#ifdef _WIN32
+# ifndef __PRETTY_FUNCTION__
+#  define SYNFIG_DEFINED_PRETTY_FUNCTION_
+#  define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif
+#endif
+
 #define SYNFIG_EXCEPTION_GUARD_BEGIN() \
 	{ \
 		int _exception_guard_error_code = 0; \
@@ -15,27 +22,27 @@
 		} \
 		catch(int ret) \
 		{ \
-			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:int: %i", __FUNCTION__, ret); \
+			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:int: %i", __PRETTY_FUNCTION__, ret); \
 			_exception_guard_error_code = ret; \
 		} \
 		catch(std::string& str) \
 		{ \
-			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:string: %s", __FUNCTION__, str.c_str()); \
+			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:string: %s", __PRETTY_FUNCTION__, str.c_str()); \
 			_exception_guard_error_code = 1001; \
 		} \
 		catch(std::exception& x) \
 		{ \
-			_exception_guard_error_str = etl::strprintf("%s Standard Exception: %s", __FUNCTION__, x.what()); \
+			_exception_guard_error_str = etl::strprintf("%s Standard Exception: %s", __PRETTY_FUNCTION__, x.what()); \
 			_exception_guard_error_code = 1002; \
 		} \
 		catch(Glib::Exception& x) \
 		{ \
-			_exception_guard_error_str = etl::strprintf("%s GLib Exception: %s", __FUNCTION__, x.what().c_str()); \
+			_exception_guard_error_str = etl::strprintf("%s GLib Exception: %s", __PRETTY_FUNCTION__, x.what().c_str()); \
 			_exception_guard_error_code = 1003; \
 		} \
 		catch(...) \
 		{ \
-			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:unknown type", __FUNCTION__); \
+			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:unknown type", __PRETTY_FUNCTION__); \
 			_exception_guard_error_code = 1100; \
 		}
 
@@ -82,5 +89,10 @@
 			return success_value; \
 		} \
 	}
+
+#ifdef SYNFIG_DEFINED_PRETTY_FUNCTION_
+#undef __PRETTY_FUNCTION__
+#undef SYNFIG_UNDEF_PRETTY_FUNCTION_
+#endif
 
 #endif // SYNFIG_EXCEPTION_GUARD_H

--- a/synfig-studio/src/gui/exception_guard.h
+++ b/synfig-studio/src/gui/exception_guard.h
@@ -1,0 +1,86 @@
+#ifndef SYNFIG_EXCEPTION_GUARD_H
+#define SYNFIG_EXCEPTION_GUARD_H
+
+#include <ETL/stringf>
+#include <synfig/general.h> // for synfig::error()
+
+#define SYNFIG_EXCEPTION_GUARD_BEGIN() \
+	{ \
+		int _exception_guard_error_code = 0; \
+		std::string _exception_guard_error_str; \
+		try {
+
+/// Normally, you shouldn't use this macro directly
+#define SYNFIG_EXCEPTION_GUARD_END_COMMON \
+		} \
+		catch(int ret) \
+		{ \
+			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:int: %i", __FUNCTION__, ret); \
+			_exception_guard_error_code = ret; \
+		} \
+		catch(std::string& str) \
+		{ \
+			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:string: %s", __FUNCTION__, str.c_str()); \
+			_exception_guard_error_code = 1001; \
+		} \
+		catch(std::exception& x) \
+		{ \
+			_exception_guard_error_str = etl::strprintf("%s Standard Exception: %s", __FUNCTION__, x.what()); \
+			_exception_guard_error_code = 1002; \
+		} \
+		catch(Glib::Exception& x) \
+		{ \
+			_exception_guard_error_str = etl::strprintf("%s GLib Exception: %s", __FUNCTION__, x.what().c_str()); \
+			_exception_guard_error_code = 1003; \
+		} \
+		catch(...) \
+		{ \
+			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:unknown type", __FUNCTION__); \
+			_exception_guard_error_code = 1100; \
+		}
+
+/// It should return (void), no matter what happens
+#define SYNFIG_EXCEPTION_GUARD_END() \
+	SYNFIG_EXCEPTION_GUARD_END_COMMON \
+		if (!_exception_guard_error_str.empty()) { \
+			synfig::error("%s", _exception_guard_error_str.c_str()); \
+			return; \
+		} else { \
+			return; \
+		} \
+	}
+
+/// It should return a boolean. On success, return success_value; inverse value otherwise
+#define SYNFIG_EXCEPTION_GUARD_END_BOOL(success_value) \
+	SYNFIG_EXCEPTION_GUARD_END_COMMON \
+		if (!_exception_guard_error_str.empty()) { \
+			synfig::error("%s", _exception_guard_error_str.c_str()); \
+			return !success_value; \
+		} else { \
+			return success_value; \
+		} \
+	}
+
+/// It should return an integer. On success, return success_value; internal code otherwise
+#define SYNFIG_EXCEPTION_GUARD_END_INT(success_value) \
+	SYNFIG_EXCEPTION_GUARD_END_COMMON \
+		if (!_exception_guard_error_str.empty()) { \
+			synfig::error("%s", _exception_guard_error_str.c_str()); \
+			return _exception_guard_error_code; \
+		} else { \
+			return success_value; \
+		} \
+	}
+
+/// It should return a pointer. On success, return success_value; nullptr otherwise
+#define SYNFIG_EXCEPTION_GUARD_END_NULL(success_value) \
+	SYNFIG_EXCEPTION_GUARD_END_COMMON \
+		if (!_exception_guard_error_str.empty()) { \
+			synfig::error("%s", _exception_guard_error_str.c_str()); \
+			return nullptr; \
+		} else { \
+			return success_value; \
+		} \
+	}
+
+#endif // SYNFIG_EXCEPTION_GUARD_H

--- a/synfig-studio/src/gui/main.cpp
+++ b/synfig-studio/src/gui/main.cpp
@@ -44,6 +44,8 @@
 #include "main_win32.h"
 #endif
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -118,39 +120,12 @@ int main(int argc, char **argv)
 	cout << endl;
 	cout << "   " << _("synfig studio -- starting up application...") << endl << endl;
 
-	try
-	{
-		studio::App app(etl::dirname(binary_path), &argc, &argv);
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
+	studio::App app(etl::dirname(binary_path), &argc, &argv);
 
-		app.run();
-	}
-	catch(int ret)
-	{
-		std::cerr<<"Application shutdown with errors ("<<ret<<')'<<std::endl;
-		return ret;
-	}
-	catch(string& str)
-	{
-		std::cerr<<"Uncaught Exception:string: "<<str.c_str()<<std::endl;
-		throw;
-	}
-	catch(std::exception& x)
-	{
-		std::cerr<<"Standard Exception: "<<x.what()<<std::endl;
-		throw;
-	}
-	catch(Glib::Exception& x)
-	{
-		std::cerr<<"GLib Exception: "<<x.what()<<std::endl;
-		throw;
-	}
-	catch(...)
-	{
-		std::cerr<<"Uncaught Exception"<<std::endl;
-		throw;
-	}
-
+	app.run();
 	std::cerr<<"Application appears to have terminated successfully"<<std::endl;
 
 	return 0;
+	SYNFIG_EXCEPTION_GUARD_END_INT(0)
 }

--- a/synfig-studio/src/gui/mainwindow.cpp
+++ b/synfig-studio/src/gui/mainwindow.cpp
@@ -48,6 +48,8 @@
 #include "gui/widgets/widget_time.h"
 #include "gui/widgets/widget_vector.h"
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -283,6 +285,7 @@ void MainWindow::remove_custom_workspace_menu_item_handlers()
 bool
 MainWindow::on_key_press_event(GdkEventKey* key_event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	Gtk::Widget * widget = get_focus();
 	if (widget && (dynamic_cast<Gtk::Editable*>(widget) || dynamic_cast<Gtk::TextView*>(widget) || dynamic_cast<Gtk::DrawingArea*>(widget))) {
 		bool handled = gtk_window_propagate_key_event(this->gobj(), key_event);
@@ -290,6 +293,7 @@ MainWindow::on_key_press_event(GdkEventKey* key_event)
 			return true;
 	}
 	return Gtk::Window::on_key_press_event(key_event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -61,6 +61,8 @@
 #include <cairomm/context.h>
 #include <cairomm/enums.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -1029,6 +1031,7 @@ void studio::Widget_Preview::seek_frame(int frames)
 
 bool studio::Widget_Preview::scroll_move_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	switch(event->type)
 	{
 		case GDK_BUTTON_PRESS:
@@ -1044,6 +1047,7 @@ bool studio::Widget_Preview::scroll_move_event(GdkEvent *event)
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 synfig::Time studio::Widget_Preview::get_position() const
@@ -1150,6 +1154,7 @@ void Widget_Preview::show_toolbar()
 //shortcut keys TODO: customizable shortcut keys would be awesome.
 bool studio::Widget_Preview::on_key_pressed(GdkEventKey *ev)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	//hide and show toolbar
 	if (ev->keyval == gdk_keyval_from_name("h"))
 	{
@@ -1240,6 +1245,7 @@ bool studio::Widget_Preview::on_key_pressed(GdkEventKey *ev)
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool

--- a/synfig-studio/src/gui/selectdraghelper.h
+++ b/synfig-studio/src/gui/selectdraghelper.h
@@ -33,6 +33,8 @@
 #include <synfigapp/canvasinterface.h>
 #include "app.h"
 
+#include <gui/exception_guard.h>
+
 namespace synfigapp {
 namespace Action {
 class PassiveGrouper;
@@ -349,6 +351,7 @@ template <class T>
 bool
 SelectDragHelper<T>::process_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	switch(event->type) {
 	case GDK_SCROLL:
 		return process_scroll_event(&event->scroll);
@@ -369,6 +372,7 @@ SelectDragHelper<T>::process_event(GdkEvent *event)
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 template<class T>

--- a/synfig-studio/src/gui/states/state_mirror.cpp
+++ b/synfig-studio/src/gui/states/state_mirror.cpp
@@ -55,6 +55,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -209,6 +211,7 @@ StateMirror_Context::StateMirror_Context(CanvasView* canvas_view):
 bool
 StateMirror_Context::key_press_event(GdkEventKey *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (event->keyval==GDK_KEY_Shift_L || event->keyval==GDK_KEY_Shift_R)
 	{
 		if (shift_is_pressed) return false;
@@ -218,11 +221,13 @@ StateMirror_Context::key_press_event(GdkEventKey *event)
 	}
 
 	return false; //Pass on the event to other handlers, just in case
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 StateMirror_Context::key_release_event(GdkEventKey *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (event->keyval==GDK_KEY_Shift_L || event->keyval==GDK_KEY_Shift_R )
 	{
 		if (!shift_is_pressed) return false;
@@ -232,6 +237,7 @@ StateMirror_Context::key_release_event(GdkEventKey *event)
 	}
 
 	return false; //Pass on the event to other handlers, just in case
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void

--- a/synfig-studio/src/gui/trees/childrentree.cpp
+++ b/synfig-studio/src/gui/trees/childrentree.cpp
@@ -42,6 +42,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -242,6 +244,7 @@ ChildrenTree::on_waypoint_clicked_childrentree(const etl::handle<synfig::Node>& 
 bool
 ChildrenTree::on_tree_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
     switch(event->type)
     {
 	case GDK_BUTTON_PRESS:
@@ -343,6 +346,7 @@ ChildrenTree::on_tree_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool

--- a/synfig-studio/src/gui/trees/keyframetree.cpp
+++ b/synfig-studio/src/gui/trees/keyframetree.cpp
@@ -41,6 +41,7 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
 #endif
 
 /* === U S I N G =========================================================== */
@@ -262,6 +263,7 @@ KeyframeTree::on_edited_description(const Glib::ustring&path_string,const Glib::
 bool
 KeyframeTree::on_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
     switch(event->type)
     {
 	case GDK_KEY_PRESS:
@@ -332,6 +334,7 @@ KeyframeTree::on_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void

--- a/synfig-studio/src/gui/trees/keyframetree.h
+++ b/synfig-studio/src/gui/trees/keyframetree.h
@@ -117,7 +117,7 @@ private:
 
 	void on_edited_description(const Glib::ustring&path_string,const Glib::ustring &description);
 
-	bool on_event(GdkEvent *event);
+	virtual bool on_event(GdkEvent *event);
 
 	void on_rend_desc_changed();
 

--- a/synfig-studio/src/gui/trees/layergrouptree.cpp
+++ b/synfig-studio/src/gui/trees/layergrouptree.cpp
@@ -38,6 +38,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -202,6 +204,7 @@ LayerGroupTree::on_edited_description(const Glib::ustring&path_string,const Glib
 bool
 LayerGroupTree::on_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
     switch(event->type)
     {
 	case GDK_BUTTON_PRESS:
@@ -265,7 +268,7 @@ LayerGroupTree::on_event(GdkEvent *event)
 		break;
 	}
 	return Gtk::TreeView::on_event(event);
-	//return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 

--- a/synfig-studio/src/gui/trees/layergrouptree.h
+++ b/synfig-studio/src/gui/trees/layergrouptree.h
@@ -88,7 +88,7 @@ private:
 
 private:
 
-	bool on_event(GdkEvent *event);
+	virtual bool on_event(GdkEvent *event);
 	void on_toggle(const Glib::ustring& path_string);
 	void on_layer_renamed(const Glib::ustring&path_string,const Glib::ustring& value);
 

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -53,6 +53,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -74,9 +76,9 @@ using namespace studio;
 	Return true if we process event,
 	False to pass it
 */
-bool LayerTree::onKeyPress(GdkEventKey* event)
+bool LayerTree::on_key_press_event(GdkEventKey* event)
 {
-
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	switch (event->keyval) {
 		case GDK_KEY_Delete: {
 			LayerList layers = get_selected_layers();
@@ -117,13 +119,14 @@ bool LayerTree::onKeyPress(GdkEventKey* event)
 	}
 
     return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 
 LayerTree::LayerTree():
 	layer_amount_adjustment_(Gtk::Adjustment::create(1,0,1,0.01,0.01,0))
 {
-	layer_tree_view().signal_key_press_event().connect(sigc::mem_fun(*this, &LayerTree::onKeyPress));
+	layer_tree_view().signal_key_press_event().connect(sigc::mem_fun(*this, &LayerTree::on_key_press_event));
 
 	create_layer_tree();
 	create_param_tree();
@@ -838,6 +841,7 @@ LayerTree::on_waypoint_clicked_layertree(const etl::handle<synfig::Node>& node,
 bool
 LayerTree::on_layer_tree_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
     switch(event->type)
     {
 	case GDK_BUTTON_PRESS:
@@ -911,11 +915,13 @@ LayerTree::on_layer_tree_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 LayerTree::on_param_tree_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
     switch(event->type)
     {
 	case GDK_BUTTON_PRESS:
@@ -1058,6 +1064,7 @@ LayerTree::on_param_tree_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 

--- a/synfig-studio/src/gui/trees/layertree.h
+++ b/synfig-studio/src/gui/trees/layertree.h
@@ -253,7 +253,7 @@ public:
 private:
 	void get_expanded_layers(LayerList &list, const Gtk::TreeNodeChildren &rows)const;
 
-	bool onKeyPress(GdkEventKey* event);
+	bool on_key_press_event(GdkEventKey* event);
 
 }; // END of LayerTree
 

--- a/synfig-studio/src/gui/widgets/widget_canvastimeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_canvastimeslider.cpp
@@ -39,6 +39,8 @@
 
 #include "gui/timeplotdata.h"
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -160,6 +162,7 @@ Widget_CanvasTimeslider::show_tooltip(const synfig::Point &p, const synfig::Poin
 bool
 Widget_CanvasTimeslider::on_button_press_event(GdkEventButton *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (event->button == 1 && canvas_view && canvas_view->get_work_area()) {
 		lock_ducks = new LockDucks(etl::handle<CanvasView>(canvas_view));
 		canvas_view->get_work_area()->clear_ducks();
@@ -172,32 +175,39 @@ Widget_CanvasTimeslider::on_button_press_event(GdkEventButton *event)
 	if (event->button == 1 || event->button == 2)
 		tooltip.hide();
 	return Widget_Timeslider::on_button_press_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_CanvasTimeslider::on_button_release_event(GdkEventButton *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (event->button == 1 && canvas_view)
 		lock_ducks.reset();
 	//if ( (event->button == 1 && !(event->state & Gdk::BUTTON2_MASK))
 	//  || (event->button == 2 && !(event->state & Gdk::BUTTON1_MASK)) )
 	//	show_tooltip(Point(event->x, event->y), Point(event->x_root, event->y_root));
 	return Widget_Timeslider::on_button_release_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_CanvasTimeslider::on_motion_notify_event(GdkEventMotion* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if ((event->state & (Gdk::BUTTON1_MASK | Gdk::BUTTON2_MASK)) == 0)
 		show_tooltip(Point(event->x, event->y), Point(event->x_root, event->y_root));
 	return Widget_Timeslider::on_motion_notify_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_CanvasTimeslider::on_leave_notify_event(GdkEventCrossing*)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	tooltip.hide();
 	return true;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool

--- a/synfig-studio/src/gui/widgets/widget_color.cpp
+++ b/synfig-studio/src/gui/widgets/widget_color.cpp
@@ -42,6 +42,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -158,6 +160,7 @@ Widget_Color::get_value() const
 bool
 Widget_Color::on_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	switch(event->type)
 	{
 	case GDK_BUTTON_PRESS:
@@ -182,6 +185,7 @@ Widget_Color::on_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -44,6 +44,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -247,6 +249,7 @@ ColorSlider::on_draw(const Cairo::RefPtr<Cairo::Context> &cr)
 bool
 ColorSlider::on_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	const int width(get_width());
 	float x = 0;
 	if( GDK_SCROLL == event->type ){
@@ -308,6 +311,7 @@ ColorSlider::on_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 /* === M E T H O D S ======================================================= */
@@ -532,8 +536,10 @@ Widget_ColorEdit::on_hex_edited()
 bool
 Widget_ColorEdit::on_hex_focus_out(GdkEventFocus* /*event*/)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	on_hex_edited();
 	return true;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void

--- a/synfig-studio/src/gui/widgets/widget_coloredit.h
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.h
@@ -165,15 +165,15 @@ protected:
 
 	void on_value_changed();
 
+	void on_slider_moved(ColorSlider::Type type, float amount);
+	void on_hex_edited();
+	bool on_hex_focus_out(GdkEventFocus* event);
+
 public:
 
 	sigc::signal<void>& signal_activated() { return signal_activated_; }
 
 	sigc::signal<void>& signal_activate() { return signal_activated_; }
-
-	void on_slider_moved(ColorSlider::Type type, float amount);
-	void on_hex_edited();
-	bool on_hex_focus_out(GdkEventFocus* event);
 
 	//Glib::SignalProxy0<void> signal_activate() { return spinbutton_A->signal_activate(); }
 

--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -59,6 +59,7 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
 #endif
 
 /* === U S I N G =========================================================== */
@@ -594,6 +595,7 @@ Widget_Curves::set_value_descs(etl::handle<synfigapp::CanvasInterface> canvas_in
 bool
 Widget_Curves::on_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (channel_point_sd.process_event(event))
 		return true;
 
@@ -619,6 +621,7 @@ Widget_Curves::on_event(GdkEvent *event)
 	}
 
 	return Widget_TimeGraphBase::on_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool

--- a/synfig-studio/src/gui/widgets/widget_defaults.cpp
+++ b/synfig-studio/src/gui/widgets/widget_defaults.cpp
@@ -52,6 +52,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -115,6 +117,7 @@ public:
 	bool
 	on_event(GdkEvent *event)
 	{
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		const int y(static_cast<int>(event->button.y));
 
 		const int h(get_height());
@@ -170,6 +173,8 @@ public:
 		}
 
 		return false;
+
+		SYNFIG_EXCEPTION_GUARD_END_BOOL(false)
 	}
 
 };

--- a/synfig-studio/src/gui/widgets/widget_distance.cpp
+++ b/synfig-studio/src/gui/widgets/widget_distance.cpp
@@ -38,6 +38,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -89,13 +91,17 @@ Widget_Distance::on_output()
 bool
 Widget_Distance::on_key_press_event(GdkEventKey* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	return SpinButton::on_key_press_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_Distance::on_key_release_event(GdkEventKey* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	return SpinButton::on_key_release_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 

--- a/synfig-studio/src/gui/widgets/widget_distance.h
+++ b/synfig-studio/src/gui/widgets/widget_distance.h
@@ -55,10 +55,11 @@ protected:
 	int	on_input(double* new_value);
 	bool on_output();
 
-public:
-	//sigc::signal<void> &signal_value_changed() { return signal_value_changed_; }
 	bool on_key_press_event(GdkEventKey* event);
 	bool on_key_release_event(GdkEventKey* event);
+
+public:
+	//sigc::signal<void> &signal_value_changed() { return signal_value_changed_; }
 	void set_value(const synfig::Distance &data);
 	synfig::Distance get_value()const;
 	Widget_Distance();

--- a/synfig-studio/src/gui/widgets/widget_gradient.cpp
+++ b/synfig-studio/src/gui/widgets/widget_gradient.cpp
@@ -40,6 +40,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -263,6 +265,7 @@ Widget_Gradient::update_cpoint(const synfig::Gradient::CPoint &x)
 bool
 Widget_Gradient::on_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	//if(editable_)
 	{
 		const int x(static_cast<int>(event->button.x));
@@ -350,4 +353,5 @@ Widget_Gradient::on_event(GdkEvent *event)
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }

--- a/synfig-studio/src/gui/widgets/widget_gradient.h
+++ b/synfig-studio/src/gui/widgets/widget_gradient.h
@@ -88,8 +88,7 @@ public:
 
 	void update_cpoint(const synfig::Gradient::CPoint &x);
 
-
-
+protected:
 	bool on_draw(const ::Cairo::RefPtr< ::Cairo::Context>& cr);
 
 	bool on_event(GdkEvent *event);

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -38,7 +38,7 @@
 #include <gui/app.h>
 #include "widget_keyframe_list.h"
 #include <gui/localization.h>
-
+#include <gui/exception_guard.h>
 #endif
 
 /* === U S I N G =========================================================== */
@@ -297,6 +297,7 @@ Widget_Keyframe_List::perform_move_kf(bool delta)
 bool
 Widget_Keyframe_List::on_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (!time_model || get_width() <= 0 || !kf_list || !editable)
 		return false;
 
@@ -439,6 +440,7 @@ Widget_Keyframe_List::on_event(GdkEvent *event)
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.h
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.h
@@ -135,6 +135,7 @@ public:
 		bool fill,
 		const synfig::Color &color );
 
+protected:
 	// Events handlers
 	bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr);
 	bool on_event(GdkEvent *event);

--- a/synfig-studio/src/gui/widgets/widget_soundwave.cpp
+++ b/synfig-studio/src/gui/widgets/widget_soundwave.cpp
@@ -41,6 +41,8 @@
 #include <gdkmm.h>
 #include <glibmm/convert.h>
 #include <cstring>
+
+#include <gui/exception_guard.h>
 #endif
 
 using namespace studio;
@@ -147,9 +149,11 @@ const synfig::Time& Widget_SoundWave::get_delay() const
 
 bool Widget_SoundWave::on_event(GdkEvent* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (mouse_handler.process_event(event))
 		return true;
 	return Widget_TimeGraphBase::on_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool Widget_SoundWave::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)

--- a/synfig-studio/src/gui/widgets/widget_time.cpp
+++ b/synfig-studio/src/gui/widgets/widget_time.cpp
@@ -36,6 +36,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -134,6 +136,7 @@ Widget_Time::refresh_value()
 bool
 Widget_Time::on_event(GdkEvent* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	const Time scroll_amount(0.25);
 
 	switch(event->type)
@@ -164,24 +167,29 @@ Widget_Time::on_event(GdkEvent* event)
 	}
 
 	return Gtk::Entry::on_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_Time::on_focus_out_event(GdkEventFocus* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	refresh_value();
 	refresh_text();
 	return Gtk::Entry::on_focus_out_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_Time::on_focus_in_event(GdkEventFocus* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	// if defined, show the full time format "0h 0m 5s 0f" when the time widget gets focus
 	if (getenv("SYNFIG_SHOW_FULL_TIME_ON_FOCUS"))
 		set_text(time_.get_string(fps_,App::get_time_format()|Time::FORMAT_FULL));
 
 	return Gtk::Entry::on_focus_in_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 GType Widget_Time::gtype = 0;

--- a/synfig-studio/src/gui/widgets/widget_timeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.cpp
@@ -48,6 +48,8 @@
 
 #include "gui/timeplotdata.h"
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -213,8 +215,10 @@ Widget_Timeslider::draw_background(const Cairo::RefPtr<Cairo::Context> &cr)
 
 bool Widget_Timeslider::on_configure_event(GdkEventConfigure* configure)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	time_plot_data->set_extra_time_margin(configure->height);
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
@@ -343,6 +347,7 @@ Widget_Timeslider::on_draw(const Cairo::RefPtr<Cairo::Context> &cr)
 bool
 Widget_Timeslider::on_button_press_event(GdkEventButton *event) //for clicking
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	lastx = (double)event->x;
 
 	if (!time_plot_data->time_model || get_width() <= 0 || get_height() <= 0)
@@ -354,17 +359,21 @@ Widget_Timeslider::on_button_press_event(GdkEventButton *event) //for clicking
 	}
 
 	return event->button == 1 || event->button == 2;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_Timeslider::on_button_release_event(GdkEventButton *event){
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	lastx = (double)event->x;
 	return event->button == 1 || event->button == 2;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_Timeslider::on_motion_notify_event(GdkEventMotion* event) //for dragging
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	double dx = (double)event->x - lastx;
 	lastx = (double)event->x;
 
@@ -386,11 +395,13 @@ Widget_Timeslider::on_motion_notify_event(GdkEventMotion* event) //for dragging
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for zooming
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	etl::handle<TimeModel> &time_model = time_plot_data->time_model;
 
 	if (!time_model || get_width() <= 0 || get_height() <= 0)
@@ -416,4 +427,5 @@ Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for zooming
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -40,6 +40,8 @@
 
 #include <synfig/general.h>
 #include <synfig/timepointcollect.h>
+
+#include <gui/exception_guard.h>
 #endif
 
 using namespace studio;
@@ -337,6 +339,7 @@ void Widget_Timetrack::set_action_state(Widget_Timetrack::ActionState action_sta
 
 bool Widget_Timetrack::on_event(GdkEvent* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (waypoint_sd.process_event(event))
 		return true;
 
@@ -368,6 +371,7 @@ bool Widget_Timetrack::on_event(GdkEvent* event)
 	}
 
 	return Widget_TimeGraphBase::on_event(event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -68,6 +68,7 @@
 #include "workarearenderer/renderer_dragbox.h"
 #include "workarearenderer/renderer_bbox.h"
 
+#include <gui/exception_guard.h>
 #endif
 
 /* === U S I N G =========================================================== */
@@ -957,6 +958,7 @@ WorkArea::get_focus_point()const
 bool
 WorkArea::on_key_press_event(GdkEventKey* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (Smach::RESULT_OK == canvas_view->get_smach().process_event(
 		EventKeyboard(EVENT_WORKAREA_KEY_DOWN, event->keyval, Gdk::ModifierType(event->state))))
 			return true;
@@ -1007,18 +1009,22 @@ WorkArea::on_key_press_event(GdkEventKey* event)
 	set_guide_snap(guide_snap_holder);
 
 	return true;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 WorkArea::on_key_release_event(GdkEventKey* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	return Smach::RESULT_OK == canvas_view->get_smach().process_event(
 		EventKeyboard(EVENT_WORKAREA_KEY_UP, event->keyval, Gdk::ModifierType(event->state)) );
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 WorkArea::on_drawing_area_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	synfig::Point mouse_pos;
     float bezier_click_pos(0);
 	const float radius((abs(pw)+abs(ph))*4);
@@ -1556,7 +1562,6 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 			{
 				if(canvas_view->get_smach().process_event(EventBox(drag_point,mouse_pos,MouseButton(event->button.button),modifier))==Smach::RESULT_ACCEPT)
 					return true;
-
                 /*
                  * Commented out because now the work is
                  * done in Renderer_Dragbox::event_vfunc
@@ -1717,11 +1722,13 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 	}
 
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 WorkArea::on_hruler_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	switch(event->type) {
 	case GDK_BUTTON_PRESS:
 		if (get_drag_mode() == DRAG_NONE && show_guides) {
@@ -1737,8 +1744,8 @@ WorkArea::on_hruler_event(GdkEvent *event)
 			// coordinate system from the canvas.
 			event->motion.y -= hruler->get_height()+2;
 
-			// call the on drawing area event to refresh eveything.
-			on_drawing_area_event(event);
+			// call the on drawing area event to refresh everything.
+			return on_drawing_area_event(event);
 		}
 		return true;
 	case GDK_BUTTON_RELEASE:
@@ -1752,11 +1759,13 @@ WorkArea::on_hruler_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool
 WorkArea::on_vruler_event(GdkEvent *event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	switch(event->type) {
 	case GDK_BUTTON_PRESS:
 		if (get_drag_mode() == DRAG_NONE && show_guides) {
@@ -1772,8 +1781,8 @@ WorkArea::on_vruler_event(GdkEvent *event)
 			// coordinate system from the canvas.
 			event->motion.x -= vruler->get_width()+2;
 
-			// call the on drawing area event to refresh eveything.
-			on_drawing_area_event(event);
+			// call the on drawing area event to refresh everything.
+			return on_drawing_area_event(event);
 		}
 		return true;
 	case GDK_BUTTON_RELEASE:
@@ -1787,6 +1796,7 @@ WorkArea::on_vruler_event(GdkEvent *event)
 		break;
 	}
 	return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void

--- a/synfig-studio/src/gui/workarearenderer/renderer_dragbox.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_dragbox.cpp
@@ -41,6 +41,8 @@
 
 #include <gui/localization.h>
 
+#include <gui/exception_guard.h>
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -81,6 +83,7 @@ Renderer_Dragbox::get_enabled_vfunc()const
 bool
 Renderer_Dragbox::event_vfunc(GdkEvent* event)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
     switch(event->type)
     {
     case GDK_BUTTON_PRESS:
@@ -164,6 +167,7 @@ Renderer_Dragbox::event_vfunc(GdkEvent* event)
     }
 
     return false;
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 void

--- a/synfig-studio/src/gui/workarearenderer/renderer_dragbox.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_dragbox.h
@@ -53,11 +53,6 @@ class Renderer_Dragbox : public studio::WorkAreaRenderer
 public:
 	~Renderer_Dragbox();
 
-    //! Redraw the drag box
-	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
-	//! Catch some mouse events to select objects (handles) in the workarea
-	bool event_vfunc(GdkEvent* event);
-
 	const synfig::Point& get_drag_point()const;
 	const synfig::Point& get_curr_point()const;
 
@@ -72,6 +67,11 @@ private:
 
 protected:
 	bool get_enabled_vfunc()const;
+
+	//! Redraw the drag box
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
+	//! Catch some mouse events to select objects (handles) in the workarea
+	bool event_vfunc(GdkEvent* event);
 };
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/workarearenderer/renderer_guides.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_guides.h
@@ -51,10 +51,10 @@ public:
 	std::list<float>& get_guide_list_x();
 	std::list<float>& get_guide_list_y();
 
-	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
+protected:
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable, const Gdk::Rectangle& expose_area);
 	bool event_vfunc(GdkEvent* event);
 
-protected:
 	bool get_enabled_vfunc()const;
 };
 


### PR DESCRIPTION
This huge commit was made based on the discovery of the error reported
by Svarov-RZM in Github issue comment https://github.com/synfig/synfig/issues/1442#issuecomment-633446649

After some investigation (reported in https://github.com/synfig/synfig/issues/1442#issuecomment-633718069 ), the problem is some GTK callback events call some synfigapp actions that may throw exceptions to report
errors that would never be caught except by the main App class and main()
standard function. So, in an user perspective: Synfig Studio crashes.

For this reason, I surrounded all callback contents (60) with a try-catch
statement.

This commit avoids the crash, prints the error (or tries to) and make the
callback return the failure (if the callback can do it), propagating the error without a sudden close of the software.

I also renamed one to follow the convention used by the rest of the code:
onKeyPressed() -> on_key_pressed_event().

Besides, I ensure every callback to be private or protected:
there's no reason to they be public.

Finally, I checked if the callbacks methods were being called by other methods that were not signal calls. Only Workarea::on_drawing_area_event()
is used that way, but inside the same class in the methods: on_hruler_event() and on_vruler_event(). So I think it's safe, because
I made them look to the return value and handle it.