### PR TITLE
Change installation folder of synfig images and icons

### DIFF
--- a/synfig-studio/Makefile.am
+++ b/synfig-studio/Makefile.am
@@ -71,7 +71,7 @@ desktop_DATA = org.synfig.SynfigStudio.desktop
 
 @INTLTOOL_DESKTOP_RULE@
 
-mimeinfodir              = $(prefix)/share/mime-info
+mimeinfodir              = $(datadir)/mime-info
 mimeinfo_DATA            = synfigstudio.keys synfigstudio.mime
 
 # Appdata
@@ -85,7 +85,7 @@ icondir                 = $(datadir)/pixmaps
 icon_DATA               = images/synfig_icon.png images/sif_icon.png
 endif
 
-mimedir              = $(prefix)/share/mime/packages
+mimedir              = $(datadir)/mime/packages
 mime_DATA            = org.synfig.SynfigStudio.xml
 
 ACLOCAL_AMFLAGS=-I m4

--- a/synfig-studio/Makefile.am
+++ b/synfig-studio/Makefile.am
@@ -79,12 +79,6 @@ appdatadir = $(datadir)/appdata
 appdata_DATA = org.synfig.SynfigStudio.appdata.xml
 @INTLTOOL_XML_RULE@
 
-# Icon
-if WITH_IMAGES
-icondir                 = $(datadir)/pixmaps
-icon_DATA               = images/synfig_icon.png images/sif_icon.png
-endif
-
 mimedir              = $(datadir)/mime/packages
 mime_DATA            = org.synfig.SynfigStudio.xml
 

--- a/synfig-studio/configure.ac
+++ b/synfig-studio/configure.ac
@@ -25,8 +25,6 @@ API_VERSION=1.0
 imageext=png
 synfig_datadir="${datadir}/synfig"
 
-imagedir="${datadir}/pixmaps/synfigstudio"
-
 GETTEXT_PACKAGE=synfigstudio
 LOCALEDIR=[${datadir}/locale]
 

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -412,6 +412,9 @@ CLEANDIRS = \
 	128x128 \
 	256x256
 
+appicondir="${datadir}/icons/hicolor"
+
+imagedir="${datadir}/pixmaps/synfigstudio"
 image_DATA = $(IMAGES) $(ICONS)
 
 
@@ -660,59 +663,59 @@ if !MACOSX_PKG
 	-mkdir 16x16
 	$(SYNFIG) --quiet $< -o $@ --time 0f -w 16 -h 16
 
-icons16dir = $(datadir)/icons/hicolor/16x16/apps
+icons16dir = $(appicondir)/16x16/apps
 icons16_DATA = 16x16/synfig_icon.$(EXT)
 
 22x22/synfig_icon.$(EXT): synfig_icon.sif
 	-mkdir 22x22
 	$(SYNFIG) --quiet $< -o $@ --time 0f -w 22 -h 22
 
-icons22dir = $(datadir)/icons/hicolor/22x22/apps
+icons22dir = $(appicondir)/22x22/apps
 icons22_DATA = 22x22/synfig_icon.$(EXT)
 
 24x24/synfig_icon.$(EXT): synfig_icon.sif
 	-mkdir 24x24
 	$(SYNFIG) --quiet $< -o $@ --time 0f -w 24 -h 24
 
-icons24dir = $(datadir)/icons/hicolor/24x24/apps
+icons24dir = $(appicondir)/24x24/apps
 icons24_DATA = 24x24/synfig_icon.$(EXT)
 
 32x32/synfig_icon.$(EXT): synfig_icon.sif
 	-mkdir 32x32
 	$(SYNFIG) --quiet $< -o $@ --time 0f -w 32 -h 32
 
-icons32dir = $(datadir)/icons/hicolor/32x32/apps
+icons32dir = $(appicondir)/32x32/apps
 icons32_DATA = 32x32/synfig_icon.$(EXT)
 
 48x48/synfig_icon.$(EXT): synfig_icon.sif
 	-mkdir 48x48
 	$(SYNFIG) --quiet $< -o $@ --time 0f -w 48 -h 48
 
-icons48dir = $(datadir)/icons/hicolor/48x48/apps
+icons48dir = $(appicondir)/48x48/apps
 icons48_DATA = 48x48/synfig_icon.$(EXT)
 
 64x64/synfig_icon.$(EXT): synfig_icon.sif
 	-mkdir 64x64
 	$(SYNFIG) --quiet $< -o $@ --time 0f -w 64 -h 64
 
-icons64dir = $(datadir)/icons/hicolor/64x64/apps
+icons64dir = $(appicondir)/64x64/apps
 icons64_DATA = 64x64/synfig_icon.$(EXT)
 
 128x128/synfig_icon.$(EXT): synfig_icon.sif
 	-mkdir 128x128
 	$(SYNFIG) --quiet $< -o $@ --time 0f -w 128 -h 128
 
-icons128dir = $(datadir)/icons/hicolor/128x128/apps
+icons128dir = $(appicondir)/128x128/apps
 icons128_DATA = 128x128/synfig_icon.$(EXT)
 
 256x256/synfig_icon.$(EXT): synfig_icon.sif
 	-mkdir 256x256
 	$(SYNFIG) --quiet $< -o $@ --time 0f -w 256 -h 256
 
-+icons256dir = $(datadir)/icons/hicolor/256x256/apps
++icons256dir = $(appicondir)/256x256/apps
 +icons256_DATA = 256x256/synfig_icon.$(EXT)
 
-iconsscalabledir = $(datadir)/icons/hicolor/scalable/apps
+iconsscalabledir = $(appicondir)/scalable/apps
 iconsscalable_DATA = org.synfig.SynfigStudio.svg
 
 endif

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -191,6 +191,9 @@ EXTRA_DIST = \
 IMAGES = \
 	installer_logo.bmp \
 	installer_logo_osx.$(EXT) \
+	splash_screen.$(EXT)
+
+ICONS = \
 	clear_redo_icon.$(EXT) \
 	clear_undo_icon.$(EXT) \
 	reset_colors_icon.$(EXT) \
@@ -199,7 +202,6 @@ IMAGES = \
 	sif_icon.$(EXT) \
 	synfig_icon.$(EXT) \
 	about_icon.$(EXT) \
-	splash_screen.$(EXT) \
 	valuenode_icon.$(EXT) \
 	duplicate_icon.$(EXT) \
 	group_icon.$(EXT) \
@@ -377,7 +379,7 @@ IMAGES = \
 	utils_timetrack_align_icon.$(EXT)
 
 if WIN32_PKG
-ICONS = \
+WIN32_ICONS = \
 	sif_icon.ico \
 	synfig_icon.ico
 endif
@@ -392,6 +394,7 @@ endif
 CLEANFILES = \
 	$(IMAGES) \
 	$(ICONS) \
+	$(WIN32_ICONS) \
 	$(SPLASH_DEV) \
 	logo_tmp.sif \
 	images.nsh \
@@ -412,11 +415,16 @@ CLEANDIRS = \
 
 appicondir="${datadir}/icons/hicolor"
 
-imagedir="${datadir}/pixmaps/synfigstudio"
-image_DATA = $(IMAGES) $(ICONS)
+imagedir="${synfig_datadir}/images"
+image_DATA = $(IMAGES)
 
+iconsdir="${synfig_datadir}/icons/classic"
+icons_DATA = $(ICONS)
 
-all: $(IMAGES)
+win32iconsdir="${datadir}/pixmaps"
+win32icons_DATA = $(WIN32_ICONS)
+
+all: $(IMAGES) $(ICONS)
 
 .sifz.ico:
 	bash $(srcdir)/../build_tools/sif2ico.sh $<

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -397,8 +397,6 @@ CLEANFILES = \
 	images.nsh \
 	unimages.nsh \
 	installer_logo.bmp \
-	sif_icon.ico \
-	synfig_icon.ico \
 	icons.nsh \
 	unicons.nsh
 
@@ -420,9 +418,6 @@ image_DATA = $(IMAGES) $(ICONS)
 
 all: $(IMAGES)
 
-SUFFIXES = .sif .tif .png .sifz .bmp
-#.SUFFIXES: $(SUFFIXES)
-
 .sifz.ico:
 	bash $(srcdir)/../build_tools/sif2ico.sh $<
 	echo "  File \"images\\$@\"" >>./icons.nsh
@@ -436,12 +431,6 @@ SUFFIXES = .sif .tif .png .sifz .bmp
 clean-local:
 	$(RM) -r $(CLEANDIRS)
 
-#.sif.$(EXT) .sifz.$(EXT) .sif.bmp .sifz.bmp:
-#%.bmp: %.sif %.sifz
-#	$(SYNFIG) -q $< -o $@ --time 0f
-#	echo "  File \"images\\$@\"" >>./images.nsh
-#	echo "  Delete \"\$$INSTDIR\\share\\pixmaps\\$@\"" >>./unimages.nsh
-#
 .sifz.bmp:
 	$(SYNFIG) --quiet $< -o $@ --time 0f
 	echo "  File \"images\\$@\"" >>./images.nsh

--- a/synfig-studio/src/gui/Makefile.am
+++ b/synfig-studio/src/gui/Makefile.am
@@ -130,7 +130,6 @@ synfigstudio_CXXFLAGS = \
 	@SYNFIG_CFLAGS@ \
 	@GTKMM_CFLAGS@ \
 	@JACK_CFLAGS@ \
-	-DIMAGE_DIR=\"$(imagedir)\" \
 	-DIMAGE_EXT=\"$(imageext)\" \
 	-DSYNFIG_DATADIR=\"$(synfig_datadir)\" \
 	-DLOCALEDIR=\"${LOCALEDIR}\"

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1373,7 +1373,7 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 	}
 
 	// paths
-	String path_to_icons = ResourceHelper::get_image_path();
+	String path_to_icons = ResourceHelper::get_icon_path();
 
 	String path_to_plugins = ResourceHelper::get_plugin_path();
 
@@ -2327,6 +2327,20 @@ App::apply_gtk_settings()
 		Glib::RefPtr<Gdk::Screen> screen = Gdk::Screen::get_default();
 		Gtk::StyleContext::add_provider_for_screen(screen,css, GTK_STYLE_PROVIDER_PRIORITY_USER);
 	}
+}
+
+std::string
+App::get_synfig_icon_theme()
+{
+	if (const char *env_theme = getenv("SYNFIG_ICON_THEME")) {
+		std::string icon_theme(env_theme);
+		if (!icon_theme.empty()) {
+			// SYNFIG_ICON_THEME is not a path!
+			if (icon_theme.find("/") == icon_theme.npos && icon_theme.find("\\") == icon_theme.npos )
+				return icon_theme;
+		}
+	}
+	return "classic";
 }
 
 bool

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -345,6 +345,8 @@ public:
 	static void restore_default_settings();
 	static void apply_gtk_settings();
 
+	static std::string get_synfig_icon_theme();
+
 	static const std::list<std::string>& get_recent_files();
 
 	static const std::vector<std::string> get_workspaces();

--- a/synfig-studio/src/gui/resourcehelper.cpp
+++ b/synfig-studio/src/gui/resourcehelper.cpp
@@ -37,29 +37,7 @@
 
 synfig::String studio::ResourceHelper::get_image_path()
 {
-
-#ifndef IMAGE_DIR
-#	define IMAGE_DIR "/usr/local/share/pixmaps/synfigstudio"
-#endif
-
-	std::string imagepath;
-	char* synfig_root=getenv("SYNFIG_ROOT");
-	if(synfig_root) {
-		//  Only class About didn't use the synfigstudio directory when using
-		//  SYNFIG_ROOT env variable. However, if it weren't set, it would use
-		//  IMAGE_DIR builtin variable that includes "synfigstudio". It means
-		//  that that About icon is in both folders. Therefore, it is safe to
-		//  choose this path.
-		imagepath=std::string(synfig_root)+"/share/pixmaps/synfigstudio";
-	}
-	else {
-#if defined CMAKE_BUILD || defined _WIN32
-        imagepath=App::get_base_path()+"/share/pixmaps/synfigstudio";
-#else
-        imagepath=IMAGE_DIR;
-#endif
-	}
-
+	std::string imagepath = get_synfig_data_path() + ETL_DIRECTORY_SEPARATOR + "images";
 	return imagepath;
 }
 
@@ -74,24 +52,37 @@ synfig::String studio::ResourceHelper::get_image_path(const synfig::String& imag
 
 synfig::String studio::ResourceHelper::get_synfig_data_path()
 {
-#if defined CMAKE_BUILD || defined _WIN32
-	std::string synfig_datadir = App::get_base_path();
-#else
-	std::string synfig_datadir = SYNFIG_DATADIR;
-#endif
-
+	std::string synfig_datadir;
 	if (char* synfig_root = getenv("SYNFIG_ROOT")) {
 		synfig_datadir = std::string(synfig_root)
 			+ ETL_DIRECTORY_SEPARATOR + "share/synfig";
+	} else {
+#if defined CMAKE_BUILD || defined _WIN32
+		synfig_datadir = App::get_base_path();
+#else
+		synfig_datadir = SYNFIG_DATADIR;
+#endif
 	}
 
 	return synfig_datadir;
 }
 
+synfig::String studio::ResourceHelper::get_icon_path()
+{
+	std::string iconpath = get_synfig_data_path() + ETL_DIRECTORY_SEPARATOR + "icons";
+	iconpath += ETL_DIRECTORY_SEPARATOR + App::get_synfig_icon_theme();
+	return iconpath;
+}
+
+synfig::String studio::ResourceHelper::get_icon_path(const synfig::String& icon_filename)
+{
+	return get_icon_path() + '/' + icon_filename;
+}
+
 synfig::String studio::ResourceHelper::get_plugin_path()
 {
-	std::string uipath = get_synfig_data_path() + ETL_DIRECTORY_SEPARATOR + "plugins";
-	return uipath;
+	std::string pluginpath = get_synfig_data_path() + ETL_DIRECTORY_SEPARATOR + "plugins";
+	return pluginpath;
 }
 
 synfig::String studio::ResourceHelper::get_plugin_path(const synfig::String& plugin_filename)
@@ -101,8 +92,8 @@ synfig::String studio::ResourceHelper::get_plugin_path(const synfig::String& plu
 
 synfig::String studio::ResourceHelper::get_sound_path()
 {
-	std::string uipath = get_synfig_data_path() + ETL_DIRECTORY_SEPARATOR + "sounds";
-	return uipath;
+	std::string soundpath = get_synfig_data_path() + ETL_DIRECTORY_SEPARATOR + "sounds";
+	return soundpath;
 }
 
 synfig::String studio::ResourceHelper::get_sound_path(const synfig::String& sound_filename)

--- a/synfig-studio/src/gui/resourcehelper.h
+++ b/synfig-studio/src/gui/resourcehelper.h
@@ -36,6 +36,9 @@ public:
 
 	static synfig::String get_synfig_data_path();
 
+	static synfig::String get_icon_path();
+	static synfig::String get_icon_path(const synfig::String& icon_filename);
+
 	static synfig::String get_plugin_path();
 	static synfig::String get_plugin_path(const synfig::String& plugin_filename);
 

--- a/synfig-studio/src/gui/splash.cpp
+++ b/synfig-studio/src/gui/splash.cpp
@@ -202,10 +202,11 @@ Splash::Splash():
 	set_resizable(false);
 	set_type_hint(Gdk::WINDOW_TYPE_HINT_SPLASHSCREEN);
 	set_auto_startup_notification(false);
+	std::string icon_path = ResourceHelper::get_icon_path("synfig_icon." IMAGE_EXT);
 	try {
-		set_icon_from_file(imagepath+"synfig_icon."+IMAGE_EXT);
+		set_icon_from_file(icon_path);
 	} catch(...) {
-		synfig::warning("Unable to open "+imagepath+"synfig_icon."+IMAGE_EXT);
+		synfig::warning("Unable to open "+icon_path);
 	}
 	add(*frame);
 


### PR DESCRIPTION
Install icons in `share/synfig/icons/classic` and enable theming instead of `share/pixmaps/(synfigstudio| or not on windows)`.
Regular images are installed in `share/synfig/images`

Other icon set (theme) can be placed in a folder inside `share/synfig/icons/` (eg. `share/synfig/icons/new-theme-folder`)

Theme can be changed at start by setting the envvar SYNFIG_ICON_THEME (eg. `SYNFIG_ICON_THEME=new-theme-folder`)

I didn't touch the CMake stuff... I can't test Windows or Mac and its installation scripts.

