### PR TITLE
Revert "fix sync scrolling of params and timetrack"

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3674,22 +3674,6 @@ CanvasView::set_ext_widget(const String& x, Gtk::Widget* y, bool own)
 		keyframe_tree=dynamic_cast<KeyframeTree*>(y);
 }
 
-AdjustmentGroup::Handle
-CanvasView::get_adjustment_group(const synfig::String& x)
-{
-	AdjustmentGroupBook::const_iterator i = adjustment_group_book_.find(x);
-	return i == adjustment_group_book_.end() ? AdjustmentGroup::Handle() : i->second;
-}
-
-void
-CanvasView::set_adjustment_group(const synfig::String& x, AdjustmentGroup::Handle y)
-{
-	if (y)
-		adjustment_group_book_[x] = y;
-	else
-		adjustment_group_book_.erase(x);
-}
-
 Gtk::UIManager::ui_merge_id
 CanvasView::get_popup_id()
 {

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -81,7 +81,6 @@
 #include "render.h"
 #include "duckmatic.h"
 #include "timemodel.h"
-#include "helpers.h"
 #include "cellrenderer/cellrenderer_timetrack.h"
 #include "docks/dockable.h"
 #include "dialogs/canvasoptions.h"
@@ -201,7 +200,6 @@ public:
 	
 	typedef std::map<synfig::String, WidgetBookEntry> WidgetBook;
 	typedef std::map<synfig::String, Glib::RefPtr<Glib::ObjectBase> > RefObjBook;
-	typedef std::map<synfig::String, AdjustmentGroup::Handle> AdjustmentGroupBook;
 	
 	//! Create an instance of this class whenever doing a longer task.
 	/*! Make sure that you check the bool value of this class occasionally
@@ -286,7 +284,6 @@ private:
 
 	RefObjBook ref_obj_book_;
 	WidgetBook ext_widget_book_;
-	AdjustmentGroupBook adjustment_group_book_;
 
 	//! The time_window adjustment governs the position of the time window on the whole time line
 	etl::handle<TimeModel> time_model_;
@@ -531,16 +528,13 @@ public:
 	Gtk::Widget* get_ext_widget(const synfig::String& x);
 	void set_ext_widget(const synfig::String& x, Gtk::Widget* y, bool own = true);
 
-	AdjustmentGroup::Handle get_adjustment_group(const synfig::String& x);
-	void set_adjustment_group(const synfig::String& x, AdjustmentGroup::Handle y);
-
 	Gtk::UIManager::ui_merge_id get_popup_id();
 	void set_popup_id(Gtk::UIManager::ui_merge_id popup_id);
 	Gtk::UIManager::ui_merge_id get_toolbar_id();
 	void set_toolbar_id(Gtk::UIManager::ui_merge_id toolbar_id);
 
 	//std::map<synfig::String,Gtk::Widget*>& tree_view_book() { return tree_view_book_; }
-	//std::map<synfig::String,Gtk::Widget*>& ext_widget_book() { return ext_widget_book_; }
+	//std::map<synfig::String,Gtk::Widget*>& ext_widget_book() { return tree_view_book_; }
 
 	//! Pop up menu for the main menu and the caret menu (not tools and not the bezier ones).
 	/*! Signal handler for work_area->signal_popup_menu */

--- a/synfig-studio/src/gui/docks/dock_curves.cpp
+++ b/synfig-studio/src/gui/docks/dock_curves.cpp
@@ -135,8 +135,7 @@ Dock_Curves::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 	);
 
 	studio::LayerTree* tree_layer(dynamic_cast<studio::LayerTree*>(canvas_view->get_ext_widget("layers_cmp")));
-	tree_layer->signal_param_tree_header_height_changed().connect(
-		sigc::mem_fun(*this, &studio::Dock_Curves::on_update_header_height) );
+	tree_layer->signal_param_tree_header_height_changed().connect(sigc::mem_fun(*this, &studio::Dock_Curves::on_update_header_height));
 
 	curves->signal_waypoint_clicked().connect([=](synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button) {
 		if (button != 3)
@@ -215,19 +214,31 @@ Dock_Curves::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view
 		table_->attach(*last_widget_curves_, 0, 1, 2, 3, Gtk::FILL|Gtk::EXPAND, Gtk::FILL|Gtk::EXPAND);
 		table_->attach(hscrollbar_,          0, 1, 3, 4, Gtk::FILL|Gtk::EXPAND, Gtk::FILL|Gtk::SHRINK);
 		table_->attach(vscrollbar_,          1, 2, 0, 3, Gtk::FILL|Gtk::SHRINK, Gtk::FILL|Gtk::EXPAND);
-		table_->show_all();
 		add(*table_);
+
+		last_widget_curves_->show();
+		table_->show_all();
+		show_all();
 	}
 }
 
 void
-Dock_Curves::on_update_header_height(int height)
+Dock_Curves::on_update_header_height( int header_height)
 {
-	int w = 0, h = 0;
-	widget_kf_list_.get_size_request(w, h);
-	int ts_height = std::max(1, height - h);
+	// FIXME very bad hack (timetrack dock also contains this)
+	//! Adapt the border size "according" to different windows manager rendering
+#ifdef _WIN32
+	header_height-=2;
+#elif defined(__APPLE__)
+	header_height+=6;
+#else
+// *nux and others
+	header_height+=2;
+#endif
 
-	widget_timeslider_.get_size_request(w, h);
-	if (h != ts_height)
-		widget_timeslider_.set_size_request(-1, ts_height);
+	int kf_list_height=10;
+
+	//widget_timeslider_.set_size_request(-1, header_height+1);
+	widget_timeslider_.set_size_request(-1, header_height - kf_list_height + 5);
+	widget_kf_list_.set_size_request(-1, kf_list_height);
 }

--- a/synfig-studio/src/gui/docks/dock_curves.h
+++ b/synfig-studio/src/gui/docks/dock_curves.h
@@ -71,7 +71,7 @@ public:
 private:
 	//! Signal handler for studio::LayerTree::signal_param_tree_header_height_changed
 	/* \see studio::LayerTree::signal_param_tree_header_height_changed */
-	void on_update_header_height(int height);
+	void on_update_header_height( int header_height);
 }; // END of Dock_Curves
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/docks/dock_layers.cpp
+++ b/synfig-studio/src/gui/docks/dock_layers.cpp
@@ -225,8 +225,6 @@ Dock_Layers::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 	canvas_view->set_ext_widget(get_name()+"_cmp", layer_tree); // (a)
 	canvas_view->set_ext_widget(get_name(), &layer_tree->layer_tree_view(), false);
 	canvas_view->set_ext_widget("params", &layer_tree->param_tree_view(), false);
-	
-	canvas_view->set_adjustment_group("params", new AdjustmentGroup());
 
 	layer_tree->set_model(layer_tree_store); // (b)
 	canvas_view->set_tree_model("params", layer_tree->param_tree_view().get_model()); // (c)

--- a/synfig-studio/src/gui/docks/dock_params.h
+++ b/synfig-studio/src/gui/docks/dock_params.h
@@ -27,8 +27,8 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <gtkmm/accelgroup.h>
-
+#include "docks/dockable.h"
+#include <gtkmm/treeview.h>
 #include "instance.h"
 #include "docks/dock_canvasspecific.h"
 
@@ -43,8 +43,6 @@ namespace studio {
 class Dock_Params : public Dock_CanvasSpecific
 {
 	Glib::RefPtr<Gtk::ActionGroup> action_group;
-	Glib::RefPtr<Gtk::Adjustment> vadjustment;
-	sigc::connection refresh_selected_param_connection;
 
 protected:
 	virtual void init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view);
@@ -53,6 +51,8 @@ protected:
 	void refresh_selected_param();
 
 public:
+
+
 	Dock_Params();
 	~Dock_Params();
 }; // END of Dock_Keyframes

--- a/synfig-studio/src/gui/docks/dock_timetrack.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack.h
@@ -28,10 +28,10 @@
 
 /* === H E A D E R S ======================================================= */
 
+#include "docks/dockable.h"
 #include <gtkmm/treeview.h>
 #include <gtkmm/scrollbar.h>
 #include <gtkmm/grid.h>
-
 #include "instance.h"
 #include "docks/dock_canvasspecific.h"
 
@@ -42,6 +42,8 @@
 /* === C L A S S E S & S T R U C T S ======================================= */
 
 namespace studio {
+class Widget_CanvasTimeslider;
+class Widget_Keyframe_List;
 
 class Dock_Timetrack_Old : public Dock_CanvasSpecific
 {
@@ -50,10 +52,13 @@ class Dock_Timetrack_Old : public Dock_CanvasSpecific
 	Widget_CanvasTimeslider widget_timeslider_;
 	Widget_Keyframe_List widget_kf_list_;
 	Gtk::Grid *grid_;
+	Gtk::TreeView *mimic_tree_view;
 
 protected:
 	virtual void init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view);
 	virtual void changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view);
+
+	void refresh_selected_param();
 
 public:
 	Dock_Timetrack_Old();
@@ -62,7 +67,7 @@ public:
 private:
 	//! Signal handler for studio::LayerTree::signal_param_tree_header_height_changed
 	/* \see studio::LayerTree::signal_param_tree_header_height_changed */
-	void on_update_header_height(int height);
+	void on_update_header_height( int header_height);
 }; // END of Dock_Timetrack
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/docks/dockable.h
+++ b/synfig-studio/src/gui/docks/dockable.h
@@ -93,9 +93,6 @@ public:
 	void reset_toolbar();
 	void clear();
 
-	Gtk::ScrolledWindow* get_container() const
-		{ return container; }
-
 	void attach_dnd_to(Gtk::Widget& widget);
 	virtual void present();
 	virtual Gtk::Widget* create_tab_label();

--- a/synfig-studio/src/gui/helpers.cpp
+++ b/synfig-studio/src/gui/helpers.cpp
@@ -30,7 +30,6 @@
 #endif
 
 #include <gtk/gtk.h>
-#include <glibmm/main.h>
 
 #include <synfig/general.h>
 
@@ -58,92 +57,6 @@ is_old_gtk_adjustment() {
 }
 
 /* === M E T H O D S ======================================================= */
-
-AdjustmentGroup::AdjustmentGroup():
-	lock() { }
-
-AdjustmentGroup::~AdjustmentGroup()
-{
-	for(std::list<Item>::iterator i = items.begin(); i != items.end(); ++i) {
-		i->connection_changed.disconnect();
-		i->connection_value_changed.disconnect();
-	}
-	connection_timeout.disconnect();
-}
-
-void AdjustmentGroup::add(Glib::RefPtr<Gtk::Adjustment> adjustment)
-{
-	for(std::list<Item>::iterator i = items.begin(); i != items.end(); ++i)
-		if (i->adjustment == adjustment) return;
-
-	items.push_back(Item());
-	Item &item = items.back();
-
-	item.adjustment = adjustment;
-	item.connection_changed = item.adjustment->signal_changed().connect(
-		sigc::bind( sigc::mem_fun(this, &AdjustmentGroup::changed), adjustment ) );
-	item.connection_value_changed = item.adjustment->signal_value_changed().connect(
-		sigc::bind( sigc::mem_fun(this, &AdjustmentGroup::changed), adjustment ) );
-
-	changed( adjustment );
-}
-
-void AdjustmentGroup::remove(Glib::RefPtr<Gtk::Adjustment> adjustment)
-{
-	bool found = false;
-	for(std::list<Item>::iterator i = items.begin(); i != items.end(); )
-		if (i->adjustment == adjustment) {
-			i->connection_changed.disconnect();
-			i->connection_value_changed.disconnect();
-			i = items.erase(i);
-			found = true;
-		} else ++i;
-	if (found) changed(adjustment);
-}
-  
-void
-AdjustmentGroup::changed(Glib::RefPtr<Gtk::Adjustment> adjustment)
-{
-	if (lock || items.empty()) return;
-
-	double position = items.front().adjustment->get_value();
-
-	double maxSize = 0;
-	for(std::list<Item>::iterator i = items.begin(); i != items.end(); ++i) {
-		if (i->adjustment == adjustment) {
-			i->origSize = i->adjustment->get_upper()
-			            - i->adjustment->get_page_size();
-			position = i->adjustment->get_value();
-		}
-		maxSize = std::max(maxSize, i->origSize);
-	}
-
-	connection_timeout.disconnect();
-	connection_timeout = Glib::signal_timeout().connect(
-		sigc::bind_return(
-			sigc::bind( sigc::mem_fun(this, &AdjustmentGroup::set), position, maxSize ),
-			false ),
-		0 );
-}
-
-void
-AdjustmentGroup::set(double position, double size)
-{
-	BoolLock boollock(lock);
-	connection_timeout.disconnect();
-	for(std::list<Item>::iterator i = items.begin(); i != items.end(); ++i) {
-		double value = i->adjustment->get_value();
-		double page = i->adjustment->get_page_size();
-		double upper = i->adjustment->get_upper();
-		double newUpper = size + page;
-
-		if (fabs(newUpper - upper) > 0.1)
-			i->adjustment->set_upper(newUpper);
-		if (fabs(position - value) > 0.1)
-			i->adjustment->set_value(position);
-	}
-};
-
 
 void
 ConfigureAdjustment::emit_changed()

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -1116,6 +1116,246 @@ LayerTree::on_layer_tree_view_query_tooltip(int x, int y, bool keyboard_tooltip,
 	return true;
 }
 
+// void
+// LayerTree::on_raise_pressed()
+// {
+// 	synfigapp::Action::ParamList param_list;
+// 	param_list.add("time",layer_tree_store_->canvas_interface()->get_time());
+// 	param_list.add("canvas",layer_tree_store_->canvas_interface()->get_canvas());
+// 	param_list.add("canvas_interface",layer_tree_store_->canvas_interface());
+//
+// 	{
+// 		synfigapp::SelectionManager::LayerList layer_list(get_selection_manager()->get_selected_layers());
+// 		synfigapp::SelectionManager::LayerList::iterator iter;
+//
+// 		for(iter=layer_list.begin();iter!=layer_list.end();++iter)
+// 			param_list.add("layer",Layer::Handle(*iter));
+// 	}
+// 	synfigapp::Action::Handle action(synfigapp::Action::create("LayerRaise"));
+// 	action->set_param_list(param_list);
+// 	layer_tree_store_->canvas_interface()->get_instance()->perform_action(action);
+// }
+
+// void
+// LayerTree::on_lower_pressed()
+// {
+// 	synfigapp::Action::ParamList param_list;
+// 	param_list.add("time",layer_tree_store_->canvas_interface()->get_time());
+// 	param_list.add("canvas",layer_tree_store_->canvas_interface()->get_canvas());
+// 	param_list.add("canvas_interface",layer_tree_store_->canvas_interface());
+//
+// 	{
+// 		synfigapp::SelectionManager::LayerList layer_list(get_selection_manager()->get_selected_layers());
+// 		synfigapp::SelectionManager::LayerList::iterator iter;
+//
+// 		for(iter=layer_list.begin();iter!=layer_list.end();++iter)
+// 			param_list.add("layer",Layer::Handle(*iter));
+// 	}
+//
+// 	synfigapp::Action::Handle action(synfigapp::Action::create("LayerLower"));
+// 	action->set_param_list(param_list);
+// 	layer_tree_store_->canvas_interface()->get_instance()->perform_action(action);
+// }
+
+// void
+// LayerTree::on_duplicate_pressed()
+// {
+// 	synfigapp::Action::ParamList param_list;
+// 	param_list.add("time",layer_tree_store_->canvas_interface()->get_time());
+// 	param_list.add("canvas",layer_tree_store_->canvas_interface()->get_canvas());
+// 	param_list.add("canvas_interface",layer_tree_store_->canvas_interface());
+//
+// 	{
+// 		synfigapp::SelectionManager::LayerList layer_list(get_selection_manager()->get_selected_layers());
+// 		synfigapp::SelectionManager::LayerList::iterator iter;
+//
+// 		for(iter=layer_list.begin();iter!=layer_list.end();++iter)
+// 			param_list.add("layer",Layer::Handle(*iter));
+// 	}
+//
+// 	synfigapp::Action::Handle action(synfigapp::Action::create("LayerDuplicate"));
+// 	action->set_param_list(param_list);
+// 	layer_tree_store_->canvas_interface()->get_instance()->perform_action(action);
+// }
+
+// void
+// LayerTree::on_encapsulate_pressed()
+// {
+// 	synfigapp::Action::ParamList param_list;
+// 	param_list.add("time",layer_tree_store_->canvas_interface()->get_time());
+// 	param_list.add("canvas",layer_tree_store_->canvas_interface()->get_canvas());
+// 	param_list.add("canvas_interface",layer_tree_store_->canvas_interface());
+//
+// 	{
+// 		synfigapp::SelectionManager::LayerList layer_list(get_selection_manager()->get_selected_layers());
+// 		synfigapp::SelectionManager::LayerList::iterator iter;
+//
+// 		for(iter=layer_list.begin();iter!=layer_list.end();++iter)
+// 			param_list.add("layer",Layer::Handle(*iter));
+// 	}
+//
+// 	synfigapp::Action::Handle action(synfigapp::Action::create("LayerEncapsulate"));
+// 	action->set_param_list(param_list);
+// 	layer_tree_store_->canvas_interface()->get_instance()->perform_action(action);
+// }
+
+// void
+// LayerTree::on_delete_pressed()
+// {
+// 	synfigapp::Action::ParamList param_list;
+// 	param_list.add("time",layer_tree_store_->canvas_interface()->get_time());
+// 	param_list.add("canvas",layer_tree_store_->canvas_interface()->get_canvas());
+// 	param_list.add("canvas_interface",layer_tree_store_->canvas_interface());
+//
+// 	{
+// 		synfigapp::SelectionManager::LayerList layer_list(get_selection_manager()->get_selected_layers());
+// 		synfigapp::SelectionManager::LayerList::iterator iter;
+//
+// 		for(iter=layer_list.begin();iter!=layer_list.end();++iter)
+// 			param_list.add("layer",Layer::Handle(*iter));
+// 	}
+//
+// 	synfigapp::Action::Handle action(synfigapp::Action::create("LayerRemove"));
+// 	action->set_param_list(param_list);
+// 	layer_tree_store_->canvas_interface()->get_instance()->perform_action(action);
+// }
+
+/*
+void
+LayerTree::on_drag_data_get(const Glib::RefPtr<Gdk::DragContext>&context, Gtk::SelectionData& selection_data, guint info, guint time)
+{
+	synfig::info("Dragged data of type \"%s\"",selection_data.get_data_type());
+	synfig::info("Dragged data of target \"%s\"",gdk_atom_name(selection_data->target));
+	synfig::info("Dragged selection=\"%s\"",gdk_atom_name(selection_data->selection));
+
+	Gtk::TreeModel::Path path;
+	Gtk::TreeViewColumn *column;
+	int cell_x, cell_y;
+	if(get_selection()
+	Gtk::TreeRow row = *(get_selection()->get_selected());
+
+	if(synfig::String(gdk_atom_name(selection_data->target))=="LAYER" && (bool)row[model.is_layer])
+	{
+		Layer* layer(((Layer::Handle)row[model.layer]).get());
+		assert(layer);
+		selection_data.set(8, reinterpret_cast<const guchar*>(&layer), sizeof(layer));
+		return;
+	}
+}
+
+void
+LayerTree::on_drop_drag_data_received(const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, Gtk::SelectionData& selection_data, guint info, guint time)
+{
+	synfig::info("Dropped data of type \"%s\"",selection_data.get_data_type());
+	synfig::info("Dropped data of target \"%s\"",gdk_atom_name(selection_data->target));
+	synfig::info("Dropped selection=\"%s\"",gdk_atom_name(selection_data->selection));
+	synfig::info("Dropped x=%d, y=%d",x,y);
+	bool success=false;
+	bool dropped_on_specific_row=false;
+
+	Gtk::TreeModel::Path path;
+	Gtk::TreeViewColumn *column;
+	int cell_x, cell_y;
+	if(!get_path_at_pos(
+		x,y,	// x, y
+		path, // TreeModel::Path&
+		column, //TreeViewColumn*&
+		cell_x,cell_y //int&cell_x,int&cell_y
+		)
+	)
+	{
+		dropped_on_specific_row=false;
+	}
+	else
+		dropped_on_specific_row=true;
+
+	Gtk::TreeRow row = *(get_model()->get_iter(path));
+
+	if ((selection_data.get_length() >= 0) && (selection_data.get_format() == 8))
+	{
+		if(synfig::String(selection_data.get_data_type())=="LAYER")do
+		{
+			Layer::Handle src(*reinterpret_cast<Layer**>(selection_data.get_data()));
+			assert(src);
+
+			Canvas::Handle dest_canvas;
+			Layer::Handle dest_layer;
+
+			if(dropped_on_specific_row)
+			{
+				dest_canvas=(Canvas::Handle)(row[model.canvas]);
+				dest_layer=(Layer::Handle)(row[model.layer]);
+				assert(dest_canvas);
+			}
+			else
+				dest_canvas=layer_tree_store_->canvas_interface()->get_canvas();
+
+			// In this case, we are just moving.
+			if(dest_canvas==src->get_canvas())
+			{
+				if(!dest_layer || dest_layer==src)
+					break;
+
+				synfigapp::Action::Handle action(synfigapp::Action::create("LayerMove"));
+				action->set_param("canvas",dest_canvas);
+				action->set_param("canvas_interface",layer_tree_store_->canvas_interface());
+				action->set_param("layer",src);
+				action->set_param("new_index",dest_canvas->get_depth(dest_layer));
+				if(layer_tree_store_->canvas_interface()->get_instance()->perform_action(action))
+					success=true;
+				else
+					success=false;
+				break;
+			}
+		}while(0);
+	}
+
+	// Finish the drag
+	context->drag_finish(success, false, time);
+}
+*/
+
+/*bool
+LayerTree::on_drag_motion(const Glib::RefPtr<Gdk::DragContext>& context,int x, int    y, guint    time)
+{
+	return get_layer_tree_view().on_drag_motion(context,x,y,time);
+}
+
+void
+LayerTree::on_drag_data_received(const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, Gtk::SelectionData& selection_data, guint info, guint time)
+{
+	get_layer_tree_view().on_drag_data_received(context,x,y,selection_data,info,time);
+*/
+/*
+	if(context->gobj()->source_window==context->gobj()->dest_window)
+	{
+		Gtk::TreeView::on_drag_data_received(context,x,y,selection_data,info,time);
+		return;
+	}
+
+	Gtk::TreeModel::Path path;
+	Gtk::TreeViewColumn *column;
+	int cell_x, cell_y;
+	if(!get_path_at_pos(
+		x,y,	// x, y
+		path, // TreeModel::Path&
+		column, //TreeViewColumn*&
+		cell_x,cell_y //int&cell_x,int&cell_y
+		)
+	)
+	{
+		context->drag_finish(false, false, time);
+	}
+
+	if(layer_tree_store_->row_drop_possible(path,selection_data))
+	{
+		if(layer_tree_store_->drag_data_received(path,selection_data))
+			context->drag_finish(true, false, time);
+	}
+	context->drag_finish(false, false, time);
+}
+*/
+
 void
 LayerTree::on_param_column_label_tree_style_updated()
 {
@@ -1127,21 +1367,45 @@ LayerTree::on_param_column_label_tree_draw(const ::Cairo::RefPtr< ::Cairo::Conte
 {
 	if (param_tree_style_changed)
 	{
-		update_param_tree_header_height();
+		if (update_param_tree_header_height())	signal_param_tree_header_height_changed()(param_tree_header_height);
 		param_tree_style_changed = false;
 	}
 	return true;
 }
 
-void
+bool
 LayerTree::update_param_tree_header_height()
 {
-	int width = 0, height = 0;
-	param_tree_view().convert_bin_window_to_widget_coords(0, 0, width, height);
-	if (param_tree_header_height != height) {
-		param_tree_header_height = height;
-		Glib::signal_timeout().connect_once(
-			sigc::bind( signal_param_tree_header_height_changed(), param_tree_header_height ),
-			0 );
+	bool header_height_updated = false;
+	const Gtk::TreeViewColumn* column = param_tree_view().get_column (0);
+	if (column)
+	{
+		if(column->get_widget())
+		{
+			if(column->get_widget()->get_parent())
+			{
+				const Gtk::Container* container;
+				if((container = column->get_widget()->get_parent()->get_parent()))
+				{
+					int header_height = container->get_height();
+					if (header_height != param_tree_header_height)
+					{
+						param_tree_header_height = header_height;
+						header_height_updated = true;
+					}
+				}
+				else
+				{
+					int header_height = column->get_widget()->get_parent()->get_height();
+					if (header_height != param_tree_header_height)
+					{
+						param_tree_header_height = header_height;
+						header_height_updated = true;
+					}
+				}
+
+			}
+		}
 	}
+	return header_height_updated;
 }

--- a/synfig-studio/src/gui/trees/layertree.h
+++ b/synfig-studio/src/gui/trees/layertree.h
@@ -154,7 +154,7 @@ private:
 	//! Update the param_tree_view header height.
 	/*! \return true if param_tree_header_height updated, else false
 	*/
-	void update_param_tree_header_height();
+	bool update_param_tree_header_height();
 
 	/*
  -- ** -- S I G N A L   T E R M I N A L S -------------------------------------

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -64,7 +64,7 @@ Widget_Keyframe_List::Widget_Keyframe_List():
 	moving_tooltip(Gtk::WINDOW_POPUP),
 	moving_tooltip_y()
 {
-	set_size_request(-1, 10);
+	set_size_request(-1, 64);
 	add_events( Gdk::BUTTON_PRESS_MASK
 			  | Gdk::BUTTON_RELEASE_MASK
 			  | Gdk::BUTTON1_MOTION_MASK

--- a/synfig-studio/src/gui/widgets/widget_soundwave.cpp
+++ b/synfig-studio/src/gui/widgets/widget_soundwave.cpp
@@ -32,7 +32,7 @@
 #include <synfig/general.h>
 #include <gui/canvasview.h>
 #include <gui/timeplotdata.h>
-
+#include <gui/helpers.h>
 #include <gui/localization.h>
 
 #include <Mlt.h>

--- a/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timegraphbase.cpp
@@ -31,6 +31,7 @@
 
 #include <gui/canvasview.h>
 #include <gui/timeplotdata.h>
+#include <gui/helpers.h>
 
 #include <cairomm/cairomm.h>
 #include <gdkmm.h>


### PR DESCRIPTION
Reverts commit aeb01c14cafdb409f5a67a865a5ad8b5fa06b0b7.

This applies fix for issue #1442 to master branch.

Actually, we need to check if #1442 takes place on master (for this we have to build packages and test). It is possible the issue is not takes place on master because of new timetrack.

Also, commit aeb01c14cafdb seems to be fixing several things at once. Maybe we should split it into parts?