### PR TITLE
Fix opening files with Arabic names

### DIFF
--- a/synfig-core/src/modules/mod_bmp/trgt_bmp.cpp
+++ b/synfig-core/src/modules/mod_bmp/trgt_bmp.cpp
@@ -30,6 +30,7 @@
 #	include <config.h>
 #endif
 
+#include <glib/gstdio.h>
 #include "trgt_bmp.h"
 #include <synfig/general.h>
 #include <synfig/localization.h>
@@ -219,12 +220,12 @@ bmp::start_frame(synfig::ProgressCallback *callback)
 						   sequence_separator +
 						   etl::strprintf("%04d",imagecount) +
 						   filename_extension(filename));
-		file=fopen(newfilename.c_str(),POPEN_BINARY_WRITE_TYPE);
+		file=g_fopen(newfilename.c_str(),POPEN_BINARY_WRITE_TYPE);
 		if(callback)callback->task(newfilename+_(" (animated)"));
 	}
 	else
 	{
-		file=fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE);
+		file=g_fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE);
 		if(callback)callback->task(filename);
 	}
 

--- a/synfig-core/src/modules/mod_dv/trgt_dv.cpp
+++ b/synfig-core/src/modules/mod_dv/trgt_dv.cpp
@@ -35,6 +35,7 @@
 #include <synfig/localization.h>
 #include <synfig/general.h>
 
+#include <glib/gstdio.h>
 #include <ETL/stringf>
 #include "trgt_dv.h"
 #include <cstdio>
@@ -196,7 +197,7 @@ dv_trgt::init(synfig::ProgressCallback * /* cb */)
 		// Close the unneeded pipeout
 		close(p[0]);
 		// Open filename to stdout
-		FILE* outfile = fopen(filename.c_str(),"wb");
+		FILE* outfile = g_fopen(filename.c_str(),"wb");
 		if( outfile == NULL ){
 			synfig::error(_("Unable to open pipe to encodedv"));
 			return false;

--- a/synfig-core/src/modules/mod_gif/trgt_gif.cpp
+++ b/synfig-core/src/modules/mod_gif/trgt_gif.cpp
@@ -36,6 +36,7 @@
 #include <synfig/general.h>
 #include <synfig/color.h>
 
+#include <glib/gstdio.h>
 #include <ETL/stringf>
 #include "trgt_gif.h"
 #include <cstdio>
@@ -62,7 +63,7 @@ SYNFIG_TARGET_SET_CVS_ID(gif,"$Id$");
 gif::gif(const char *filename_, const synfig::TargetParam & /* params */):
 	bs(),
 	filename(filename_),
-	file( (filename=="-")?stdout:fopen(filename_,POPEN_BINARY_WRITE_TYPE) ),
+	file( (filename=="-")?stdout:g_fopen(filename_,POPEN_BINARY_WRITE_TYPE) ),
 	codesize(),
 	rootsize(),
 	nextcode(),

--- a/synfig-core/src/modules/mod_jpeg/trgt_jpeg.cpp
+++ b/synfig-core/src/modules/mod_jpeg/trgt_jpeg.cpp
@@ -32,6 +32,7 @@
 #	include <config.h>
 #endif
 
+#include <glib/gstdio.h>
 #include "trgt_jpeg.h"
 #include <ETL/stringf>
 #endif
@@ -113,12 +114,12 @@ jpeg_trgt::start_frame(synfig::ProgressCallback *callback)
 						   sequence_separator +
 						   etl::strprintf("%04d",imagecount) +
 						   filename_extension(filename));
-		file=fopen(newfilename.c_str(),POPEN_BINARY_WRITE_TYPE);
+		file=g_fopen(newfilename.c_str(),POPEN_BINARY_WRITE_TYPE);
 		if(callback)callback->task(newfilename);
 	}
 	else
 	{
-		file=fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE);
+		file=g_fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE);
 		if(callback)callback->task(filename);
 	}
 

--- a/synfig-core/src/modules/mod_mng/trgt_mng.cpp
+++ b/synfig-core/src/modules/mod_mng/trgt_mng.cpp
@@ -37,6 +37,7 @@
 #include <synfig/listimporter.h>
 #include <synfig/general.h>
 
+#include <glib/gstdio.h>
 #include "trgt_mng.h"
 #include <libmng.h>
 #include <ETL/stringf>
@@ -179,7 +180,7 @@ mng_trgt::init(synfig::ProgressCallback * /* cb */)
 	time_t t = time (NULL);
 	struct tm* gmt = gmtime(&t);
 	w=desc.get_w(); h=desc.get_h();
-	file = fopen(filename.c_str(), POPEN_BINARY_WRITE_TYPE);
+	file = g_fopen(filename.c_str(), POPEN_BINARY_WRITE_TYPE);
 	if (file == NULL) goto cleanup_on_error;
 	mng = mng_initialize((mng_ptr)file, mng_alloc_proc, mng_free_proc, MNG_NULL);
 	if (mng == MNG_NULL) goto cleanup_on_error;

--- a/synfig-core/src/modules/mod_png/trgt_png.cpp
+++ b/synfig-core/src/modules/mod_png/trgt_png.cpp
@@ -35,6 +35,7 @@
 #include <synfig/localization.h>
 #include <synfig/general.h>
 
+#include <glib/gstdio.h>
 #include "trgt_png.h"
 #include <png.h>
 #include <ETL/stringf>
@@ -150,12 +151,12 @@ png_trgt::start_frame(synfig::ProgressCallback *callback)
 						   sequence_separator +
 						   etl::strprintf("%04d",imagecount) +
 						   filename_extension(filename));
-		file=fopen(newfilename.c_str(),POPEN_BINARY_WRITE_TYPE);
+		file=g_fopen(newfilename.c_str(),POPEN_BINARY_WRITE_TYPE);
 		if(callback)callback->task(newfilename);
 	}
 	else
 	{
-		file=fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE);
+		file=g_fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE);
 		if(callback)callback->task(filename);
 	}
 

--- a/synfig-core/src/modules/mod_png/trgt_png_spritesheet.cpp
+++ b/synfig-core/src/modules/mod_png/trgt_png_spritesheet.cpp
@@ -38,6 +38,7 @@
 #include <synfig/localization.h>
 #include <synfig/general.h>
 
+#include <glib/gstdio.h>
 #include "trgt_png_spritesheet.h"
 #include <png.h>
 #include <ETL/stringf>
@@ -168,7 +169,7 @@ png_trgt_spritesheet::set_rend_desc(RendDesc *given_desc)
 
 	if (params.append)
 	{
-		in_file_pointer = fopen(filename.c_str(), "rb");
+		in_file_pointer = g_fopen(filename.c_str(), "rb");
 		if (!in_file_pointer)
 			synfig::error(strprintf("[read_png_file] File %s could not be opened for reading", filename.c_str()));
 		else
@@ -403,7 +404,7 @@ png_trgt_spritesheet::write_png_file()
     if (filename == "-")
     	out_file_pointer=stdout;
     else
-    	out_file_pointer=fopen(filename.c_str(), POPEN_BINARY_WRITE_TYPE);
+    	out_file_pointer=g_fopen(filename.c_str(), POPEN_BINARY_WRITE_TYPE);
 
 	
     png_ptr=png_create_write_struct(PNG_LIBPNG_VER_STRING, (png_voidp)this,png_out_error, png_out_warning);

--- a/synfig-core/src/modules/mod_ppm/mptr_ppm.cpp
+++ b/synfig-core/src/modules/mod_ppm/mptr_ppm.cpp
@@ -31,6 +31,7 @@
 #	include <config.h>
 #endif
 
+#include <glib/gstdio.h>
 #include "mptr_ppm.h"
 #include <synfig/importer.h>
 #include <synfig/time.h>
@@ -65,7 +66,7 @@ SYNFIG_IMPORTER_SET_SUPPORTS_FILE_SYSTEM_WRAPPER(ppm_mptr, false);
 bool
 ppm_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &/*renddesc*/, Time, synfig::ProgressCallback *cb)
 {
-	SmartFILE file(fopen(identifier.filename.c_str(),"rb"));
+	SmartFILE file(g_fopen(identifier.filename.c_str(),"rb"));
 	if(!file)
 	{
 		if(cb)cb->error("pp_mptr::GetFrame(): "+strprintf(_("Unable to open %s"),identifier.filename.c_str()));

--- a/synfig-core/src/modules/mod_ppm/trgt_ppm.cpp
+++ b/synfig-core/src/modules/mod_ppm/trgt_ppm.cpp
@@ -32,6 +32,7 @@
 #	include <config.h>
 #endif
 
+#include <glib/gstdio.h>
 #include "trgt_ppm.h"
 #include <ETL/stringf>
 #include <cstdio>
@@ -108,12 +109,12 @@ ppm::start_frame(synfig::ProgressCallback *callback)
 						   sequence_separator +
 						   etl::strprintf("%04d",imagecount) +
 						   filename_extension(filename));
-		file=SmartFILE(fopen(newfilename.c_str(),POPEN_BINARY_WRITE_TYPE));
+		file=SmartFILE(g_fopen(newfilename.c_str(),POPEN_BINARY_WRITE_TYPE));
 		if(callback)callback->task(newfilename);
 	}
 	else
 	{
-		file=SmartFILE(fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE));
+		file=SmartFILE(g_fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE));
 		if(callback)callback->task(filename);
 	}
 

--- a/synfig-core/src/modules/mod_yuv420p/trgt_yuv.cpp
+++ b/synfig-core/src/modules/mod_yuv420p/trgt_yuv.cpp
@@ -30,6 +30,7 @@
 #	include <config.h>
 #endif
 
+#include <glib/gstdio.h>
 #include "trgt_yuv.h"
 #include <ETL/stringf>
 #include <cstdio>
@@ -63,7 +64,7 @@ SYNFIG_TARGET_SET_CVS_ID(yuv,"$Id$");
 
 yuv::yuv(const char *FILENAME, const synfig::TargetParam& /* params */):
 	filename(FILENAME),
-	file( (filename=="-")?stdout:fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE) ),
+	file( (filename=="-")?stdout:g_fopen(filename.c_str(),POPEN_BINARY_WRITE_TYPE) ),
 	dithering(true)
 {
 	// YUV420P doesn't have an alpha channel

--- a/synfig-core/src/modules/mptr_mplayer/mptr_mplayer.cpp
+++ b/synfig-core/src/modules/mptr_mplayer/mptr_mplayer.cpp
@@ -31,6 +31,7 @@
 #	include <config.h>
 #endif
 
+#include <glib/gstdio.h>
 #include <synfig/synfig.h>
 #include <ETL/stringf>
 #include "mptr_mplayer.h"
@@ -78,8 +79,8 @@ mplayer_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &rendde
 		return false;
 	}
 */
-	FILE *sizefile=fopen("/tmp/tmp.synfig.size","rt");
-	FILE *rgbfile=fopen("/tmp/tmp.synfig.rgbdata","rb");
+	FILE *sizefile=g_fopen("/tmp/tmp.synfig.size","rt");
+	FILE *rgbfile=g_fopen("/tmp/tmp.synfig.rgbdata","rb");
 	if(!rgbfile)
 	{
 		cerr<<"unable to open /tmp/tmp.synfig.rgbdata"<<endl;

--- a/synfig-core/src/synfig/filecontainerzip.cpp
+++ b/synfig-core/src/synfig/filecontainerzip.cpp
@@ -34,9 +34,7 @@
 #include <cstddef>
 
 #include <libxml++/libxml++.h>
-#ifdef _WIN32
-#include <glibmm.h>
-#endif
+#include <glib/gstdio.h>
 
 #include <ETL/stringf>
 
@@ -378,11 +376,7 @@ std::list<FileContainerZip::HistoryRecord> FileContainerZip::read_history(const 
 {
 	std::list<HistoryRecord> list;
 	
-#ifdef _WIN32
-	FILE *f = fopen(Glib::locale_from_utf8(fix_slashes(container_filename)).c_str(), "rb");
-#else
-	FILE *f = fopen(container_filename.c_str(), "rb");
-#endif
+	FILE *f = g_fopen(fix_slashes(container_filename).c_str(), "rb");
 	if (f == NULL) return list;
 
 	fseek(f, 0, SEEK_END);
@@ -400,11 +394,7 @@ std::list<FileContainerZip::HistoryRecord> FileContainerZip::read_history(const 
 bool FileContainerZip::create(const String &container_filename)
 {
 	if (is_opened()) return false;
-#ifdef _WIN32
-	storage_file_ = fopen(Glib::locale_from_utf8(fix_slashes(container_filename)).c_str(), "w+b");
-#else
-	storage_file_ = fopen(fix_slashes(container_filename).c_str(), "w+b");
-#endif	
+	storage_file_ = g_fopen(fix_slashes(container_filename).c_str(), "w+b");
 	
 	if (is_opened()) changed_ = true;
 	return is_opened();
@@ -412,11 +402,8 @@ bool FileContainerZip::create(const String &container_filename)
 
 bool FileContainerZip::open_from_history(const String &container_filename, file_size_t truncate_storage_size) {
 	if (is_opened()) return false;
-#ifdef _WIN32
-	FILE *f = fopen(Glib::locale_from_utf8(fix_slashes(container_filename)).c_str(), "r+b");
-#else
-	FILE *f = fopen(fix_slashes(container_filename).c_str(), "r+b");
-#endif		
+	FILE *f = g_fopen(fix_slashes(container_filename).c_str(), "r+b");
+
 	if (f == NULL) return false;
 
 	// check size of file

--- a/synfig-core/src/synfig/filesystemnative.cpp
+++ b/synfig-core/src/synfig/filesystemnative.cpp
@@ -31,6 +31,7 @@
 
 #include <giomm.h>
 #include <glibmm.h>
+#include <glib/gstdio.h>
 #include <sys/stat.h>
 
 #include "general.h"
@@ -154,11 +155,7 @@ bool FileSystemNative::file_rename(const String &from_filename, const String &to
 
 FileSystem::ReadStream::Handle FileSystemNative::get_read_stream(const String &filename)
 {
-#ifdef _WIN32
-	FILE *f = fopen(Glib::locale_from_utf8(fix_slashes(filename)).c_str(), "rb");
-#else
-	FILE *f = fopen(fix_slashes(filename).c_str(), "rb");
-#endif
+	FILE *f = g_fopen(fix_slashes(filename).c_str(), "rb");
 	return f == NULL
 	     ? FileSystem::ReadStream::Handle()
 	     : FileSystem::ReadStream::Handle(new ReadStream(this, f));
@@ -166,11 +163,7 @@ FileSystem::ReadStream::Handle FileSystemNative::get_read_stream(const String &f
 
 FileSystem::WriteStream::Handle FileSystemNative::get_write_stream(const String &filename)
 {
-#ifdef _WIN32
-	FILE *f = fopen(Glib::locale_from_utf8(fix_slashes(filename)).c_str(), "wb");
-#else
-	FILE *f = fopen(fix_slashes(filename).c_str(), "wb");
-#endif
+	FILE *f = g_fopen(fix_slashes(filename).c_str(), "wb");
 	return f == NULL
 	     ? FileSystem::WriteStream::Handle()
 	     : FileSystem::WriteStream::Handle(new WriteStream(this, f));

--- a/synfig-core/src/synfig/filesystemnative.cpp
+++ b/synfig-core/src/synfig/filesystemnative.cpp
@@ -119,37 +119,12 @@ bool FileSystemNative::directory_scan(const String &dirname, FileList &out_files
 
 bool FileSystemNative::file_remove(const String &filename)
 {
-	return 0 == remove(fix_slashes(filename).c_str());
+	return 0 == g_remove(fix_slashes(filename).c_str());
 }
 
 bool FileSystemNative::file_rename(const String &from_filename, const String &to_filename)
 {
-#ifdef _WIN32
-	
-	// On Win32 platforms, rename() has bad behavior. Work around it.
-	
-	// Make random filename and ensure there's no file with such name exist
-	struct stat buf;
-	String old_file;
-	do {
-		synfig::GUID guid;
-		old_file = to_filename+"."+guid.get_string().substr(0,8);
-	} while (stat(Glib::locale_from_utf8(old_file).c_str(), &buf) != -1);
-	
-	rename(Glib::locale_from_utf8(to_filename).c_str(),Glib::locale_from_utf8(old_file).c_str());
-	
-	if(rename(Glib::locale_from_utf8(from_filename).c_str(),Glib::locale_from_utf8(to_filename).c_str())!=0)
-	{
-		rename(Glib::locale_from_utf8(old_file).c_str(),Glib::locale_from_utf8(to_filename).c_str());
-		synfig::error("synfig::save_canvas(): Unable to rename file to correct filename, errno=%d",errno);
-		return false;
-	}
-	remove(Glib::locale_from_utf8(old_file).c_str());
-	
-	return true;
-#else
-	return 0 == rename(from_filename.c_str(), to_filename.c_str());
-#endif
+	return 0 == g_rename(from_filename.c_str(), to_filename.c_str());
 }
 
 

--- a/synfig-core/src/tool/main.cpp
+++ b/synfig-core/src/tool/main.cpp
@@ -90,6 +90,12 @@ int main(int argc, char* argv[])
 	setlocale(LC_ALL, "");
 	Glib::init(); // need to use Gio functions before app is started
 
+#ifdef _WIN32
+	argv = g_win32_get_command_line();
+#else
+	argv = g_strdupv(argv);
+#endif
+
 	SynfigToolGeneralOptions::create_singleton_instance(argv[0]);
 
 	std::string binary_path =
@@ -312,4 +318,6 @@ int main(int argc, char* argv[])
     catch(std::exception& e) {
         std::cout << e.what() << std::endl;
     }
+
+	g_strfreev(argv);
 }

--- a/synfig-core/src/tool/main.cpp
+++ b/synfig-core/src/tool/main.cpp
@@ -91,10 +91,14 @@ int main(int argc, char* argv[])
 	Glib::init(); // need to use Gio functions before app is started
 
 #ifdef _WIN32
-	argv = g_win32_get_command_line();
-#else
-	argv = g_strdupv(argv);
-#endif
+	// to be able to open files whose name is not latin (eg. arabic)
+	class ArgVGuard {
+		char **modified_argv;
+	public:
+		ArgVGuard(char ***argv) { modified_argv = *argv = g_win32_get_command_line(); }
+		~ArgVGuard() { g_strfreev(modified_argv); }
+	} argv_guard(&argv);
+ #endif
 
 	SynfigToolGeneralOptions::create_singleton_instance(argv[0]);
 
@@ -319,5 +323,4 @@ int main(int argc, char* argv[])
         std::cout << e.what() << std::endl;
     }
 
-	g_strfreev(argv);
 }

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1690,7 +1690,7 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 			{
 				studio_init_cb.task(_("Loading files..."));
 				splash_screen.hide();
-				open(Glib::locale_to_utf8((*argv)[*argc]));
+				open((*argv)[*argc]);
 				opened_any = true;
 				splash_screen.show();
 			}

--- a/synfig-studio/src/gui/ipc.cpp
+++ b/synfig-studio/src/gui/ipc.cpp
@@ -309,7 +309,7 @@ IPC::process_command(const synfig::String& command_line)
 			break;
 		case 'O': // Open <arg>
 			App::signal_present_all()();
-			App::open(Glib::locale_to_utf8(args));
+			App::open(args);
 			break;
 		case 'X': // Quit
 		case 'Q': // Quit

--- a/synfig-studio/src/gui/main.cpp
+++ b/synfig-studio/src/gui/main.cpp
@@ -69,6 +69,12 @@ int main(int argc, char **argv)
 {
 
 #ifdef _WIN32
+	argv = g_win32_get_command_line();
+#else
+	argv = g_strdupv(argv);
+#endif
+
+#ifdef _WIN32
 	if (consoleOptionEnabled(argc, argv))
 	{
 		redirectIOToConsole();
@@ -93,6 +99,7 @@ int main(int argc, char **argv)
 	bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
 	textdomain(GETTEXT_PACKAGE);
 #endif
+	
 	{
 		SmartFILE file(IPC::make_connection());
 		if(file)
@@ -125,6 +132,8 @@ int main(int argc, char **argv)
 
 	app.run();
 	std::cerr<<"Application appears to have terminated successfully"<<std::endl;
+
+	g_strfreev(argv);
 
 	return 0;
 	SYNFIG_EXCEPTION_GUARD_END_INT(0)

--- a/synfig-studio/src/gui/main.cpp
+++ b/synfig-studio/src/gui/main.cpp
@@ -69,10 +69,14 @@ int main(int argc, char **argv)
 {
 
 #ifdef _WIN32
-	argv = g_win32_get_command_line();
-#else
-	argv = g_strdupv(argv);
-#endif
+	// to be able to open files whose name is not latin (eg. arabic)
+	class ArgVGuard {
+		char **modified_argv;
+	public:
+		ArgVGuard(char ***argv) { modified_argv = *argv = g_win32_get_command_line(); }
+		~ArgVGuard() { g_strfreev(modified_argv); }
+	} argv_guard(&argv);
+ #endif
 
 #ifdef _WIN32
 	if (consoleOptionEnabled(argc, argv))
@@ -132,8 +136,6 @@ int main(int argc, char **argv)
 
 	app.run();
 	std::cerr<<"Application appears to have terminated successfully"<<std::endl;
-
-	g_strfreev(argv);
 
 	return 0;
 	SYNFIG_EXCEPTION_GUARD_END_INT(0)

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -484,11 +484,7 @@ RenderSettings::submit_next_render_pass()
 		App::dock_info_->set_render_progress(0.0); //For this pass
 		
 		TargetAlphaMode pass_alpha_mode = pass_info.first;
-#ifdef _WIN32
-		String pass_filename = Glib::locale_from_utf8(pass_info.second);
-#else
 		String pass_filename = pass_info.second;
-#endif
 
 		Target::Handle target=Target::create(calculated_target_name,pass_filename, tparam);
 		if(!target)

--- a/synfig-studio/src/player/main.cpp
+++ b/synfig-studio/src/player/main.cpp
@@ -62,10 +62,14 @@ int main(int argc, char **argv)
 	Glib::init();
 
 #ifdef _WIN32
-	argv = g_win32_get_command_line();
-#else
-	argv = g_strdupv(argv);
-#endif
+	// to be able to open files whose name is not latin (eg. arabic)
+	class ArgVGuard {
+		char **modified_argv;
+	public:
+		ArgVGuard(char ***argv) { modified_argv = *argv = g_win32_get_command_line(); }
+		~ArgVGuard() { g_strfreev(modified_argv); }
+	} argv_guard(&argv);
+ #endif
 
 	bool r_time;
 
@@ -157,8 +161,6 @@ int main(int argc, char **argv)
 	
 	if (result) error("Gtk::Application finished with error code: %d", result);
 	info("end");
-
-	g_strfreev(argv);
 
 	return result;
 }

--- a/synfig-studio/src/player/main.cpp
+++ b/synfig-studio/src/player/main.cpp
@@ -60,6 +60,13 @@ int main(int argc, char **argv)
 #endif
 
 	Glib::init();
+
+#ifdef _WIN32
+	argv = g_win32_get_command_line();
+#else
+	argv = g_strdupv(argv);
+#endif
+
 	bool r_time;
 
 	String binary_path = get_binary_path(argv[0]);
@@ -150,6 +157,9 @@ int main(int argc, char **argv)
 	
 	if (result) error("Gtk::Application finished with error code: %d", result);
 	info("end");
+
+	g_strfreev(argv);
+
 	return result;
 }
 


### PR DESCRIPTION
Closes #1517.

Previously we used `Glib::locale_to_utf8()` function, and it worked well for simple encodings (i.e. Russian). But for languages which use wide characters (UTF-16) (i.e. Arabic) this didn't worked. So now we use `g_win32_get_command_line()` function instead (https://developer.gnome.org/glib/stable/glib-Windows-Compatibility-Functions.html#g-win32-get-command-line).

But that was not enough. After adding `g_win32_get_command_line()` function the filename was converted properly, but file opening procedure still failing 

After debugging I found that we have to do similar replacement for places where we access filesystem. 
The solution is to use Glib's `g_fopen()` function instead of `fopen()` - https://people.gnome.org/~ryanl/glib-docs/glib-File-Utilities.html#g-fopen.

It is possible we need to use `g_fopen()` (and [similar Glib's wrappers](https://people.gnome.org/~ryanl/glib-docs/glib-File-Utilities.html)) in other places...