### PR TITLE
[CMake] Fixed MacOS build

### DIFF
--- a/1-setup-osx-brew.sh
+++ b/1-setup-osx-brew.sh
@@ -15,7 +15,7 @@ set -e
 
 if ! ( which brew >/dev/null ); then
     echo "No brew found. Installing..."
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
 WORKDIR=`dirname "$0"`

--- a/synfig-core/src/CMakeLists.txt
+++ b/synfig-core/src/CMakeLists.txt
@@ -38,6 +38,7 @@ pkg_check_modules(LIBMNG libmng) # for mod_mng (set as optional as it is not cor
 pkg_check_modules(LIBJPEG REQUIRED libjpeg) # for mod_mng
 pkg_check_modules(OPENEXR REQUIRED OpenEXR) # for mod_openexr
 pkg_check_modules(MAGICKCORE REQUIRED MagickCore) # for Magick++
+pkg_check_modules(FONT_CONFIG FontConfig) # for FontConfig
 
 ## TODO: move to module where it is actually required
 pkg_check_modules(PANGO REQUIRED pango)
@@ -57,7 +58,8 @@ foreach(pkg_config_lib
   LIBJPEG
   OPENEXR
   MAGICKCORE
-  PANGO)
+  PANGO
+  FONT_CONFIG)
     include_directories(${${pkg_config_lib}_INCLUDE_DIRS})
     link_directories(${${pkg_config_lib}_LIBRARY_DIRS})
 endforeach()
@@ -83,6 +85,10 @@ include (CheckFunctionExists)
 CHECK_FUNCTION_EXISTS(fork HAVE_FORK)
 CHECK_FUNCTION_EXISTS(pipe HAVE_PIPE)
 CHECK_FUNCTION_EXISTS(waitpid HAVE_WAITPID)
+
+if(FONT_CONFIG_FOUND)
+  add_definitions(-DWITH_FONTCONFIG)
+endif()
 
 add_definitions(-DHAVE_CONFIG_H)
 configure_file(config.h.cmake.in config.h)

--- a/synfig-core/src/modules/CMakeLists.txt
+++ b/synfig-core/src/modules/CMakeLists.txt
@@ -32,7 +32,6 @@ set(MODS_ENABLED
     mod_jpeg
 #    mod_libavcodec # - build failure
 #    mod_magickpp # - made optional
-    mod_mng
     mod_noise
     mod_openexr
     mod_particle
@@ -42,6 +41,11 @@ set(MODS_ENABLED
     mod_yuv420p
 #    mptr_mplayer # - "This code has vulnerabilities"
 )
+if(LIBMNG_FOUND)
+  list(APPEND MODS_ENABLED mod_mng)
+else()
+  message(STATUS "mod_mng: Disabled")
+endif()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/lib/synfig/modules)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/lib/synfig/modules)

--- a/synfig-core/src/modules/lyr_freetype/CMakeLists.txt
+++ b/synfig-core/src/modules/lyr_freetype/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(lyr_freetype
         "${CMAKE_CURRENT_LIST_DIR}/lyr_freetype.cpp"
 )
 
-target_link_libraries(lyr_freetype synfig ${CAIRO_LIBRARIES} ${PANGO_LIBRARIES} ${PANGOCAIRO_LIBRARIES} ${FT_LIBRARIES})
+target_link_libraries(lyr_freetype synfig ${CAIRO_LIBRARIES} ${PANGO_LIBRARIES} ${PANGOCAIRO_LIBRARIES} ${FT_LIBRARIES} ${FONT_CONFIG_LIBRARIES})
 
 install (
     TARGETS lyr_freetype

--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -8,6 +8,20 @@ add_library(synfig SHARED "")
 
 message(STATUS "MLT DIR: ${MLT_INCLUDE_DIRS}")
 
+# By default, the libtool places its headers in the system directory (/usr/local/include), and
+# compiler automatically finds ltdl.h header. But on MacOS, CMake overrides the system directory
+# using the `-sysroot` flag, and this header cannot be found. (https://gitlab.kitware.com/cmake/cmake/-/issues/19120)
+# So, we need to manually find it.
+
+if(APPLE)
+    find_path(LTDL_INCLUDE_DIRS ltdl.h)
+    find_library(LTDL_LIBRARIES ltdl)
+    message(STATUS "Libltdl headers:   ${LTDL_INCLUDE_DIRS}")
+    message(STATUS "Libltdl libraries: ${LTDL_LIBRARIES}")
+else()
+    set(LTDL_LIBRARIES ltdl)
+endif()
+
 target_include_directories(synfig
 #    SYSTEM BEFORE PUBLIC
 SYSTEM PUBLIC
@@ -20,6 +34,7 @@ PUBLIC
         ${PANGO_INCLUDE_DIRS}
         ${MLT_INCLUDE_DIRS}
         ${FFTW_INCLUDE_DIRS}
+        ${LTDL_INCLUDE_DIRS}
 )
 
 target_sources(synfig
@@ -127,10 +142,8 @@ target_link_libraries(synfig
         ${MLT_LIBRARIES}
         ${ZLIB_LIBRARIES}
         ${FFTW_LIBRARIES}
+        ${LTDL_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
-
-        # TODO: properly detect ltdl
-        ltdl
 )
 
 ## Install headers

--- a/synfig-studio/src/CMakeLists.txt
+++ b/synfig-studio/src/CMakeLists.txt
@@ -23,7 +23,7 @@ pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
 pkg_check_modules(LIBXML REQUIRED libxml++-2.6)
 pkg_check_modules(MLT REQUIRED mlt++) # required for widget_soundwave
 
-foreach(pkg_config_lib SIGCPP GTKMM LIBXML MLT)
+foreach(pkg_config_lib SIGCPP GTKMM LIBXML MLT FFTW)
     include_directories(${${pkg_config_lib}_INCLUDE_DIRS})
     link_directories(${${pkg_config_lib}_LIBRARY_DIRS})
 endforeach()


### PR DESCRIPTION
Also now you can use XCode for developing.

![Xcode](https://user-images.githubusercontent.com/5604544/86633244-a0e03980-bffa-11ea-8aee-53ac658a7bc2.png)

Generating Xcode project:
```
cmake ../synfig -GXcode
```

if you get error 
```
CMake Error:
Xcode 1.5 not supported.
```
then you need to switch tools:
```
sudo xcode-select --switch /Applications/Xcode.app/
```