### PR TITLE
fix crash when undoing creation of a moved/changed vertex of spline

### DIFF
--- a/synfig-studio/src/gui/trees/historytreestore.cpp
+++ b/synfig-studio/src/gui/trees/historytreestore.cpp
@@ -34,9 +34,6 @@
 
 #include "trees/historytreestore.h"
 #include <synfig/valuenode.h>
-#include "iconcontroller.h"
-#include <synfig/valuenodes/valuenode_timedswap.h>
-#include <gtkmm/button.h>
 #include <synfigapp/action.h>
 #include "instance.h"
 
@@ -142,8 +139,6 @@ HistoryTreeStore::insert_action(Gtk::TreeRow row,etl::handle<synfigapp::Action::
 			insert_action(child_row,*iter,true,is_undo,is_redo);
 		}
 	}
-
-	//row[model.icon] = Gtk::Button().render_icon_pixbuf(Gtk::StockID("synfig-canvas"),Gtk::ICON_SIZE_SMALL_TOOLBAR);
 }
 
 
@@ -194,7 +189,6 @@ HistoryTreeStore::on_redo_stack_cleared()
 void
 HistoryTreeStore::on_new_action(etl::handle<synfigapp::Action::Undoable> action)
 {
-//	Gtk::TreeRow row = *(append());
 	Gtk::TreeRow row;
 	Gtk::TreeModel::Children::iterator iter;
 	for(iter=children().begin(); iter != children().end(); ++iter)

--- a/synfig-studio/src/gui/trees/historytreestore.cpp
+++ b/synfig-studio/src/gui/trees/historytreestore.cpp
@@ -58,7 +58,7 @@ using namespace studio;
 
 static HistoryTreeStore::Model& ModelHack()
 {
-	static HistoryTreeStore::Model* model(0);
+	static HistoryTreeStore::Model* model(nullptr);
 	if(!model)model=new HistoryTreeStore::Model;
 	return *model;
 }
@@ -216,7 +216,7 @@ HistoryTreeStore::on_action_status_changed(etl::handle<synfigapp::Action::Undoab
 	for(iter=children_.begin(); iter != children_.end(); ++iter)
 	{
 		Gtk::TreeModel::Row row = *iter;
-		if(action == (etl::handle<synfigapp::Action::Undoable>)row[model.action])
+		if(action == row.get_value(model.action))
 		{
 			row[model.is_active]=action->is_active();
 			return;

--- a/synfig-studio/src/gui/trees/historytreestore.cpp
+++ b/synfig-studio/src/gui/trees/historytreestore.cpp
@@ -97,20 +97,20 @@ HistoryTreeStore::rebuild()
 	const synfigapp::Action::Stack& undo_stack = instance()->undo_action_stack();
 
 	for (iter = undo_stack.begin(); iter != undo_stack.end(); ++iter)
-		insert_action(*(prepend()), *iter, true, true, false);
+		insert_action(*(prepend()), *iter, true, false);
 
 	curr_row=*children().end();
 
 	const synfigapp::Action::Stack& redo_stack = instance()->redo_action_stack();
 
 	for(iter = redo_stack.begin(); iter != redo_stack.end(); ++iter)
-		insert_action(*(append()), *iter, true, false, true);
+		insert_action(*(append()), *iter, false, true);
 
 	signal_undo_tree_changed()();
 }
 
 void
-HistoryTreeStore::insert_action(Gtk::TreeRow row,etl::handle<synfigapp::Action::Undoable> action, bool /*is_active*/, bool is_undo, bool is_redo)
+HistoryTreeStore::insert_action(Gtk::TreeRow row,etl::handle<synfigapp::Action::Undoable> action, bool is_undo, bool is_redo)
 {
 	assert(action);
 
@@ -136,7 +136,7 @@ HistoryTreeStore::insert_action(Gtk::TreeRow row,etl::handle<synfigapp::Action::
 		for(iter=group->action_list().begin();iter!=group->action_list().end();++iter)
 		{
 			Gtk::TreeRow child_row = *(append(row.children()));
-			insert_action(child_row,*iter,true,is_undo,is_redo);
+			insert_action(child_row,*iter,is_undo,is_redo);
 		}
 	}
 }

--- a/synfig-studio/src/gui/trees/historytreestore.cpp
+++ b/synfig-studio/src/gui/trees/historytreestore.cpp
@@ -162,28 +162,32 @@ HistoryTreeStore::on_redo()
 void
 HistoryTreeStore::on_undo_stack_cleared()
 {
-	Gtk::TreeModel::Children::iterator iter,next;
 	Gtk::TreeModel::Children children_(children());
+	Gtk::TreeModel::Children::iterator iter = children_.begin();
 
-	for(next=children_.begin(),iter=next++; iter != children_.end(); iter=(next!=children_.end())?next++:next)
+	while(iter != children_.end())
 	{
 		Gtk::TreeModel::Row row = *iter;
 		if(row[model.is_undo])
-			erase(iter);
+			iter = erase(iter);
+		else
+			++iter;
 	}
 }
 
 void
 HistoryTreeStore::on_redo_stack_cleared()
 {
-	Gtk::TreeModel::Children::iterator iter,next;
 	Gtk::TreeModel::Children children_(children());
+	Gtk::TreeModel::Children::iterator iter = children_.begin();
 
-	for(next=children_.begin(),iter=next++; iter != children_.end(); iter=(next!=children_.end())?next++:next)
+	while(iter != children_.end())
 	{
 		Gtk::TreeModel::Row row = *iter;
 		if(row[model.is_redo])
-			erase(iter);
+			iter = erase(iter);
+		else
+			++iter;
 	}
 }
 

--- a/synfig-studio/src/gui/trees/historytreestore.h
+++ b/synfig-studio/src/gui/trees/historytreestore.h
@@ -54,7 +54,6 @@ public:
 	class Model : public Gtk::TreeModel::ColumnRecord
 	{
 	public:
-	public:
 		Gtk::TreeModelColumn<etl::handle<synfigapp::Action::Undoable> > action;
 		Gtk::TreeModelColumn<Glib::ustring> name;
 		Gtk::TreeModelColumn<Glib::RefPtr<Gdk::Pixbuf> > icon;
@@ -141,9 +140,6 @@ private:
 
 public:
 
-	HistoryTreeStore(etl::loose_handle<studio::Instance> instance_);
-	~HistoryTreeStore();
-
 	etl::loose_handle<studio::Instance> instance() { return instance_; }
 	etl::loose_handle<const studio::Instance> instance()const { return instance_; }
 
@@ -155,13 +151,16 @@ public:
 
 	static bool search_func(const Glib::RefPtr<TreeModel>&,int,const Glib::ustring&,const TreeModel::iterator&);
 
+	static Glib::RefPtr<HistoryTreeStore> create(etl::loose_handle<studio::Instance> instance);
+
 	/*
  -- ** -- P R O T E C T E D   M E T H O D S -----------------------------------
 	*/
 
-public:
+protected:
 
-	static Glib::RefPtr<HistoryTreeStore> create(etl::loose_handle<studio::Instance> instance);
+	HistoryTreeStore(etl::loose_handle<studio::Instance> instance_);
+	~HistoryTreeStore();
 
 }; // END of class HistoryTreeStore
 

--- a/synfig-studio/src/gui/trees/historytreestore.h
+++ b/synfig-studio/src/gui/trees/historytreestore.h
@@ -92,7 +92,8 @@ public:
 private:
 
 	etl::loose_handle<studio::Instance> instance_;
-	Gtk::TreeIter curr_row;
+	//! points to next action
+	Gtk::TreeIter next_action_iter;
 
 	/*
  -- ** -- P R I V A T E   M E T H O D S ---------------------------------------
@@ -145,9 +146,9 @@ public:
 	etl::loose_handle<studio::Instance> instance() { return instance_; }
 	etl::loose_handle<const studio::Instance> instance()const { return instance_; }
 
+	//! Use this method carefully: if redo action stack refers to not-yet-(re)created objects
+	//! - like vertex movements -, the Action::get_local_name() can make App crash!
 	void rebuild();
-
-	void refresh() { rebuild(); }
 
 	static bool search_func(const Glib::RefPtr<TreeModel>&,int,const Glib::ustring&,const TreeModel::iterator&);
 

--- a/synfig-studio/src/gui/trees/historytreestore.h
+++ b/synfig-studio/src/gui/trees/historytreestore.h
@@ -100,6 +100,8 @@ private:
 
 private:
 
+	void insert_action(Gtk::TreeRow row, etl::handle<synfigapp::Action::Undoable> action, bool is_undo=true, bool is_redo=false);
+
 	/*
  -- ** -- P R I V A T E   D A T A ---------------------------------------------
 	*/
@@ -146,8 +148,6 @@ public:
 	void rebuild();
 
 	void refresh() { rebuild(); }
-
-	void insert_action(Gtk::TreeRow row,etl::handle<synfigapp::Action::Undoable> action, bool is_active=true, bool is_undo=true, bool is_redo=false);
 
 	static bool search_func(const Glib::RefPtr<TreeModel>&,int,const Glib::ustring&,const TreeModel::iterator&);
 


### PR DESCRIPTION
fix crash when undoing creation of a moved/changed vertex of spline

It happened because the history tree rebuilds on every
undo/redo. It doesn't do it anymore.

Long chain:
The history tree row description would call to
Action::ValueDescSet::get_local_name() and it would
make a 'long' stack until it crashes, as follow:

```
-> Action::ValueDescSet::get_local_name()
 -> ValueDesc::get_description()
  -> ValueDesc::is_exported()
   -> ValueDesc::get_value_node()
    -> LinkableValueNode::get_link()
```
AND FINALLY it crashes due to the invalid link index!

Test case:
* Create a polygon or spline.
* Click on a vertex to open context menu
* Select "Create Item"
* Move the new vertex
* Ctrl+Z (ok, vertex 'unmoved')
* Ctrl+Z (crash)
