### PR TITLE
Don't crash if exception thrown while rendering WorkArea

### DIFF
--- a/synfig-core/src/synfig/exception.cpp
+++ b/synfig-core/src/synfig/exception.cpp
@@ -49,58 +49,63 @@ using namespace synfig;
 
 /* === M E T H O D S ======================================================= */
 
-Exception::BadLinkName::BadLinkName(const String &what):
+Exception::Exception::Exception(const String& what):
 	std::runtime_error(what)
-//	std::runtime_error(_("Bad Link Name")+what.empty()?"":(String(": ")+what))
+{
+}
+
+Exception::BadLinkName::BadLinkName(const String &what):
+	Exception(what)
+//	Exception(_("Bad Link Name")+what.empty()?"":(String(": ")+what))
 {
 	synfig::error("EXCEPTION: bad link name: "+what);
 }
 
 Exception::BadType::BadType(const String &what):
-	std::runtime_error(what)
-//	std::runtime_error(_("Bad Type")+what.empty()?"":(String(": ")+what))
+	Exception(what)
+//	Exception(_("Bad Type")+what.empty()?"":(String(": ")+what))
 {
 //	synfig::error("EXCEPTION: bad type: "+what);
 }
 
 Exception::BadFrameRate::BadFrameRate(const String &what):
-	std::runtime_error(what)
-//	std::runtime_error(_("Bad Link Name")+what.empty()?"":(String(": ")+what))
+	Exception(what)
+//	Exception(_("Bad Link Name")+what.empty()?"":(String(": ")+what))
 {
 	synfig::error("EXCEPTION: bad frame rate: "+what);
 }
 
 Exception::BadTime::BadTime(const String &what):
-	std::runtime_error(what)
-//	std::runtime_error(_("Bad Link Name")+what.empty()?"":(String(": ")+what))
+	Exception(what)
+//	Exception(_("Bad Link Name")+what.empty()?"":(String(": ")+what))
 {
 	synfig::error("EXCEPTION: bad time: "+what);
 }
 
 Exception::NotFound::NotFound(const String &what):
-	std::runtime_error(what)
-//	std::runtime_error(_("Not Found")+what.empty()?"":(String(": ")+what))
+	Exception(what)
+//	Exception(_("Not Found")+what.empty()?"":(String(": ")+what))
 {
 //	synfig::error("EXCEPTION: not found: "+what);
 }
 
 Exception::IDNotFound::IDNotFound(const String &what):
 	NotFound(what)
-//	std::runtime_error(_("Not Found")+what.empty()?"":(String(": ")+what))
+//	Exception(_("Not Found")+what.empty()?"":(String(": ")+what))
 {
 //	synfig::error("EXCEPTION: not found: "+what);
 }
 
 Exception::FileNotFound::FileNotFound(const String &what):
 	NotFound(what)
-//	std::runtime_error(_("Not Found")+what.empty()?"":(String(": ")+what))
+//	Exception(_("Not Found")+what.empty()?"":(String(": ")+what))
 {
 	synfig::error("EXCEPTION: file not found: "+what);
 }
 
 Exception::IDAlreadyExists::IDAlreadyExists(const String &what):
-	std::runtime_error(what)
-//	std::runtime_error(_("ID Already Exists")+what.empty()?"":(String(": ")+what))
+	Exception(what)
+//	Exception(_("ID Already Exists")+what.empty()?"":(String(": ")+what))
 {
 	synfig::error("EXCEPTION: id already exists: "+what);
 }

--- a/synfig-core/src/synfig/exception.h
+++ b/synfig-core/src/synfig/exception.h
@@ -40,25 +40,31 @@ namespace synfig {
 
 namespace Exception {
 
-class BadLinkName : public std::runtime_error
+class Exception : public std::runtime_error
+{
+public:
+	Exception(const String &what);
+};
+
+class BadLinkName : public Exception
 {
 public:
 	BadLinkName(const String &what);
 }; // END of class BadLinkName
 
-class BadType : public std::runtime_error
+class BadType : public Exception
 {
 public:
 	BadType(const String &what);
 }; // END of class BadType
 
-class IDAlreadyExists : public std::runtime_error
+class IDAlreadyExists : public Exception
 {
 public:
 	IDAlreadyExists(const String &what);
 };
 
-class NotFound : public std::runtime_error
+class NotFound : public Exception
 {
 public:
 	NotFound(const String &what);
@@ -76,13 +82,13 @@ public:
 	FileNotFound(const String &what);
 };
 
-class BadTime : public std::runtime_error
+class BadTime : public Exception
 {
 public:
 	BadTime(const String &what);
 };
 
-class BadFrameRate : public std::runtime_error
+class BadFrameRate : public Exception
 {
 public:
 	BadFrameRate(const String &what);

--- a/synfig-studio/src/gui/exception_guard.h
+++ b/synfig-studio/src/gui/exception_guard.h
@@ -30,6 +30,11 @@
 			_exception_guard_error_str = etl::strprintf("%s Uncaught Exception:string: %s", __PRETTY_FUNCTION__, str.c_str()); \
 			_exception_guard_error_code = 1001; \
 		} \
+		catch(synfig::Exception::Exception& x) \
+		{ \
+			_exception_guard_error_str = etl::strprintf("%s Synfig Exception: %s", __PRETTY_FUNCTION__, x.what()); \
+			_exception_guard_error_code = 1002; \
+		} \
 		catch(std::exception& x) \
 		{ \
 			_exception_guard_error_str = etl::strprintf("%s Standard Exception: %s", __PRETTY_FUNCTION__, x.what()); \

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -1916,6 +1916,8 @@ WorkArea::get_window_rect() const
 bool
 WorkArea::refresh(const Cairo::RefPtr<Cairo::Context> &/*cr*/)
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
+
 	assert(get_canvas());
 
 	//!Check if the window we want draw is ready
@@ -1959,6 +1961,8 @@ WorkArea::refresh(const Cairo::RefPtr<Cairo::Context> &/*cr*/)
 	}
 
 	return true;
+
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 String

--- a/synfig-studio/src/synfigapp/value_desc.cpp
+++ b/synfig-studio/src/synfigapp/value_desc.cpp
@@ -52,6 +52,15 @@ using namespace synfigapp;
 
 const ValueDesc ValueDesc::blank;
 
+void ValueDesc::on_id_changed()
+{
+	try {
+		name = get_value_node()->get_id();
+	} catch (Exception::IDNotFound &) {
+		name.clear();
+	}
+}
+
 String
 ValueDesc::get_description(bool show_exported_name)const
 {


### PR DESCRIPTION
It is related to #231 . It doesn't crash anymore.

A Exported ValueNode duck, if selected, make Studio crash when user unexport the valuenode.
The duck stores a ValueDesc that refers to exported valuenode by its name. When unexported, there isn't a valuenode with that name anymore.

The perfect(?) solution would be to self'destroy' the duck if it detects its valuenode name (id) changed to empty string.