### PR TITLE
fix uncaught exceptions in destructors

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -533,6 +533,7 @@ LockDucks::LockDucks(CanvasView &canvas_view):
 
 LockDucks::~LockDucks() {
 	if (!canvas_view) return;
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	if (--(canvas_view->ducks_locks) == 0) {
 		if (canvas_view->ducks_rebuild_requested)
 			canvas_view->rebuild_ducks();
@@ -540,6 +541,7 @@ LockDucks::~LockDucks() {
 		if (canvas_view->ducks_rebuild_queue_requested)
 			canvas_view->queue_rebuild_ducks();
 	}
+	SYNFIG_EXCEPTION_GUARD_END()
 }
 
 
@@ -716,6 +718,8 @@ CanvasView::CanvasView(etl::loose_handle<Instance> instance,etl::handle<CanvasIn
 
 CanvasView::~CanvasView()
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
+
 	#ifdef WITH_JACK
 	set_jack_enabled(false);
 	#endif
@@ -748,6 +752,8 @@ CanvasView::~CanvasView()
 
 	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
 		info("CanvasView::~CanvasView(): Deleted");
+
+	SYNFIG_EXCEPTION_GUARD_END()
 }
 
 void CanvasView::save_all()

--- a/synfig-studio/src/gui/exception_guard.h
+++ b/synfig-studio/src/gui/exception_guard.h
@@ -62,6 +62,15 @@
 		} \
 	}
 
+/// It should return (void), no matter what happens
+#define SYNFIG_EXCEPTION_GUARD_END_NO_RETURN() \
+	SYNFIG_EXCEPTION_GUARD_END_COMMON \
+		if (!_exception_guard_error_str.empty()) { \
+			synfig::error("%s", _exception_guard_error_str.c_str()); \
+		} \
+	}
+
+
 /// It should return a boolean. On success, return success_value; inverse value otherwise
 #define SYNFIG_EXCEPTION_GUARD_END_BOOL(success_value) \
 	SYNFIG_EXCEPTION_GUARD_END_COMMON \

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -53,6 +53,7 @@
 #include <synfigapp/main.h>
 
 #include <gui/localization.h>
+#include <gui/exception_guard.h>
 
 #endif
 
@@ -707,7 +708,9 @@ StatePolygon_Context::event_refresh_tool_options(const Smach::event& /*x*/)
 
 StatePolygon_Context::~StatePolygon_Context()
 {
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	run();
+	SYNFIG_EXCEPTION_GUARD_END_NO_RETURN()
 
 	save_settings();
 	// Restore layer clicking

--- a/synfig-studio/src/gui/states/state_stroke.cpp
+++ b/synfig-studio/src/gui/states/state_stroke.cpp
@@ -51,6 +51,7 @@
 #include <synfigapp/main.h>
 
 #include <gui/localization.h>
+#include <gui/exception_guard.h>
 
 #endif
 
@@ -145,9 +146,11 @@ StateStroke_Context::~StateStroke_Context()
 
 	App::dock_toolbox->refresh();
 
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	// Send the stroke data to whatever previously called this state.
 	if(stroke_data->size()>=2)
 		get_canvas_view()->get_smach().process_event(EventStroke(stroke_data,width_data,modifier));
+	SYNFIG_EXCEPTION_GUARD_END_NO_RETURN()
 }
 
 Smach::event_result


### PR DESCRIPTION
a destructor shouldn't throw exception anyway:
https://rules.sonarsource.com/cpp/RSPEC-3654

fix Coverity issues CID 308620, 308960, 308965, 308978, 308612, 344421, 344423, 308639