### PR TITLE
Setting up VERSIONINFO resource for CMake Windows builds.

### DIFF
--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -307,6 +307,21 @@ install(
     DESTINATION share/pixmaps/synfigstudio
 )
 
+# WIN32 Icon
+if(WIN32)
+    add_custom_command(
+        OUTPUT ${PIXMAPS_DIR}/synfig_icon.ico
+        COMMAND synfig_bin ${CMAKE_CURRENT_SOURCE_DIR}/synfig_icon.sif -o ${PIXMAPS_DIR}/synfig_icon.ico --time 0f --quiet
+        DEPENDS ${SYNFIG_SPLASH_SCREEN} synfig_bin
+    )
+
+    list(APPEND PIXMAPS ${PIXMAPS_DIR}/synfig_icon.ico)
+    install(
+        FILES ${PIXMAPS_DIR}/synfig_icon.ico
+        DESTINATION share/pixmaps/synfigstudio
+    )
+endif()
+
 add_custom_target(
     build_images
     DEPENDS synfig_bin ${PIXMAPS}

--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -28,7 +28,12 @@ endif()
 ## Targets
 ##
 
-add_executable(synfigstudio main.cpp)
+if(WIN32)
+    configure_file(synfigstudio.rc ${CMAKE_CURRENT_BINARY_DIR}/synfigstudio.rc)
+    add_executable(synfigstudio main.cpp ${CMAKE_CURRENT_BINARY_DIR}/synfigstudio.rc)
+else()
+    add_executable(synfigstudio main.cpp)
+endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/synfig-studio/src/gui/synfigstudio.rc
+++ b/synfig-studio/src/gui/synfigstudio.rc
@@ -1,0 +1,28 @@
+APPLICATION_ICON    ICON    "${SYNFIG_BUILD_ROOT}/share/synfig/icons/classic/synfig_icon.ico" 
+ 
+1 VERSIONINFO 
+    FILEVERSION     ${STUDIO_VERSION_MAJOR},${STUDIO_VERSION_MINOR},${STUDIO_VERSION_PATCH},0 
+    PRODUCTVERSION  ${STUDIO_VERSION_MAJOR},${STUDIO_VERSION_MINOR},${STUDIO_VERSION_PATCH},0 
+    FILEOS          0x40004 
+    FILETYPE        1 
+BEGIN 
+    BLOCK "StringFileInfo" 
+    BEGIN 
+        BLOCK "040904E4" 
+        BEGIN 
+            VALUE "Comments",         "Published under the GNU GPL" 
+            VALUE "CompanyName",      "Synfig Developers" 
+            VALUE "FileDescription",  "Vector animation program" 
+            VALUE "FileVersion",      "${STUDIO_VERSION}" 
+            VALUE "InternalName",     "synfigstudio" 
+            VALUE "LegalCopyright",   " (c) Synfig Developers 2001-2020" 
+            VALUE "OriginalFilename", "synfigstudio.exe" 
+            VALUE "ProductName",      "synfigstudio.exe" 
+            VALUE "ProductVersion",   "${STUDIO_VERSION}" 
+        END 
+    END 
+    BLOCK "VarFileInfo" 
+    BEGIN 
+        VALUE "Translation", 0x0409, 1252 
+    END 
+END 


### PR DESCRIPTION
Fixes: #1412

![image](https://user-images.githubusercontent.com/34449856/88147368-b5d3e400-cc1a-11ea-989a-998f0f93919e.png)

Toolbar (not pinned):
![image](https://user-images.githubusercontent.com/34449856/88147532-f4699e80-cc1a-11ea-8141-cfe1dcd7143a.png)

Toolbar (pinned):
![image](https://user-images.githubusercontent.com/34449856/88147571-077c6e80-cc1b-11ea-8e52-9f423d617a3a.png)
