### PR TITLE
don't crash debug version when rotating vertex order

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuenodedynamiclistinsert.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuenodedynamiclistinsert.cpp
@@ -201,7 +201,7 @@ Action::ValueNodeDynamicListInsert::perform()
 		if (composite && composite->get_type() == type_bline_point)
 			composite->set_link("split_radius", ValueNode_Const::create(false));
 	}
-	assert(list_entry.value_node.rcount()==1);
+	assert(list_entry.value_node.rcount()>=1);
 
 	value_node->add(list_entry,index);
 	assert(list_entry.value_node.rcount()>=2);


### PR DESCRIPTION
As stated here https://github.com/synfig/synfig/issues/280#issuecomment-591782338 , I don't know if I can just remove the assert,
so let do my work without crash :)