### PR TITLE
Fixed libmng linking problem on 32-bit platform

### DIFF
--- a/1-setup-windows-msys2.sh
+++ b/1-setup-windows-msys2.sh
@@ -45,14 +45,8 @@ $ARCH-imagemagick \
 $ARCH-libxml++2.6 \
 $ARCH-pango \
 $ARCH-gtkmm3 \
-$ARCH-openexr
-
-# Install libmng on 64 bit system.
-MACHINE_TYPE=$(uname -m)
-if [${MACHINE_TYPE} == 'x86_64']; then
-    echo "64 bit system"
-    pacman -S --needed --noconfirm --color=auto $ARCH-libmng
-fi
+$ARCH-openexr \
+$ARCH-libmng
 
 # build mlt
 bash ${SCRIPT_DIR}/autobuild/msys2/build_mlt.sh

--- a/synfig-core/src/modules/mod_mng/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_mng/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(mod_mng
         "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
 )
 
+target_compile_options(mod_mng PRIVATE ${LIBMNG_CFLAGS})
 target_link_libraries(mod_mng synfig ${LIBMNG_LIBRARIES})
 
 install (


### PR DESCRIPTION
The problem was in different compilation flags, since `libmng` was compiled with the `stdcall` convention, and tried to link with the Synfig using `cdecl` convention.
After the compilation flags are added, linker "knows" how to link this library.