### PR TITLE
fix old timetrack crashing on waypoint right-clicking

### DIFF
--- a/synfig-studio/src/gui/docks/dock_timetrack.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack.cpp
@@ -307,6 +307,7 @@ public:
 		Gtk::TreeView::set_model(store);
 		store->signal_changed().connect(sigc::mem_fun(*this, &TimeTrackView::queue_draw));
 		cellrenderer_time_track->set_canvas_interface( store->canvas_interface() );
+		param_tree_store_ = store;
 	}
 
 	void


### PR DESCRIPTION
Reported by tawatoons in https://forums.synfig.org/t/synfig-1-3-15-crash-on-right-clicking-waypoint/11252

It's probably due to a commit reverting for fixing another issue in Windows
