### PR TITLE
fix big keyframe markers in Dock_SoundLayer (and any other now)

### DIFF
--- a/synfig-studio/src/gui/docks/dock_soundwave.cpp
+++ b/synfig-studio/src/gui/docks/dock_soundwave.cpp
@@ -115,6 +115,9 @@ void Dock_SoundWave::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas
 		file_settings_box.set_visible(!filename.empty());
 	});
 	canvas_view->set_ext_widget(get_name(), widget_sound);
+
+	studio::LayerTree* tree_layer(dynamic_cast<studio::LayerTree*>(canvas_view->get_ext_widget("layers_cmp")));
+	tree_layer->signal_param_tree_header_height_changed().connect(sigc::mem_fun(*this, &Dock_SoundWave::on_update_header_height));
 }
 
 void Dock_SoundWave::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
@@ -262,4 +265,27 @@ void Dock_SoundWave::setup_file_setting_data()
 
 	delay_widget.set_fps(current_widget_sound->get_time_model()->get_frame_rate());
 	delay_widget.set_value(current_widget_sound->get_delay());
+}
+
+
+void
+Dock_SoundWave::on_update_header_height(int header_height)
+{
+	// COPIED FROM Dock_Curves
+	// FIXME very bad hack (timetrack dock also contains this)
+	//! Adapt the border size "according" to different windows manager rendering
+#ifdef _WIN32
+	header_height-=2;
+#elif defined(__APPLE__)
+	header_height+=6;
+#else
+// *nux and others
+	header_height+=2;
+#endif
+
+	int kf_list_height=10;
+
+	//widget_timeslider_.set_size_request(-1, header_height+1);
+	widget_timeslider.set_size_request(-1, header_height - kf_list_height + 5);
+	widget_kf_list.set_size_request(-1, kf_list_height);
 }

--- a/synfig-studio/src/gui/docks/dock_soundwave.h
+++ b/synfig-studio/src/gui/docks/dock_soundwave.h
@@ -76,6 +76,8 @@ private:
 
 	bool load_sound_file(const std::string & filename);
 	void setup_file_setting_data();
+
+	void on_update_header_height(int header_height);
 };
 
 }

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -64,7 +64,7 @@ Widget_Keyframe_List::Widget_Keyframe_List():
 	moving_tooltip(Gtk::WINDOW_POPUP),
 	moving_tooltip_y()
 {
-	set_size_request(-1, 64);
+	set_size_request(-1, 10);
 	add_events( Gdk::BUTTON_PRESS_MASK
 			  | Gdk::BUTTON_RELEASE_MASK
 			  | Gdk::BUTTON1_MOTION_MASK


### PR DESCRIPTION
Its default height was 64px. Now it's 10.
Besides, I also copied the Dock_Curves code for height updating.

fix #1601 