### PR TITLE
Make position of dialog buttons consistent

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2946,11 +2946,11 @@ App::dialog_open_file_with_history_button(const std::string &title, std::string 
 
 	dialog->set_transient_for(*App::main_window);
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
 	Gtk::Button* history_button = dialog->add_button(_("Open history"), RESPONSE_ACCEPT_WITH_HISTORY);
 	// TODO: the Open history button should be file type sensitive one.
 	dialog->set_response_sensitive(RESPONSE_ACCEPT_WITH_HISTORY, true);
+	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
 
 	// File filters
 	// Synfig Documents

--- a/synfig-studio/src/gui/dialogs/canvasproperties.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasproperties.cpp
@@ -116,11 +116,6 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	canvas_interface_->signal_rend_desc_changed().connect(sigc::mem_fun(*this,&studio::CanvasProperties::refresh));
 	canvas_interface_->signal_id_changed().connect(sigc::mem_fun(*this,&studio::CanvasProperties::refresh));
 
-	Gtk::Button *ok_button(manage(new class Gtk::Button(Gtk::StockID("gtk-ok"))));
-	ok_button->show();
-	add_action_widget(*ok_button,2);
-	ok_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::CanvasProperties::on_ok_pressed));
-
 	Gtk::Button *apply_button(manage(new class Gtk::Button(Gtk::StockID("gtk-apply"))));
 	apply_button->show();
 	add_action_widget(*apply_button,1);
@@ -131,7 +126,10 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	add_action_widget(*cancel_button,0);
 	cancel_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::CanvasProperties::on_cancel_pressed));
 
-	//set_default_response(1);
+	Gtk::Button *ok_button(manage(new class Gtk::Button(Gtk::StockID("gtk-ok"))));
+	ok_button->show();
+	add_action_widget(*ok_button,2);
+	ok_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::CanvasProperties::on_ok_pressed));
 
 	get_vbox()->show_all();
 	refresh();

--- a/synfig-studio/src/gui/dialogs/dialog_input.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_input.cpp
@@ -109,8 +109,8 @@ Dialog_Input::Dialog_Input(Gtk::Window& parent):
 	scrolled_window(NULL)
 {
 	set_type_hint(Gdk::WINDOW_TYPE_HINT_UTILITY);
-	add_button(_("OK"), Gtk::RESPONSE_OK);
 	add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	add_button(_("OK"), Gtk::RESPONSE_OK);
 	reset();
 }
 

--- a/synfig-studio/src/gui/dialogs/dialog_keyframe.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_keyframe.cpp
@@ -63,25 +63,25 @@ Dialog_Keyframe::Dialog_Keyframe(Gtk::Window& parent, etl::handle<synfigapp::Can
 {
 	// Set up the buttons
 	{
-		Gtk::Button *ok_button(manage(new class Gtk::Button(Gtk::StockID("gtk-ok"))));
-		ok_button->show();
-		add_action_widget(*ok_button,2);
-		ok_button->signal_clicked().connect(sigc::mem_fun(*this, &Dialog_Keyframe::on_ok_pressed));
+		Gtk::Button *delete_button(manage(new class Gtk::Button(Gtk::StockID("gtk-delete"))));
+		delete_button->show();
+		add_action_widget(*delete_button,3);
+		delete_button->signal_clicked().connect(sigc::mem_fun(*this, &Dialog_Keyframe::on_delete_pressed));
 
 		Gtk::Button *apply_button(manage(new class Gtk::Button(Gtk::StockID("gtk-apply"))));
 		apply_button->show();
 		add_action_widget(*apply_button,1);
 		apply_button->signal_clicked().connect(sigc::mem_fun(*this, &Dialog_Keyframe::on_apply_pressed));
 
-		Gtk::Button *delete_button(manage(new class Gtk::Button(Gtk::StockID("gtk-delete"))));
-		delete_button->show();
-		add_action_widget(*delete_button,3);
-		delete_button->signal_clicked().connect(sigc::mem_fun(*this, &Dialog_Keyframe::on_delete_pressed));
-
 		Gtk::Button *cancel_button(manage(new class Gtk::Button(Gtk::StockID("gtk-close"))));
 		cancel_button->show();
 		add_action_widget(*cancel_button,0);
 		cancel_button->signal_clicked().connect(sigc::mem_fun(*this, &Dialog_Keyframe::hide));
+
+		Gtk::Button *ok_button(manage(new class Gtk::Button(Gtk::StockID("gtk-ok"))));
+		ok_button->show();
+		add_action_widget(*ok_button,2);
+		ok_button->signal_clicked().connect(sigc::mem_fun(*this, &Dialog_Keyframe::on_ok_pressed));
 	}
 
 	Gtk::Grid *grid=manage(new Gtk::Grid());

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -187,15 +187,15 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	dialogBox->pack_start(widget_rend_desc);
 
 
-	Gtk::Button *render_button(manage(new class Gtk::Button(Gtk::StockID(_("Render")))));
-	render_button->show();
-	add_action_widget(*render_button,1);
-	render_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::RenderSettings::on_render_pressed));
-
 	Gtk::Button *cancel_button(manage(new class Gtk::Button(Gtk::StockID("gtk-cancel"))));
 	cancel_button->show();
 	add_action_widget(*cancel_button,0);
 	cancel_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::RenderSettings::on_cancel_pressed));
+
+	Gtk::Button *render_button(manage(new class Gtk::Button(Gtk::StockID(_("Render")))));
+	render_button->show();
+	add_action_widget(*render_button,1);
+	render_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::RenderSettings::on_render_pressed));
 
 	set_title(_("Render Settings")+String(" - ")+canvas_interface_->get_canvas()->get_name());
 

--- a/synfig-studio/ui/canvas_options.glade
+++ b/synfig-studio/ui/canvas_options.glade
@@ -22,20 +22,6 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="ok_button">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkButton" id="apply_button">
                 <property name="label">gtk-apply</property>
                 <property name="visible">True</property>
@@ -48,7 +34,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
@@ -63,6 +49,20 @@
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ok_button">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
Fix #1165 

The final order of buttons will be fixed (then we'll deal with different OSes):
Other | Cancel/Close | Ok/Confirm 