### PR TITLE
[Lottie Exporter] Export outlines without variable widths

### DIFF
--- a/synfig-studio/plugins/lottie-exporter/CMakeLists.txt
+++ b/synfig-studio/plugins/lottie-exporter/CMakeLists.txt
@@ -5,7 +5,8 @@ set(PLUGIN_LOTTIE_EXPORTER_FILES
     lottie-exporter.py
     settings.py
     test_bodymovin.js
-
+    export_without_variable_width.py
+    
     # common
     common/Bline.py
     common/Canvas.py

--- a/synfig-studio/plugins/lottie-exporter/CMakeLists.txt
+++ b/synfig-studio/plugins/lottie-exporter/CMakeLists.txt
@@ -61,6 +61,7 @@ set(PLUGIN_LOTTIE_EXPORTER_FILES
 
     # properties/shapePropKeyframe
     properties/shapePropKeyframe/circle.py
+    properties/shapePropKeyframe/constant_width_outline.py
     properties/shapePropKeyframe/helper.py
     properties/shapePropKeyframe/outline.py
     properties/shapePropKeyframe/polygon.py

--- a/synfig-studio/plugins/lottie-exporter/Makefile.am
+++ b/synfig-studio/plugins/lottie-exporter/Makefile.am
@@ -5,8 +5,9 @@ PLUGIN_NAME = lottie-exporter
 EXTRA_FILES = bodymovin.js \
 			  canvas.py \
 			  settings.py \
-			  test_bodymovin.js
-
+			  test_bodymovin.js \
+			  export_without_variable_width.py
+			  
 plugindir = $(synfig_datadir)/plugins/$(PLUGIN_NAME)
 plugin_DATA = \
 			  $(PLUGIN_NAME).py \

--- a/synfig-studio/plugins/lottie-exporter/common/Param.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Param.py
@@ -1228,6 +1228,7 @@ class Param:
         if is_animated(node) == settings.ANIMATED:
             for waypoint in node:
                 fr = common.misc.get_frame(waypoint)
+                settings.WAYPOINTS_LIST.append(fr)
                 if fr > window["last"]:
                     window["last"] = fr
                 if fr < window["first"]:

--- a/synfig-studio/plugins/lottie-exporter/export_without_variable_width.py
+++ b/synfig-studio/plugins/lottie-exporter/export_without_variable_width.py
@@ -136,6 +136,7 @@ parser.add_argument("outfile")
 ns = parser.parse_args()
 	
 settings.init()
+settings.WITHOUT_VARIABLE_WIDTH = True
 
 out = parse(ns.infile)
 if ns.outfile.endswith(".html"):

--- a/synfig-studio/plugins/lottie-exporter/layers/driver.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/driver.py
@@ -60,20 +60,21 @@ def append_blur_dict(layer,itr,group_flag):
 	blur_dict = []
 	layers = [settings.blur_dictionary[layer_var] for layer_var in settings.non_blur_dictionary[itr]]
 	gen_layer_blur(blur_dict,layers)
-	if group_flag:
-		for asset_index,_ in enumerate(settings.lottie_format["assets"]):
-			if "layers" in _.keys():
-				for index,val in enumerate(settings.lottie_format["assets"][asset_index]["layers"]):
-					blur_flag = blur_test(settings.lottie_format["assets"][asset_index]["layers"][index]["ef"])
-					if not blur_flag:
-						for blur in blur_dict:
-							settings.lottie_format["assets"][asset_index]["layers"][index]["ef"].append(blur)
+	if len(layers)!=0:
+		if group_flag:
+			for asset_index,_ in enumerate(settings.lottie_format["assets"]):
+				if "layers" in _.keys():
+					for index,val in enumerate(settings.lottie_format["assets"][asset_index]["layers"]):
+						blur_flag = blur_test(settings.lottie_format["assets"][asset_index]["layers"][index]["ef"])
+						if not blur_flag:
+							for blur in blur_dict:
+								settings.lottie_format["assets"][asset_index]["layers"][index]["ef"].append(blur)
 
-	else:
-		for index,val in enumerate(settings.lottie_format["layers"]):
-			if settings.lottie_format["layers"][index]["nm"] == layer.get_description():
-				for blur in blur_dict:
-					settings.lottie_format["layers"][index]["ef"].append(blur)
+		else:
+			for index,val in enumerate(settings.lottie_format["layers"]):
+				if settings.lottie_format["layers"][index]["nm"] == layer.get_description():
+					for blur in blur_dict:
+						settings.lottie_format["layers"][index]["ef"].append(blur)
 
 def gen_layers(lottie, canvas, layer_itr):
 	"""

--- a/synfig-studio/plugins/lottie-exporter/layers/driver.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/driver.py
@@ -99,7 +99,10 @@ def gen_layers(lottie, canvas, layer_itr):
 	skeleton = settings.SKELETON_LAYER
 	blur = settings.BLUR_LAYER
 	supported_layers = set.union(shape, solid, shape_solid, image, pre_comp, group, skeleton,blur)
-
+	if settings.WITHOUT_VARIABLE_WIDTH:
+		shape.add("outline")
+		settings.WITHOUT_VARIABLE_WIDTH = False
+		
 	while itr >= 0:
 		layer = canvas[itr]
 		if layer.get_type() not in supported_layers:  # Only supported layers

--- a/synfig-studio/plugins/lottie-exporter/layers/shape.py
+++ b/synfig-studio/plugins/lottie-exporter/layers/shape.py
@@ -14,6 +14,7 @@ from shapes.gFill import gen_linear_gradient, gen_radial_gradient
 from helpers.blendMode import get_blend
 from helpers.transform import gen_helpers_transform
 from synfig.rectangle import gen_dummy_rectangle
+from properties.shapePropKeyframe.constant_width_outline import gen_bline_outline_constant
 sys.path.append("..")
 
 
@@ -58,12 +59,17 @@ def gen_layer_shape(lottie, layer, idx):
         gen_shapes_rectangle(lottie["shapes"][0], layer.get_layer(), index.inc())
     elif layer.get_type() in {"linear_gradient", "radial_gradient"}:
         gen_shapes_shape(lottie["shapes"][0], layer, index.inc())
+    elif layer.get_type() in {"outline"}:
+        settings.OUTLINE_FLAG = True
+        gen_bline_outline_constant(lottie["shapes"][0],layer.get_param("bline"),layer,lottie["ks"],index.inc())
 
     lottie["shapes"].append({})  # For the fill or color
     if layer.get_type() in {"linear_gradient"}:
         gen_linear_gradient(lottie["shapes"][1], layer, index.inc())
     elif layer.get_type() in {"radial_gradient"}:
         gen_radial_gradient(lottie["shapes"][1], layer, index.inc())
+    elif layer.get_type() in {"outline"}:
+        pass
     else:
         gen_shapes_fill(lottie["shapes"][1], layer)
 

--- a/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
+++ b/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
@@ -133,7 +133,7 @@ def init_logs():
 parser = argparse.ArgumentParser()
 parser.add_argument("infile")
 parser.add_argument("outfile")
-parser.add_argument("-without_variable_width", default=False)
+parser.add_argument("--without_variable_width",action='store', default=False)
 ns = parser.parse_args()
 	
 settings.init()

--- a/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
+++ b/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
@@ -133,9 +133,13 @@ def init_logs():
 parser = argparse.ArgumentParser()
 parser.add_argument("infile")
 parser.add_argument("outfile")
+parser.add_argument("-without_variable_width", default=False)
 ns = parser.parse_args()
-
+	
 settings.init()
+
+if ns.without_variable_width == "True":
+	settings.WITHOUT_VARIABLE_WIDTH = True
 
 out = parse(ns.infile)
 if ns.outfile.endswith(".html"):

--- a/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
+++ b/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
@@ -62,7 +62,7 @@ def gen_html(file_name):
     Returns:
         (None)
     """
-    if len(settings.blur_dictionary) != 0:
+    if len(settings.blur_dictionary) != 0 or settings.OUTLINE_FLAG:
         settings.lottie_format["v"] = "5.6.5"
         bodymovin_path = os.path.join(os.path.dirname(sys.argv[0]), "test_bodymovin.js")
     else:

--- a/synfig-studio/plugins/lottie-exporter/plugin.xml.in
+++ b/synfig-studio/plugins/lottie-exporter/plugin.xml.in
@@ -11,4 +11,20 @@
        <_description>Lottie HTML Preview (*.html)</_description>
        <exec stdout="log">lottie-exporter.py</exec>
    </exporter>
+   <exporter>
+       <extension>html</extension>
+       <_description>Lottie HTML Preview without variable widths (*.html)</_description>
+       <exec stdout="log">lottie-exporter.py</exec>
+       <options>
+			<option name="-without_variable_width" value="True" type="hidden" />
+		</options>
+   </exporter>
+   <exporter>
+       <extension>json</extension>
+       <_description>Lottie HTML Preview without variable widths(*.json)</_description>
+       <exec stdout="log">lottie-exporter.py</exec>
+       <options>
+			<option name="-without_variable_width" value="True" type="hidden" />
+		</options>
+   </exporter>
 </plugin> 

--- a/synfig-studio/plugins/lottie-exporter/plugin.xml.in
+++ b/synfig-studio/plugins/lottie-exporter/plugin.xml.in
@@ -14,17 +14,11 @@
    <exporter>
        <extension>html</extension>
        <_description>Lottie HTML Preview without variable widths (*.html)</_description>
-       <exec stdout="log" interpreter="python">lottie-exporter.py</exec>
-       <options>
-			<option name="--without_variable_width" value="True" type="hidden" />
-		</options>
+       <exec stdout="log" interpreter="python">export_without_variable_width.py</exec>
    </exporter>
    <exporter>
        <extension>json</extension>
        <_description>Lottie HTML Preview without variable widths(*.json)</_description>
-       <exec stdout="log" interpreter="python">lottie-exporter.py</exec>
-       <options>
-			   <option name="--without_variable_width" value="True" type="hidden" />
-		   </options>
+       <exec stdout="log" interpreter="python">export_without_variable_width.py</exec>
    </exporter>
 </plugin> 

--- a/synfig-studio/plugins/lottie-exporter/plugin.xml.in
+++ b/synfig-studio/plugins/lottie-exporter/plugin.xml.in
@@ -14,17 +14,17 @@
    <exporter>
        <extension>html</extension>
        <_description>Lottie HTML Preview without variable widths (*.html)</_description>
-       <exec stdout="log">lottie-exporter.py</exec>
+       <exec stdout="log" interpreter="python">lottie-exporter.py</exec>
        <options>
-			<option name="-without_variable_width" value="True" type="hidden" />
+			<option name="--without_variable_width" value="True" type="hidden" />
 		</options>
    </exporter>
    <exporter>
        <extension>json</extension>
        <_description>Lottie HTML Preview without variable widths(*.json)</_description>
-       <exec stdout="log">lottie-exporter.py</exec>
+       <exec stdout="log" interpreter="python">lottie-exporter.py</exec>
        <options>
-			<option name="-without_variable_width" value="True" type="hidden" />
-		</options>
+			   <option name="--without_variable_width" value="True" type="hidden" />
+		   </options>
    </exporter>
 </plugin> 

--- a/synfig-studio/plugins/lottie-exporter/plugin.xml.in
+++ b/synfig-studio/plugins/lottie-exporter/plugin.xml.in
@@ -2,13 +2,13 @@
 <plugin>
    <_name>Export to Lottie format</_name>
    <exporter>
-       <extension>json</extension>
-       <_description>Lottie Animation (*.json)</_description>
+       <extension>html</extension>
+       <_description>Lottie HTML Preview (*.html)</_description>
        <exec stdout="log">lottie-exporter.py</exec>
    </exporter>
    <exporter>
-       <extension>html</extension>
-       <_description>Lottie HTML Preview (*.html)</_description>
+       <extension>json</extension>
+       <_description>Lottie Animation (*.json)</_description>
        <exec stdout="log">lottie-exporter.py</exec>
    </exporter>
    <exporter>
@@ -18,7 +18,7 @@
    </exporter>
    <exporter>
        <extension>json</extension>
-       <_description>Lottie HTML Preview without variable widths(*.json)</_description>
+       <_description>Lottie Animation without variable widths (*.json)</_description>
        <exec stdout="log" interpreter="python">export_without_variable_width.py</exec>
    </exporter>
 </plugin> 

--- a/synfig-studio/plugins/lottie-exporter/properties/shapeKeyframed.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapeKeyframed.py
@@ -13,7 +13,6 @@ from properties.shapePropKeyframe.rectangle import gen_list_rectangle
 from properties.shapePropKeyframe.star import gen_list_star
 from common.Param import Param
 from common.Layer import Layer
-import settings
 sys.path.append("../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/properties/shapeKeyframed.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapeKeyframed.py
@@ -13,6 +13,7 @@ from properties.shapePropKeyframe.rectangle import gen_list_rectangle
 from properties.shapePropKeyframe.star import gen_list_star
 from common.Param import Param
 from common.Layer import Layer
+import settings
 sys.path.append("../")
 
 

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/Makefile.am
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/Makefile.am
@@ -4,6 +4,7 @@ PLUGIN_NAME = properties/shapePropKeyframe
 
 EXTRA_FILES = \
 			  circle.py \
+			  constant_width_outline.py \
 			  helper.py \
 			  outline.py \
 			  polygon.py \

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/constant_width_outline.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/constant_width_outline.py
@@ -1,0 +1,200 @@
+# pylint: disable=line-too-long
+"""
+Will store all the functions and modules for generation of outline layer
+in Lottie format without variable widths
+"""
+
+import sys
+import math
+import settings
+from common.Bline import Bline
+from common.Vector import Vector
+from common.misc import is_animated
+from common.Count import Count
+from synfig.animation import to_Synfig_axis
+from properties.value import gen_properties_value
+from properties.valueKeyframed import gen_value_Keyframed
+from properties.shapePropKeyframe.helper import add_reverse, add, move_to, get_tangent_at_frame, insert_dict_at, animate_tangents, cubic_to
+from properties.shapePropKeyframe.outline import get_outline_param_at_frame,synfig_outline
+
+def gen_bline_outline_constant(lottie, bline_point, layer, transformation, idx):
+	"""
+	"""
+	index = Count()
+	lottie["ty"]  = "gr"
+	lottie["nm"]  = "Shape "+ str(idx)
+	lottie["np"]  = 3
+	lottie["cix"] = 2
+	lottie["bm"]  = 0
+	lottie["ix"]  = idx
+	lottie["mn"]  = "ADBE Vector Group " +str(idx)
+	lottie["hd"]  = "false"
+	lottie["it"]  = []
+	lottie["it"].append({})
+	lottie["it"].append({})
+	lottie["it"].append({})
+
+	#Creating transformation dictionary
+	lottie["it"][2]["ty"] = "tr"
+	lottie["it"][2]["nm"] = "Transform"
+	lottie["it"][2].update(transformation)
+	#Creating stroke dictionary
+	lottie["it"][1]["ty"] = "st"
+	lottie["it"][1]["lc"] = 2
+	lottie["it"][1]["lj"] = 1
+	lottie["it"][1]["ml"] = 37
+	lottie["it"][1]["bm"] = 0
+	lottie["it"][1]["nm"] = "Stroke " + str(idx)
+	lottie["it"][1]["mn"] = "ADBE Vector Graphic - Stroke " +str(idx)
+	lottie["it"][1]["hd"] = "false"
+	lottie["it"][1]["c"]  = {}
+	lottie["it"][1]["o"]  = {}
+	lottie["it"][1]["w"]  = {}
+
+	#Color
+	color = layer.get_param("color").get()
+	is_animate = is_animated(color[0])
+	if is_animate == settings.ANIMATED:
+		gen_value_Keyframed(lottie["it"][1]["c"], color[0], index.inc())
+
+	else:
+		if is_animate == settings.NOT_ANIMATED:
+			val = color[0]
+		else:
+			val = color[0][0][0]
+		red = float(val[0].text)
+		green = float(val[1].text)
+		blue = float(val[2].text)
+		red, green, blue = red ** (1/settings.GAMMA[0]), green ** (1/settings.GAMMA[1]), blue ** (1/ settings.GAMMA[2])
+		alpha = float(val[3].text)
+		gen_properties_value(lottie["it"][1]["c"],
+							[red, green, blue, alpha],
+							index.inc(),
+							settings.DEFAULT_ANIMATED,
+							settings.NO_INFO)
+
+	#Opacity
+	opacity = layer.get_param("amount").get()
+	is_animate = is_animated(opacity[0])
+	if is_animate == settings.ANIMATED:
+		# Telling the function that this is for opacity
+		opacity[0].attrib['type'] = 'opacity'
+		gen_value_Keyframed(lottie["it"][1]["o"], opacity[0], index.inc())
+
+	else:
+		if is_animate == settings.NOT_ANIMATED:
+			val = float(opacity[0].attrib["value"]) * settings.OPACITY_CONSTANT
+		else:
+			val = float(opacity[0][0][0].attrib["value"]) * settings.OPACITY_CONSTANT
+		gen_properties_value(lottie["it"][1]["o"],
+							 val,
+							 index.inc(),
+							 settings.DEFAULT_ANIMATED,
+							 settings.NO_INFO)
+
+	#Constant width
+	width = layer.get_param("width")
+	width.scale_convert_link(5)
+	width.animate("real")
+	width.fill_path(lottie["it"][1],"w")
+
+	#Creating shape dictionary
+	lottie["it"][0]["ind"] =  0
+	lottie["it"][0]["ty"] = "sh"
+	lottie["it"][0]["ix"] = 1
+	lottie["it"][0]["ks"] = {}
+	lottie["it"][0]["nm"] =  "Path 1",
+	lottie["it"][0]["mn"] =  "ADBE Vector Shape - Group",
+	lottie["it"][0]["hd"] =  "false"
+	lottie["it"][0]["ks"]["a"] = 1 
+	lottie["it"][0]["ks"]["ix"] = lottie["it"][0]["ix"] + 1 
+	lottie["it"][0]["ks"]["k"] = []
+
+	bline = Bline(bline_point[0], bline_point)
+
+	window = {}
+	window["first"] = sys.maxsize
+	window["last"] = -1
+
+	for entry in bline.get_entry_list():
+		pos = entry["point"]
+		width = entry["width"]
+		t1 = entry["t1"]
+		t2 = entry["t2"]
+		split_r = entry["split_radius"]
+		split_a = entry["split_angle"]
+
+		pos.update_frame_window(window)
+		# Empty the pos and fill in the new animated pos
+		pos.animate("vector")
+
+		width.update_frame_window(window)
+		width.animate("real")
+
+		split_r.update_frame_window(window)
+		split_r.animate_without_path("bool")
+
+		split_a.update_frame_window(window)
+		split_a.animate_without_path("bool")
+
+		animate_tangents(t1, window)
+		animate_tangents(t2, window)
+
+
+	outer_width = layer.get_param("width")
+	sharp_cusps = layer.get_param("sharp_cusps")
+	expand = layer.get_param("expand")
+	r_tip0 = layer.get_param("round_tip[0]")
+	r_tip1 = layer.get_param("round_tip[1]")
+	homo_width = layer.get_param("homogeneous_width")
+	origin = layer.get_param("origin")
+
+	# Animating the origin
+	origin.update_frame_window(window)
+	origin.animate("vector")
+
+	# Animating the outer width
+	outer_width.update_frame_window(window)
+	outer_width.animate("real")
+
+	# Animating the sharp_cusps
+	sharp_cusps.update_frame_window(window)
+	sharp_cusps.animate_without_path("bool")
+
+	# Animating the expand param
+	expand.update_frame_window(window)
+	expand.animate("real")
+
+	# Animating the round tip 0
+	r_tip0.update_frame_window(window)
+	r_tip0.animate_without_path("bool")
+
+	# Animating the round tip 1
+	r_tip1.update_frame_window(window)
+	r_tip1.animate_without_path("bool")
+
+	# Animating the homogeneous width
+	homo_width.update_frame_window(window)
+	homo_width.animate_without_path("bool")
+	# Minimizing the window size
+	if window["first"] == sys.maxsize and window["last"] == -1:
+		window["first"] = window["last"] = 0
+	temp = []
+	fr = window["first"]
+	while fr <= window["last"]:
+		st_val, en_val = insert_dict_at(temp, -1, fr, False)  # This loop needs to be considered somewhere down
+
+		synfig_outline(bline, st_val, origin, outer_width, sharp_cusps, expand, r_tip0, r_tip1, homo_width, fr)
+		synfig_outline(bline, en_val, origin, outer_width, sharp_cusps, expand, r_tip0, r_tip1, homo_width, fr + 1)
+		fr+=1
+	frames = list(set(settings.WAYPOINTS_LIST))
+	length = bline.get_len()
+
+	for fr in frames:
+		st_val = insert_dict_at(lottie["it"][0]["ks"]["k"], -1, fr, False,True)
+		cur_origin = origin.get_value(fr)
+		for point in range(0,length):
+			pos_ret, width, t1, t2, split_r_val, split_a_val = get_outline_param_at_frame(bline[point],fr)
+			cubic_to(pos_ret,t1,t2,st_val,cur_origin,False,True)
+
+

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/constant_width_outline.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/constant_width_outline.py
@@ -80,11 +80,7 @@ def gen_bline_outline_constant(lottie, bline_point, layer, transformation, idx):
 	#Constant width
 	loop = bline.get_loop()
 	width = layer.get_param("width")
-	if loop:
-		width.scale_convert_link(1)
-	else:
-		width.scale_convert_link(4)
-
+	width.scale_convert_link(1)
 	width.animate("real")
 	width.fill_path(lottie["it"][1],"w")
 
@@ -93,8 +89,8 @@ def gen_bline_outline_constant(lottie, bline_point, layer, transformation, idx):
 	lottie["it"][0]["ty"] = "sh"
 	lottie["it"][0]["ix"] = 1
 	lottie["it"][0]["ks"] = {}
-	lottie["it"][0]["nm"] =  "Path 1",
-	lottie["it"][0]["mn"] =  "ADBE Vector Shape - Group",
+	lottie["it"][0]["nm"] =  "Path 1"
+	lottie["it"][0]["mn"] =  "ADBE Vector Shape - Group"
 	lottie["it"][0]["hd"] =  "false"
 	lottie["it"][0]["ks"]["a"] = 1 
 	lottie["it"][0]["ks"]["ix"] = lottie["it"][0]["ix"] + 1 
@@ -176,10 +172,11 @@ def gen_bline_outline_constant(lottie, bline_point, layer, transformation, idx):
 		flag = True
 
 	for fr in frames:
-		st_val = insert_dict_at(lottie["it"][0]["ks"]["k"], -1, fr, flag,True)
-		cur_origin = origin.get_value(fr)
-		for point in range(0,length):
-			pos_ret, width, t1, t2, split_r_val, split_a_val = get_outline_param_at_frame(bline[point],fr)
-			cubic_to(pos_ret,t1,t2,st_val,cur_origin,False,True)
+		if fr!=1:
+			st_val = insert_dict_at(lottie["it"][0]["ks"]["k"], -1, fr, flag,True)
+			cur_origin = origin.get_value(fr)
+			for point in range(0,length):
+				pos_ret, width, t1, t2, split_r_val, split_a_val = get_outline_param_at_frame(bline[point],fr)
+				cubic_to(pos_ret,t1,t2,st_val,cur_origin,False,True)
 
 

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
@@ -153,7 +153,7 @@ def add_reverse(side, lottie, origin_cur):
         i -= 1
 
 
-def cubic_to(vec, tan1, tan2, lottie, origin_cur, is_rectangle=False):
+def cubic_to(vec, tan1, tan2, lottie, origin_cur, is_rectangle=False,constant_width=False):
     """
     Will have to manipulate the tangents here, but they are not managed as tan1
     and tan2 both are zero always
@@ -171,7 +171,10 @@ def cubic_to(vec, tan1, tan2, lottie, origin_cur, is_rectangle=False):
     vec *= settings.PIX_PER_UNIT
     tan1 *= settings.PIX_PER_UNIT
     tan2 *= settings.PIX_PER_UNIT
-    tan1, tan2 = convert_tangent_to_lottie(3*tan1, 3*tan2)
+    if constant_width:
+        tan1, tan2 = convert_tangent_to_lottie(tan1, tan2)
+    else:
+        tan1, tan2 = convert_tangent_to_lottie(3*tan1, 3*tan2)
     pos = change_axis(vec[0], vec[1], not is_rectangle)
     for i in range(len(pos)):
         pos[i] += origin_cur[i]
@@ -227,7 +230,7 @@ def convert_tangent_to_lottie(t1, t2):
     return t1, t2
 
 
-def insert_dict_at(lottie, idx, fr, loop):
+def insert_dict_at(lottie, idx, fr, loop,constant=False):
     """
     Inserts dictionary values in the main dictionary, required by shape layer of
     lottie format
@@ -250,14 +253,23 @@ def insert_dict_at(lottie, idx, fr, loop):
     lottie[idx]["i"]["x"] = lottie[idx]["i"]["y"] = 0.5     # Does not matter because frames are adjacent
     lottie[idx]["o"]["x"] = lottie[idx]["o"]["y"] = 0.5     # Does not matter because frames are adjacent
     lottie[-1]["t"] = fr
-    lottie[idx]["s"], lottie[idx]["e"] = [], []
-    st_val, en_val = lottie[idx]["s"], lottie[idx]["e"]
+    if constant:
+        lottie[idx]["s"] = []
+        st_val = lottie[idx]["s"]
 
-    st_val.append({}), en_val.append({})
-    st_val, en_val = st_val[0], en_val[0]
-    st_val["i"], st_val["o"], st_val["v"], st_val["c"] = [], [], [], loop
-    en_val["i"], en_val["o"], en_val["v"], en_val["c"] = [], [], [], loop
-    return st_val, en_val
+        st_val.append({})
+        st_val = st_val[0]
+        st_val["i"], st_val["o"], st_val["v"], st_val["c"] = [], [], [], loop
+        return st_val
+    else:
+        lottie[idx]["s"], lottie[idx]["e"] = [], []
+        st_val, en_val = lottie[idx]["s"], lottie[idx]["e"]
+
+        st_val.append({}), en_val.append({})
+        st_val, en_val = st_val[0], en_val[0]
+        st_val["i"], st_val["o"], st_val["v"], st_val["c"] = [], [], [], loop
+        en_val["i"], en_val["o"], en_val["v"], en_val["c"] = [], [], [], loop
+        return st_val, en_val
 
 
 def quadratic_to_cubic(qp0, qp1, qp2):

--- a/synfig-studio/plugins/lottie-exporter/settings.py
+++ b/synfig-studio/plugins/lottie-exporter/settings.py
@@ -61,7 +61,7 @@ ADDITIONAL_PRECOMP_HEIGHT = 0
 NOT_SUPPORTED_TEXT = "Layer '%s' is not supported yet. For more information, contact us on Synfig forums or Github page"
 NOT_ACTIVE_TEXT = "Layer '%s' is not active"
 EXCLUDE_FROM_RENDERING = "Layer '%s' is excluded from rendering"
-SHAPE_LAYER = {"simple_circle", "linear_gradient", "radial_gradient","outline"}
+SHAPE_LAYER = {"simple_circle", "linear_gradient", "radial_gradient"}
 BLUR_LAYER = {"blur"}
 SOLID_LAYER = {"SolidColor"}
 SHAPE_SOLID_LAYER = {"region", "polygon", "outline", "circle", "rectangle", "filled_rectangle", "star"} 
@@ -81,6 +81,7 @@ NOT_ANIMATED = 0
 LEVEL = 0 #Indicates the depth of a layer
 OUTLINE_FLAG = False #Flag to check for outline as outline needs the newer version of bodymovin.js
 WAYPOINTS_LIST = []
+WITHOUT_VARIABLE_WIDTH = False
 
 def init():
     """

--- a/synfig-studio/plugins/lottie-exporter/settings.py
+++ b/synfig-studio/plugins/lottie-exporter/settings.py
@@ -61,7 +61,7 @@ ADDITIONAL_PRECOMP_HEIGHT = 0
 NOT_SUPPORTED_TEXT = "Layer '%s' is not supported yet. For more information, contact us on Synfig forums or Github page"
 NOT_ACTIVE_TEXT = "Layer '%s' is not active"
 EXCLUDE_FROM_RENDERING = "Layer '%s' is excluded from rendering"
-SHAPE_LAYER = {"simple_circle", "linear_gradient", "radial_gradient"}
+SHAPE_LAYER = {"simple_circle", "linear_gradient", "radial_gradient","outline"}
 BLUR_LAYER = {"blur"}
 SOLID_LAYER = {"SolidColor"}
 SHAPE_SOLID_LAYER = {"region", "polygon", "outline", "circle", "rectangle", "filled_rectangle", "star"} 
@@ -79,6 +79,8 @@ ANIMATED = 2
 SINGLE_WAYPOINT = 1
 NOT_ANIMATED = 0
 LEVEL = 0 #Indicates the depth of a layer
+OUTLINE_FLAG = False #Flag to check for outline as outline needs the newer version of bodymovin.js
+WAYPOINTS_LIST = []
 
 def init():
     """


### PR DESCRIPTION
Added support for exporting outlines without variable widths. A few tweaks needed but there is a huge decrease in file size on checking so far :smiley: .
@AnishGG please check