### PR TITLE
fix memory leak on thread pool

### DIFF
--- a/synfig-core/src/synfig/threadpool.cpp
+++ b/synfig-core/src/synfig/threadpool.cpp
@@ -177,6 +177,7 @@ ThreadPool::~ThreadPool() {
 			threads.pop_back();
 		}
 		thread->join();
+		delete thread;
 	}
 
 	{


### PR DESCRIPTION
ThreadPools::threads is filled with threads allocated in ThreadPool::wakeup() . They're never destroyed.

They can be safely deleted after joined.
https://stackoverflow.com/questions/30090299/delete-stdthread-after-calling-join