### PR TITLE
Fixed 'Error: Broken pipe' message, when installing brew packages on MacOS

### DIFF
--- a/1-setup-osx-brew.sh
+++ b/1-setup-osx-brew.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zlib not required because it is already part of OSX
+# zlib not required because it is already part of MacOS/OSX
 
 # Travis-CI workaround
 # When we install a package that is already installed inside the travis VM, and we have an outdated brew
@@ -23,7 +23,29 @@ pushd "${WORKDIR}" > /dev/null
 WORKDIR=`pwd`
 popd > /dev/null
 
-PACKAGES="adwaita-icon-theme autoconf automake ccache libtool intltool imagemagick gettext pkg-config glibmm libxml++ cairo fftw pango mlt boost gtkmm3 sdl2 sdl2_mixer libxml2 libxslt"
+PACKAGES="\
+adwaita-icon-theme \
+autoconf \
+automake \
+boost \
+cairo \
+ccache \
+fftw \
+gettext \
+glibmm \
+gtkmm3 \
+imagemagick \
+intltool \
+libtool \
+libxml++ \
+libxml2 \
+libxslt \
+mlt \
+pango \
+pkg-config \
+python \
+sdl2 \
+sdl2_mixer"
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
@@ -40,13 +62,13 @@ if [ $OS -lt 15 ] && [ -z "$TRAVIS_BUILD_DIR" ]; then # For OSX < 10.11
     git checkout a91becd6afc177b0cada2cf9cce2e3bde514053b # librsvg 2.40.20 (without rust) 2017.12.16
     cd /usr/local/Homebrew/
     git checkout 1.4.1
-    brew info gobject-introspection | grep --quiet 'Not installed' && brew install ${WORKDIR}/autobuild/osx/gobject-introspection.rb
+    brew info gobject-introspection | grep >/dev/null 'Not installed' && brew install ${WORKDIR}/autobuild/osx/gobject-introspection.rb
 fi
 
 for pkg in $PACKAGES;
 do
     echo "Checking $pkg..."
-    brew info "$pkg" | grep --quiet 'Not installed' && brew install "$pkg"
+    brew info "$pkg" | grep 'Not installed' >/dev/null && brew install "$pkg"
 done
 
 if ! ( which pip >/dev/null ); then
@@ -62,21 +84,3 @@ if `which pip3 >/dev/null`; then
     PIPBINARY=pip3
 fi
 STATIC_DEPS=true sudo $PIPBINARY install lxml
-
-
-#HOMEBREW_NO_AUTO_UPDATE=1 brew bundle -no-upgrade --file=-<<-EOF
-#brew "autoconf"
-#brew "automake"
-#brew "boost"
-#brew "cairo"
-#brew "fftw"
-#brew "gettext"
-#brew "glibmm"
-#brew "gtkmm3"
-#brew "intltool"
-#brew "libtool"
-#brew "libxml++"
-#brew "mlt"
-#brew "pango"
-#brew "pkg-config"
-#EOF


### PR DESCRIPTION
There was a strange message when installing formulas:
```
🍺  /usr/local/Cellar/intltool/0.51.0: 19 files, 185.8K
Checking imagemagick...
Error: Broken pipe
==> Installing dependencies for imagemagick: xz, libpng, libtiff, freetype
```

It was happening because `grep --quiet 'Not installed' ` exits right after the first occurrence of the search string, and pipe is broken. 
Now output is redirected to `/dev/null` instead of using `quiet` mode.

Also added `python` package as explicit dependency and brew formulas list is sorted.