### PR TITLE
[CMake] Fixed path for splash screen image and added Adwaita icons for MSYS2 builds.

### DIFF
--- a/cmake/InstallMSYS2.cmake
+++ b/cmake/InstallMSYS2.cmake
@@ -132,4 +132,7 @@ if(WIN32)
     )
     file(COPY ${LIB_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/lib)
     install(DIRECTORY ${LIB_DIRECTORIES} DESTINATION lib)
+
+    file(COPY ${MINGW_PATH}/share/icons/Adwaita DESTINATION ${SYNFIG_BUILD_ROOT}/share/icons)
+    install(DIRECTORY ${MINGW_PATH}/share/icons/Adwaita DESTINATION share/icons)
 endif()

--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -296,15 +296,16 @@ elseif(${CMAKE_BUILD_TYPE} MATCHES Release)
     set(SYNFIG_SPLASH_SCREEN ${CMAKE_CURRENT_SOURCE_DIR}/splash_screen.sif)
 endif()
 
+set(SPLASH_SCREEN_DIR ${SYNFIG_BUILD_ROOT}/share/synfig/images)
 add_custom_command(
-    OUTPUT ${PIXMAPS_DIR}/splash_screen.png
-    COMMAND synfig_bin ${SYNFIG_SPLASH_SCREEN} -o ${PIXMAPS_DIR}/splash_screen.png --time 0f --quiet
+    OUTPUT ${SPLASH_SCREEN_DIR}/splash_screen.png
+    COMMAND synfig_bin ${SYNFIG_SPLASH_SCREEN} -o ${SPLASH_SCREEN_DIR}/splash_screen.png --time 0f --quiet
     DEPENDS ${SYNFIG_SPLASH_SCREEN} synfig_bin
 )
 
-list(APPEND PIXMAPS ${PIXMAPS_DIR}/splash_screen.png)
+list(APPEND PIXMAPS ${SPLASH_SCREEN_DIR}/splash_screen.png)
 install(
-    FILES ${PIXMAPS_DIR}/splash_screen.png
+    FILES ${SPLASH_SCREEN_DIR}/splash_screen.png
     DESTINATION share/pixmaps/synfigstudio
 )
 


### PR DESCRIPTION
Fixes the issue raised [here](https://github.com/synfig/synfig/issues/1058#issuecomment-683697028) in #1058.

