### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,24 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SYNFIG_BUILD_ROOT}/bin)
 
+# MSYS is defined for MSYS Makefiles generator and undefined for Ninja (for example)
+# But if you run CMake from MSYS shell, we can still detect MSYS by environment variables (MINGW_PREFIX)
+# https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/How-To-Write-Platform-Checks
+if(MINGW AND NOT MSYS)
+	if (NOT DEFINED ENV{MINGW_PREFIX})
+		message(FATAL_ERROR "Currently we only support MSYS2 environment for MinGW compiler on Windows."
+				" Please pass '-DMSYS=1' to your CMake command to force using MSYS."
+				" Also you need to set MINGW_PREFIX environment variable if your MSYS2 installation is not in standard path (c:\\msys64\\)")
+	else()
+		set(MSYS ON)
+	endif()
+endif()
+
 #set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 #set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Debug)
+	set(CMAKE_BUILD_TYPE Debug)
 endif()
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-inline-functions -fno-inline -g -O0 -Wall")
@@ -43,7 +56,7 @@ include_directories(synfig-core/src)
 add_subdirectory(synfig-studio)
 
 if(WIN32)
-    include(InstallMSYS2)
+	include(InstallMSYS2)
 endif()
 
 include(CPackConfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ add_subdirectory(synfig-core)
 include_directories(synfig-core/src)
 add_subdirectory(synfig-studio)
 
-if(WIN32)
+if(MSYS)
 	include(InstallMSYS2)
 endif()
 

--- a/cmake/InstallMSYS2.cmake
+++ b/cmake/InstallMSYS2.cmake
@@ -92,7 +92,7 @@ if(WIN32)
 #    file(COPY ${MINGW_LIBS} DESTINATION ${SYNFIG_BUILD_ROOT}/bin)
     install(FILES ${MINGW_LIBS} DESTINATION bin)
 
-    find_program(CYGPATH_EXECUTABLE cygpath)
+    find_program(CYGPATH_EXECUTABLE cygpath ${MINGW_PATH}/../usr/bin/)
     if(CYGPATH_EXECUTABLE)
         set(MLT_PATH "/opt/mlt-6.16.0")
         execute_process(

--- a/cmake/InstallMSYS2.cmake
+++ b/cmake/InstallMSYS2.cmake
@@ -4,13 +4,31 @@ if(WIN32)
     set(MINGW_BIN "${MINGW_PATH}/bin")
     set(MINGW_LIB "${MINGW_PATH}/lib")
 
+    # MSYS2 Hacks
+
+    # This code fixes MSYS2 related problems and can be safely removed after these problems are resolved
+
+    # ImageMagick has problems finding modules in MSYS2. For example, if you copy `magick.exe` somewhere
+    # outside the `/mingw64/bin` folder and try to do some manipulation with images, for example:
+    # `./magick.exe test.jpg test.png`, then this command will fail with error
+    # `magick.exe: NoDecodeDelegateForThisImageFormat `JPEG '@ error / Create.c / ReadImage / 562.`
+    # `synfig-cli` also fails when trying to make icons and images, so to fix this issue we need to copy ImageMagick's
+    # libs inside our build directory. Read more about ImageMagick paths and environment variables:
+    # https://imagemagick.org/script/resources.php#environment
+
+    file(GLOB MAGICK_LIBS ${MINGW_LIB}/ImageMagick-*)
+    file(COPY ${MAGICK_LIBS} DESTINATION ${SYNFIG_BUILD_ROOT}/lib)
+
+    # End of hacks
+
+
     # /output/bin
     file(GLOB MINGW_LIBS
         ${MINGW_BIN}/libatk-1.0-[0-9]*.dll
         ${MINGW_BIN}/libatkmm-1.6-[0-9]*.dll
         ${MINGW_BIN}/libbz2-[0-9]*.dll
-        ${MINGW_BIN}/libbrotlicommon.dll 
-        ${MINGW_BIN}/libbrotlidec.dll 
+        ${MINGW_BIN}/libbrotlicommon.dll
+        ${MINGW_BIN}/libbrotlidec.dll
         ${MINGW_BIN}/libcairo-[0-9]*.dll
         ${MINGW_BIN}/libcairo-gobject-[0-9]*.dll
         ${MINGW_BIN}/libcairo-script-interpreter-[0-9]*.dll
@@ -19,7 +37,7 @@ if(WIN32)
         ${MINGW_BIN}/libdl.dll
         ${MINGW_BIN}/libepoxy-[0-9]*.dll
         ${MINGW_BIN}/libexpat-[0-9]*.dll
-        ${MINGW_BIN}/libffi-[0-9]*.dll 
+        ${MINGW_BIN}/libffi-[0-9]*.dll
         ${MINGW_BIN}/libfftw3-[0-9]*.dll
         ${MINGW_BIN}/libfftw3f-[0-9]*.dll
         ${MINGW_BIN}/libfribidi-[0-9]*.dll
@@ -71,8 +89,8 @@ if(WIN32)
         ${MINGW_BIN}/libxml2-[0-9]*.dll
         ${MINGW_BIN}/zlib[0-9]*.dll
     )
-    file(COPY ${MINGW_LIBS} DESTINATION ${SYNFIG_BUILD_ROOT}/bin)
-    install(FILES ${MINGW_LIBS} DESTINATION bin) 
+#    file(COPY ${MINGW_LIBS} DESTINATION ${SYNFIG_BUILD_ROOT}/bin)
+    install(FILES ${MINGW_LIBS} DESTINATION bin)
 
     find_program(CYGPATH_EXECUTABLE cygpath)
     if(CYGPATH_EXECUTABLE)
@@ -109,7 +127,7 @@ if(WIN32)
         ${MINGW_PATH}/etc/ImageMagick-[0-9]*
         ${MINGW_PATH}/etc/gtk-3.[0-9]*
     )
-    file(COPY ${ETC_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/etc)
+#    file(COPY ${ETC_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/etc)
     INSTALL(DIRECTORY ${ETC_DIRECTORIES} DESTINATION etc)
 
     # /output/lib
@@ -130,9 +148,9 @@ if(WIN32)
         ${MINGW_LIB}/libxml++-2.[0-9]
         ${MINGW_LIB}/pkgconfig
     )
-    file(COPY ${LIB_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/lib)
+#    file(COPY ${LIB_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/lib)
     install(DIRECTORY ${LIB_DIRECTORIES} DESTINATION lib)
 
-    file(COPY ${MINGW_PATH}/share/icons/Adwaita DESTINATION ${SYNFIG_BUILD_ROOT}/share/icons)
+#    file(COPY ${MINGW_PATH}/share/icons/Adwaita DESTINATION ${SYNFIG_BUILD_ROOT}/share/icons)
     install(DIRECTORY ${MINGW_PATH}/share/icons/Adwaita DESTINATION share/icons)
 endif()

--- a/cmake/InstallMSYS2.cmake
+++ b/cmake/InstallMSYS2.cmake
@@ -1,156 +1,154 @@
-if(WIN32)
-    set(MINGW_PATH $ENV{MINGW_PREFIX})
+set(MINGW_PATH $ENV{MINGW_PREFIX})
 
-    set(MINGW_BIN "${MINGW_PATH}/bin")
-    set(MINGW_LIB "${MINGW_PATH}/lib")
+set(MINGW_BIN "${MINGW_PATH}/bin")
+set(MINGW_LIB "${MINGW_PATH}/lib")
 
-    # MSYS2 Hacks
+# MSYS2 Hacks
 
-    # This code fixes MSYS2 related problems and can be safely removed after these problems are resolved
+# This code fixes MSYS2 related problems and can be safely removed after these problems are resolved
 
-    # ImageMagick has problems finding modules in MSYS2. For example, if you copy `magick.exe` somewhere
-    # outside the `/mingw64/bin` folder and try to do some manipulation with images, for example:
-    # `./magick.exe test.jpg test.png`, then this command will fail with error
-    # `magick.exe: NoDecodeDelegateForThisImageFormat `JPEG '@ error / Create.c / ReadImage / 562.`
-    # `synfig-cli` also fails when trying to make icons and images, so to fix this issue we need to copy ImageMagick's
-    # libs inside our build directory. Read more about ImageMagick paths and environment variables:
-    # https://imagemagick.org/script/resources.php#environment
+# ImageMagick has problems finding modules in MSYS2. For example, if you copy `magick.exe` somewhere
+# outside the `/mingw64/bin` folder and try to do some manipulation with images, for example:
+# `./magick.exe test.jpg test.png`, then this command will fail with error
+# `magick.exe: NoDecodeDelegateForThisImageFormat `JPEG '@ error / Create.c / ReadImage / 562.`
+# `synfig-cli` also fails when trying to make icons and images, so to fix this issue we need to copy ImageMagick's
+# libs inside our build directory. Read more about ImageMagick paths and environment variables:
+# https://imagemagick.org/script/resources.php#environment
 
-    file(GLOB MAGICK_LIBS ${MINGW_LIB}/ImageMagick-*)
-    file(COPY ${MAGICK_LIBS} DESTINATION ${SYNFIG_BUILD_ROOT}/lib)
+file(GLOB MAGICK_LIBS ${MINGW_LIB}/ImageMagick-*)
+file(COPY ${MAGICK_LIBS} DESTINATION ${SYNFIG_BUILD_ROOT}/lib)
 
-    # End of hacks
+# End of hacks
 
 
-    # /output/bin
-    file(GLOB MINGW_LIBS
-        ${MINGW_BIN}/libatk-1.0-[0-9]*.dll
-        ${MINGW_BIN}/libatkmm-1.6-[0-9]*.dll
-        ${MINGW_BIN}/libbz2-[0-9]*.dll
-        ${MINGW_BIN}/libbrotlicommon.dll
-        ${MINGW_BIN}/libbrotlidec.dll
-        ${MINGW_BIN}/libcairo-[0-9]*.dll
-        ${MINGW_BIN}/libcairo-gobject-[0-9]*.dll
-        ${MINGW_BIN}/libcairo-script-interpreter-[0-9]*.dll
-        ${MINGW_BIN}/libcairomm-1.0-[0-9]*.dll
-        ${MINGW_BIN}/libdatrie-[0-9]*.dll
-        ${MINGW_BIN}/libdl.dll
-        ${MINGW_BIN}/libepoxy-[0-9]*.dll
-        ${MINGW_BIN}/libexpat-[0-9]*.dll
-        ${MINGW_BIN}/libffi-[0-9]*.dll
-        ${MINGW_BIN}/libfftw3-[0-9]*.dll
-        ${MINGW_BIN}/libfftw3f-[0-9]*.dll
-        ${MINGW_BIN}/libfribidi-[0-9]*.dll
-        ${MINGW_BIN}/libfontconfig-[0-9]*.dll
-        ${MINGW_BIN}/libfreetype-[0-9]*.dll
-        ${MINGW_BIN}/libgailutil-3-[0-9]*.dll
-        ${MINGW_BIN}/libgcc_s_seh-[0-9]*.dll
-        ${MINGW_BIN}/libgdk_pixbuf-2.0-[0-9]*.dll
-        ${MINGW_BIN}/libgdk-3-[0-9]*.dll
-        ${MINGW_BIN}/libgdkmm-3.0-[0-9]*.dll
-        ${MINGW_BIN}/libgio-2.0-[0-9]*.dll
-        ${MINGW_BIN}/libgiomm-2.4-[0-9]*.dll
-        ${MINGW_BIN}/libglib-2.0-[0-9]*.dll
-        ${MINGW_BIN}/libglibmm_generate_extra_defs-2.4-[0-9]*.dll
-        ${MINGW_BIN}/libglibmm-2.4-[0-9]*.dll
-        ${MINGW_BIN}/libgmodule-2.0-[0-9]*.dll
-        ${MINGW_BIN}/libgobject-2.0-[0-9]*.dll
-        ${MINGW_BIN}/libgraphite[0-9]*.dll
-        ${MINGW_BIN}/libgthread-2.0-[0-9]*.dll
-        ${MINGW_BIN}/libgtk-3-[0-9]*.dll
-        ${MINGW_BIN}/libgtkmm-3.0-[0-9]*.dll
-        ${MINGW_BIN}/libharfbuzz-[0-9]*.dll
-        ${MINGW_BIN}/libiconv-[0-9]*.dll
-        ${MINGW_BIN}/libintl-[0-9]*.dll
-        ${MINGW_BIN}/liblzma-[0-9]*.dll
-        ${MINGW_BIN}/libltdl-[0-9]*.dll
-        ${MINGW_BIN}/libMagick++-[A-Z0-9.-]*.dll
-        ${MINGW_BIN}/libMagickCore-[A-Z0-9.-]*.dll
-        ${MINGW_BIN}/libMagickWand-[A-Z0-9.-]*.dll
-        ${MINGW_BIN}/libpango-1.0-[0-9]*.dll
-        ${MINGW_BIN}/libpangocairo-1.0-[0-9]*.dll
-        ${MINGW_BIN}/libpangoft2-1.0-[0-9]*.dll
-        ${MINGW_BIN}/libpangomm-1.4-[0-9]*.dll
-        ${MINGW_BIN}/libpangowin32-1.0-[0-9]*.dll
-        ${MINGW_BIN}/libpcre-[0-9]*.dll
-        ${MINGW_BIN}/libpixman-1-[0-9]*.dll
-        ${MINGW_BIN}/libpng16-1[0-9]*.dll
-        ${MINGW_BIN}/libpng16-config
-        ${MINGW_BIN}/libquadmath-[0-9]*.dll
-        ${MINGW_BIN}/librsvg-2-[0-9]*.dll
-        ${MINGW_BIN}/libsigc-2.0-[0-9]*.dll
-        ${MINGW_BIN}/libssp-[0-9]*.dll
-        ${MINGW_BIN}/libstdc++-[0-9]*.dll
-        ${MINGW_BIN}/libthai-[0-9]*.dll
-        ${MINGW_BIN}/libtiff-[0-9]*.dll
-        ${MINGW_BIN}/libtiffxx-[0-9]*.dll
-        ${MINGW_BIN}/libwinpthread-[0-9]*.dll
-        ${MINGW_BIN}/libxml++-2.6-[0-9]*.dll
-        ${MINGW_BIN}/libxml2-[0-9]*.dll
-        ${MINGW_BIN}/zlib[0-9]*.dll
-    )
+# /output/bin
+file(GLOB MINGW_LIBS
+	    ${MINGW_BIN}/libatk-1.0-[0-9]*.dll
+	    ${MINGW_BIN}/libatkmm-1.6-[0-9]*.dll
+	    ${MINGW_BIN}/libbz2-[0-9]*.dll
+	    ${MINGW_BIN}/libbrotlicommon.dll
+	    ${MINGW_BIN}/libbrotlidec.dll
+	    ${MINGW_BIN}/libcairo-[0-9]*.dll
+	    ${MINGW_BIN}/libcairo-gobject-[0-9]*.dll
+	    ${MINGW_BIN}/libcairo-script-interpreter-[0-9]*.dll
+	    ${MINGW_BIN}/libcairomm-1.0-[0-9]*.dll
+	    ${MINGW_BIN}/libdatrie-[0-9]*.dll
+	    ${MINGW_BIN}/libdl.dll
+	    ${MINGW_BIN}/libepoxy-[0-9]*.dll
+	    ${MINGW_BIN}/libexpat-[0-9]*.dll
+	    ${MINGW_BIN}/libffi-[0-9]*.dll
+	    ${MINGW_BIN}/libfftw3-[0-9]*.dll
+	    ${MINGW_BIN}/libfftw3f-[0-9]*.dll
+	    ${MINGW_BIN}/libfribidi-[0-9]*.dll
+	    ${MINGW_BIN}/libfontconfig-[0-9]*.dll
+	    ${MINGW_BIN}/libfreetype-[0-9]*.dll
+	    ${MINGW_BIN}/libgailutil-3-[0-9]*.dll
+	    ${MINGW_BIN}/libgcc_s_seh-[0-9]*.dll
+	    ${MINGW_BIN}/libgdk_pixbuf-2.0-[0-9]*.dll
+	    ${MINGW_BIN}/libgdk-3-[0-9]*.dll
+	    ${MINGW_BIN}/libgdkmm-3.0-[0-9]*.dll
+	    ${MINGW_BIN}/libgio-2.0-[0-9]*.dll
+	    ${MINGW_BIN}/libgiomm-2.4-[0-9]*.dll
+	    ${MINGW_BIN}/libglib-2.0-[0-9]*.dll
+	    ${MINGW_BIN}/libglibmm_generate_extra_defs-2.4-[0-9]*.dll
+	    ${MINGW_BIN}/libglibmm-2.4-[0-9]*.dll
+	    ${MINGW_BIN}/libgmodule-2.0-[0-9]*.dll
+	    ${MINGW_BIN}/libgobject-2.0-[0-9]*.dll
+	    ${MINGW_BIN}/libgraphite[0-9]*.dll
+	    ${MINGW_BIN}/libgthread-2.0-[0-9]*.dll
+	    ${MINGW_BIN}/libgtk-3-[0-9]*.dll
+	    ${MINGW_BIN}/libgtkmm-3.0-[0-9]*.dll
+	    ${MINGW_BIN}/libharfbuzz-[0-9]*.dll
+	    ${MINGW_BIN}/libiconv-[0-9]*.dll
+	    ${MINGW_BIN}/libintl-[0-9]*.dll
+	    ${MINGW_BIN}/liblzma-[0-9]*.dll
+	    ${MINGW_BIN}/libltdl-[0-9]*.dll
+	    ${MINGW_BIN}/libMagick++-[A-Z0-9.-]*.dll
+	    ${MINGW_BIN}/libMagickCore-[A-Z0-9.-]*.dll
+	    ${MINGW_BIN}/libMagickWand-[A-Z0-9.-]*.dll
+	    ${MINGW_BIN}/libpango-1.0-[0-9]*.dll
+	    ${MINGW_BIN}/libpangocairo-1.0-[0-9]*.dll
+	    ${MINGW_BIN}/libpangoft2-1.0-[0-9]*.dll
+	    ${MINGW_BIN}/libpangomm-1.4-[0-9]*.dll
+	    ${MINGW_BIN}/libpangowin32-1.0-[0-9]*.dll
+	    ${MINGW_BIN}/libpcre-[0-9]*.dll
+	    ${MINGW_BIN}/libpixman-1-[0-9]*.dll
+	    ${MINGW_BIN}/libpng16-1[0-9]*.dll
+	    ${MINGW_BIN}/libpng16-config
+	    ${MINGW_BIN}/libquadmath-[0-9]*.dll
+	    ${MINGW_BIN}/librsvg-2-[0-9]*.dll
+	    ${MINGW_BIN}/libsigc-2.0-[0-9]*.dll
+	    ${MINGW_BIN}/libssp-[0-9]*.dll
+	    ${MINGW_BIN}/libstdc++-[0-9]*.dll
+	    ${MINGW_BIN}/libthai-[0-9]*.dll
+	    ${MINGW_BIN}/libtiff-[0-9]*.dll
+	    ${MINGW_BIN}/libtiffxx-[0-9]*.dll
+	    ${MINGW_BIN}/libwinpthread-[0-9]*.dll
+	    ${MINGW_BIN}/libxml++-2.6-[0-9]*.dll
+	    ${MINGW_BIN}/libxml2-[0-9]*.dll
+	    ${MINGW_BIN}/zlib[0-9]*.dll
+	    )
 #    file(COPY ${MINGW_LIBS} DESTINATION ${SYNFIG_BUILD_ROOT}/bin)
-    install(FILES ${MINGW_LIBS} DESTINATION bin)
+install(FILES ${MINGW_LIBS} DESTINATION bin)
 
-    find_program(CYGPATH_EXECUTABLE cygpath ${MINGW_PATH}/../usr/bin/)
-    if(CYGPATH_EXECUTABLE)
-        set(MLT_PATH "/opt/mlt-6.16.0")
-        execute_process(
-            COMMAND ${CYGPATH_EXECUTABLE} -m ${MLT_PATH}
-            OUTPUT_VARIABLE MLT_DIRECTORY
-            ERROR_QUIET
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        message(${MLT_DIRECTORY})
-    else()
-        message(WARNING "-- cygpath tool not found, using relative path for MLT.")
-        set(MLT_DIRECTORY "${MINGW_PATH}/../opt/mlt-6.16.0")
-    endif()
-
-    file(GLOB MLT_FILES
-        ${MLT_DIRECTORY}/libmlt++-3.dll
-        ${MLT_DIRECTORY}/libmlt-6.dll
-        ${MLT_DIRECTORY}/melt.exe
+find_program(CYGPATH_EXECUTABLE cygpath ${MINGW_PATH}/../usr/bin/)
+if(CYGPATH_EXECUTABLE)
+    set(MLT_PATH "/opt/mlt-6.16.0")
+    execute_process(
+		    COMMAND ${CYGPATH_EXECUTABLE} -m ${MLT_PATH}
+		    OUTPUT_VARIABLE MLT_DIRECTORY
+		    ERROR_QUIET
+		    OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    file(COPY ${MLT_FILES} DESTINATION ${SYNFIG_BUILD_ROOT}/bin)
-    install(FILES ${MLT_FILES} DESTINATION bin)
+    message(${MLT_DIRECTORY})
+else()
+    message(WARNING "-- cygpath tool not found, using relative path for MLT.")
+    set(MLT_DIRECTORY "${MINGW_PATH}/../opt/mlt-6.16.0")
+endif()
 
-   file(GLOB MLT_DIRECTORIES
-        ${MLT_DIRECTORY}/lib
-        ${MLT_DIRECTORY}/share
-    )
-    file(COPY ${MLT_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/bin)
-    install(DIRECTORY ${MLT_DIRECTORIES} DESTINATION bin)
+file(GLOB MLT_FILES
+	    ${MLT_DIRECTORY}/libmlt++-3.dll
+	    ${MLT_DIRECTORY}/libmlt-6.dll
+	    ${MLT_DIRECTORY}/melt.exe
+	    )
+file(COPY ${MLT_FILES} DESTINATION ${SYNFIG_BUILD_ROOT}/bin)
+install(FILES ${MLT_FILES} DESTINATION bin)
 
-    # /output/etc
-    file(GLOB ETC_DIRECTORIES
-        ${MINGW_PATH}/etc/ImageMagick-[0-9]*
-        ${MINGW_PATH}/etc/gtk-3.[0-9]*
-    )
+file(GLOB MLT_DIRECTORIES
+	    ${MLT_DIRECTORY}/lib
+	    ${MLT_DIRECTORY}/share
+	    )
+file(COPY ${MLT_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/bin)
+install(DIRECTORY ${MLT_DIRECTORIES} DESTINATION bin)
+
+# /output/etc
+file(GLOB ETC_DIRECTORIES
+	    ${MINGW_PATH}/etc/ImageMagick-[0-9]*
+	    ${MINGW_PATH}/etc/gtk-3.[0-9]*
+	    )
 #    file(COPY ${ETC_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/etc)
-    INSTALL(DIRECTORY ${ETC_DIRECTORIES} DESTINATION etc)
+INSTALL(DIRECTORY ${ETC_DIRECTORIES} DESTINATION etc)
 
-    # /output/lib
-    file(GLOB LIB_DIRECTORIES
-        ${MINGW_LIB}/atkmm-1.[0-9]
-        ${MINGW_LIB}/cmake
-        ${MINGW_LIB}/gdk-pixbuf-2.[0-9]
-        ${MINGW_LIB}/giomm-2.[0-9]
-        ${MINGW_LIB}/glibmm-2.[0-9]
-        ${MINGW_LIB}/gtkmm-3.[0-9]
-        ${MINGW_LIB}/pangomm-1.[0-9]
-        ${MINGW_LIB}/sigc++-2.[0-9]
-        ${MINGW_LIB}/cairomm-1.[0-9]
-        ${MINGW_LIB}/gdkmm-3.[0-9]
-        ${MINGW_LIB}/glib-2.[0-9]
-        ${MINGW_LIB}/gtk-3.[0-9]
-        ${MINGW_LIB}/ImageMagick-*
-        ${MINGW_LIB}/libxml++-2.[0-9]
-        ${MINGW_LIB}/pkgconfig
-    )
+# /output/lib
+file(GLOB LIB_DIRECTORIES
+	    ${MINGW_LIB}/atkmm-1.[0-9]
+	    ${MINGW_LIB}/cmake
+	    ${MINGW_LIB}/gdk-pixbuf-2.[0-9]
+	    ${MINGW_LIB}/giomm-2.[0-9]
+	    ${MINGW_LIB}/glibmm-2.[0-9]
+	    ${MINGW_LIB}/gtkmm-3.[0-9]
+	    ${MINGW_LIB}/pangomm-1.[0-9]
+	    ${MINGW_LIB}/sigc++-2.[0-9]
+	    ${MINGW_LIB}/cairomm-1.[0-9]
+	    ${MINGW_LIB}/gdkmm-3.[0-9]
+	    ${MINGW_LIB}/glib-2.[0-9]
+	    ${MINGW_LIB}/gtk-3.[0-9]
+	    ${MINGW_LIB}/ImageMagick-*
+	    ${MINGW_LIB}/libxml++-2.[0-9]
+	    ${MINGW_LIB}/pkgconfig
+	    )
 #    file(COPY ${LIB_DIRECTORIES} DESTINATION ${SYNFIG_BUILD_ROOT}/lib)
-    install(DIRECTORY ${LIB_DIRECTORIES} DESTINATION lib)
+install(DIRECTORY ${LIB_DIRECTORIES} DESTINATION lib)
 
 #    file(COPY ${MINGW_PATH}/share/icons/Adwaita DESTINATION ${SYNFIG_BUILD_ROOT}/share/icons)
-    install(DIRECTORY ${MINGW_PATH}/share/icons/Adwaita DESTINATION share/icons)
-endif()
+install(DIRECTORY ${MINGW_PATH}/share/icons/Adwaita DESTINATION share/icons)

--- a/cmake/SynfigIntltool.cmake
+++ b/cmake/SynfigIntltool.cmake
@@ -26,7 +26,7 @@ set(INTLTOOL_OPTIONS_DEFAULT "--quiet")
 # generator uses the standard Windows `cmd` shell for building), `intltool-merge`
 # cannot be started, because it is just a Perl script, and `cmd` does not know how
 # to run it. In this case, we need to explicitly add the interpreter to the command.
-if(INTLTOOL_MERGE_EXECUTABLE AND MINGW AND NOT MSYS)
+if(INTLTOOL_MERGE_EXECUTABLE AND MSYS)
     message(STATUS "Fixing intltool-merge command...")
     set(INTLTOOL_MERGE_EXECUTABLE c:/msys64/usr/bin/perl ${INTLTOOL_MERGE_EXECUTABLE})
 endif()

--- a/synfig-studio/CMakeLists.txt
+++ b/synfig-studio/CMakeLists.txt
@@ -27,6 +27,7 @@ STUDIO_INTLTOOL_MERGE(
     INSTALL_DESTINATION "share/appdata"
 )
 
+if(NOT WIN32) # desktop file needs to be build only for nix systems
 STUDIO_INTLTOOL_MERGE(
     DESKTOP
     TARGET_NAME desktop_file
@@ -34,6 +35,7 @@ STUDIO_INTLTOOL_MERGE(
     OUTPUT_FILE "org.synfig.SynfigStudio.desktop"
     INSTALL_DESTINATION "share/applications"
 )
+endif()
 
 if(TARGET desktop_file)
     add_custom_command(

--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -297,6 +297,7 @@ elseif(${CMAKE_BUILD_TYPE} MATCHES Release)
 endif()
 
 set(SPLASH_SCREEN_DIR ${SYNFIG_BUILD_ROOT}/share/synfig/images)
+file(MAKE_DIRECTORY ${SPLASH_SCREEN_DIR})
 add_custom_command(
     OUTPUT ${SPLASH_SCREEN_DIR}/splash_screen.png
     COMMAND synfig_bin ${SYNFIG_SPLASH_SCREEN} -o ${SPLASH_SCREEN_DIR}/splash_screen.png --time 0f --quiet


### PR DESCRIPTION
- [CMake] Improved cygpath detection in some situations (when you run CMake from IDE for example)
- [CMake] Added error message if MSYS2 environment not detected on Windows. Improved MSYS2 detection by using environment variable (MINGW_PREFIX)
- [CMake] `desktop_file` target disabled for Windows build. Fixes 'sed not found' error
- [CMake] Fixed splash screen image build. It could not be built because the target directory did not exist
- [CMake/MSYS2] Disabled copying of dependent libraries to build output during configuration stage. Added hacks for MSYS2 ImageMagick (required to `build_images` target).
