### PR TITLE
Update jackdial.h

### DIFF
--- a/autobuild/osx/app-template/Contents/Info.plist
+++ b/autobuild/osx/app-template/Contents/Info.plist
@@ -4,7 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
-	
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleGetInfoString</key>
 	<string>_VERSION_, © 2001-2008 The Synfig Team</string>
 	<key>CFBundleShortVersionString</key>

--- a/autobuild/osx/app-template/Contents/Info.plist
+++ b/autobuild/osx/app-template/Contents/Info.plist
@@ -4,8 +4,7 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	>
 	<key>CFBundleGetInfoString</key>
 	<string>_VERSION_, © 2001-2008 The Synfig Team</string>
 	<key>CFBundleShortVersionString</key>

--- a/synfig-studio/src/gui/dials/jackdial.h
+++ b/synfig-studio/src/gui/dials/jackdial.h
@@ -64,7 +64,7 @@ public:
 	void set_offset(const synfig::Time &value)       { offset->set_value(value); }
 	synfig::Time get_offset() const                  { return offset->get_value(); }
 	void set_fps(float value)                        { offset->set_fps(value); }
-}; // END of class FrameDial
+}; // END of class JackDial
 
 }; // END of namespace studio
 


### PR DESCRIPTION
Issue : #1742  JackDial class was having incorrect documented name at the end of the class declaration as 'FrameDial' 

Fix: Renamed the "FrameDial" to 'JackDial'
