### PR TITLE
Fix to the isssue #1705

### DIFF
--- a/autobuild/osx/app-template/Contents/Info.plist
+++ b/autobuild/osx/app-template/Contents/Info.plist
@@ -4,7 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
-	
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleGetInfoString</key>
 	<string>_VERSION_, © 2001-2008 The Synfig Team</string>
 	<key>CFBundleShortVersionString</key>

--- a/autobuild/osx/app-template/Contents/Info.plist
+++ b/autobuild/osx/app-template/Contents/Info.plist
@@ -4,7 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
-	>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleGetInfoString</key>
 	<string>_VERSION_, © 2001-2008 The Synfig Team</string>
 	<key>CFBundleShortVersionString</key>

--- a/autobuild/osx/app-template/Contents/Info.plist
+++ b/autobuild/osx/app-template/Contents/Info.plist
@@ -4,8 +4,7 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	>
 	<key>CFBundleGetInfoString</key>
 	<string>_VERSION_, © 2001-2008 The Synfig Team</string>
 	<key>CFBundleShortVersionString</key>

--- a/synfig-studio/src/gui/dials/jackdial.h
+++ b/synfig-studio/src/gui/dials/jackdial.h
@@ -64,7 +64,7 @@ public:
 	void set_offset(const synfig::Time &value)       { offset->set_value(value); }
 	synfig::Time get_offset() const                  { return offset->get_value(); }
 	void set_fps(float value)                        { offset->set_fps(value); }
-}; // END of class FrameDial
+}; // END of class JackDial
 
 }; // END of namespace studio
 


### PR DESCRIPTION
This is a fix to the issue #1705 Missing Bundle Identifier key in Info.plist (macOS build). I have edited the info.plist file on the windows environment using some sort of plist runner and i guess this should work perfectly. 

Thanks :)