### PR TITLE
Removed Warning Message if Config File is Found

### DIFF
--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -173,7 +173,6 @@ bool retrieve_modules_to_load(String filename,std::list<String> &modules_to_load
 
 	if(!file)
 	{
-		synfig::warning("Cannot open "+filename);
 		return false;
 	}
 
@@ -358,6 +357,9 @@ synfig::Main::Main(const synfig::String& basepath,ProgressCallback *cb):
 	if (i == locations.size())
 	{
 		synfig::warning("Cannot find '%s', trying to load default modules", MODULE_LIST_FILENAME);
+		synfig::warning("Searched in the following directories: ");
+		for (i=0;i<locations.size();i++) 
+			synfig::warning(" - "+locations[i]);
 		Module::register_default_modules(cb);
 	}
 


### PR DESCRIPTION
Fixes issue #1715 

Redundant warnings were being produced every time the config file synfig_modules.cfg was not found at the given location. However the **_warning should be printed only if all the locations have been checked._**
Hence this line on **main.cpp : 176** can be removed.
The final warning is already printed at line 359 which I have not modified