### PR TITLE
Don't search for linux paths on Windows for synfig_modules.cfg

### DIFF
--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -335,7 +335,9 @@ synfig::Main::Main(const synfig::String& basepath,ProgressCallback *cb):
 		locations.push_back(SYSCONFDIR"/" MODULE_LIST_FILENAME);
 	#endif
 		locations.push_back(root_path + ETL_DIRECTORY_SEPARATOR + "etc" + ETL_DIRECTORY_SEPARATOR + MODULE_LIST_FILENAME);
+	#ifndef _WIN32
 		locations.push_back("/usr/local/etc/" MODULE_LIST_FILENAME);
+	#endif
 	#ifdef __APPLE__
 		locations.push_back("/Library/Frameworks/synfig.framework/Resources/" MODULE_LIST_FILENAME);
 		locations.push_back("/Library/Synfig/" MODULE_LIST_FILENAME);


### PR DESCRIPTION
Fix issue #1754 

Synfig currently searches for` synfig_modules.cfg` in various paths at startup. It is also searching for it on a linux path 
`/usr/local/etc `even on a windows system. This PR adds an `#ifdef`  guard to disable the path on windows.


