### PR TITLE
Improve Canvas Zoom Keyboard Shortcut UX

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1351,8 +1351,8 @@ DEFINE_ACTION("keyframe-properties", _("Properties"));
 	ACCEL2(Gtk::AccelKey(')',Gdk::MOD1_MASK|Gdk::CONTROL_MASK,			"<Actions>/action_group_layer_action_manager/amount-inc"		));
 	ACCEL2(Gtk::AccelKey(']',Gdk::CONTROL_MASK,					"<Actions>/canvasview/jump-next-keyframe"				));
 	ACCEL2(Gtk::AccelKey('[',Gdk::CONTROL_MASK,					"<Actions>/canvasview/jump-prev-keyframe"				));
-	ACCEL2(Gtk::AccelKey('=',Gdk::CONTROL_MASK,					"<Actions>/canvasview/canvas-zoom-in"					));
-	ACCEL2(Gtk::AccelKey('-',Gdk::CONTROL_MASK,					"<Actions>/canvasview/canvas-zoom-out"					));
+	ACCEL("equal",									"<Actions>/canvasview/canvas-zoom-in"					);
+	ACCEL("minus",									"<Actions>/canvasview/canvas-zoom-out"					);
 	ACCEL2(Gtk::AccelKey('+',Gdk::CONTROL_MASK,					"<Actions>/canvasview/time-zoom-in"					));
 	ACCEL2(Gtk::AccelKey('_',Gdk::CONTROL_MASK,					"<Actions>/canvasview/time-zoom-out"					));
 	ACCEL2(Gtk::AccelKey('.',Gdk::CONTROL_MASK,					"<Actions>/canvasview/seek-next-frame"					));
@@ -1360,7 +1360,7 @@ DEFINE_ACTION("keyframe-properties", _("Properties"));
 	ACCEL2(Gtk::AccelKey('>',Gdk::CONTROL_MASK,					"<Actions>/canvasview/seek-next-second"					));
 	ACCEL2(Gtk::AccelKey('<',Gdk::CONTROL_MASK,					"<Actions>/canvasview/seek-prev-second"					));
 	ACCEL("<Mod1>o",								"<Actions>/canvasview/toggle-onion-skin"				);
-	ACCEL("<Control><Shift>z",							"<Actions>/canvasview/canvas-zoom-fit"					);
+	ACCEL("0",									"<Actions>/canvasview/canvas-zoom-fit"					);
 	ACCEL("<Control>p",								"<Actions>/canvasview/play"						);
 
 


### PR DESCRIPTION
Fixes #1768 

Initially the keyboard shortcuts for:

```
canvas-zoom-in:  ctrl + "="
canvas-zoom-out:  ctrl + "-"
canvas-zoom-fit:  ctrl + shift + "z"
```

The Improved Keyboard shortcuts for : 

```
canvas-zoom-in:  "="
canvas-zoom-out:  "-"
canvas-zoom-fit:  "0"
```
 