### PR TITLE
Add braces to avoid ambiguous else on extractBorders (fixes [-Wdangling-else] warning)

### DIFF
--- a/synfig-studio/src/synfigapp/vectorizer/centerlinepolygonizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinepolygonizer.cpp
@@ -415,10 +415,12 @@ static BorderList *extractBorders(const Handle &ras, int threshold, int despeckl
         {
           if ((foundPath = extractPath(byteImage, x, y, !enteredRegionType,
                                        xOuterPixel, despeckling)))
+          {
             if (enteredRegionType == outer)
               innerBorders.push_back(foundPath);
             else
               outerBorders.push_back(foundPath);
+          }
         }
 
         // If leaving a white region, remember it - in order to establish


### PR DESCRIPTION
Changes: Adding braces on `if`-`else` statement on `extractBorders`
Why: To remove dangling else warning message according to issue #1757 
Impact: No dangling else warning message