### PR TITLE
#1722: Set modal property on AboutDialog

### DIFF
--- a/synfig-studio/src/gui/dialogs/about.cpp
+++ b/synfig-studio/src/gui/dialogs/about.cpp
@@ -79,6 +79,7 @@ using namespace studio;
 About::About()
 {
 	set_transient_for((Gtk::Window&)(*App::main_window));
+	set_modal(true);
 	set_program_name(PACKAGE_NAME);
 	set_version(VERSION);
 	set_comments(_("2D vector animation studio"));


### PR DESCRIPTION
Sets modal on about dialog so that it behaves similar to the preferences window.

Closes #1722 