### PR TITLE
Improved css

### DIFF
--- a/synfig-studio/configure.ac
+++ b/synfig-studio/configure.ac
@@ -217,6 +217,8 @@ AC_CONFIG_FILES([
     brushes/CD_concept/Makefile
     src/Makefile
     src/gui/Makefile
+    src/gui/resources/Makefile
+    src/gui/resources/css/Makefile
     src/synfigapp/Makefile
     src/player/Makefile
     images/Makefile

--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -84,6 +84,8 @@ include(trees/CMakeLists.txt)
 include(widgets/CMakeLists.txt)
 include(workarearenderer/CMakeLists.txt)
 
+add_subdirectory(resources)
+
 target_include_directories(synfigstudio PRIVATE ${MLT_INCLUDE_DIRS}) # required for widget_soundwave
 
 target_link_libraries(synfigstudio

--- a/synfig-studio/src/gui/Makefile.am
+++ b/synfig-studio/src/gui/Makefile.am
@@ -3,6 +3,9 @@
 MAINTAINERCLEANFILES = \
 	Makefile.in
 
+SUBDIRS = \
+	resources
+
 synfigstudio_src = main.cpp
 
 #include makefile inserts from subdirectories

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -59,6 +59,7 @@
 #include <gtkmm/toggletoolbutton.h>
 #include <gtkmm/separatortoolitem.h>
 #include <gtkmm/menutoolbutton.h>
+#include <gtkmm/stylecontext.h>
 
 #include <glibmm/uriutils.h>
 #include <glibmm/convert.h>
@@ -596,6 +597,10 @@ CanvasView::CanvasView(etl::loose_handle<Instance> instance,etl::handle<CanvasIn
 	keyframe_dialog          (*App::main_window,canvas_interface_),
 	preview_dialog           ()
 {
+	// Make this toolbar small for space efficiency
+	auto style_context = this->get_style_context();
+	style_context->add_class("synfigstudio-efficient-workspace");
+
 	canvas_options = CanvasOptions::create(*App::main_window, this);
 
 	layer_tree=0;
@@ -944,7 +949,6 @@ CanvasView::create_time_bar()
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-animate_mode_off"), iconsize));
 		animatebutton = Gtk::manage(new class Gtk::ToggleButton());
 		animatebutton->set_tooltip_text(_("Turn on animate editing mode"));
-		icon->set_padding(0,0);
 		icon->show();
 		animatebutton->add(*icon);
 		animatebutton->signal_toggled().connect(sigc::mem_fun(*this, &CanvasView::toggle_animatebutton));
@@ -957,7 +961,6 @@ CanvasView::create_time_bar()
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-timetrack"), iconsize));
 		timetrackbutton = Gtk::manage(new class Gtk::ToggleButton());
 		timetrackbutton->set_tooltip_text(_("Toggle timebar"));
-		icon->set_padding(0,0);
 		icon->show();
 		timetrackbutton->add(*icon);
 		timetrackbutton->signal_toggled().connect(sigc::mem_fun(*this, &CanvasView::toggle_timetrackbutton));
@@ -1178,7 +1181,6 @@ CanvasView::create_display_bar()
 
 	{ // Setup render options dialog button
 		Gtk::Image *icon = Gtk::manage(new Gtk::Image(Gtk::StockID("synfig-render_options"), iconsize));
-		icon->set_padding(0, 0);
 		icon->show();
 
 		render_options_button = Gtk::manage(new class Gtk::ToolButton());
@@ -1194,7 +1196,6 @@ CanvasView::create_display_bar()
 
 	{ // Setup preview options dialog button
 		Gtk::Image *icon = Gtk::manage(new Gtk::Image(Gtk::StockID("synfig-preview_options"), iconsize));
-		icon->set_padding(0, 0);
 		icon->show();
 
 		preview_options_button = Gtk::manage(new class Gtk::ToolButton());
@@ -1233,7 +1234,6 @@ CanvasView::create_display_bar()
 
 	{ // Set up the show grid toggle button
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-toggle_show_grid"), iconsize));
-		icon->set_padding(0, 0);
 		icon->show();
 
 		show_grid = Gtk::manage(new class Gtk::ToggleToolButton());
@@ -1250,7 +1250,6 @@ CanvasView::create_display_bar()
 
 	{ // Set up the snap to grid toggle button
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-toggle_snap_grid"), iconsize));
-		icon->set_padding(0, 0);
 		icon->show();
 
 		snap_grid = Gtk::manage(new class Gtk::ToggleToolButton());
@@ -1270,7 +1269,6 @@ CanvasView::create_display_bar()
 
 	{ // Setup refresh button
 		Gtk::Image *icon = Gtk::manage(new Gtk::Image(Gtk::StockID("gtk-refresh"), iconsize));
-		icon->set_padding(0, 0);
 		icon->show();
 
 		refreshbutton = Gtk::manage(new class Gtk::ToolButton());
@@ -1305,7 +1303,6 @@ CanvasView::create_display_bar()
 
 	{ // Set up the background rendering button
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-toggle_background_rendering"), iconsize));
-		icon->set_padding(0, 0);
 		icon->show();
 
 		background_rendering_button = Gtk::manage(new class Gtk::ToggleToolButton());
@@ -1338,7 +1335,6 @@ CanvasView::create_display_bar()
 
 	{ // Set up the onion skin toggle button
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-toggle_onion_skin"), iconsize));
-		icon->set_padding(0, 0);
 		icon->show();
 
 		onion_skin = Gtk::manage(new class Gtk::ToggleToolButton());
@@ -1391,7 +1387,6 @@ CanvasView::create_display_bar()
 
 	{
 		Gtk::Image *icon = Gtk::manage(new Gtk::Image(Gtk::StockID("gtk-stop"), iconsize));
-		icon->set_padding(0, 0);
 		icon->show();
 
 		stopbutton = Gtk::manage(new class Gtk::Button());
@@ -2368,7 +2363,6 @@ CanvasView::on_mode_changed(CanvasInterface::Mode mode)
 		animatebutton->remove();
 		animatebutton->add(*icon);
 		animatebutton->set_tooltip_text(_("Turn off animate editing mode"));
-		icon->set_padding(0,0);
 		icon->show();
 		animatebutton->set_active(true);
 	}
@@ -2379,7 +2373,6 @@ CanvasView::on_mode_changed(CanvasInterface::Mode mode)
 		animatebutton->remove();
 		animatebutton->add(*icon);
 		animatebutton->set_tooltip_text(_("Turn on animate editing mode"));
-		icon->set_padding(0,0);
 		icon->show();
 		animatebutton->set_active(false);
 	}
@@ -2391,7 +2384,6 @@ CanvasView::on_mode_changed(CanvasInterface::Mode mode)
 		futurekeyframebutton->remove();
 		futurekeyframebutton->add(*icon);
 		futurekeyframebutton->set_tooltip_text(_("Unlock future keyframes"));
-		icon->set_padding(0,0);
 		icon->show();
 		futurekeyframebutton->set_active(true);
 	}
@@ -2402,7 +2394,6 @@ CanvasView::on_mode_changed(CanvasInterface::Mode mode)
 		futurekeyframebutton->remove();
 		futurekeyframebutton->add(*icon);
 		futurekeyframebutton->set_tooltip_text(_("Lock future keyframes"));
-		icon->set_padding(0,0);
 		icon->show();
 		futurekeyframebutton->set_active(false);
 	}
@@ -2413,7 +2404,6 @@ CanvasView::on_mode_changed(CanvasInterface::Mode mode)
 		pastkeyframebutton->remove();
 		pastkeyframebutton->add(*icon);
 		pastkeyframebutton->set_tooltip_text(_("Unlock past keyframes"));
-		icon->set_padding(0,0);
 		icon->show();
 		pastkeyframebutton->set_active(true);
 	}
@@ -2424,7 +2414,6 @@ CanvasView::on_mode_changed(CanvasInterface::Mode mode)
 		pastkeyframebutton->remove();
 		pastkeyframebutton->add(*icon);
 		pastkeyframebutton->set_tooltip_text(_("Lock past keyframes"));
-		icon->set_padding(0,0);
 		icon->show();
 		pastkeyframebutton->set_active(false);
 	}

--- a/synfig-studio/src/gui/dials/keyframedial.cpp
+++ b/synfig-studio/src/gui/dials/keyframedial.cpp
@@ -57,8 +57,8 @@ KeyFrameDial::KeyFrameDial(): Gtk::Table(2, 1, false)
 {
 	toggle_keyframe_past = create_icon(Gtk::ICON_SIZE_BUTTON, "synfig-keyframe_lock_past_on",_("Unlock past keyframe"));
 	toggle_keyframe_future = create_icon(Gtk::ICON_SIZE_BUTTON, "synfig-keyframe_lock_future_on",_("Unlock future keyframe"));
-	attach(*toggle_keyframe_past, 0, 1, 0, 1, Gtk::SHRINK, Gtk::SHRINK, 0, 0);
-	attach(*toggle_keyframe_future, 1, 2, 0, 1, Gtk::SHRINK, Gtk::SHRINK, 0, 0);
+	attach(*toggle_keyframe_past, 0, 1, 0, 1, Gtk::SHRINK, Gtk::EXPAND, 0, 0);
+	attach(*toggle_keyframe_future, 1, 2, 0, 1, Gtk::SHRINK, Gtk::EXPAND, 0, 0);
 }
 
 Gtk::ToggleButton *

--- a/synfig-studio/src/gui/dials/resolutiondial.cpp
+++ b/synfig-studio/src/gui/dials/resolutiondial.cpp
@@ -95,6 +95,9 @@ ResolutionDial::init_button(Gtk::ToolButton &button, Gtk::IconSize size, const G
 void
 ResolutionDial::init_toggle_button(Gtk::ToggleToolButton &button, const char *label, const char *tooltip)
 {
+	// For label left/right padding
+	button.set_name("low-resolution");
+
 	button.set_label(label);
 	button.set_tooltip_text(tooltip);
 	button.set_is_important(true);

--- a/synfig-studio/src/gui/docks/dock_history.cpp
+++ b/synfig-studio/src/gui/docks/dock_history.cpp
@@ -36,6 +36,8 @@
 #include "app.h"
 
 #include <gtkmm/scrolledwindow.h>
+#include <gtkmm/stylecontext.h>
+
 #include <cassert>
 #include "instance.h"
 #include <synfigapp/action.h>
@@ -68,6 +70,10 @@ Dock_History::Dock_History():
 	Dock_CanvasSpecific("history",_("History"),Gtk::StockID("synfig-history")),
 	action_group(Gtk::ActionGroup::create("action_group_dock_history"))
 {
+	// Make History toolbar small for space efficiency
+	auto context = get_style_context();
+	context->add_class("synfigstudio-efficient-workspace");
+
 	App::signal_instance_deleted().connect(sigc::mem_fun(*this,&studio::Dock_History::delete_instance));
 	App::signal_instance_selected().connect(sigc::mem_fun(*this,&studio::Dock_History::set_selected_instance_signal));
 

--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -171,6 +171,9 @@ studio::Dock_Info::Dock_Info()
 	render_progress_label->set_markup(etl::strprintf("<b>%s</b>", _("Render Progress: ")));
 	table->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8,1);
 
+	// Render progress CSS ID
+	render_progress.set_name("render-progress");
+
 	table->attach_next_to(render_progress, *render_progress_label, Gtk::POS_BOTTOM, 7,1);
 	render_progress.set_hexpand(true);
 	render_progress.set_vexpand(false);

--- a/synfig-studio/src/gui/docks/dock_keyframes.cpp
+++ b/synfig-studio/src/gui/docks/dock_keyframes.cpp
@@ -35,6 +35,8 @@
 #include "app.h"
 
 #include <gtkmm/scrolledwindow.h>
+#include <gtkmm/stylecontext.h>
+
 #include <cassert>
 #include "instance.h"
 #include "trees/keyframetreestore.h"
@@ -65,6 +67,10 @@ Dock_Keyframes::Dock_Keyframes():
 	Dock_CanvasSpecific("keyframes", _("Keyframes"),Gtk::StockID("synfig-keyframes")),
 	keyframe_action_manager(new KeyframeActionManager())
 {
+	// Make Keyframes toolbar small for space efficiency
+	auto context = get_style_context();
+	context->add_class("synfigstudio-efficient-workspace");
+
 	keyframe_action_manager->set_ui_manager(App::ui_manager());
 	keyframe_action_manager->signal_show_keyframe_properties().connect(
 		sigc::mem_fun(*this,&Dock_Keyframes::show_keyframe_properties) );

--- a/synfig-studio/src/gui/docks/dock_layergroups.cpp
+++ b/synfig-studio/src/gui/docks/dock_layergroups.cpp
@@ -35,6 +35,8 @@
 #include "app.h"
 
 #include <gtkmm/scrolledwindow.h>
+#include <gtkmm/stylecontext.h>
+
 #include <cassert>
 #include "instance.h"
 #include "canvasview.h"
@@ -67,6 +69,10 @@ Dock_LayerGroups::Dock_LayerGroups():
 	action_group_group_ops(Gtk::ActionGroup::create("action_group_dock_layergroups")),
 	group_action_manager(new GroupActionManager)
 {
+	// Make Sets toolbar buttons small for space efficiency
+	auto context = get_style_context();
+	context->add_class("synfigstudio-efficient-workspace");
+
 	group_action_manager->set_ui_manager(App::ui_manager());
 
 	action_group_group_ops->add( Gtk::Action::create("toolbar-groups", _("Set Ops")) );

--- a/synfig-studio/src/gui/docks/dock_layers.cpp
+++ b/synfig-studio/src/gui/docks/dock_layers.cpp
@@ -32,6 +32,8 @@
 
 #include <synfig/general.h>
 
+#include <gtkmm/stylecontext.h>
+
 #include <glibmm/markup.h>
 
 #include "docks/dock_layers.h"
@@ -69,6 +71,10 @@ Dock_Layers::Dock_Layers():
 	Dock_CanvasSpecific("layers",_("Layers"),Gtk::StockID("synfig-layer")),
 	layer_action_manager(new LayerActionManager)
 {
+	// Make Layers button small for space efficiency
+	auto style_context = this->get_style_context();
+	style_context->add_class("synfigstudio-efficient-workspace");
+
 	if(layer_action_manager)layer_action_manager->set_ui_manager(App::ui_manager());
 
 	action_group_new_layers=Gtk::ActionGroup::create("action_group_new_layers");

--- a/synfig-studio/src/gui/docks/dock_metadata.cpp
+++ b/synfig-studio/src/gui/docks/dock_metadata.cpp
@@ -36,6 +36,8 @@
 #include "app.h"
 
 #include <gtkmm/scrolledwindow.h>
+#include <gtkmm/stylecontext.h>
+
 #include <cassert>
 #include "instance.h"
 #include "trees/metadatatreestore.h"
@@ -65,6 +67,10 @@ Dock_MetaData::Dock_MetaData():
 	Dock_CanvasSpecific("meta_data",_("Canvas MetaData"),Gtk::StockID("synfig-meta_data")),
 	action_group(Gtk::ActionGroup::create("action_group_dock_meta_data"))
 {
+	// Make Canvas MetaData toolbar small for space efficiency
+	auto context = get_style_context();
+	context->add_class("synfigstudio-efficient-workspace");
+
 	action_group->add(Gtk::Action::create(
 		"action-MetadataAdd",
 		Gtk::StockID("gtk-add"),

--- a/synfig-studio/src/gui/docks/dock_soundwave.cpp
+++ b/synfig-studio/src/gui/docks/dock_soundwave.cpp
@@ -40,6 +40,8 @@
 #include <synfig/canvasfilenaming.h>
 #include <synfigapp/value_desc.h>
 
+#include <gtkmm/stylecontext.h>
+
 #include <glibmm/convert.h> // Glib::filename_from_uri
 
 #endif
@@ -441,6 +443,10 @@ Dock_SoundWave::Dock_SoundWave()
 	: Dock_CanvasSpecific("soundwave", _("Sound"), Gtk::StockID("synfig-layer_other_sound")),
 	  current_grid_sound(nullptr)
 {
+	// Make Sound toolbar buttons small for space efficiency
+	auto context = get_style_context();
+	context->add_class("synfigstudio-efficient-workspace");
+
 	set_use_scrolled(false);
 
 	widget_kf_list.set_hexpand();

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -45,6 +45,7 @@
 #include <gtkmm/spinbutton.h>
 #include <gtkmm/menu.h>
 #include <gtkmm/imagemenuitem.h>
+#include <gtkmm/stylecontext.h>
 #include <synfigapp/main.h>
 #include "../../app.h"
 #include "../../dialogs/dialog_color.h"
@@ -126,6 +127,10 @@ Dock_PalEdit::Dock_PalEdit():
 	//palette_settings(new PaletteSettings(this,"colors")),
 	table(2,2,false)
 {
+	// Make Palette Editor toolbar buttons small for space efficiency
+	auto context = get_style_context();
+	context->add_class("synfigstudio-efficient-workspace");
+
 	action_group=Gtk::ActionGroup::create("action_group_pal_edit");
 	action_group->add(Gtk::Action::create(
 		"palette-add-color",

--- a/synfig-studio/src/gui/resourcehelper.cpp
+++ b/synfig-studio/src/gui/resourcehelper.cpp
@@ -123,3 +123,14 @@ synfig::String studio::ResourceHelper::get_brush_path(const synfig::String& brus
 {
 	return get_brush_path() + '/' + brush_filename;
 }
+
+synfig::String studio::ResourceHelper::get_css_path()
+{
+	std::string csspath = get_synfig_data_path() + ETL_DIRECTORY_SEPARATOR + "css";
+	return csspath;
+}
+
+synfig::String studio::ResourceHelper::get_css_path(const synfig::String& css_filename)
+{
+	return get_css_path() + '/' + css_filename;
+}

--- a/synfig-studio/src/gui/resourcehelper.h
+++ b/synfig-studio/src/gui/resourcehelper.h
@@ -50,6 +50,9 @@ public:
 
 	static synfig::String get_brush_path();
 	static synfig::String get_brush_path(const synfig::String& brush_filename);
+
+	static synfig::String get_css_path();
+	static synfig::String get_css_path(const synfig::String& css_filename);
 };
 
 };

--- a/synfig-studio/src/gui/resources/CMakeLists.txt
+++ b/synfig-studio/src/gui/resources/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(css)

--- a/synfig-studio/src/gui/resources/Makefile.am
+++ b/synfig-studio/src/gui/resources/Makefile.am
@@ -1,0 +1,7 @@
+# $Id$
+
+MAINTAINERCLEANFILES = \
+	Makefile.in
+
+SUBDIRS = \
+  css

--- a/synfig-studio/src/gui/resources/css/CMakeLists.txt
+++ b/synfig-studio/src/gui/resources/css/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(INSTALL_DESTINATION "share/synfig/css")
+set(CSS_FILES
+	synfig.css
+	synfig.mac.css
+)
+
+foreach(CSS_FILE ${CSS_FILES})
+	configure_file(${CSS_FILE} ${SYNFIG_BUILD_ROOT}/${INSTALL_DESTINATION}/${CSS_FILE} COPYONLY)
+endforeach()
+
+install(FILES ${CSS_FILES}
+	DESTINATION ${INSTALL_DESTINATION}
+)

--- a/synfig-studio/src/gui/resources/css/Makefile.am
+++ b/synfig-studio/src/gui/resources/css/Makefile.am
@@ -1,0 +1,10 @@
+# $Id$
+
+MAINTAINERCLEANFILES = Makefile.in
+
+CSSFILES = \
+  synfig.css \
+  synfig.mac.css
+
+cssdir = $(synfig_datadir)/css
+dist_css_DATA = $(CSSFILES)

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -1,0 +1,53 @@
+#render-progress * {
+	min-height: 20px;
+}
+
+/*
+ * Toolbar buttons are too big for default Adwaita theme
+ * Make it small
+ */
+.synfigstudio-efficient-workspace button {
+	padding: 0px;
+}
+
+/*
+ * The above sets button padding to 0
+ * That means buttons are tightly cramped together without spaces
+ * Set button's image padding to 5 px to give consistent top-right-bottom-left space
+ */
+.synfigstudio-efficient-workspace button > image {
+	padding: 5px;
+}
+
+/*
+ * Image padding for buttons are set
+ * Now set padding for text inside buttons
+ */
+#low-resolution label {
+	padding-left : 5px;
+	padding-right: 5px;
+}
+
+/*
+ * Make spinbuttons and entries look consistent with small toolbar buttons
+ */
+.synfigstudio-efficient-workspace entry, spinbutton {
+	min-height: 16px;
+}
+
+/*
+ * We don't want the combobox icons touching the left/right edge.
+ * Give some lil' space.
+ */
+.synfigstudio-efficient-workspace combobox button {
+	padding-left : 5px;
+	padding-right: 5px;
+}
+
+/*
+ * Our timetrack ruler is tight
+ * Set some padding below to give it more space
+ */
+#timetrack button {
+	padding-bottom: 5px;
+}

--- a/synfig-studio/src/gui/resources/css/synfig.mac.css
+++ b/synfig-studio/src/gui/resources/css/synfig.mac.css
@@ -1,0 +1,9 @@
+@import url("synfig.css");
+
+/*
+ * Fix #810: Insensitive context menus on OS X
+ */
+.window-frame, .window-frame:backdrop {
+	box-shadow: none;
+	margin    : 0;
+}

--- a/synfig-studio/src/gui/widgets/widget_defaults.cpp
+++ b/synfig-studio/src/gui/widgets/widget_defaults.cpp
@@ -41,6 +41,7 @@
 #include "app.h"
 #include <gtkmm/menu.h>
 #include <gtkmm/scale.h>
+#include <gtkmm/stylecontext.h>
 #include <gtkmm/toolitem.h>
 #include <gtkmm/toolitemgroup.h>
 #include <gtkmm/toolpalette.h>
@@ -185,6 +186,10 @@ public:
 
 Widget_Defaults::Widget_Defaults()
 {
+	// Make Brushes button small for space efficiency
+	auto style_context = this->get_style_context();
+	style_context->add_class("synfigstudio-efficient-workspace");
+
 	Gtk::IconSize iconsize = Gtk::IconSize::from_name("synfig-tiny_icon");
 
 	// widget colors: outline color and fill color.

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -123,6 +123,12 @@ bool Widget_Timetrack::use_canvas_view(etl::loose_handle<CanvasView> canvas_view
 		return false;
 	}
 	Gtk::TreeView* params_treeview = dynamic_cast<Gtk::TreeView*>(canvas_view->get_ext_widget("params"));
+
+	// This parameter dock is connected to timetrack
+	// We have to set padding to this widget to achieve our intended padding
+	// behavior for our timetrack
+	params_treeview->set_name("timetrack");
+
 	if (!params_treeview) {
 		synfig::error(_("Params treeview widget doesn't exist"));
 		return false;


### PR DESCRIPTION
Fixes #1061
Fixes #1390

- Compile OS X specific code only in its environment
- Use classes to apply changes to multiple widgets
- Use ids to apply changes to specific widgets
- Don't style dialogs

Use [Windows](https://stackoverflow.com/questions/37035936/how-to-get-native-windows-decorations-on-gtk3-on-windows-7-and-msys2) gtk3 theme to have a proper global look and feel instead of modifying UI by hand.

In my opinion, synfigstudio main window toolbar buttons need to be scaled down for every platform for space efficiency. But not the other parts of GUI ie., dialogs and their buttons. These things should be left alone. Or let third-party themes do the trick. Like this [Windows 8](https://www.gnome-look.org/p/1013223/) theme.

<strike>I need help with styling timeslider. Couldn't figure out how to increase its height with CSS. Or is it even possible?</strike>