### PR TITLE
[MSYS/CMake] Fix hard-coded path (c:/msys64/usr/bin/perl)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if(MINGW AND NOT MSYS)
 				" Also you need to set MINGW_PREFIX environment variable if your MSYS2 installation is not in standard path (c:\\msys64\\)")
 	else()
 		set(MSYS ON)
+		set(MSYS_ROOT "$ENV{MINGW_PREFIX}/..")
 	endif()
 endif()
 

--- a/cmake/SynfigIntltool.cmake
+++ b/cmake/SynfigIntltool.cmake
@@ -1,4 +1,4 @@
-find_program(INTLTOOL_MERGE_EXECUTABLE intltool-merge PATHS c:/msys64/usr/bin)
+find_program(INTLTOOL_MERGE_EXECUTABLE intltool-merge PATHS ${MSYS_ROOT}/usr/bin)
 mark_as_advanced(INTLTOOL_MERGE_EXECUTABLE)
 
 if(INTLTOOL_MERGE_EXECUTABLE)
@@ -28,7 +28,7 @@ set(INTLTOOL_OPTIONS_DEFAULT "--quiet")
 # to run it. In this case, we need to explicitly add the interpreter to the command.
 if(INTLTOOL_MERGE_EXECUTABLE AND MSYS)
     message(STATUS "Fixing intltool-merge command...")
-    set(INTLTOOL_MERGE_EXECUTABLE c:/msys64/usr/bin/perl ${INTLTOOL_MERGE_EXECUTABLE})
+    set(INTLTOOL_MERGE_EXECUTABLE ${MSYS_ROOT}/usr/bin/perl ${INTLTOOL_MERGE_EXECUTABLE})
 endif()
 
 function(STUDIO_INTLTOOL_MERGE)


### PR DESCRIPTION
Fixes https://github.com/synfig/synfig/issues/1785