### PR TITLE
[MSVC] Added export variables

### DIFF
--- a/synfig-core/src/synfig/color/cairocolor.cpp
+++ b/synfig-core/src/synfig/color/cairocolor.cpp
@@ -46,7 +46,7 @@
 
 namespace synfig {
 
-const float CairoColor::range = CairoColor::ceil - CairoColor::floor;
+//const float CairoColor::range = CairoColor::ceil - CairoColor::floor;
 
 /* === M E T H O D S ======================================================= */
 

--- a/synfig-core/src/synfig/color/cairocolor.h
+++ b/synfig-core/src/synfig/color/cairocolor.h
@@ -58,9 +58,9 @@ private:
 	value_type pixel;
 
 public:
-	static const unsigned char ceil=255;	
-	static const unsigned char floor=0;
-	static const float range;
+	static constexpr unsigned char ceil=255;
+	static constexpr unsigned char floor=0;
+	static constexpr float range = CairoColor::ceil - CairoColor::floor;
 	static const value_type amask=0xFF<<24;
 	static const value_type rmask=0xFF<<16;
 	static const value_type gmask=0xFF<<8;

--- a/synfig-core/src/synfig/general.h
+++ b/synfig-core/src/synfig/general.h
@@ -30,6 +30,7 @@
 
 #include <clocale>
 #include "string.h"
+#include "synfig_export.h"
 
 
 /* === M A C R O S ========================================================= */
@@ -67,7 +68,7 @@ public:
 };
 
 //! If true, do not report "info"-level log, only errors and warnings
-extern bool synfig_quiet_mode;
+SYNFIG_EXPORT extern bool synfig_quiet_mode;
 
 //! Reports an error
 /*! Call this when an error occurs, describing what happened */

--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -71,6 +71,7 @@
 #include "loadcanvas.h"
 
 #include <giomm.h>
+#include <synfig/synfig_export.h>
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
@@ -439,7 +440,7 @@ current_time()
 	return String(b);
 }
 
-bool synfig::synfig_quiet_mode = false;
+SYNFIG_EXPORT bool synfig::synfig_quiet_mode = false;
 
 void
 synfig::error(const char *format,...)

--- a/synfig-core/src/synfig/rendering/common/task/taskblend.cpp
+++ b/synfig-core/src/synfig/rendering/common/task/taskblend.cpp
@@ -45,7 +45,7 @@ using namespace rendering;
 /* === M E T H O D S ======================================================= */
 
 
-Task::Token TaskBlend::token(
+SYNFIG_EXPORT Task::Token TaskBlend::token(
 	DescAbstract<TaskBlend>("Blend") );
 
 int

--- a/synfig-core/src/synfig/rendering/common/task/taskblend.h
+++ b/synfig-core/src/synfig/rendering/common/task/taskblend.h
@@ -68,7 +68,7 @@ class TaskBlend: public Task,
 {
 public:
 	typedef etl::handle<TaskBlend> Handle;
-	static Token token;
+	SYNFIG_EXPORT static Token token;
 	virtual Token::Handle get_token() const { return token.handle(); }
 
 	Color::BlendMethod blend_method;

--- a/synfig-core/src/synfig/rendering/common/task/taskblur.cpp
+++ b/synfig-core/src/synfig/rendering/common/task/taskblur.cpp
@@ -48,7 +48,7 @@ using namespace rendering;
 /* === M E T H O D S ======================================================= */
 
 
-Task::Token TaskBlur::token(
+SYNFIG_EXPORT Task::Token TaskBlur::token(
 	DescAbstract<TaskBlur>("Blur") );
 
 Rect

--- a/synfig-core/src/synfig/rendering/common/task/taskblur.h
+++ b/synfig-core/src/synfig/rendering/common/task/taskblur.h
@@ -45,7 +45,7 @@ class TaskBlur: public Task
 {
 public:
 	typedef etl::handle<TaskBlur> Handle;
-	static Token token;
+	SYNFIG_EXPORT static Token token;
 	virtual Token::Handle get_token() const { return token.handle(); }
 
 	Blur blur;

--- a/synfig-core/src/synfig/rendering/common/task/taskcontour.cpp
+++ b/synfig-core/src/synfig/rendering/common/task/taskcontour.cpp
@@ -45,7 +45,7 @@ using namespace rendering;
 /* === M E T H O D S ======================================================= */
 
 
-Task::Token TaskContour::token(
+SYNFIG_EXPORT Task::Token TaskContour::token(
 	DescAbstract<TaskContour>("Contour") );
 
 

--- a/synfig-core/src/synfig/rendering/common/task/taskcontour.h
+++ b/synfig-core/src/synfig/rendering/common/task/taskcontour.h
@@ -46,7 +46,7 @@ class TaskContour: public Task, public TaskInterfaceTransformation
 {
 public:
 	typedef etl::handle<TaskContour> Handle;
-	static Token token;
+	SYNFIG_EXPORT static Token token;
 	virtual Token::Handle get_token() const { return token.handle(); }
 
 public:

--- a/synfig-core/src/synfig/rendering/common/task/taskpixelprocessor.cpp
+++ b/synfig-core/src/synfig/rendering/common/task/taskpixelprocessor.cpp
@@ -45,11 +45,11 @@ using namespace rendering;
 /* === M E T H O D S ======================================================= */
 
 
-Task::Token TaskPixelProcessor::token(
+SYNFIG_EXPORT Task::Token TaskPixelProcessor::token(
 	DescAbstract<TaskPixelProcessor>("PixelProcessor") );
 Task::Token TaskPixelGamma::token(
 	DescAbstract<TaskPixelGamma, TaskPixelProcessor>("PixelGamma") );
-Task::Token TaskPixelColorMatrix::token(
+SYNFIG_EXPORT Task::Token TaskPixelColorMatrix::token(
 	DescAbstract<TaskPixelColorMatrix, TaskPixelProcessor>("PixelColorMatrix") );
 
 

--- a/synfig-core/src/synfig/rendering/common/task/taskpixelprocessor.h
+++ b/synfig-core/src/synfig/rendering/common/task/taskpixelprocessor.h
@@ -51,7 +51,7 @@ class TaskPixelProcessor: public Task,
 {
 public:
 	typedef etl::handle<TaskPixelProcessor> Handle;
-	static Token token;
+	SYNFIG_EXPORT static Token token;
 	virtual Token::Handle get_token() const { return token.handle(); }
 
 	const Task::Handle& sub_task() const { return Task::sub_task(0); }
@@ -108,7 +108,7 @@ class TaskPixelColorMatrix: public TaskPixelProcessor
 {
 public:
 	typedef etl::handle<TaskPixelColorMatrix> Handle;
-	static Token token;
+	SYNFIG_EXPORT static Token token;
 	virtual Token::Handle get_token() const { return token.handle(); }
 
 	ColorMatrix matrix;

--- a/synfig-core/src/synfig/rendering/software/task/tasksw.cpp
+++ b/synfig-core/src/synfig/rendering/software/task/tasksw.cpp
@@ -47,6 +47,6 @@ using namespace rendering;
 
 /* === M E T H O D S ======================================================= */
 
-ModeToken TaskSW::mode_token("software");
+SYNFIG_EXPORT ModeToken TaskSW::mode_token("software");
 
 /* === E N T R Y P O I N T ================================================= */

--- a/synfig-core/src/synfig/rendering/software/task/tasksw.h
+++ b/synfig-core/src/synfig/rendering/software/task/tasksw.h
@@ -48,7 +48,7 @@ public:
 	typedef Task::LockReadGeneric<TargetSurface> LockRead;
 	typedef Task::LockWriteGeneric<TargetSurface> LockWrite;
 
-	static ModeToken mode_token;
+	SYNFIG_EXPORT static ModeToken mode_token;
 	virtual Surface::Token::Handle get_mode_target_token() const
 		{ return TargetSurface::token.handle(); }
 	virtual bool get_mode_allow_source_as_target() const

--- a/synfig-core/src/synfig/rendering/task.cpp
+++ b/synfig-core/src/synfig/rendering/task.cpp
@@ -51,7 +51,7 @@ using namespace rendering;
 synfig::Token Mode::mode_token;
 synfig::Token Task::token;
 
-const Task::Handle Task::blank;
+SYNFIG_EXPORT const Task::Handle Task::blank;
 
 SYNFIG_EXPORT Task::Token TaskSurface::token(
 	DescSpecial<TaskSurface>("Surface") );

--- a/synfig-core/src/synfig/rendering/task.h
+++ b/synfig-core/src/synfig/rendering/task.h
@@ -350,7 +350,7 @@ public:
 	static synfig::Token token;
 	virtual Token::Handle get_token() const = 0;
 
-	static const etl::handle<Task> blank;
+	SYNFIG_EXPORT static const etl::handle<Task> blank;
 
 private:
 	mutable bool bounds_calculated;

--- a/synfig-studio/src/synfigapp/synfigapp_export.h
+++ b/synfig-studio/src/synfigapp/synfigapp_export.h
@@ -1,0 +1,38 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file synfig/synfig_export.h
+**	\brief Export definition for MSVC
+**
+**	$Id$
+**
+**	\legal
+**	......... ... 2020 Artem Konoplin
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+
+#ifndef __SYNFIGAPP_EXPORT_H
+#define __SYNFIGAPP_EXPORT_H
+
+#ifdef _MSC_VER
+// We need this export only for MSVC. Even on MinGW, it breaks linkning.
+#ifdef synfigapp_EXPORTS
+/* We are building this library */
+#define SYNFIGAPP_EXPORT __declspec(dllexport)
+#else
+/* We are using this library */
+#define SYNFIGAPP_EXPORT __declspec(dllimport)
+#endif
+#else
+#define SYNFIGAPP_EXPORT
+#endif
+
+#endif

--- a/synfig-studio/src/synfigapp/value_desc.cpp
+++ b/synfig-studio/src/synfigapp/value_desc.cpp
@@ -50,7 +50,7 @@ using namespace synfigapp;
 
 /* === M E T H O D S ======================================================= */
 
-const ValueDesc ValueDesc::blank;
+SYNFIGAPP_EXPORT const ValueDesc ValueDesc::blank;
 
 void ValueDesc::on_id_changed()
 {

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -37,6 +37,7 @@
 #include <synfig/valuenodes/valuenode_const.h>
 #include <synfig/canvas.h>
 #include <synfig/interpolation.h>
+#include "synfigapp_export.h"
 
 /* === M A C R O S ========================================================= */
 
@@ -73,7 +74,7 @@ class ValueDesc
 	ValueDesc *parent_desc;
 	int links_count;
 
-	static const ValueDesc blank;
+	SYNFIGAPP_EXPORT static const ValueDesc blank;
 
 	static ValueDesc* init_parent(const ValueDesc& parent)
 	{


### PR DESCRIPTION
MSVC requires you to add an dllimport/dllexport modifier to every public static member/variable which you want to use.