### PR TITLE
Adding FontConfig Support in FontFamily Widget

### DIFF
--- a/synfig-studio/src/CMakeLists.txt
+++ b/synfig-studio/src/CMakeLists.txt
@@ -34,6 +34,10 @@ endforeach()
 ## Config
 ##
 
+if(FONT_CONFIG_FOUND)
+add_definitions(-DWITH_FONTCONFIG)
+endif()
+
 add_definitions(-DHAVE_CONFIG_H)
 configure_file(config.h.cmake.in config.h)
 

--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -87,6 +87,7 @@ include(workarearenderer/CMakeLists.txt)
 target_include_directories(synfigstudio PRIVATE ${MLT_INCLUDE_DIRS}) # required for widget_soundwave
 
 target_link_libraries(synfigstudio
+	${FONT_CONFIG_LIBRARIES}
 	${GTKMM_LIBRARIES}
 	${Gettext_LIBRARIES}
 	${MLT_LIBRARIES} # required for widget_soundwave


### PR DESCRIPTION
@ice0 @rodolforg 

This will solve the issue #1766 

I've added fontconfig support in the FontFamily widget by editing its cmake files . 

Kindly review it and guide me further if i have to make some changes.

Thanks :)