### PR TITLE
ColorAccumulator's `==` overload may be incorrect

### DIFF
--- a/synfig-core/src/synfig/color/cairocoloraccumulator.h
+++ b/synfig-core/src/synfig/color/cairocoloraccumulator.h
@@ -102,7 +102,7 @@ public:
 	
 	bool
 	operator==(const CairoColorAccumulator &rhs)const
-	{ return r_==rhs.r_ && g_==rhs.g_ && b_==rhs.b_ && a_!=rhs.a_; }
+	{ return r_==rhs.r_ && g_==rhs.g_ && b_==rhs.b_ && a_==rhs.a_; }
 	
 	bool
 	operator!=(const CairoColorAccumulator &rhs)const

--- a/synfig-core/src/synfig/color/coloraccumulator.h
+++ b/synfig-core/src/synfig/color/coloraccumulator.h
@@ -100,7 +100,7 @@ public:
 
 	bool
 	operator==(const ColorAccumulator &rhs)const
-	{ return r_==rhs.r_ && g_==rhs.g_ && b_==rhs.b_ && a_!=rhs.a_; }
+	{ return r_==rhs.r_ && g_==rhs.g_ && b_==rhs.b_ && a_==rhs.a_; }
 
 	bool
 	operator!=(const ColorAccumulator &rhs)const


### PR DESCRIPTION
I'm not sure if this actually was the intent, but it doesn't look correct to me.  I'd like someone else from the project to comment on this.  Normally I'd expect to see a comment in the code explaining why "equality requires the alpha component to be unequal", but that isn't there.