### PR TITLE
[Autotools] Verbose mode is disabled by default

### DIFF
--- a/ETL/configure.ac
+++ b/ETL/configure.ac
@@ -5,6 +5,8 @@ AC_PREREQ(2.60)
 AC_INIT([Extended Template Library],[1.5.0],[https://github.com/synfig/synfig/issues],[ETL])
 AC_REVISION
 
+AM_SILENT_RULES([yes])
+
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_HEADERS([ETL/etl_profile_.h])
 AC_CANONICAL_HOST

--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -6,6 +6,8 @@ AC_PREREQ([2.60])
 AC_INIT([Synfig Core],[1.5.0],[https://github.com/synfig/synfig/issues],[synfig])
 AC_REVISION()
 
+AM_SILENT_RULES([yes])
+
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_HEADERS([config.h])
 AC_CANONICAL_HOST

--- a/synfig-studio/configure.ac
+++ b/synfig-studio/configure.ac
@@ -6,6 +6,8 @@ AC_PREREQ([2.60])
 AC_INIT([Synfig Studio],[1.5.0],[https://github.com/synfig/synfig/issues],[synfigstudio])
 AC_REVISION()
 
+AM_SILENT_RULES([yes])
+
 AM_CONDITIONAL(DEVELOPMENT_SNAPSHOT, true)
 
 AC_CONFIG_AUX_DIR([config])


### PR DESCRIPTION
Build output is much cleaner now when using autotools