### PR TITLE
restore ctrl-c ctrl+v ctrl+a in Color and Gradient Dialogs

### DIFF
--- a/synfig-studio/src/gui/dialogs/dialog_color.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_color.cpp
@@ -69,7 +69,6 @@ Dialog_Color::Dialog_Color():
 			sigc::mem_fun(*this, &Dialog_Color::on_set_fc_pressed));
 	create_close_button();
 
-	add_accel_group(App::ui_manager()->get_accel_group());
 	show_all_children();
 }
 

--- a/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
@@ -107,8 +107,6 @@ Dialog_Gradient::Dialog_Gradient():
 	table->attach(*spinbutton_pos, 0, 1, 1, 2, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
 
 
-	add_accel_group(App::ui_manager()->get_accel_group());
-
 	show_all_children();
 }
 


### PR DESCRIPTION
fix #1713

As a consequence, application shortcuts/hotkeys will only work
when those dialogs are not on focus, but this behaviour
should be expected by user.