### PR TITLE
[MacOS] Fixed SynfigStudio.app won't start if renamed

### DIFF
--- a/autobuild/osx/app-template/Contents/Info.plist
+++ b/autobuild/osx/app-template/Contents/Info.plist
@@ -2,11 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+
+	<key>LSMultipleInstancesProhibited</key>
+	<true/>
+
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+
 	<key>CFBundleIdentifier</key>
 	<string>org.synfig.SynfigStudio</string>
-	
+
+	<key>CFBundleExecutable</key>
+	<string>SynfigStudio</string>
+
 	<key>CFBundleGetInfoString</key>
 	<string>_VERSION_, © 2001-2020 The Synfig Team</string>
 	<key>CFBundleShortVersionString</key>

--- a/autobuild/osx/synfig_osx_launcher.cpp
+++ b/autobuild/osx/synfig_osx_launcher.cpp
@@ -9,5 +9,7 @@ int main(int argc, char* argv[]) {
     buf = buf.substr(0, found + 1); // get the directory where exe is located
   }
 
-  return system(buf.append("SynfigStudio.sh").c_str());
+  buf = "\"" + buf + "SynfigStudio.sh" + "\"";
+
+  return system(buf.c_str());
 }


### PR DESCRIPTION
Improved Info.plist (https://developer.apple.com/documentation/bundleresources/information_property_list?language=objc)

- Multiple instances prohibited
- SynfigStudio.app will launch even if renamed
- SynfigStudio.app will launch even if contain spaces in name