### PR TITLE
Fix crash in Spline Tangent converter

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
@@ -102,10 +102,9 @@ ValueNode_BLineCalcTangent::operator()(Time t, Real amount)const
 		printf("%s:%d operator()\n", __FILE__, __LINE__);
 
 	const ValueBase::List bline = (*bline_)(t).get_list();
-	handle<ValueNode_BLine> bline_value_node( handle<ValueNode_BLine>::cast_dynamic(bline_) );
-	assert(bline_value_node);
+	const ValueBase bline_value_node = (*bline_)(t);
 
-	const bool looped = bline_value_node->get_loop();
+	const bool looped = bline_value_node.get_loop();
 	int size = (int)bline.size();
 	int count = looped ? size : size - 1;
 	if (count < 1) return Vector();


### PR DESCRIPTION
Part of https://github.com/synfig/synfig/issues/1731
This fixes crash in 'Spline Tangent' converter similar to one that was addressed in 'Spline Vertex' previously.