### PR TITLE
Add double quotes and option when ID_LIKE=ubuntu debian in PopOS

### DIFF
--- a/1-setup-linux-native.sh
+++ b/1-setup-linux-native.sh
@@ -30,7 +30,7 @@ echo "Detecting Linux OS..."
 # Check if /etc/os-release file is available
 if [ -f /etc/os-release ]; then
     source /etc/os-release
-    if [ -z $ID_LIKE ] && [ ! -z $ID ]; then
+    if [ -z "$ID_LIKE" ] && [ ! -z $ID ]; then
         ID_LIKE=$ID
     fi
     echo "ID_LIKE=$ID_LIKE"
@@ -38,7 +38,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 # Fallback whether /etc/os-release is not available, or if ID_LIKE is not set
-if [ -z $ID_LIKE ]; then
+if [ -z "$ID_LIKE" ]; then
     if command -v dnf >/dev/null; then
         # Fedora DNF package manager
         export ID_LIKE="fedora"
@@ -189,7 +189,7 @@ elif [ "$ID_LIKE" == "arch" ]; then
     echo
     sudo pacman -S --needed --noconfirm $PKG_LIST || true
 
-elif [ "$ID_LIKE" == "debian" ] || [ "$ID_LIKE" == "ubuntu" ] ; then
+elif [ "$ID_LIKE" == "debian" ] || [ "$ID_LIKE" == "ubuntu" ] || [ "$ID_LIKE" == "ubuntu debian" ]; then
     if [ ! -f /etc/altlinux-release ]; then
             #  Debian / Ubuntu
             PKG_LIST=" \


### PR DESCRIPTION
Problem with `1-setup-linux-native.sh` when `ID_LIKE` contains space, for example, in Pop!_OS `ID_LIKE="ubuntu debian"`

```
Detecting Linux OS...
./1-setup-linux-native.sh: line 33: [: ubuntu: binary operator expected
ID_LIKE=ubuntu debian
VERSION_ID=20.10
./1-setup-linux-native.sh: line 41: [: ubuntu: binary operator expected
Checking dependencies...
WARNING: This build script does not work with package management systems other than yum, zypper, apt or pacman! You should install dependent packages manually.
REQUIRED PACKAGES: 
libpng-devel libjpeg-devel freetype-devel fontconfig-devel atk-devel pango-devel cairo-devel gtk3-devel gettext-devel libxml2-devel libxml++-devel gcc-c++ autoconf automake libtool libtool-ltdl-devel shared-mime-info OpenEXR-devel libmng-devel ImageMagick-c++-devel gtkmm30-devel glibmm24-devel

Done.

```

Fix: add quotes around the variable, add another option for `ubuntu debian` in if statement