### PR TITLE
[Synfig Studio] Fixed crash when frame rendering throws exception while animating

### DIFF
--- a/synfig-studio/src/gui/asyncrenderer.cpp
+++ b/synfig-studio/src/gui/asyncrenderer.cpp
@@ -889,6 +889,7 @@ AsyncRenderer::render_target()
 {
 	etl::handle<Target> target(AsyncRenderer::target);
 
+	std::string error_str;
 	try {
 		if(target && target->render(cb))
 		{
@@ -901,9 +902,18 @@ AsyncRenderer::render_target()
 			return;
 #endif
 		}
+	} catch (std::runtime_error &err) {
+		error_str = std::string(_("AsynRenderer: ")) + _("runtime error: ") + err.what();
+	} catch (std::exception &ex) {
+		error_str = std::string(_("AsynRenderer: ")) + _("exception: ") + ex.what();
+	} catch (std::string &str) {
+		error_str = std::string(_("AsynRenderer: ")) + _("string exception: ") + str;
 	} catch (...) {
+		error_str = std::string(_("AsynRenderer: ")) + _("internal error: ") + _("some exception has been thrown while rendering");
+	}
+
+	if (!error_str.empty()) {
 		status = RENDERING_ERROR;
-		string error_str = _("Internal error: some exception has been thrown while rendering");
 		synfig::error(error_str);
 		if (cb)
 			cb->error(error_str);

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -2120,8 +2120,10 @@ WorkArea::sync_render(bool refresh)
 	std::string error_msg;
 	for (auto& msg : error_msg_list)
 		error_msg.append(msg + "\n");
-	if (!error_msg.empty())
+	if (!error_msg.empty()) {
 		App::get_ui_interface()->error(error_msg);
+		canvas_view->stop_async();
+	}
 }
 
 void

--- a/synfig-studio/src/gui/workarearenderer/CMakeLists.txt
+++ b/synfig-studio/src/gui/workarearenderer/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(synfigstudio
         "${CMAKE_CURRENT_LIST_DIR}/renderer_canvas.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer_dragbox.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer_ducks.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/renderer_frameerror.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer_grid.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer_guides.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer_timecode.cpp"

--- a/synfig-studio/src/gui/workarearenderer/Makefile_insert
+++ b/synfig-studio/src/gui/workarearenderer/Makefile_insert
@@ -4,6 +4,7 @@ WORKAREARENDERER_HH = \
 	workarearenderer/renderer_canvas.h \
 	workarearenderer/renderer_dragbox.h \
 	workarearenderer/renderer_ducks.h \
+	workarearenderer/renderer_frameerror.h \
 	workarearenderer/renderer_grid.h \
 	workarearenderer/renderer_guides.h \
 	workarearenderer/renderer_timecode.h \
@@ -16,6 +17,7 @@ WORKAREARENDERER_CC = \
 	workarearenderer/renderer_canvas.cpp \
 	workarearenderer/renderer_dragbox.cpp \
 	workarearenderer/renderer_ducks.cpp \
+	workarearenderer/renderer_frameerror.cpp \
 	workarearenderer/renderer_grid.cpp \
 	workarearenderer/renderer_guides.cpp \
 	workarearenderer/renderer_timecode.cpp \

--- a/synfig-studio/src/gui/workarearenderer/renderer_canvas.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_canvas.cpp
@@ -42,6 +42,7 @@
 #include <synfig/rendering/common/task/tasktransformation.h>
 
 #include <gui/canvasview.h>
+#include <gui/localization.h>
 #include <gui/timemodel.h>
 #include <gui/workarea.h>
 
@@ -447,7 +448,26 @@ Renderer_Canvas::enqueue_render_frame(
 
 	// build rendering task
 	canvas->set_time(id.time);
-	canvas->load_resources(id.time);
+
+	std::string loading_error_msg;
+	try {
+		canvas->load_resources(id.time);
+	} catch (std::runtime_error &err) {
+		loading_error_msg = err.what();
+	} catch (std::exception &ex) {
+		loading_error_msg = ex.what();
+	} catch (std::string &str) {
+		loading_error_msg = str;
+	} catch (...) {
+		loading_error_msg = _("Unknown reason");
+	}
+	if (!loading_error_msg.empty()) {
+		std::string full_error_msg = etl::strprintf(_("Error loading canvas resources at %s (%s):\n\t%s"), id.time.get_string().c_str(), canvas->get_name().c_str(), loading_error_msg.c_str());
+		rendering_error_msg_map[id.time].insert(full_error_msg);
+		synfig::error(full_error_msg);
+		return false;
+	}
+
 	canvas->set_outline_grow(rend_desc.get_outline_grow());
 	rendering::Task::Handle task = canvas->build_rendering_task(context_params);
 
@@ -657,6 +677,7 @@ Renderer_Canvas::clear_render()
 				erase_tile(i->second, j, events);
 			}
 		tiles.clear();
+		rendering_error_msg_map.clear();
 	}
 	rendering::Renderer::cancel(events);
 	if (cleared && get_work_area())
@@ -727,6 +748,27 @@ Renderer_Canvas::get_render_status(StatusMap &out_map)
 			calc_frame_status(current_thumb.with_time(i->first), current_thumb.rect()) );
 		if (i->second == FS_None) out_map.erase(i++); else ++i;
 	}
+}
+
+void Renderer_Canvas::get_rendering_error_messages(std::vector<std::string>& messages)
+{
+	std::lock_guard<std::mutex> lock(mutex);
+
+	messages.clear();
+	for (auto& msgs_for_time : rendering_error_msg_map) {
+		for (auto& msg : msgs_for_time.second)
+			messages.push_back(msg);
+	}
+}
+
+void Renderer_Canvas::get_rendering_error_messages_for_time(const Time& time, std::set<std::string>& message_set)
+{
+	std::lock_guard<std::mutex> lock(mutex);
+
+	message_set.clear();
+	auto it = rendering_error_msg_map.find(time);
+	if (it != rendering_error_msg_map.end())
+		message_set = it->second;
 }
 
 void

--- a/synfig-studio/src/gui/workarearenderer/renderer_canvas.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_canvas.h
@@ -213,6 +213,8 @@ private:
 		const synfig::RectInt &window_rect,
 		const FrameId &id );
 
+	std::map<synfig::Time, std::set<std::string>> rendering_error_msg_map;
+
 public:
 	Renderer_Canvas();
 	~Renderer_Canvas();
@@ -224,6 +226,9 @@ public:
 	void clear_render();
 
 	void get_render_status(StatusMap &out_map);
+
+	void get_rendering_error_messages(std::vector<std::string>& messages);
+	void get_rendering_error_messages_for_time(const synfig::Time& time, std::set<std::string>& message_set);
 
 	// just paint already rendered tiles at window
 	void render_vfunc(

--- a/synfig-studio/src/gui/workarearenderer/renderer_frameerror.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_frameerror.cpp
@@ -1,0 +1,82 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file renderer_frameerror.h
+**	\brief Workarea renderer of frame rendering error messages of current frame
+**
+**	$Id$
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include "renderer_frameerror.h"
+
+#include <gui/workarea.h>
+#include <gui/workarearenderer/renderer_canvas.h>
+
+#endif
+
+/* === U S I N G =========================================================== */
+
+
+using namespace studio;
+
+studio::Renderer_FrameError::~Renderer_FrameError()
+{
+}
+
+void Renderer_FrameError::render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable, const Gdk::Rectangle& /*expose_area*/)
+{
+	if (!get_work_area())
+		return;
+
+	const etl::handle<Renderer_Canvas> renderer_canvas = get_work_area()->get_renderer_canvas();
+	if (renderer_canvas) {
+		std::set<std::string> message_set;
+		renderer_canvas->get_rendering_error_messages_for_time(get_work_area()->get_time(), message_set);
+		if (!message_set.empty()) {
+			std::string full_msg;
+			for (const std::string& msg : message_set)
+				full_msg.append(msg + "\n");
+
+			Pango::FontDescription font;
+			font.set_family("Monospace");
+
+			int text_pixel_width = drawable->get_width() - 30;
+			if (text_pixel_width < 30)
+				text_pixel_width = 30;
+
+			Glib::RefPtr<Pango::Layout> layout(Pango::Layout::create(get_work_area()->get_pango_context()));
+			layout->set_text(full_msg);
+			layout->set_font_description(font);
+			layout->set_width(text_pixel_width * PANGO_SCALE);
+
+			Cairo::RefPtr<Cairo::Context> cr = drawable->create_cairo_context();
+			cr->save();
+
+			cr->set_source_rgb(1,0,0);
+			cr->move_to(10, 30);
+			layout->show_in_cairo_context(cr);
+
+			cr->restore();
+		}
+	}
+}

--- a/synfig-studio/src/gui/workarearenderer/renderer_frameerror.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_frameerror.h
@@ -1,0 +1,40 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file renderer_frameerror.h
+**	\brief Workarea renderer of frame rendering error messages of current frame
+**
+**	$Id$
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**
+**	This package is free software; you can redistribute it and/or
+**	modify it under the terms of the GNU General Public License as
+**	published by the Free Software Foundation; either version 2 of
+**	the License, or (at your option) any later version.
+**
+**	This package is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+**	General Public License for more details.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+#ifndef SYNFIG_STUDIO_RENDERER_FRAMEERROR_H
+#define SYNFIG_STUDIO_RENDERER_FRAMEERROR_H
+
+#include "workarearenderer.h"
+
+namespace studio {
+
+class Renderer_FrameError : public studio::WorkAreaRenderer
+{
+public:
+	~Renderer_FrameError();
+
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable, const Gdk::Rectangle& expose_area);
+};
+
+}; // END of namespace studio
+
+#endif // SYNFIG_STUDIO_RENDERER_FRAMEERROR_H


### PR DESCRIPTION
It now displays the exception message inside WorkArea when the current frame throws an exception.

It also displays an error dialog while animating in WorkArea

**Description**

If a frame throws an exception/error, Synfig shows its message:

- in console/prompt
- in work area at problematic frame:
![a782b3880b4612b31c89fa472be27af07976bffd](https://user-images.githubusercontent.com/5604544/99925730-cdaaa880-2d71-11eb-86fb-45675ff0d70f.png)

- via error message dialog, while animating:
![f976d23fbb9c6bdd9e550f2b1003bbc5a7da4743](https://user-images.githubusercontent.com/5604544/99925751-dac79780-2d71-11eb-889d-19ca2a02281b.png)


fix crash-bug reported in forums by lgolden:
https://forums.synfig.org/t/lst-file-from-papagayo-crashes-synfig/11540