### PR TITLE
minor cleanup in WorkArea Renderers

### DIFF
--- a/synfig-studio/src/gui/workarearenderer/renderer_background.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_background.cpp
@@ -30,20 +30,13 @@
 #	include <config.h>
 #endif
 
-#include <synfig/general.h>
-
 #include "renderer_background.h"
-#include "workarea.h"
-#include <ETL/misc>
-
-#include <gui/localization.h>
+#include <gui/workarea.h>
 
 #endif
 
 /* === U S I N G =========================================================== */
 
-using namespace std;
-using namespace etl;
 using namespace synfig;
 using namespace studio;
 

--- a/synfig-studio/src/gui/workarearenderer/renderer_background.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_background.h
@@ -45,7 +45,7 @@ protected:
 
 public:
     ~Renderer_Background();
-    void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
+    void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area);
 };
 	
 }; // END of namespace studio

--- a/synfig-studio/src/gui/workarearenderer/renderer_bbox.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_bbox.cpp
@@ -31,23 +31,21 @@
 #	include <config.h>
 #endif
 
-#include <synfig/general.h>
-
 #include "renderer_bbox.h"
-#include "workarea.h"
-#include "canvasview.h"
-#include <gui/localization.h>
+#include <gui/canvasview.h>
+#include <gui/workarea.h>
 
 #endif
 
 /* === U S I N G =========================================================== */
 
-using namespace std;
-using namespace etl;
 using namespace synfig;
 using namespace studio;
 
 /* === M A C R O S ========================================================= */
+
+#define BBOX_COLOR_OUTLINE      Gdk::Color("#ffffff")
+#define BBOX_COLOR_FAILBACK     Gdk::Color("#000000")
 
 /* === G L O B A L S ======================================================= */
 
@@ -55,16 +53,12 @@ using namespace studio;
 
 /* === M E T H O D S ======================================================= */
 
-Renderer_BBox::Renderer_BBox()
-{
-}
-
 Renderer_BBox::~Renderer_BBox()
 {
 }
 
 const synfig::Rect&
-Renderer_BBox::get_bbox()
+Renderer_BBox::get_bbox() const
 {
 	return get_work_area()->get_canvas_view()->get_bbox();
 }
@@ -101,9 +95,9 @@ Renderer_BBox::render_vfunc(
 		br[0]=(br[0]-window_startx)/pw;
 		br[1]=(br[1]-window_starty)/ph;
 		if(tl[0]>br[0])
-			swap(tl[0],br[0]);
+			std::swap(tl[0],br[0]);
 		if(tl[1]>br[1])
-			swap(tl[1],br[1]);
+			std::swap(tl[1],br[1]);
 
 		cr->save();
 		cr->set_line_cap(Cairo::LINE_CAP_BUTT);

--- a/synfig-studio/src/gui/workarearenderer/renderer_bbox.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_bbox.h
@@ -29,14 +29,9 @@
 /* === H E A D E R S ======================================================= */
 
 #include "workarearenderer.h"
-#include <vector>
-#include <synfig/vector.h>
 #include <synfig/rect.h>
 
 /* === M A C R O S ========================================================= */
-
-#define BBOX_COLOR_OUTLINE      Gdk::Color("#ffffff")
-#define BBOX_COLOR_FAILBACK     Gdk::Color("#000000")
 
 /* === T Y P E D E F S ===================================================== */
 
@@ -49,15 +44,11 @@ class Renderer_BBox : public studio::WorkAreaRenderer
 	synfig::Rect bbox;
 
 public:
-	Renderer_BBox();
 	~Renderer_BBox();
 
-	const synfig::Rect& get_bbox();
+	const synfig::Rect& get_bbox() const;
 
-	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
-
-protected:
-	//bool get_enabled_vfunc()const;
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area);
 };
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/workarearenderer/renderer_bonesetup.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_bonesetup.cpp
@@ -30,24 +30,16 @@
 #	include <config.h>
 #endif
 
-#include <synfig/general.h>
-
 #include "renderer_bonesetup.h"
-#include "workarea.h"
-#include <pangomm/layout.h>
-#include <pangomm/context.h>
-#include <pango/pango.h>
-#include "app.h"
-#include <cassert>
 
 #include <gui/localization.h>
+#include <gui/workarea.h>
+#include <cassert>
 
 #endif
 
 /* === U S I N G =========================================================== */
 
-using namespace std;
-using namespace etl;
 using namespace synfig;
 using namespace studio;
 

--- a/synfig-studio/src/gui/workarearenderer/renderer_bonesetup.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_bonesetup.h
@@ -32,7 +32,9 @@
 
 /* === M A C R O S ========================================================= */
 
+namespace studio {
 static const int bonesetup_x  = 4, bonesetup_y  =  16;
+};
 
 /* === T Y P E D E F S ===================================================== */
 
@@ -46,7 +48,7 @@ class Renderer_BoneSetup : public studio::WorkAreaRenderer
 public:
 	~Renderer_BoneSetup();
 
-	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area);
 
 protected:
 	bool get_enabled_vfunc()const;

--- a/synfig-studio/src/gui/workarearenderer/renderer_canvas.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_canvas.cpp
@@ -32,22 +32,18 @@
 #	include <config.h>
 #endif
 
-#include <ctime>
 #include <cstring>
 #include <valarray>
 
-#include <glib.h>
-
 #include <synfig/general.h>
-#include <synfig/canvas.h>
 #include <synfig/context.h>
 #include <synfig/threadpool.h>
 #include <synfig/rendering/renderer.h>
 #include <synfig/rendering/common/task/tasktransformation.h>
 
-#include <gui/app.h>
 #include <gui/canvasview.h>
 #include <gui/timemodel.h>
+#include <gui/workarea.h>
 
 #include "renderer_canvas.h"
 

--- a/synfig-studio/src/gui/workarearenderer/renderer_canvas.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_canvas.h
@@ -28,16 +28,14 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <climits>
-
 #include <vector>
 #include <map>
 
-#include <synfig/time.h>
+#include <synfig/canvas.h>
 #include <synfig/rendering/task.h>
 #include <synfig/rendering/renderer.h>
+#include <synfig/time.h>
 
-#include "../workarea.h"
 #include "workarearenderer.h"
 
 /* === M A C R O S ========================================================= */

--- a/synfig-studio/src/gui/workarearenderer/renderer_dragbox.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_dragbox.cpp
@@ -33,26 +33,21 @@
 #	include <config.h>
 #endif
 
-#include <synfig/general.h>
-
 #include "renderer_dragbox.h"
-#include "workarea.h"
-#include <ETL/misc>
-
-#include <gui/localization.h>
 
 #include <gui/exception_guard.h>
+#include <gui/workarea.h>
 
 #endif
 
 /* === U S I N G =========================================================== */
 
-using namespace std;
-using namespace etl;
 using namespace synfig;
 using namespace studio;
 
 /* === M A C R O S ========================================================= */
+
+#define DRAGBOX_COLOR_OUTLINE      Gdk::Color("#000000")
 
 /* === G L O B A L S ======================================================= */
 
@@ -218,9 +213,9 @@ Renderer_Dragbox::render_vfunc(
 		br[0]=(br[0]-window_startx)/pw;
 		br[1]=(br[1]-window_starty)/ph;
 		if(tl[0]>br[0])
-			swap(tl[0],br[0]);
+			std::swap(tl[0],br[0]);
 		if(tl[1]>br[1])
-			swap(tl[1],br[1]);
+			std::swap(tl[1],br[1]);
 
 		cr->rectangle(
 			tl[0],

--- a/synfig-studio/src/gui/workarearenderer/renderer_dragbox.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_dragbox.h
@@ -31,15 +31,12 @@
 /* === H E A D E R S ======================================================= */
 
 #include "workarearenderer.h"
-#include "duckmatic.h"
-#include <vector>
+#include <gui/duckmatic.h>
 #include <synfig/vector.h>
 #include <synfig/guidset.h>
 
 
 /* === M A C R O S ========================================================= */
-
-#define DRAGBOX_COLOR_OUTLINE      Gdk::Color("#000000")
 
 /* === T Y P E D E F S ===================================================== */
 
@@ -69,7 +66,7 @@ protected:
 	bool get_enabled_vfunc()const;
 
 	//! Redraw the drag box
-	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area);
 	//! Catch some mouse events to select objects (handles) in the workarea
 	bool event_vfunc(GdkEvent* event);
 };

--- a/synfig-studio/src/gui/workarearenderer/renderer_ducks.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_ducks.h
@@ -29,59 +29,8 @@
 /* === H E A D E R S ======================================================= */
 
 #include "workarearenderer.h"
-#include <vector>
 
 /* === M A C R O S ========================================================= */
-
-/** DUCK_COLOR_NOT_EDITABLE : light grey - for parameter (handle) like converted (linked also?) for example*/
-#define DUCK_COLOR_NOT_EDITABLE	Gdk::Color("#cfcfcf")
-/** DUCK_COLOR_ORIGIN : green */
-#define DUCK_COLOR_ORIGIN        Gdk::Color("#00ff00") // green
-/** DUCK_COLOR_ANGLE : blue */
-#define DUCK_COLOR_ANGLE		Gdk::Color("#0000ff") // blue
-/** DUCK_COLOR_RADIUS : cyan */
-#define DUCK_COLOR_RADIUS		Gdk::Color("#00ffff") // cyan
-/** DUCK_COLOR_LINEAR : cyan for linear radius ducks */
-#define DUCK_COLOR_LINEAR		Gdk::Color("#00ffff") // cyan // for linear radius ducks
-/** DUCK_COLOR_TANGENT_1 : yellow */
-#define DUCK_COLOR_TANGENT_1	Gdk::Color("#ffff00") // yellow
-/** DUCK_COLOR_TANGENT_2 : red (not used) */
-#define DUCK_COLOR_TANGENT_2	Gdk::Color("#ff0000") // red
-/** DUCK_COLOR_SKEW : red */
-#define DUCK_COLOR_SKEW         Gdk::Color("#ff0000") // red
-/** DUCK_COLOR_VERTEX : orange */
-#define DUCK_COLOR_VERTEX		Gdk::Color("#ff7f00") // orange
-/** DUCK_COLOR_WIDTH : magenta */
-#define DUCK_COLOR_WIDTH		Gdk::Color("#ff00ff") // magenta
-/** DUCK_COLOR_WIDTHPOINT_POSITION : purple */
-#define DUCK_COLOR_WIDTHPOINT_POSITION	Gdk::Color("#d3afff") // purple
-/** DUCK_COLOR_OTHER : green */
-#define DUCK_COLOR_OTHER		Gdk::Color("#00ff00") // green
-/** DUCK_COLOR_OUTLINE : black , the outline around each duck*/
-#define DUCK_COLOR_OUTLINE		Gdk::Color("#000000") // the outline around each duck
-/** DUCK_COLOR_BEZIER_1 : black, the 2 colors used to draw bezier curves */
-#define DUCK_COLOR_BEZIER_1		Gdk::Color("#000000") // black // the 2 colors used to draw bezier curves
-/** DUCK_COLOR_BEZIER_2 : grey , the second colors used to draw bezier curves*/
-#define DUCK_COLOR_BEZIER_2		Gdk::Color("#afafaf") // grey
-/** DUCK_COLOR_COLOR_BOX_1 : white , the first color used to draw boxes*/
-#define DUCK_COLOR_BOX_1		Gdk::Color("#ffffff") // white // the 2 colors used to draw boxes
-/** DUCK_COLOR_BOX_2 : black , the second color used to draw boxes*/
-#define DUCK_COLOR_BOX_2		Gdk::Color("#000000") // black
-/** DUCK_COLOR_SELECTED : red , the color of the box drawn when a valuenode is selected*/
-#define DUCK_COLOR_SELECTED		Gdk::Color("#ff0000") // red // the color of the box drawn when a valuenode is selected
-/** DUCK_COLOR_CONNECT_INSIDE : the color of the inside of the line connecting a vertex duck to the tangent ducks */
-#define DUCK_COLOR_CONNECT_INSIDE	Gdk::Color("#9fefef") // the color of the inside of the line connecting a vertex duck to the tangent ducks
-/** DUCK_COLOR_CONNECT_OUTSIDE : black, the color of the outside of the line connecting a vertex duck to the tangent ducks*/
-#define DUCK_COLOR_CONNECT_OUTSIDE	Gdk::Color("#000000") // the color of the outside of the line connecting a vertex duck to the tangent ducks
-/** DUCK_COLOR_WIDTH_TEXT_1 : black, the color of the text's shadow when hovering over a width duck*/
-#define DUCK_COLOR_WIDTH_TEXT_1	Gdk::Color("#000000") // the color of the text's shadow when hovering over a width duck
-/** DUCK_COLOR_WIDTH_TEXT_2 : magenta, the color of the text when hovering over a width duck*/
-#define DUCK_COLOR_WIDTH_TEXT_2	Gdk::Color("#ff00ff") // the color of the text when hovering over a width duck
-/** DUCK_COLOR_TRANSFO_TEXT_1 : black , the color of the text's shadow when hovering over any duck of a transformation widget*/
-#define DUCK_COLOR_TRANSFO_TEXT_1 Gdk::Color("#000000") // the color of the text's shadow when hovering over any duck of a transformation widget
-/** ACTIVE_BONE : Color of active bone rectangle */
-#define ACTIVE_BONE Gdk::Color("#fff700") // the color of the text's shadow when hovering over any duck of a transformation widget
-
 
 /* === T Y P E D E F S ===================================================== */
 
@@ -99,10 +48,7 @@ public:
 	//! \TODO immense function !! break into parts and clean
 	//! \Param[in] drawable
 	//! \Param[in] expose_area
-	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
-
-protected:
-//	bool get_enabled_vfunc()const;
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area);
 };
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/workarearenderer/renderer_grid.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_grid.cpp
@@ -30,13 +30,10 @@
 #	include <config.h>
 #endif
 
-#include <synfig/general.h>
-
 #include "renderer_grid.h"
-#include "workarea.h"
-#include <ETL/misc>
 
-#include <gui/localization.h>
+#include <ETL/misc>
+#include <gui/workarea.h>
 
 #endif
 

--- a/synfig-studio/src/gui/workarearenderer/renderer_grid.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_grid.h
@@ -28,7 +28,6 @@
 /* === H E A D E R S ======================================================= */
 
 #include "workarearenderer.h"
-#include <vector>
 
 /* === M A C R O S ========================================================= */
 
@@ -46,7 +45,7 @@ public:
 
 	synfig::Vector get_grid_size()const;
 
-	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area);
 
 protected:
 	bool get_enabled_vfunc()const;

--- a/synfig-studio/src/gui/workarearenderer/renderer_guides.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_guides.cpp
@@ -30,36 +30,24 @@
 #	include <config.h>
 #endif
 
-#include <synfig/general.h>
-
 #include "renderer_guides.h"
-#include "workarea.h"
-#include <ETL/misc>
-
-#include <gui/localization.h>
+#include <gui/workarea.h>
 
 #endif
 
 /* === U S I N G =========================================================== */
 
-using namespace std;
-using namespace etl;
-using namespace synfig;
 using namespace studio;
 
 /* === M A C R O S ========================================================= */
+
+#define GUIDE_COLOR_CURRENT     Gdk::Color("#ff6f6f")
 
 /* === G L O B A L S ======================================================= */
 
 /* === P R O C E D U R E S ================================================= */
 
 /* === M E T H O D S ======================================================= */
-
-Renderer_Guides::Renderer_Guides()//:
-	//dragging(false)
-{
-
-}
 
 Renderer_Guides::~Renderer_Guides()
 {

--- a/synfig-studio/src/gui/workarearenderer/renderer_guides.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_guides.h
@@ -28,11 +28,8 @@
 /* === H E A D E R S ======================================================= */
 
 #include "workarearenderer.h"
-#include <vector>
 
 /* === M A C R O S ========================================================= */
-
-#define GUIDE_COLOR_CURRENT     Gdk::Color("#ff6f6f")
 
 /* === T Y P E D E F S ===================================================== */
 
@@ -42,10 +39,7 @@ namespace studio {
 
 class Renderer_Guides : public studio::WorkAreaRenderer
 {
-	//bool dragging;
-	// Warining: Unused variable dragging
 public:
-	Renderer_Guides();
 	~Renderer_Guides();
 
 	std::list<float>& get_guide_list_x();

--- a/synfig-studio/src/gui/workarearenderer/renderer_timecode.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_timecode.cpp
@@ -31,28 +31,21 @@
 #	include <config.h>
 #endif
 
-#include <synfig/general.h>
-
 #include "renderer_timecode.h"
-#include "workarea.h"
-#include <pangomm/layout.h>
-#include <pangomm/context.h>
-#include <pango/pango.h>
-#include "app.h"
-#include <cassert>
 
-#include <gui/localization.h>
+#include <cassert>
+#include <gui/workarea.h>
 
 #endif
 
 /* === U S I N G =========================================================== */
 
-using namespace std;
-using namespace etl;
 using namespace synfig;
 using namespace studio;
 
 /* === M A C R O S ========================================================= */
+
+#define TIMECODE_COLOR_TEXT     Gdk::Color("#5f0000")
 
 /* === G L O B A L S ======================================================= */
 
@@ -70,12 +63,6 @@ Renderer_Timecode::get_enabled_vfunc()const
 	Canvas::Handle canvas(get_work_area()->get_canvas());
 	return (canvas->rend_desc().get_time_start()!=canvas->rend_desc().get_time_end() ||
 		canvas->get_time()!=canvas->rend_desc().get_time_start());
-}
-
-synfig::Vector
-Renderer_Timecode::get_grid_size()const
-{
-	return get_work_area()->get_grid_size();
 }
 
 void
@@ -115,7 +102,7 @@ Renderer_Timecode::render_vfunc(
 		cr->save();
 
 		cr->set_source_rgb(GDK_COLOR_TO_RGB(TIMECODE_COLOR_TEXT));
-		cr->move_to(4,4);
+		cr->move_to(timecode_x, timecode_y);
 		layout->show_in_cairo_context(cr);
 
 		cr->restore();

--- a/synfig-studio/src/gui/workarearenderer/renderer_timecode.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_timecode.h
@@ -28,13 +28,12 @@
 /* === H E A D E R S ======================================================= */
 
 #include "workarearenderer.h"
-#include <vector>
 
 /* === M A C R O S ========================================================= */
 
-#define TIMECODE_COLOR_TEXT     Gdk::Color("#5f0000")
-
+namespace studio {
 static const int timecode_x  = 4, timecode_y  =  4;
+};
 
 /* === T Y P E D E F S ===================================================== */
 
@@ -48,9 +47,7 @@ class Renderer_Timecode : public studio::WorkAreaRenderer
 public:
 	~Renderer_Timecode();
 
-	synfig::Vector get_grid_size()const;
-
-	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area	);
+	void render_vfunc(const Glib::RefPtr<Gdk::Window>& drawable,const Gdk::Rectangle& expose_area);
 
 protected:
 	bool get_enabled_vfunc()const;


### PR DESCRIPTION
* remove unused #include
* remove extra whitespace inside method arguments
* remove unused "using namespace"
* move macro #define for rendering colors to implementation file
* remove unused (and wrong) method in Renderer_Timecode
* remove unnecessary constructors
* some other minor changes