### PR TITLE
"This tool has no options" label now centered vertically

### DIFF
--- a/synfig-studio/src/gui/docks/dialog_tooloptions.cpp
+++ b/synfig-studio/src/gui/docks/dialog_tooloptions.cpp
@@ -78,6 +78,7 @@ Dialog_ToolOptions::clear()
 	set_local_name(_("Tool Options"));
 	add(sub_vbox_);
 	set_widget(empty_label);
+	sub_vbox_.set_valign(Gtk::Align::ALIGN_CENTER);
 	empty_label.show();
 
 	set_stock_id(Gtk::StockID("synfig-about"));
@@ -91,6 +92,7 @@ Dialog_ToolOptions::set_widget(Gtk::Widget&x)
 		sub_vbox_.remove(**i);
 	sub_vbox_.show();
 	sub_vbox_.pack_start(x,false,false);
+	sub_vbox_.set_valign(Gtk::Align::ALIGN_FILL);
 	x.show();
 }
 


### PR DESCRIPTION
When `Tools` without user editable options are selected, the label in the `Tool Options` window is not vertically centered.
This is unpleasant to look at.

This merge request centers the label vertically:

Before:
![before](https://user-images.githubusercontent.com/5604544/100695840-acc30280-33c4-11eb-91a0-940406846f1a.png)

After:
![no-options-label](https://user-images.githubusercontent.com/6705690/100630803-46d66c80-332b-11eb-801f-d6f4bdcbbbf9.png)