### PR TITLE
[Autotools] Added missing `synfig_export.h` file

### DIFF
--- a/synfig-core/src/synfig/Makefile.am
+++ b/synfig-core/src/synfig/Makefile.am
@@ -52,6 +52,7 @@ VALUEHEADERS = \
 	weightedvalue.h \
 	pair.h \
 	type.h \
+	synfig_export.h \
 	base_types.h \
 	value.h
 


### PR DESCRIPTION
Synfig fails to build with 3-step build (ETL, core, studio)