### PR TITLE
Fix crash in Spline Width and return of improper type in Spline converters

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
@@ -107,7 +107,15 @@ ValueNode_BLineCalcTangent::operator()(Time t, Real amount)const
 	const bool looped = bline_value_node.get_loop();
 	int size = (int)bline.size();
 	int count = looped ? size : size - 1;
-	if (count < 1) return Vector();
+	if (count < 1)
+	{
+		Type &type(get_type());
+		if (type == type_angle)  return Angle();
+		if (type == type_real)   return Real();
+		if (type == type_vector) return Vector();
+		assert(0);
+		return ValueBase();
+	}
 
 	bool loop         = (*loop_)(t).get(bool());
 	bool homogeneous  = (*homogeneous_)(t).get(bool());

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
@@ -100,10 +100,9 @@ ValueNode_BLineCalcWidth::operator()(Time t, Real amount)const
 		printf("%s:%d operator()\n", __FILE__, __LINE__);
 
 	const ValueBase::List bline = (*bline_)(t).get_list();
-	handle<ValueNode_BLine> bline_value_node( handle<ValueNode_BLine>::cast_dynamic(bline_) );
-	assert(bline_value_node);
+	const ValueBase bline_value_node = (*bline_)(t);
 
-	const bool looped = bline_value_node->get_loop();
+	const bool looped = bline_value_node.get_loop();
 	int size = (int)bline.size();
 	int count = looped ? size : size - 1;
 	if (count < 1) return Vector();

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
@@ -105,7 +105,7 @@ ValueNode_BLineCalcWidth::operator()(Time t, Real amount)const
 	const bool looped = bline_value_node.get_loop();
 	int size = (int)bline.size();
 	int count = looped ? size : size - 1;
-	if (count < 1) return Vector();
+	if (count < 1) return Real();
 
 	bool loop         = (*loop_)(t).get(bool());
 	bool homogeneous  = (*homogeneous_)(t).get(bool());


### PR DESCRIPTION
Fix https://github.com/synfig/synfig/issues/1731
This is the final part. Feel free to close the linked issue after merging.

The pull request contains two commits:
* First fixes crash in 'Spline Width' converter when you try to wrap it in 'Switch'. Similar to previously addressed in 'Spline Vertex' and 'Spline Tangent' converters.
* Second addresses the regression introduced in this commit: a90d014c56f0cbee21c2ab0ef68936b9e84c49b1
It was no longer possible to convert real values to 'Spline Tangent/Width' and angle to 'Spline Tangent'. The reason is that upon creation of converter the size of spline would be zero and code will always return ValueBase of vector type so 'Bad Connection' error would be thrown (expected real, got vector). See linked issue for screenshot of the error.