### PR TITLE
[Synfig Studio] Center "Scale to fit Canvas" switch vertically to avoid stretching

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -4426,6 +4426,7 @@ studio::App::scale_imported_box()
 	Gtk::Switch *toggle_resize = manage(new Gtk::Switch);
 	
 	label_resize->set_margin_end(5);
+	toggle_resize->set_valign(Gtk::ALIGN_CENTER);
 	toggle_resize->set_active(App::resize_imported_images);
 	
 	toggle_resize->property_active().signal_changed().connect(


### PR DESCRIPTION
Fix #1910

![issue-1910](https://user-images.githubusercontent.com/6705690/102013792-8dc45900-3d52-11eb-9598-12a3179b098c.png)