### PR TITLE
[Synfig Studio] Add Show/Snap Guides to Toolbar

### DIFF
--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -223,6 +223,8 @@ public:
 
 	void set_grid_snap_toggle(bool flag) { grid_snap_toggle->set_active(flag); }
 	void set_grid_show_toggle(bool flag) { grid_show_toggle->set_active(flag); }
+	void set_guides_snap_toggle(bool flag) { guides_snap_toggle->set_active(flag); }
+	void set_guides_show_toggle(bool flag) { guides_show_toggle->set_active(flag); }
 	void set_onion_skin_toggle(bool flag) { onion_skin_toggle->set_active(flag); }
 
 	void set_background_rendering_toggle(bool flag) { background_rendering_toggle->set_active(flag); }
@@ -303,11 +305,15 @@ private:
 	Gtk::SpinButton *future_onion_spin;
 	Gtk::ToggleToolButton *show_grid;
 	Gtk::ToggleToolButton *snap_grid;
+	Gtk::ToggleToolButton *show_guides;
+	Gtk::ToggleToolButton *snap_guides;
 	Gtk::ToggleToolButton *onion_skin;
 	Gtk::ToolButton *render_options_button;
 	Gtk::ToolButton *preview_options_button;
 	bool toggling_show_grid;
 	bool toggling_snap_grid;
+	bool toggling_show_guides;
+	bool toggling_snap_guides;
 	bool toggling_onion_skin;
 	bool toggling_background_rendering;
 	//! Shows current time and allows edition
@@ -333,6 +339,8 @@ private:
 
 	Glib::RefPtr<Gtk::ToggleAction> grid_snap_toggle;
 	Glib::RefPtr<Gtk::ToggleAction> grid_show_toggle;
+	Glib::RefPtr<Gtk::ToggleAction> guides_snap_toggle;
+	Glib::RefPtr<Gtk::ToggleAction> guides_show_toggle;
 	Glib::RefPtr<Gtk::ToggleAction> onion_skin_toggle;
 
 	Glib::RefPtr<Gtk::ToggleAction> background_rendering_toggle;
@@ -455,6 +463,8 @@ private:
 	void set_onion_skins();
 	void toggle_show_grid();
 	void toggle_snap_grid();
+	void toggle_show_guides();
+	void toggle_snap_guides();
 	void toggle_onion_skin();
 	void toggle_background_rendering();
 

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -329,8 +329,8 @@ IconController::init_icons(const synfig::String& path_to_icons)
 
 	INIT_STOCK_ICON(toggle_show_grid, "show_grid_icon." IMAGE_EXT, _("Toggle show grid"));
 	INIT_STOCK_ICON(toggle_snap_grid, "snap_grid_icon." IMAGE_EXT, _("Toggle snap grid"));
-	INIT_STOCK_ICON(toggle_show_guide, "show_guide_icon." IMAGE_EXT, _("Toggle show guide"));
-	INIT_STOCK_ICON(toggle_snap_guide, "snap_guide_icon." IMAGE_EXT, _("Toggle snap guide"));
+	INIT_STOCK_ICON(toggle_show_guide, "show_guideline_icon." IMAGE_EXT, _("Toggle show guide"));
+	INIT_STOCK_ICON(toggle_snap_guide, "snap_guideline_icon." IMAGE_EXT, _("Toggle snap guide"));
 
 	INIT_STOCK_ICON(toggle_onion_skin, "onion_skin_icon." IMAGE_EXT, _("Toggle onion skin"));
 


### PR DESCRIPTION
Fix #1451
Fixes also a typo in `iconcontroller.cpp` required to display guides icons.

![issue-1451](https://user-images.githubusercontent.com/6705690/102019563-975eb880-3d74-11eb-8530-7edc40b0faba.png)