### PR TITLE
[Synfig Studio] Added ability to undock panel using the context menu command

### DIFF
--- a/synfig-studio/src/gui/docks/dockable.cpp
+++ b/synfig-studio/src/gui/docks/dockable.cpp
@@ -31,6 +31,7 @@
 
 #include "docks/dockable.h"
 
+#include <gtkmm/stock.h>
 #if GTK_CHECK_VERSION (3,20,0)
 #include <gdkmm/seat.h>
 #else

--- a/synfig-studio/src/gui/docks/dockable.h
+++ b/synfig-studio/src/gui/docks/dockable.h
@@ -95,6 +95,8 @@ public:
 		{ return container; }
 
 	void attach_dnd_to(Gtk::Widget& widget);
+	void detach();
+	void detach_to_pointer();
 	virtual void present();
 	virtual Gtk::Widget* create_tab_label();
 

--- a/synfig-studio/src/gui/docks/dockbook.cpp
+++ b/synfig-studio/src/gui/docks/dockbook.cpp
@@ -42,6 +42,7 @@
 #include <gui/docks/dockable.h>
 #include <gui/docks/dockmanager.h>
 #include <gui/docks/dockdroparea.h>
+#include <gui/localization.h>
 
 #endif
 
@@ -268,12 +269,17 @@ DockBook::tab_button_pressed(GdkEventButton* event, Dockable* dockable)
 	Gtk::Menu *tabmenu=manage(new class Gtk::Menu());
 	tabmenu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), tabmenu));
 
-	Gtk::MenuItem *item = manage(new Gtk::ImageMenuItem(Gtk::StockID("gtk-close")));
+	Gtk::MenuItem *item = manage(new Gtk::MenuItem(_("Undock panel")));
+	item->signal_activate().connect(sigc::mem_fun(*dockable, &Dockable::detach_to_pointer));
+	item->show();
+	tabmenu->append(*item);
+
+	item = manage(new Gtk::ImageMenuItem(Gtk::StockID("gtk-close")));
 	item->signal_activate().connect(
 		sigc::bind(sigc::ptr_fun(&DockManager::remove_widget_by_pointer_recursive), dockable) );
-
-	tabmenu->append(*item);
 	item->show();
+	tabmenu->append(*item);
+
 	tabmenu->popup(event->button,gtk_get_current_event_time());
 
 	return true;


### PR DESCRIPTION
Now user doesn't need to drag panel out to undock it.

Some users couldn't figure it out easily how to do it, so
here we give them an alternative way.

Discussed here: https://forums.synfig.org/t/moving-panels-in-layout/11634

And move the undocked panel near to the mouse position