### PR TITLE
[Synfig Studio] Don't expand File Format Version dropdown

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3169,6 +3169,7 @@ App::dialog_save_file(const std::string &title, std::string &filename, std::stri
 				.add_enum_value(synfig::RELEASE_VERSION_0_61_07, "0.61.07", "0.61.07")
 				.add_enum_value(synfig::RELEASE_VERSION_0_61_06, "0.61.06", strprintf("0.61.06 %s", _("and older"))));
 		file_type_enum->set_value(RELEASE_VERSION_END-1); // default to the most recent version
+		file_type_enum->set_hexpand(false);
 
 		Gtk::Grid *grid = manage(new Gtk::Grid);
 		grid->attach(*manage(new Gtk::Label(_("File Format Version: "))),0,0,1,1);


### PR DESCRIPTION
Fix #1931

![issue-1931](https://user-images.githubusercontent.com/6705690/102219407-b9287e80-3edf-11eb-8208-9089a937ad09.png)