### PR TITLE
[Synfig Studio] Disabled resizing of the Preview Options dialog

### DIFF
--- a/synfig-studio/src/gui/resources/ui/preview_options.glade
+++ b/synfig-studio/src/gui/resources/ui/preview_options.glade
@@ -20,6 +20,7 @@
   <object class="GtkDialog" id="preview_options">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Preview Options</property>
+    <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
     <child>
       <placeholder/>


### PR DESCRIPTION
With current master it's possible to increase the size of `Preview Options` dialog:
![resize-preview-dialog](https://user-images.githubusercontent.com/6705690/102825292-c01f2780-43de-11eb-90e2-e75882990d41.png)

which has no benefit for user and is not pleasant to look at.