### PR TITLE
[Synfig Studio] Make Preview tooltips and titles consistent with other dialogs

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1135,7 +1135,7 @@ CanvasView::create_display_bar()
 		render_options_button->signal_clicked().connect(
 			sigc::mem_fun0(render_settings,&RenderSettings::present));
 		render_options_button->set_label(_("Render"));
-		render_options_button->set_tooltip_text( _("Shows the Render Settings Dialog"));
+		render_options_button->set_tooltip_text(_("Open Render Settings Dialog"));
 		render_options_button->show();
 
 		displaybar->append(*render_options_button);
@@ -1150,7 +1150,7 @@ CanvasView::create_display_bar()
 		preview_options_button->signal_clicked().connect(
 			sigc::mem_fun(*this,&CanvasView::on_preview_option));
 		preview_options_button->set_label(_("Preview"));
-		preview_options_button->set_tooltip_text(_("Shows the Preview Settings Dialog"));
+		preview_options_button->set_tooltip_text(_("Open Preview Settings Dialog"));
 		preview_options_button->show();
 
 		displaybar->append(*preview_options_button);

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1135,7 +1135,7 @@ CanvasView::create_display_bar()
 		render_options_button->signal_clicked().connect(
 			sigc::mem_fun0(render_settings,&RenderSettings::present));
 		render_options_button->set_label(_("Render"));
-		render_options_button->set_tooltip_text(_("Open Render Settings Dialog"));
+		render_options_button->set_tooltip_text( _("Shows the Render Settings Dialog"));
 		render_options_button->show();
 
 		displaybar->append(*render_options_button);
@@ -1150,7 +1150,7 @@ CanvasView::create_display_bar()
 		preview_options_button->signal_clicked().connect(
 			sigc::mem_fun(*this,&CanvasView::on_preview_option));
 		preview_options_button->set_label(_("Preview"));
-		preview_options_button->set_tooltip_text(_("Open Preview Settings Dialog"));
+		preview_options_button->set_tooltip_text(_("Shows the Preview Settings Dialog"));
 		preview_options_button->show();
 
 		displaybar->append(*preview_options_button);

--- a/synfig-studio/src/gui/dialogs/dialog_preview.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_preview.cpp
@@ -39,6 +39,7 @@
 #include <gui/exception_guard.h>
 #include <gui/localization.h>
 #include <gui/resourcehelper.h>
+#include "app.h"
 
 #endif
 
@@ -58,12 +59,12 @@ using namespace studio;
 /* === E N T R Y P O I N T ================================================= */
 
 //dialog_preview stuff...
-Dialog_Preview::Dialog_Preview()
-:settings(this,"preview"),preview_table(1, 1, true)
-
+Dialog_Preview::Dialog_Preview():
+	settings(this, "preview"),
+	preview_table(1, 1, true)
 {
 	set_title(_("Preview"));
-	set_keep_above();
+	set_transient_for(*App::main_window);
 	add(preview_table);
 	preview_table.attach(preview, 0, 1, 0, 1);
 	preview.show();

--- a/synfig-studio/src/gui/dialogs/dialog_preview.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_preview.cpp
@@ -62,7 +62,7 @@ Dialog_Preview::Dialog_Preview()
 :settings(this,"preview"),preview_table(1, 1, true)
 
 {
-	set_title(_("Preview Window"));
+	set_title(_("Preview"));
 	set_keep_above();
 	add(preview_table);
 	preview_table.attach(preview, 0, 1, 0, 1);

--- a/synfig-studio/src/gui/dials/framedial.cpp
+++ b/synfig-studio/src/gui/dials/framedial.cpp
@@ -64,10 +64,10 @@ FrameDial::FrameDial():
 	seek_next_keyframe (create_button("synfig-animate_seek_next_keyframe" , _("Seek to next keyframe")    )),
 	seek_end           (create_button("synfig-animate_seek_end"           , _("Seek to end")              )),
 	end_time           (create_end_time_entry(                              _("End Time")                 )),
-	repeat             (create_toggle("synfig-animate_loop"               , _("Repeat")                   , true)),
-	bound_lower        (create_button("synfig-animate_bound_lower"        , _("Left bound")               , true)),
+	repeat             (create_toggle("synfig-animate_loop"               , _("Loop")                     , true)),
+	bound_lower        (create_button("synfig-animate_bound_lower"        , _("Set lower playback bound") , true)),
 	bounds_enable      (create_toggle("synfig-animate_bounds"             , _("Enable playback bounds")   )),
-	bound_upper        (create_button("synfig-animate_bound_upper"        , _("Right bound")              ))
+	bound_upper        (create_button("synfig-animate_bound_upper"        , _("Set upper playback bound") ))
 {
 	repeat->signal_toggled().connect(
 		sigc::mem_fun(*this, &FrameDial::on_repeat_toggled) );

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -447,7 +447,7 @@ Widget_Preview::Widget_Preview():
 
 	//loop
 	button = &b_loop;
-	IMAGIFY_BUTTON(button,"synfig-animate_loop", _("Repeat"));
+	IMAGIFY_BUTTON(button,"synfig-animate_loop", _("Loop"));
 	toolbar->pack_start(b_loop, Gtk::PACK_SHRINK,0);
 
 	//spacing

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -389,7 +389,7 @@ Widget_Preview::Widget_Preview():
 	Gtk::Button *prev_framebutton;
 	Gtk::Image *icon0 = manage(new Gtk::Image(Gtk::StockID("synfig-animate_seek_prev_frame"), Gtk::ICON_SIZE_BUTTON));
 	prev_framebutton = manage(new class Gtk::Button());
-	prev_framebutton->set_tooltip_text(_("Prev frame"));
+	prev_framebutton->set_tooltip_text(_("Seek to previous frame"));
 	icon0->set_padding(0,0);
 	icon0->show();
 	prev_framebutton->add(*icon0);
@@ -429,7 +429,7 @@ Widget_Preview::Widget_Preview():
 	Gtk::Button *next_framebutton;
 	Gtk::Image *icon2 = manage(new Gtk::Image(Gtk::StockID("synfig-animate_seek_next_frame"), Gtk::ICON_SIZE_BUTTON));
 	next_framebutton = manage(new class Gtk::Button());
-	next_framebutton->set_tooltip_text(_("Next frame"));
+	next_framebutton->set_tooltip_text(_("Seek to next frame"));
 	icon2->set_padding(0,0);
 	icon2->show();
 	next_framebutton->add(*icon2);
@@ -447,7 +447,7 @@ Widget_Preview::Widget_Preview():
 
 	//loop
 	button = &b_loop;
-	IMAGIFY_BUTTON(button,"synfig-animate_loop", _("Loop"));
+	IMAGIFY_BUTTON(button,"synfig-animate_loop", _("Repeat"));
 	toolbar->pack_start(b_loop, Gtk::PACK_SHRINK,0);
 
 	//spacing
@@ -459,21 +459,21 @@ Widget_Preview::Widget_Preview():
 	//halt render
 	button = manage(new Gtk::Button(/*_("Halt Render")*/));
 	button->signal_clicked().connect(sigc::mem_fun(*this, &Widget_Preview::stoprender));
-	IMAGIFY_BUTTON(button,Gtk::Stock::STOP, _("Halt render"));
+	IMAGIFY_BUTTON(button,Gtk::Stock::STOP, _("Stop rendering"));
 
 	toolbar->pack_start(*button, Gtk::PACK_SHRINK, 0);
 
 	//re-preview
 	button = manage(new Gtk::Button(/*_("Re-Preview")*/));
 	button->signal_clicked().connect(sigc::mem_fun(*this, &Widget_Preview::repreview));
-	IMAGIFY_BUTTON(button, Gtk::Stock::EDIT, _("Re-preview"));
+	IMAGIFY_BUTTON(button, Gtk::Stock::EDIT, _("Reopen the Preview Settings Dialog"));
 
 	toolbar->pack_start(*button, Gtk::PACK_SHRINK, 0);
 
 	//erase all
 	button = manage(new Gtk::Button(/*_("Erase All")*/));
 	button->signal_clicked().connect(sigc::mem_fun(*this, &Widget_Preview::eraseall));
-	IMAGIFY_BUTTON(button, Gtk::Stock::CLEAR, _("Erase all rendered frame(s)"));
+	IMAGIFY_BUTTON(button, Gtk::Stock::CLEAR, _("Erase all rendered frames"));
 
 	toolbar->pack_start(*button, Gtk::PACK_SHRINK, 0);
 

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -466,7 +466,7 @@ Widget_Preview::Widget_Preview():
 	//re-preview
 	button = manage(new Gtk::Button());
 	button->signal_clicked().connect(sigc::mem_fun(*this, &Widget_Preview::repreview));
-	IMAGIFY_BUTTON(button, "synfig-preview_options", _("Open Preview Settings Dialog"));
+	IMAGIFY_BUTTON(button, "synfig-preview_options", _("Preview Settings"));
 
 	toolbar->pack_start(*button, Gtk::PACK_SHRINK, 0);
 

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -447,7 +447,7 @@ Widget_Preview::Widget_Preview():
 
 	//loop
 	button = &b_loop;
-	IMAGIFY_BUTTON(button,"synfig-animate_loop", _("Loop"));
+	IMAGIFY_BUTTON(button, "synfig-animate_loop", _("Loop"));
 	toolbar->pack_start(b_loop, Gtk::PACK_SHRINK,0);
 
 	//spacing
@@ -457,21 +457,21 @@ Widget_Preview::Widget_Preview():
 
 
 	//halt render
-	button = manage(new Gtk::Button(/*_("Halt Render")*/));
+	button = manage(new Gtk::Button());
 	button->signal_clicked().connect(sigc::mem_fun(*this, &Widget_Preview::stoprender));
 	IMAGIFY_BUTTON(button,Gtk::Stock::STOP, _("Stop rendering"));
 
 	toolbar->pack_start(*button, Gtk::PACK_SHRINK, 0);
 
 	//re-preview
-	button = manage(new Gtk::Button(/*_("Re-Preview")*/));
+	button = manage(new Gtk::Button());
 	button->signal_clicked().connect(sigc::mem_fun(*this, &Widget_Preview::repreview));
-	IMAGIFY_BUTTON(button, Gtk::Stock::EDIT, _("Reopen the Preview Settings Dialog"));
+	IMAGIFY_BUTTON(button, "synfig-preview_options", _("Open Preview Settings Dialog"));
 
 	toolbar->pack_start(*button, Gtk::PACK_SHRINK, 0);
 
 	//erase all
-	button = manage(new Gtk::Button(/*_("Erase All")*/));
+	button = manage(new Gtk::Button());
 	button->signal_clicked().connect(sigc::mem_fun(*this, &Widget_Preview::eraseall));
 	IMAGIFY_BUTTON(button, Gtk::Stock::CLEAR, _("Erase all rendered frames"));
 

--- a/synfig-studio/src/gui/resources/ui/preview_options.glade
+++ b/synfig-studio/src/gui/resources/ui/preview_options.glade
@@ -19,7 +19,7 @@
   </object>
   <object class="GtkDialog" id="preview_options">
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Preview Options</property>
+    <property name="title" translatable="yes">Preview Settings</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
     <child>


### PR DESCRIPTION
Currently Preview Dialog is not consistent with other parts of Synfig's UI.

This merge request makes the tooltips used in the Preview Dialog consistent with Canvas player.
In addition the title of Preview Options was changed to Preview Settings to match its content (similar to Render Settings).

Fixes #1946