### PR TITLE
[Synfig Studio] fix file path on rendering file with relative path

### DIFF
--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -231,7 +231,12 @@ RenderSettings::set_entry_filename()
 	}
 
 	if (!is_absolute_path(filename))
-		filename = Glib::get_home_dir() + ETL_DIRECTORY_SEPARATOR + filename;
+	{
+		if (filename.find(App::custom_filename_prefix) == 0)
+			filename = Glib::get_home_dir() + ETL_DIRECTORY_SEPARATOR + filename;
+		else
+			filename = etl::absolute_path(filename);
+	}
 	
 	try
 	{


### PR DESCRIPTION
Issue:
1. User launches a file via Synfig Studio from command line with a relative path
(examples:
`$ synfigstudio mydir/myfile.sif`
 or
`$ synfigstudio myfile.sif`
)

2. Synfig Studio opens and loads the file normally (as always)

3. User opens Render dialog.

4. The filename entry text points to home dir + relative path!
(examples:
/home/user/mydir/myfile.sif // Problem: does mydir exist?
 or
/home/user/myfile.sif // It may be ok, but shouldn't it point to same folder of sif file?
)