### PR TITLE
[Synfig Studio] Minor cleanup on LayerTree

### DIFF
--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -117,25 +117,12 @@ bool LayerTree::on_key_press_event(GdkEventKey* event)
 }
 
 
-LayerTree::LayerTree():
-	layer_amount_adjustment_(Gtk::Adjustment::create(1,0,1,0.01,0.01,0))
+LayerTree::LayerTree()
 {
 	layer_tree_view().signal_key_press_event().connect(sigc::mem_fun(*this, &LayerTree::on_key_press_event));
 
 	create_layer_tree();
 	create_param_tree();
-
-	hbox=manage(new Gtk::HBox());
-
-	attach(*hbox, 0, 1, 1, 2, Gtk::FILL|Gtk::SHRINK, Gtk::SHRINK, 0, 0);
-	attach(blend_method_widget, 2, 3, 1, 2,Gtk::SHRINK, Gtk::SHRINK, 0, 0);
-
-	layer_amount_hscale=manage(new Gtk::HScale(layer_amount_adjustment_));
-	layer_amount_hscale->set_digits(2);
-	layer_amount_hscale->set_value_pos(Gtk::POS_LEFT);
-	layer_amount_hscale->set_sensitive(false);
-	attach(*layer_amount_hscale, 1, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::SHRINK, 1, 1);
-	layer_amount_adjustment_->signal_value_changed().connect(sigc::mem_fun(*this, &studio::LayerTree::on_amount_value_changed));
 
 	Gtk::IconSize iconsize(Gtk::ICON_SIZE_SMALL_TOOLBAR);
 
@@ -147,21 +134,8 @@ LayerTree::LayerTree():
 	layer_tree_view().show();
 	param_tree_view().show();
 
-	hbox->show();
-	layer_amount_hscale->show();
-	blend_method_widget.show();
-
 	param_tree_view().set_has_tooltip();
 	layer_tree_view().set_has_tooltip();
-
-	disable_amount_changed_signal=false;
-
-	blend_method_widget.set_param_desc(ParamDesc((int)Color::BlendMethod(),"blend_method"));
-
-	blend_method_widget.set_value((int)Color::BLEND_COMPOSITE);
-	blend_method_widget.set_size_request(150,-1);
-	blend_method_widget.set_sensitive(false);
-	blend_method_widget.signal_activate().connect(sigc::mem_fun(*this, &studio::LayerTree::on_blend_method_changed));
 
 	disable_single_click_for_param_editing = false;
 }
@@ -706,8 +680,6 @@ LayerTree::on_selection_changed()
 
 	if(layer_list.empty())
 	{
-		layer_amount_hscale->set_sensitive(false);
-		blend_method_widget.set_sensitive(false);
 		return;
 	}
 
@@ -717,57 +689,6 @@ LayerTree::on_selection_changed()
 	}
 	else
 		quick_layer=nullptr;
-
-	if(quick_layer)
-	{
-		layer_amount_hscale->set_sensitive(true);
-		disable_amount_changed_signal=true;
-		layer_amount_adjustment_->set_value(quick_layer->get_param("amount").get(Real()));
-		disable_amount_changed_signal=false;
-		if(quick_layer->get_param("blend_method").is_valid())
-		{
-			blend_method_widget.set_sensitive(true);
-			disable_amount_changed_signal=true;
-			blend_method_widget.set_value(quick_layer->get_param("blend_method"));
-			disable_amount_changed_signal=false;
-		}
-		else
-			blend_method_widget.set_sensitive(false);
-	}
-	else
-	{
-		layer_amount_hscale->set_sensitive(false);
-		blend_method_widget.set_sensitive(false);
-	}
-}
-
-void
-LayerTree::on_blend_method_changed()
-{
-	if(disable_amount_changed_signal)
-		return;
-	if(!quick_layer)
-		return;
-
-	if(quick_layer->get_param("blend_method").is_valid())
-	{
-		disable_amount_changed_signal=true;
-		signal_edited_value()(synfigapp::ValueDesc(quick_layer,"blend_method"),blend_method_widget.get_value());
-		disable_amount_changed_signal=false;
-	}
-}
-
-void
-LayerTree::on_amount_value_changed()
-{
-	if(disable_amount_changed_signal)
-		return;
-	if(!quick_layer)
-		return;
-
-	disable_amount_changed_signal=true;
-	signal_edited_value()(synfigapp::ValueDesc(quick_layer,"amount"),synfig::ValueBase(layer_amount_adjustment_->get_value()));
-	disable_amount_changed_signal=false;
 }
 
 void

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -600,8 +600,6 @@ LayerTree::set_model(Glib::RefPtr<LayerTreeStore> layer_tree_store)
 	else
 		layer_tree_view().set_model(layer_tree_store_);
 
-	layer_tree_store_->canvas_interface()->signal_dirty_preview().connect(sigc::mem_fun(*this,&studio::LayerTree::on_dirty_preview));
-
 	layer_tree_store_->canvas_interface()->signal_time_changed().connect(
 		sigc::mem_fun(
 			&param_tree_view(),
@@ -627,27 +625,6 @@ LayerTree::set_time_model(const etl::handle<TimeModel> &x)
 	cellrenderer_time_track->set_time_model(x);
 	#endif
 	x->signal_time_changed().connect(sigc::mem_fun(param_tree_view(),&Gtk::TreeView::queue_draw));
-}
-
-void
-LayerTree::on_dirty_preview()
-{
-/*
-	if(quick_layer && !disable_amount_changed_signal)
-	{
-		layer_amount_hscale->set_sensitive(true);
-		disable_amount_changed_signal=true;
-		layer_amount_adjustment_->set_value(quick_layer->get_param("amount").get(Real()));
-		disable_amount_changed_signal=false;
-		if(quick_layer->get_param("blend_method").is_valid())
-		{
-			blend_method_widget.set_sensitive(true);
-			disable_amount_changed_signal=true;
-			blend_method_widget.set_value(quick_layer->get_param("blend_method"));
-			disable_amount_changed_signal=false;
-		}
-	}
-*/
 }
 
 void

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -654,18 +654,6 @@ LayerTree::on_selection_changed()
 			last_top_selected_layer=nullptr;
 		}
 	}
-
-	if(layer_list.empty())
-	{
-		return;
-	}
-
-	if(layer_list.size()==1 && (*layer_list.begin())->get_param("amount").is_valid()&& (*layer_list.begin())->get_param("amount").same_type_as(Real()))
-	{
-		quick_layer=*layer_list.begin();
-	}
-	else
-		quick_layer=nullptr;
 }
 
 void

--- a/synfig-studio/src/gui/trees/layertree.h
+++ b/synfig-studio/src/gui/trees/layertree.h
@@ -28,10 +28,6 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <gtkmm/adjustment.h>
-#include <gtkmm/box.h>
-#include <gtkmm/scale.h>
-#include <gtkmm/table.h>
 #include <gtkmm/treeview.h>
 
 #include <gui/timemodel.h>
@@ -59,7 +55,7 @@ namespace studio {
 class CellRenderer_TimeTrack;
 class CellRenderer_ValueBase;
 
-class LayerTree : public Gtk::Table
+class LayerTree : public Gtk::Widget
 {
 	/*
  -- ** -- P U B L I C   T Y P E S ---------------------------------------------
@@ -86,12 +82,6 @@ public:
 private:
 	Gtk::TreeView layer_tree_view_;
 	Gtk::TreeView param_tree_view_;
-
-	Gtk::HBox *hbox;
-
-	Glib::RefPtr<Gtk::Adjustment> layer_amount_adjustment_;
-
-	Gtk::HScale *layer_amount_hscale;
 
 	synfig::Layer::Handle quick_layer;
 
@@ -123,10 +113,6 @@ private:
 	sigc::signal<void,synfigapp::ValueDesc,std::set<synfig::Waypoint,std::less<synfig::UniqueID> >,int> signal_waypoint_clicked_layertree_;
 
 	sigc::signal<void,int> signal_param_tree_header_height_changed_;
-
-	bool disable_amount_changed_signal;
-
-	Widget_ValueBase blend_method_widget;
 
 	bool param_tree_style_changed;
 
@@ -178,10 +164,6 @@ private:
 
 	void on_dirty_preview();
 
-	void on_amount_value_changed();
-
-	void on_blend_method_changed();
-
 	void on_param_column_label_tree_style_updated();
 	bool on_param_column_label_tree_draw(const ::Cairo::RefPtr< ::Cairo::Context>& cr);
 
@@ -190,8 +172,6 @@ private:
 	*/
 
 public:
-	Gtk::HBox& get_hbox() { return *hbox; }
-
 	Gtk::TreeView& layer_tree_view() { return layer_tree_view_; }
 	const Gtk::TreeView& layer_tree_view()const { return layer_tree_view_; }
 

--- a/synfig-studio/src/gui/trees/layertree.h
+++ b/synfig-studio/src/gui/trees/layertree.h
@@ -83,8 +83,6 @@ private:
 	Gtk::TreeView layer_tree_view_;
 	Gtk::TreeView param_tree_view_;
 
-	synfig::Layer::Handle quick_layer;
-
 	Glib::RefPtr<LayerTreeStore> layer_tree_store_;
 
 	Glib::RefPtr<LayerParamTreeStore> param_tree_store_;

--- a/synfig-studio/src/gui/trees/layertree.h
+++ b/synfig-studio/src/gui/trees/layertree.h
@@ -162,8 +162,6 @@ private:
 
 	void on_selection_changed();
 
-	void on_dirty_preview();
-
 	void on_param_column_label_tree_style_updated();
 	bool on_param_column_label_tree_draw(const ::Cairo::RefPtr< ::Cairo::Context>& cr);
 


### PR DESCRIPTION
LayerTree is a fake widget. Its goal is to provide the (real) layer and parameter TreeViews. It isn't supposed to add it to any dialog or container. However, it contains deprecated and unused widgets from the time it was a real "widget". 

I removed its unused/invisible/useless inner widgets and their signal handling. It speeds up a lot the layer movements by drag'n drop. For example, `studio::LayerTree::on_blend_method_changed()` was called at least 24 times while dragging a layer row in the Layer Panel.

After that, I saw `on_dirty_preview()` was empty and it wouldn't make sense to update neither Layer nor Parameter Panels if `CanvasInterface` emits this signal: `LayerTreeStore` already monitors layer changes (adding/removing/raising/lowering/…) Therefore, I removed `on_dirty_preview()` too.

Finally, `quick_layer` was a variable only used in the `on_dirty_preview`(), but, as everything there, it was commented out. So I deleted it too.

We can clean it up more: split into a real LayerTree and an isolated (ie, in other file) ParamTree. But I thought it would a big change to backport it to 1.4.1 if I did more.

This PR was inspired by Jose-Moreno comments in https://github.com/synfig/synfig/issues/540#issuecomment-757544837 and speeds up layer drag'n drop.