### PR TITLE
[Autotools] Fixed problem with missing *.glsl files in distribution

### DIFF
--- a/synfig-core/src/synfig/rendering/opengl/internal/glsl/Makefile_insert
+++ b/synfig-core/src/synfig/rendering/opengl/internal/glsl/Makefile_insert
@@ -8,5 +8,5 @@ RENDERING_OPENGL_INTERNAL_GLSL_FILES = \
 	rendering/opengl/internal/glsl/texture_vertex.glsl
 	
 rendering_opengl_internaldir = ${libdir}/synfig/glsl
-rendering_opengl_internal_DATA = \
+dist_rendering_opengl_internal_DATA = \
 	$(RENDERING_OPENGL_INTERNAL_GLSL_FILES)


### PR DESCRIPTION
By default, `_DATA` files are not included in a distribution (https://www.gnu.org/software/automake/manual/html_node/Data.html)

So we need to add `dist_` prefix.

Fix https://github.com/synfig/synfig/issues/311