### PR TITLE
[Synfig Studio] Improve layout of Workspaces editor

### DIFF
--- a/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
@@ -10,7 +10,7 @@
   </object>
   <object class="GtkDialog" id="dialog_workspaces">
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Custom workspace list editor</property>
+    <property name="title" translatable="yes">Workspaces editor</property>
     <property name="default_width">320</property>
     <property name="default_height">260</property>
     <property name="type_hint">dialog</property>
@@ -25,20 +25,6 @@
           <object class="GtkButtonBox">
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="workspaces_close_button">
-                <property name="label">gtk-close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -98,7 +84,6 @@
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="valign">center</property>
                 <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">12</property>
@@ -130,6 +115,21 @@
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="workspaces_close_button">
+                    <property name="label">gtk-close</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="use_stock">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>

--- a/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
@@ -10,7 +10,7 @@
   </object>
   <object class="GtkDialog" id="dialog_workspaces">
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Workspaces editor</property>
+    <property name="title" translatable="yes">Custom workspaces editor</property>
     <property name="default_width">320</property>
     <property name="default_height">260</property>
     <property name="type_hint">dialog</property>


### PR DESCRIPTION
Current layout:
![current-workspace-editor](https://user-images.githubusercontent.com/6705690/105249548-93466780-5b78-11eb-8f3f-1f2c49e9529b.png)

Improved layout:
![improved-workspace-editor](https://user-images.githubusercontent.com/6705690/105249586-a2c5b080-5b78-11eb-81c7-ad938c3eccaf.png)