### PR TITLE
[Synfig Studio] Fix parameter values of several layers shown as distance metrics when they are not

### DIFF
--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
@@ -897,7 +897,7 @@ Layer_Freetype::get_param_vocab(void)const
 		.set_description(_("Size of the text"))
 		.set_hint("size")
 		.set_origin("origin")
-		.set_scalar(1)
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("orient")
@@ -909,6 +909,7 @@ Layer_Freetype::get_param_vocab(void)const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Text Position"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("font")

--- a/synfig-core/src/modules/lyr_std/curvewarp.cpp
+++ b/synfig-core/src/modules/lyr_std/curvewarp.cpp
@@ -405,6 +405,7 @@ CurveWarp::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 				  .set_local_name(_("Origin"))
 				  .set_description(_("Position of the destiny Spline line"))
+				  .set_is_distance()
 	);
 	ret.push_back(ParamDesc("perp_width")
 				  .set_local_name(_("Width"))
@@ -415,10 +416,12 @@ CurveWarp::get_param_vocab()const
 				  .set_local_name(_("Start Point"))
 				  .set_connect("end_point")
 				  .set_description(_("First point of the source line"))
+				  .set_is_distance()
 	);
 	ret.push_back(ParamDesc("end_point")
 				  .set_local_name(_("End Point"))
 				  .set_description(_("Final point of the source line"))
+				  .set_is_distance()
 	);
 	ret.push_back(ParamDesc("bline")
 				  .set_local_name(_("Vertices"))

--- a/synfig-core/src/modules/lyr_std/insideout.cpp
+++ b/synfig-core/src/modules/lyr_std/insideout.cpp
@@ -179,6 +179,7 @@ InsideOut::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Center of the distortion"))
+		.set_is_distance()
 	);
 
 	return ret;

--- a/synfig-core/src/modules/lyr_std/perspective.cpp
+++ b/synfig-core/src/modules/lyr_std/perspective.cpp
@@ -1045,35 +1045,41 @@ Perspective::get_param_vocab()const
 		.set_local_name(_("Source TL"))
 		.set_box("src_br")
 		.set_description(_("Top Left corner of the source to perspective"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("src_br")
 		.set_local_name(_("Source BR"))
 		.set_description(_("Bottom Right corner of the source to perspective"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("dest_tl")
 		.set_local_name(_("Dest TL"))
 		.set_connect("dest_tr")
 		.set_description(_("Top Left corner of the destination"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("dest_tr")
 		.set_local_name(_("Dest TR"))
 		.set_connect("dest_br")
 		.set_description(_("Top Right corner of the destination"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("dest_br")
 		.set_local_name(_("Dest BR"))
 		.set_connect("dest_bl")
 		.set_description(_("Bottom Right corner of the destination"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("dest_bl")
 		.set_local_name(_("Dest BL"))
 		.set_connect("dest_tl")
 		.set_description(_("Bottom Left corner of the destination"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("clip")

--- a/synfig-core/src/modules/lyr_std/rotate.cpp
+++ b/synfig-core/src/modules/lyr_std/rotate.cpp
@@ -129,6 +129,7 @@ Rotate::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Origin of the rotation"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("amount")

--- a/synfig-core/src/modules/lyr_std/shade.cpp
+++ b/synfig-core/src/modules/lyr_std/shade.cpp
@@ -185,6 +185,7 @@ Layer_Shade::get_param_vocab(void)const
 	);
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("size")
 		.set_local_name(_("Size"))

--- a/synfig-core/src/modules/lyr_std/sphere_distort.cpp
+++ b/synfig-core/src/modules/lyr_std/sphere_distort.cpp
@@ -145,6 +145,7 @@ Layer_SphereDistort::get_param_vocab()const
 	ret.push_back(ParamDesc("center")
 		.set_local_name(_("Position"))
 		.set_description(_("Center of the sphere distortion"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("radius")

--- a/synfig-core/src/modules/lyr_std/stretch.cpp
+++ b/synfig-core/src/modules/lyr_std/stretch.cpp
@@ -117,6 +117,7 @@ Layer_Stretch::get_param_vocab()const
 	ret.push_back(ParamDesc("center")
 		.set_local_name(_("Center"))
 		.set_description(_("Center of the stretch distortion"))
+		.set_is_distance()
 	);
 
 	return ret;

--- a/synfig-core/src/modules/lyr_std/translate.cpp
+++ b/synfig-core/src/modules/lyr_std/translate.cpp
@@ -111,6 +111,7 @@ Translate::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Origin of the translation"))
+		.set_is_distance()
 	);
 
 	return ret;

--- a/synfig-core/src/modules/lyr_std/twirl.cpp
+++ b/synfig-core/src/modules/lyr_std/twirl.cpp
@@ -115,6 +115,7 @@ Twirl::get_param_vocab()const
 	ret.push_back(ParamDesc("center")
 		.set_local_name(_("Center"))
 		.set_description(_("Center of the circle"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("radius")

--- a/synfig-core/src/modules/lyr_std/xorpattern.cpp
+++ b/synfig-core/src/modules/lyr_std/xorpattern.cpp
@@ -136,11 +136,13 @@ XORPattern::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Center of the pattern"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("size")
 		.set_local_name(_("Size"))
 		.set_description(_("Size of the pattern"))
 		.set_origin("origin")
+		.set_is_distance()
 	);
 
 	return ret;

--- a/synfig-core/src/modules/lyr_std/zoom.cpp
+++ b/synfig-core/src/modules/lyr_std/zoom.cpp
@@ -117,6 +117,7 @@ Zoom::get_param_vocab()const
 	ret.push_back(ParamDesc("center")
 		.set_local_name(_("Origin"))
 		.set_description(_("Point to scale from"))
+		.set_is_distance()
 	);
 
 	return ret;

--- a/synfig-core/src/modules/mod_example/simplecircle.cpp
+++ b/synfig-core/src/modules/mod_example/simplecircle.cpp
@@ -148,6 +148,7 @@ SimpleCircle::get_param_vocab()const
 	ret.push_back(ParamDesc("center")
 		.set_local_name(_("Center"))
 		.set_description(_("Center of the circle"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("radius")
 		.set_local_name(_("Radius"))

--- a/synfig-core/src/modules/mod_filter/blur.cpp
+++ b/synfig-core/src/modules/mod_filter/blur.cpp
@@ -147,6 +147,7 @@ Blur_Layer::get_param_vocab(void)const
 	ret.push_back(ParamDesc("size")
 		.set_local_name(_("Size"))
 		.set_description(_("Size of the blur"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("type")
 		.set_local_name(_("Type"))

--- a/synfig-core/src/modules/mod_filter/halftone3.cpp
+++ b/synfig-core/src/modules/mod_filter/halftone3.cpp
@@ -328,6 +328,7 @@ Halftone3::get_param_vocab()const
 
 	ret.push_back(ParamDesc("size")
 		.set_local_name(_("Mask Size"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("type")
 		.set_local_name(_(" Type"))

--- a/synfig-core/src/modules/mod_filter/radialblur.cpp
+++ b/synfig-core/src/modules/mod_filter/radialblur.cpp
@@ -111,12 +111,14 @@ RadialBlur::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Origin of the blur"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("size")
 		.set_local_name(_("Size"))
 		.set_description(_("Size of the blur"))
 		.set_origin("origin")
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("fade_out")

--- a/synfig-core/src/modules/mod_geometry/checkerboard.cpp
+++ b/synfig-core/src/modules/mod_geometry/checkerboard.cpp
@@ -274,11 +274,13 @@ CheckerBoard::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Center of the checkers"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("size")
 		.set_local_name(_("Size"))
 		.set_description(_("Size of checkers"))
 		.set_origin("origin")
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("antialias")
 		.set_local_name(_("Antialiasing"))

--- a/synfig-core/src/modules/mod_geometry/rectangle.cpp
+++ b/synfig-core/src/modules/mod_geometry/rectangle.cpp
@@ -183,10 +183,12 @@ Rectangle::get_param_vocab()const
 		.set_local_name(_("Point 1"))
 		.set_box("point2")
 		.set_description(_("First corner of the rectangle"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("point2")
 		.set_local_name(_("Point 2"))
 		.set_description(_("Second corner of the rectangle"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("expand")
 		.set_is_distance()

--- a/synfig-core/src/modules/mod_gradient/conicalgradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/conicalgradient.cpp
@@ -115,6 +115,7 @@ ConicalGradient::get_param_vocab()const
 	ret.push_back(ParamDesc("center")
 		.set_local_name(_("Center"))
 		.set_description(_("Center of the cone"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("angle")

--- a/synfig-core/src/modules/mod_gradient/curvegradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/curvegradient.cpp
@@ -525,6 +525,7 @@ CurveGradient::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 				  .set_local_name(_("Origin"))
 				  .set_description(_("Offset for the Vertices List"))
+				  .set_is_distance()
 	);
 	ret.push_back(ParamDesc("width")
 				  .set_is_distance()

--- a/synfig-core/src/modules/mod_gradient/lineargradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/lineargradient.cpp
@@ -161,10 +161,12 @@ LinearGradient::get_param_vocab()const
 		.set_local_name(_("Point 1"))
 		.set_connect("p2")
 		.set_description(_("Start point of the gradient"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("p2")
 		.set_local_name(_("Point 2"))
 		.set_description(_("End point of the gradient"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("gradient")
 		.set_local_name(_("Gradient"))

--- a/synfig-core/src/modules/mod_gradient/radialgradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/radialgradient.cpp
@@ -119,6 +119,7 @@ RadialGradient::get_param_vocab()const
 	ret.push_back(ParamDesc("center")
 		.set_local_name(_("Center"))
 		.set_description(_("Center of the gradient"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("radius")

--- a/synfig-core/src/modules/mod_gradient/spiralgradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/spiralgradient.cpp
@@ -119,6 +119,7 @@ SpiralGradient::get_param_vocab()const
 	ret.push_back(ParamDesc("center")
 		.set_local_name(_("Center"))
 		.set_description(_("Center of the gradient"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("radius")

--- a/synfig-core/src/modules/mod_noise/distort.cpp
+++ b/synfig-core/src/modules/mod_noise/distort.cpp
@@ -211,11 +211,13 @@ NoiseDistort::get_param_vocab()const
 	ret.push_back(ParamDesc("displacement")
 		.set_local_name(_("Displacement"))
 		.set_description(_("How big the distortion displaces the context"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("size")
 		.set_local_name(_("Size"))
 		.set_description(_("Distance between distortions"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("seed")
 		.set_local_name(_("RandomNoise Seed"))

--- a/synfig-core/src/modules/mod_noise/noise.cpp
+++ b/synfig-core/src/modules/mod_noise/noise.cpp
@@ -272,6 +272,7 @@ Noise::get_param_vocab()const
 	ret.push_back(ParamDesc("size")
 		.set_local_name(_("Size"))
 		.set_description(_("Size of the noise"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("smooth")
 		.set_local_name(_("Interpolation"))

--- a/synfig-core/src/modules/mod_particle/plant.cpp
+++ b/synfig-core/src/modules/mod_particle/plant.cpp
@@ -408,6 +408,7 @@ Plant::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Offset for the Vertices List"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("gradient")

--- a/synfig-core/src/synfig/layers/layer_bitmap.cpp
+++ b/synfig-core/src/synfig/layers/layer_bitmap.cpp
@@ -158,11 +158,13 @@ Layer_Bitmap::get_param_vocab()const
 	ret.push_back(ParamDesc("tl")
 		.set_local_name(_("Top-Left"))
 		.set_description(_("Upper left-hand Corner of image"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("br")
 		.set_local_name(_("Bottom-Right"))
 		.set_description(_("Lower right-hand Corner of image"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("c")

--- a/synfig-core/src/synfig/layers/layer_pastecanvas.cpp
+++ b/synfig-core/src/synfig/layers/layer_pastecanvas.cpp
@@ -130,6 +130,7 @@ Layer_PasteCanvas::get_param_vocab()const
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Position offset"))
+		.set_is_distance()
 	);
 	
 	ret.push_back(ParamDesc("transformation")

--- a/synfig-core/src/synfig/layers/layer_shape.cpp
+++ b/synfig-core/src/synfig/layers/layer_shape.cpp
@@ -163,6 +163,7 @@ Layer_Shape::get_param_vocab()const
 	);
 	ret.push_back(ParamDesc("origin")
 		.set_local_name(_("Origin"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("invert")
 		.set_local_name(_("Invert"))

--- a/synfig-core/src/synfig/layers/layer_skeletondeformation.cpp
+++ b/synfig-core/src/synfig/layers/layer_skeletondeformation.cpp
@@ -109,11 +109,13 @@ Layer_SkeletonDeformation::get_param_vocab()const
 		.set_local_name(_("Point 1"))
 		.set_box("point2")
 		.set_description(_("First corner of the bounds rectangle"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("point2")
 		.set_local_name(_("Point 2"))
 		.set_description(_("Second corner of the bounds rectangle"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc("x_subdivisions")

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
@@ -594,6 +594,7 @@ ValueNode_Bone::get_children_vocab_vfunc() const
 	ret.push_back(ParamDesc(ValueBase(),"origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("The rotating origin of the bone relative to its parent"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc(ValueBase(),"angle")
@@ -609,6 +610,7 @@ ValueNode_Bone::get_children_vocab_vfunc() const
 	ret.push_back(ParamDesc(ValueBase(),"width")
 		.set_local_name(_("Bone Width"))
 		.set_description(_("Bone width at its origin"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc(ValueBase(),"scalex")
@@ -619,6 +621,7 @@ ValueNode_Bone::get_children_vocab_vfunc() const
 	ret.push_back(ParamDesc(ValueBase(),"tipwidth")
 		.set_local_name(_("Tip Width"))
 		.set_description(_("Bone width at its tip"))
+		.set_is_distance()
 	);
 
 	ret.push_back(ParamDesc(ValueBase(),"bone_depth")
@@ -629,6 +632,7 @@ ValueNode_Bone::get_children_vocab_vfunc() const
 	ret.push_back(ParamDesc(ValueBase(),"length")
 		.set_local_name(_("Length Setup"))
 		.set_description(_("The length of the bone at setup"))
+		.set_is_distance()
 	);
 
 	return ret;

--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
@@ -672,10 +672,12 @@ ValueNode_Composite::get_children_vocab_vfunc()const
 		ret.push_back(ParamDesc(ValueBase(),"width")
 			.set_local_name(_("Width"))
 			.set_description(_("The width of the Spline Point"))
+			.set_is_distance()
 		);
 		ret.push_back(ParamDesc(ValueBase(),"origin")
 			.set_local_name(_("Origin"))
 			.set_description(_("Defines the Off and On position relative to neighbours"))
+			.set_is_distance()
 		);
 		ret.push_back(ParamDesc(ValueBase(),"split")
 			.set_local_name(_("Split"))
@@ -786,6 +788,7 @@ ValueNode_Composite::get_children_vocab_vfunc()const
 		ret.push_back(ParamDesc(ValueBase(),"offset")
 			.set_local_name(_("Offset"))
 			.set_description(_("The Offset component of the transformation"))
+			.set_is_distance()
 		);
 		ret.push_back(ParamDesc(ValueBase(),"angle")
 			.set_local_name(_("Angle"))

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamic.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamic.cpp
@@ -236,6 +236,7 @@ ValueNode_Dynamic::get_children_vocab_vfunc()const
 	ret.push_back(ParamDesc(ValueBase(),"origin")
 		.set_local_name(_("Origin"))
 		.set_description(_("Basement of the dynamic system"))
+		.set_is_distance()
 	);
 	ret.push_back(ParamDesc(ValueBase(),"force")
 		.set_local_name(_("Force"))

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -65,6 +65,7 @@ using namespace studio;
 
 // Number of decimal places for real values
 static constexpr int real_num_decimals = 6;
+static constexpr int angle_num_decimals = 2;
 
 class studio::ValueBase_Entry : public Gtk::CellEditable, public Gtk::EventBox
 {
@@ -338,7 +339,8 @@ CellRenderer_ValueBase::render_vfunc(
 	else
 	if (type == type_angle)
 	{
-		property_text() = (Glib::ustring) strprintf( "%.2fᵒ", (Real) Angle::deg( data.get(Angle()) ).get() );
+		const std::string angle_format = strprintf("%%.%df°", angle_num_decimals);
+		property_text() = (Glib::ustring) strprintf( angle_format.c_str(), (Real) Angle::deg( data.get(Angle()) ).get() );
 	}
 	else
 	if (type == type_integer)
@@ -405,8 +407,9 @@ CellRenderer_ValueBase::render_vfunc(
 		sx.convert( App::distance_system, get_canvas()->rend_desc() );
 		sy.convert( App::distance_system, get_canvas()->rend_desc() );
 
+		std::string format = strprintf("%%s,%%s,%%.%df°,%%s,%%s", angle_num_decimals);
 		property_text() = static_cast<Glib::ustring>(strprintf(
-			"%s,%s,%.2fᵒ,%s,%s",
+			format.c_str(),
 			x.get_string(real_num_decimals).c_str(),
 			y.get_string(real_num_decimals).c_str(),
 			(Real) angle.get(),

--- a/synfig-studio/src/gui/widgets/widget_value.cpp
+++ b/synfig-studio/src/gui/widgets/widget_value.cpp
@@ -255,7 +255,8 @@ Widget_ValueBase::set_value(const synfig::ValueBase &data)
 		Type &type(value.get_type());
 		if (type == type_vector)
 		{
-			vector_widget->set_canvas(canvas);
+			if (child_param_desc.get_is_distance() || param_desc.get_is_distance())
+				vector_widget->set_canvas(canvas);
 			vector_widget->set_value(value.get(Vector()));
 			vector_widget->show();
 		}
@@ -455,7 +456,7 @@ Widget_ValueBase::on_grab_focus()
 	else
 	if (type == type_real)
 	{
-		if(param_desc.get_is_distance()&& canvas)
+		if((param_desc.get_is_distance() || child_param_desc.get_is_distance()) && canvas)
 			distance_widget->grab_focus();
 		else
 			real_widget->grab_focus();


### PR DESCRIPTION
It now sets an existent parameter hint (`set_is_distance`) to `synfig::Vector`/`synfig::Point` data type too, not only for `synfig::Real`.

Users are often confused because of it, like here https://forums.synfig.org/t/how-is-scale-calculated/11348