### PR TITLE
[Synfig Studio] Allow to set number of rendering threads from Preferences dialog

### DIFF
--- a/synfig-core/src/synfig/threadpool.cpp
+++ b/synfig-core/src/synfig/threadpool.cpp
@@ -277,17 +277,15 @@ ThreadPool::enqueue(const Slot &slot) {
 
 
 void 
-ThreadPool::set_threads(int no_core){
+ThreadPool::set_num_threads(int num_cores){
 	max_running_threads = g_get_num_processors();
-	if(no_core!=0){
-		max_running_threads = no_core;
+	if(num_cores!=0){
+		max_running_threads = num_cores;
 	}
 	if (const char *s = getenv("SYNFIG_GENERIC_THREADS"))
 		max_running_threads = atoi(s) + 1;
 
 	if (max_running_threads < 2) max_running_threads = 2;
-	if (max_running_threads > 2) --max_running_threads;
-	++running_threads;
 }
 
 void

--- a/synfig-core/src/synfig/threadpool.cpp
+++ b/synfig-core/src/synfig/threadpool.cpp
@@ -275,6 +275,21 @@ ThreadPool::enqueue(const Slot &slot) {
 	wakeup();
 }
 
+
+void 
+ThreadPool::set_threads(int no_core){
+	max_running_threads = g_get_num_processors();
+	if(no_core!=0){
+		max_running_threads = no_core;
+	}
+	if (const char *s = getenv("SYNFIG_GENERIC_THREADS"))
+		max_running_threads = atoi(s) + 1;
+
+	if (max_running_threads < 2) max_running_threads = 2;
+	if (max_running_threads > 2) --max_running_threads;
+	++running_threads;
+}
+
 void
 ThreadPool::wait(std::condition_variable &cond, std::unique_lock<std::mutex> &lock) {
 	if (--running_threads < max_running_threads)

--- a/synfig-core/src/synfig/threadpool.cpp
+++ b/synfig-core/src/synfig/threadpool.cpp
@@ -277,10 +277,10 @@ ThreadPool::enqueue(const Slot &slot) {
 
 
 void 
-ThreadPool::set_num_threads(int num_cores){
+ThreadPool::set_num_threads(int num_threadsd){
 	max_running_threads = g_get_num_processors();
-	if(num_cores!=0){
-		max_running_threads = num_cores;
+	if(num_threadsd!=0){
+		max_running_threads = num_threadsd;
 	}
 	if (const char *s = getenv("SYNFIG_GENERIC_THREADS"))
 		max_running_threads = atoi(s) + 1;

--- a/synfig-core/src/synfig/threadpool.cpp
+++ b/synfig-core/src/synfig/threadpool.cpp
@@ -277,10 +277,10 @@ ThreadPool::enqueue(const Slot &slot) {
 
 
 void 
-ThreadPool::set_num_threads(int num_threadsd){
+ThreadPool::set_num_threads(int num_threads){
 	max_running_threads = g_get_num_processors();
-	if(num_threadsd!=0){
-		max_running_threads = num_threadsd;
+	if(num_threads!=0){
+		max_running_threads = num_threads;
 	}
 	if (const char *s = getenv("SYNFIG_GENERIC_THREADS"))
 		max_running_threads = atoi(s) + 1;

--- a/synfig-core/src/synfig/threadpool.h
+++ b/synfig-core/src/synfig/threadpool.h
@@ -43,6 +43,7 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
+using namespace synfig;
 namespace synfig {
 
 class ThreadPool {
@@ -97,6 +98,8 @@ public:
 
 	void enqueue(const Slot &slot);
 	void wait(std::condition_variable &cond, std::unique_lock<std::mutex>& lock);
+
+	void set_threads(int no_core);
 
 	int get_max_threads() const
 		{ return max_running_threads; }

--- a/synfig-core/src/synfig/threadpool.h
+++ b/synfig-core/src/synfig/threadpool.h
@@ -43,7 +43,6 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-using namespace synfig;
 namespace synfig {
 
 class ThreadPool {
@@ -99,7 +98,7 @@ public:
 	void enqueue(const Slot &slot);
 	void wait(std::condition_variable &cond, std::unique_lock<std::mutex>& lock);
 
-	void set_threads(int no_core);
+	void set_num_threads(int num_cores);
 
 	int get_max_threads() const
 		{ return max_running_threads; }

--- a/synfig-core/src/synfig/threadpool.h
+++ b/synfig-core/src/synfig/threadpool.h
@@ -98,7 +98,7 @@ public:
 	void enqueue(const Slot &slot);
 	void wait(std::condition_variable &cond, std::unique_lock<std::mutex>& lock);
 
-	void set_num_threads(int num_cores);
+	void set_num_threads(int num_threadsd);
 
 	int get_max_threads() const
 		{ return max_running_threads; }

--- a/synfig-core/src/synfig/threadpool.h
+++ b/synfig-core/src/synfig/threadpool.h
@@ -98,7 +98,7 @@ public:
 	void enqueue(const Slot &slot);
 	void wait(std::condition_variable &cond, std::unique_lock<std::mutex>& lock);
 
-	void set_num_threads(int num_threadsd);
+	void set_num_threads(int num_threads);
 
 	int get_max_threads() const
 		{ return max_running_threads; }

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -285,7 +285,7 @@ std::set< String > studio::App::brushes_path;
 String studio::App::image_editor_path;
 
 String studio::App::sequence_separator(".");
-String studio::App::number_of_cores("" + ('0'+g_get_num_processors()) );
+int studio::App::number_of_cores(g_get_num_processors());
 String studio::App::navigator_renderer;
 String studio::App::workarea_renderer;
 
@@ -733,7 +733,7 @@ public:
 			}
 			if(key=="number_of_cores")
 			{
-				App::number_of_cores=value;
+				App::number_of_cores=atoi(value.c_str());
 				return true;
 			}
 			if(key=="navigator_renderer")

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -285,7 +285,7 @@ std::set< String > studio::App::brushes_path;
 String studio::App::image_editor_path;
 
 String studio::App::sequence_separator(".");
-int    studio::App::number_of_cores = g_get_num_processors();
+int    studio::App::number_of_threads = g_get_num_processors();
 String studio::App::navigator_renderer;
 String studio::App::workarea_renderer;
 
@@ -543,9 +543,9 @@ public:
 				value=App::sequence_separator;
 				return true;
 			}
-			if(key=="number_of_cores")
+			if(key=="number_of_threads")
 			{
-				value=App::number_of_cores;
+				value=App::number_of_threads;
 				return true;
 			}
 			if(key=="navigator_renderer")
@@ -731,9 +731,9 @@ public:
 				App::sequence_separator=value;
 				return true;
 			}
-			if(key=="number_of_cores")
+			if(key=="number_of_threads")
 			{
-				App::number_of_cores=atoi(value.c_str());
+				App::number_of_threads=atoi(value.c_str());
 				return true;
 			}
 			if(key=="navigator_renderer")
@@ -824,7 +824,7 @@ public:
 		ret.push_back("preferred_fps");
 		ret.push_back("predefined_fps");
 		ret.push_back("sequence_separator");
-		ret.push_back("number_of_cores");
+		ret.push_back("number_of_threads");
 		ret.push_back("navigator_renderer");
 		ret.push_back("workarea_renderer");
 		ret.push_back("default_background_layer_type");

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -285,6 +285,7 @@ std::set< String > studio::App::brushes_path;
 String studio::App::image_editor_path;
 
 String studio::App::sequence_separator(".");
+String studio::App::number_of_cores("" + ('0'+g_get_num_processors()) );
 String studio::App::navigator_renderer;
 String studio::App::workarea_renderer;
 
@@ -542,6 +543,11 @@ public:
 				value=App::sequence_separator;
 				return true;
 			}
+			if(key=="number_of_cores")
+			{
+				value=App::number_of_cores;
+				return true;
+			}
 			if(key=="navigator_renderer")
 			{
 				value=App::navigator_renderer;
@@ -725,6 +731,11 @@ public:
 				App::sequence_separator=value;
 				return true;
 			}
+			if(key=="number_of_cores")
+			{
+				App::number_of_cores=value;
+				return true;
+			}
 			if(key=="navigator_renderer")
 			{
 				App::navigator_renderer=value;
@@ -813,6 +824,7 @@ public:
 		ret.push_back("preferred_fps");
 		ret.push_back("predefined_fps");
 		ret.push_back("sequence_separator");
+		ret.push_back("number_of_cores");
 		ret.push_back("navigator_renderer");
 		ret.push_back("workarea_renderer");
 		ret.push_back("default_background_layer_type");

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -285,6 +285,7 @@ std::set< String > studio::App::brushes_path;
 String studio::App::image_editor_path;
 
 String studio::App::sequence_separator(".");
+int    studio::App::number_of_cores = g_get_num_processors();
 String studio::App::navigator_renderer;
 String studio::App::workarea_renderer;
 
@@ -542,6 +543,11 @@ public:
 				value=App::sequence_separator;
 				return true;
 			}
+			if(key=="number_of_cores")
+			{
+				value=App::number_of_cores;
+				return true;
+			}
 			if(key=="navigator_renderer")
 			{
 				value=App::navigator_renderer;
@@ -725,6 +731,11 @@ public:
 				App::sequence_separator=value;
 				return true;
 			}
+			if(key=="number_of_cores")
+			{
+				App::number_of_cores=atoi(value.c_str());
+				return true;
+			}
 			if(key=="navigator_renderer")
 			{
 				App::navigator_renderer=value;
@@ -813,6 +824,7 @@ public:
 		ret.push_back("preferred_fps");
 		ret.push_back("predefined_fps");
 		ret.push_back("sequence_separator");
+		ret.push_back("number_of_cores");
 		ret.push_back("navigator_renderer");
 		ret.push_back("workarea_renderer");
 		ret.push_back("default_background_layer_type");

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -813,7 +813,6 @@ public:
 		ret.push_back("preferred_fps");
 		ret.push_back("predefined_fps");
 		ret.push_back("sequence_separator");
-		ret.push_back("number_of_cores");
 		ret.push_back("navigator_renderer");
 		ret.push_back("workarea_renderer");
 		ret.push_back("default_background_layer_type");

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -285,7 +285,6 @@ std::set< String > studio::App::brushes_path;
 String studio::App::image_editor_path;
 
 String studio::App::sequence_separator(".");
-int studio::App::number_of_cores(g_get_num_processors());
 String studio::App::navigator_renderer;
 String studio::App::workarea_renderer;
 
@@ -543,11 +542,6 @@ public:
 				value=App::sequence_separator;
 				return true;
 			}
-			if(key=="number_of_cores")
-			{
-				value=App::number_of_cores;
-				return true;
-			}
 			if(key=="navigator_renderer")
 			{
 				value=App::navigator_renderer;
@@ -729,11 +723,6 @@ public:
 			if(key=="sequence_separator")
 			{
 				App::sequence_separator=value;
-				return true;
-			}
-			if(key=="number_of_cores")
-			{
-				App::number_of_cores=atoi(value.c_str());
 				return true;
 			}
 			if(key=="navigator_renderer")

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -228,7 +228,6 @@ public:
 	static synfig::String predefined_fps;
 	static float preferred_fps;
 	static synfig::String sequence_separator;
-	static int number_of_cores;
 	static synfig::String navigator_renderer;
 	static synfig::String workarea_renderer;
 	static bool enable_mainwin_menubar;

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -229,7 +229,7 @@ public:
 	static synfig::String sequence_separator;
 	static synfig::String navigator_renderer;
 	static synfig::String workarea_renderer;
-	static int number_of_cores;
+	static int number_of_threads;
 	static bool enable_mainwin_menubar;
 	static bool enable_mainwin_toolbar;
 	static synfig::String ui_language;

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -51,7 +51,6 @@
 #include <synfig/layers/layer_bitmap.h>
 #include <synfig/string.h>
 #include <synfig/time.h>
-#include <synfig/threadpool.h>
 
 #include <synfigapp/instance.h>
 

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -228,7 +228,7 @@ public:
 	static synfig::String predefined_fps;
 	static float preferred_fps;
 	static synfig::String sequence_separator;
-	static synfig::String number_of_cores;
+	static int number_of_cores;
 	static synfig::String navigator_renderer;
 	static synfig::String workarea_renderer;
 	static bool enable_mainwin_menubar;

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -229,6 +229,7 @@ public:
 	static synfig::String sequence_separator;
 	static synfig::String navigator_renderer;
 	static synfig::String workarea_renderer;
+	static int number_of_cores;
 	static bool enable_mainwin_menubar;
 	static bool enable_mainwin_toolbar;
 	static synfig::String ui_language;

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -51,6 +51,7 @@
 #include <synfig/layers/layer_bitmap.h>
 #include <synfig/string.h>
 #include <synfig/time.h>
+#include <synfig/threadpool.h>
 
 #include <synfigapp/instance.h>
 
@@ -227,6 +228,7 @@ public:
 	static synfig::String predefined_fps;
 	static float preferred_fps;
 	static synfig::String sequence_separator;
+	static synfig::String number_of_cores;
 	static synfig::String navigator_renderer;
 	static synfig::String workarea_renderer;
 	static bool enable_mainwin_menubar;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -44,6 +44,7 @@
 #include <gui/resourcehelper.h>
 #include <gui/widgets/widget_enum.h>
 #include <gui/autorecover.h>
+#include <synfig/threadpool.h>
 
 #include <synfig/rendering/renderer.h>
 

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -501,6 +501,13 @@ Dialog_Setup::create_render_page(PageInfo pi)
 	pi.grid->attach(image_sequence_separator, 1, row, 1, 1);
 	image_sequence_separator.set_hexpand(true);
 
+	// render - cores
+	attach_label(pi.grid, _("Limit render to number of cores"), ++row);
+	pi.grid->attach(core_render, 1, row, 1, 1);
+	core_render.set_hexpand(true);
+	core_render.signal_changed().connect(
+	sigc::mem_fun(*this, &Dialog_Setup::on_core_change) );
+
 	// Render - WorkArea
 	attach_label(pi.grid, _("WorkArea renderer"), ++row);
 	pi.grid->attach(workarea_renderer_combo, 1, row, 1, 1);
@@ -535,7 +542,7 @@ Dialog_Setup::create_render_page(PageInfo pi)
 	preview_background_color_button.signal_color_set().connect(
 		sigc::mem_fun(*this, &studio::Dialog_Setup::on_preview_background_color_changed) );
 
-}
+}	
 
 void
 Dialog_Setup::create_interface_page(PageInfo pi)
@@ -669,6 +676,8 @@ Dialog_Setup::on_restore_pressed()
 		fps_template_combo->set_active_text(DEFAULT_PREDEFINED_FPS);
 		adj_pref_fps->set_value(24.0);
 		image_sequence_separator.set_text(".");
+		core_render.set_text("" + ('0'+g_get_num_processors()));
+
 		workarea_renderer_combo.set_active_id("");
 		def_background_none.set_active();
 		
@@ -789,6 +798,9 @@ Dialog_Setup::on_apply_pressed()
 	// Set the preferred image sequence separator
 	App::sequence_separator     = image_sequence_separator.get_text();
 
+	// Set the number of cores
+	App::number_of_cores = core_render.get_text();
+
 	// Set the workarea render and navigator render flag
 	App::navigator_renderer = App::workarea_renderer  = workarea_renderer_combo.get_active_id();
 
@@ -902,6 +914,12 @@ void
 Dialog_Setup::on_autobackup_changed()
 {
 	auto_backup_interval.set_sensitive(toggle_autobackup.get_active());
+}
+
+void
+Dialog_Setup::on_core_change()
+{
+	ThreadPool::instance().set_threads(3);
 }
 
 void
@@ -1063,6 +1081,8 @@ Dialog_Setup::refresh()
 
 	// Refresh the sequence separator
 	image_sequence_separator.set_text(App::sequence_separator);
+
+	core_render.set_text(App::number_of_cores);
 
 	// Refresh the status of the workarea_renderer
 	workarea_renderer_combo.set_active_id(App::workarea_renderer);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -77,7 +77,7 @@ Dialog_Setup::Dialog_Setup(Gtk::Window& parent):
 	adj_pref_x_size(Gtk::Adjustment::create(480,1,10000,1,10,0)),
 	adj_pref_y_size(Gtk::Adjustment::create(270,1,10000,1,10,0)),
 	adj_pref_fps(Gtk::Adjustment::create(24.0,1.0,100,0.1,1,0)),
-	adj_number_of_core(Gtk::Adjustment::create(g_get_num_processors(),1,g_get_num_processors(),1,10,0)),
+	adj_number_of_core(Gtk::Adjustment::create(App::number_of_cores,2,g_get_num_processors(),1,10,0)),
 	pref_modification_flag(false),
 	refreshing(false)
 {
@@ -503,7 +503,7 @@ Dialog_Setup::create_render_page(PageInfo pi)
 	number_of_core_select = Gtk::manage(new Gtk::SpinButton(adj_number_of_core,0,0));
 	pi.grid->attach(*number_of_core_select, 1, row, 1, 1);
 	number_of_core_select->set_tooltip_text(_("Number of core change"));
-	number_of_core_select->signal_changed().connect(sigc::mem_fun(*this, &Dialog_Setup::on_number_of_core_select) );
+	number_of_core_select->signal_changed().connect(sigc::mem_fun(*this, &Dialog_Setup::on_number_of_thread_changed) );
 	number_of_core_select->set_hexpand(true);
 	// Render - Image sequence separator
 	attach_label(pi.grid, _("Image Sequence Separator String"), ++row);
@@ -799,6 +799,9 @@ Dialog_Setup::on_apply_pressed()
 	// Set the preferred image sequence separator
 	App::sequence_separator     = image_sequence_separator.get_text();
 
+	// Set the number of cores
+	App::number_of_cores = int(adj_number_of_core->get_value());
+
 	// Set the workarea render and navigator render flag
 	App::navigator_renderer = App::workarea_renderer  = workarea_renderer_combo.get_active_id();
 
@@ -915,9 +918,10 @@ Dialog_Setup::on_autobackup_changed()
 }
 
 void
-Dialog_Setup::on_number_of_core_select()
+Dialog_Setup::on_number_of_thread_changed()
 {
-	ThreadPool::instance().set_num_threads(int(adj_number_of_core->get_value()));
+	App::number_of_cores = int(adj_number_of_core->get_value());
+	ThreadPool::instance().set_num_threads(App::number_of_cores);
 }
 
 void
@@ -1081,7 +1085,7 @@ Dialog_Setup::refresh()
 	image_sequence_separator.set_text(App::sequence_separator);
 
 	// Refresh the number of core
-	number_of_core_select->set_value(int(adj_number_of_core->get_value()));
+	number_of_core_select->set_value(App::number_of_cores);
 
 	// Refresh the status of the workarea_renderer
 	workarea_renderer_combo.set_active_id(App::workarea_renderer);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -77,7 +77,7 @@ Dialog_Setup::Dialog_Setup(Gtk::Window& parent):
 	adj_pref_x_size(Gtk::Adjustment::create(480,1,10000,1,10,0)),
 	adj_pref_y_size(Gtk::Adjustment::create(270,1,10000,1,10,0)),
 	adj_pref_fps(Gtk::Adjustment::create(24.0,1.0,100,0.1,1,0)),
-	adj_number_of_core(Gtk::Adjustment::create(App::number_of_cores,2,g_get_num_processors(),1,10,0)),
+	adj_number_of_threads(Gtk::Adjustment::create(App::number_of_threads,2,g_get_num_processors(),1,10,0)),
 	pref_modification_flag(false),
 	refreshing(false)
 {
@@ -498,13 +498,13 @@ Dialog_Setup::create_render_page(PageInfo pi)
 	 */
 
 	int row(1);
-	// Render - Number of cores used
-	attach_label(pi.grid, _("Number of cores used"), row);
-	number_of_core_select = Gtk::manage(new Gtk::SpinButton(adj_number_of_core,0,0));
-	pi.grid->attach(*number_of_core_select, 1, row, 1, 1);
-	number_of_core_select->set_tooltip_text(_("Number of core change"));
-	number_of_core_select->signal_changed().connect(sigc::mem_fun(*this, &Dialog_Setup::on_number_of_thread_changed) );
-	number_of_core_select->set_hexpand(true);
+	// Render - Number of threads used
+	attach_label(pi.grid, _("Number of threads used"), row);
+	number_of_threads_select = Gtk::manage(new Gtk::SpinButton(adj_number_of_threads,0,0));
+	pi.grid->attach(*number_of_threads_select, 1, row, 1, 1);
+	number_of_threads_select->set_tooltip_text(_("Number of threads change"));
+	number_of_threads_select->signal_changed().connect(sigc::mem_fun(*this, &Dialog_Setup::on_number_of_thread_changed) );
+	number_of_threads_select->set_hexpand(true);
 	// Render - Image sequence separator
 	attach_label(pi.grid, _("Image Sequence Separator String"), ++row);
 	pi.grid->attach(image_sequence_separator, 1, row, 1, 1);
@@ -677,7 +677,7 @@ Dialog_Setup::on_restore_pressed()
 		fps_template_combo->set_active_text(DEFAULT_PREDEFINED_FPS);
 		adj_pref_fps->set_value(24.0);
 		image_sequence_separator.set_text(".");
-		adj_number_of_core->set_value(g_get_num_processors());
+		adj_number_of_threads->set_value(g_get_num_processors());
 
 		workarea_renderer_combo.set_active_id("");
 		def_background_none.set_active();
@@ -799,8 +799,8 @@ Dialog_Setup::on_apply_pressed()
 	// Set the preferred image sequence separator
 	App::sequence_separator     = image_sequence_separator.get_text();
 
-	// Set the number of cores
-	App::number_of_cores = int(adj_number_of_core->get_value());
+	// Set the number of threads
+	App::number_of_threads = int(adj_number_of_threads->get_value());
 
 	// Set the workarea render and navigator render flag
 	App::navigator_renderer = App::workarea_renderer  = workarea_renderer_combo.get_active_id();
@@ -920,8 +920,8 @@ Dialog_Setup::on_autobackup_changed()
 void
 Dialog_Setup::on_number_of_thread_changed()
 {
-	App::number_of_cores = int(adj_number_of_core->get_value());
-	ThreadPool::instance().set_num_threads(App::number_of_cores);
+	App::number_of_threads = int(adj_number_of_threads->get_value());
+	ThreadPool::instance().set_num_threads(App::number_of_threads);
 }
 
 void
@@ -1084,8 +1084,8 @@ Dialog_Setup::refresh()
 	// Refresh the sequence separator
 	image_sequence_separator.set_text(App::sequence_separator);
 
-	// Refresh the number of core
-	number_of_core_select->set_value(App::number_of_cores);
+	// Refresh the number of threads
+	number_of_threads_select->set_value(App::number_of_threads);
 
 	// Refresh the status of the workarea_renderer
 	workarea_renderer_combo.set_active_id(App::workarea_renderer);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -503,10 +503,10 @@ Dialog_Setup::create_render_page(PageInfo pi)
 
 	// render - cores
 	attach_label(pi.grid, _("Limit render to number of cores"), ++row);
-	pi.grid->attach(core_render, 1, row, 1, 1);
-	core_render.set_hexpand(true);
-	core_render.signal_changed().connect(
-	sigc::mem_fun(*this, &Dialog_Setup::on_core_change) );
+	pi.grid->attach(number_of_core_select, 1, row, 1, 1);
+	number_of_core_select.set_hexpand(true);
+	number_of_core_select.signal_changed().connect(
+	sigc::mem_fun(*this, &Dialog_Setup::on_number_of_core_select) );
 
 	// Render - WorkArea
 	attach_label(pi.grid, _("WorkArea renderer"), ++row);
@@ -542,7 +542,7 @@ Dialog_Setup::create_render_page(PageInfo pi)
 	preview_background_color_button.signal_color_set().connect(
 		sigc::mem_fun(*this, &studio::Dialog_Setup::on_preview_background_color_changed) );
 
-}	
+}
 
 void
 Dialog_Setup::create_interface_page(PageInfo pi)
@@ -676,7 +676,7 @@ Dialog_Setup::on_restore_pressed()
 		fps_template_combo->set_active_text(DEFAULT_PREDEFINED_FPS);
 		adj_pref_fps->set_value(24.0);
 		image_sequence_separator.set_text(".");
-		core_render.set_text("" + ('0'+g_get_num_processors()));
+		number_of_core_select.set_text(std::to_string(g_get_num_processors()));
 
 		workarea_renderer_combo.set_active_id("");
 		def_background_none.set_active();
@@ -799,7 +799,7 @@ Dialog_Setup::on_apply_pressed()
 	App::sequence_separator     = image_sequence_separator.get_text();
 
 	// Set the number of cores
-	App::number_of_cores = core_render.get_text();
+	App::number_of_cores = atoi((number_of_core_select.get_text().c_str()));
 
 	// Set the workarea render and navigator render flag
 	App::navigator_renderer = App::workarea_renderer  = workarea_renderer_combo.get_active_id();
@@ -917,9 +917,9 @@ Dialog_Setup::on_autobackup_changed()
 }
 
 void
-Dialog_Setup::on_core_change()
+Dialog_Setup::on_number_of_core_select()
 {
-	ThreadPool::instance().set_threads(3);
+	ThreadPool::instance().set_num_threads(App::number_of_cores);
 }
 
 void
@@ -1082,7 +1082,8 @@ Dialog_Setup::refresh()
 	// Refresh the sequence separator
 	image_sequence_separator.set_text(App::sequence_separator);
 
-	core_render.set_text(App::number_of_cores);
+	// Refresh the number of core
+	number_of_core_select.set_text(std::to_string(App::number_of_cores));
 
 	// Refresh the status of the workarea_renderer
 	workarea_renderer_combo.set_active_id(App::workarea_renderer);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -99,6 +99,7 @@ class Dialog_Setup : public Dialog_Template
 	void on_def_background_type_changed(); //bound on clicked
 	void on_def_background_color_changed();
 	void on_def_background_image_set();
+	void on_number_of_core_select();
 	void on_preview_background_color_changed();
 	void on_brush_path_add_clicked();
 	void on_brush_path_remove_clicked();
@@ -163,6 +164,7 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::Entry        image_sequence_separator;
 	Gtk::ComboBoxText workarea_renderer_combo;
 	Gtk::Switch       toggle_play_sound_on_render_done;
+	Gtk::Entry		  number_of_core_select;	
 
 	Gtk::Switch toggle_handle_tooltip_widthpoint;
 	Gtk::Switch toggle_handle_tooltip_radius;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -164,8 +164,8 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::Entry        image_sequence_separator;
 	Gtk::ComboBoxText workarea_renderer_combo;
 	Gtk::Switch       toggle_play_sound_on_render_done;
-	Glib::RefPtr<Gtk::Adjustment> adj_number_of_core;
-	Gtk::SpinButton*  number_of_core_select;	
+	Glib::RefPtr<Gtk::Adjustment> adj_number_of_threads;
+	Gtk::SpinButton*  number_of_threads_select;	
 
 	Gtk::Switch toggle_handle_tooltip_widthpoint;
 	Gtk::Switch toggle_handle_tooltip_radius;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -99,7 +99,7 @@ class Dialog_Setup : public Dialog_Template
 	void on_def_background_type_changed(); //bound on clicked
 	void on_def_background_color_changed();
 	void on_def_background_image_set();
-	void on_number_of_core_select();
+	void on_number_of_thread_changed();
 	void on_preview_background_color_changed();
 	void on_brush_path_add_clicked();
 	void on_brush_path_remove_clicked();
@@ -165,7 +165,7 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::ComboBoxText workarea_renderer_combo;
 	Gtk::Switch       toggle_play_sound_on_render_done;
 	Glib::RefPtr<Gtk::Adjustment> adj_number_of_core;
-	Gtk::SpinButton*	number_of_core_select;	
+	Gtk::SpinButton*  number_of_core_select;	
 
 	Gtk::Switch toggle_handle_tooltip_widthpoint;
 	Gtk::Switch toggle_handle_tooltip_radius;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -165,7 +165,7 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::ComboBoxText workarea_renderer_combo;
 	Gtk::Switch       toggle_play_sound_on_render_done;
 	Glib::RefPtr<Gtk::Adjustment> adj_number_of_core;
-	Gtk::SpinButton*		  number_of_core_select;	
+	Gtk::SpinButton*	number_of_core_select;	
 
 	Gtk::Switch toggle_handle_tooltip_widthpoint;
 	Gtk::Switch toggle_handle_tooltip_radius;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -164,7 +164,8 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::Entry        image_sequence_separator;
 	Gtk::ComboBoxText workarea_renderer_combo;
 	Gtk::Switch       toggle_play_sound_on_render_done;
-	Gtk::Entry		  number_of_core_select;	
+	Glib::RefPtr<Gtk::Adjustment> adj_number_of_core;
+	Gtk::SpinButton*		  number_of_core_select;	
 
 	Gtk::Switch toggle_handle_tooltip_widthpoint;
 	Gtk::Switch toggle_handle_tooltip_radius;


### PR DESCRIPTION
fix - #1410 
I am new to GTK :turtle: 
pls help me in verifying the logic 
currently, it only changes the core to 3 ( I don't know how to check [ how many cores is running ] )