### PR TITLE
[Core] fix missing is_distance hint for vertex coordinates

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
@@ -668,6 +668,7 @@ ValueNode_Composite::get_children_vocab_vfunc()const
 		ret.push_back(ParamDesc(ValueBase(),"point")
 			.set_local_name(_("Vertex"))
 			.set_description(_("The vertex of the Spline Point"))
+			.set_is_distance()
 		);
 		ret.push_back(ParamDesc(ValueBase(),"width")
 			.set_local_name(_("Width"))


### PR DESCRIPTION
reported by @Svarov-RM