### PR TITLE
[Synfig Studio] destructors should not call virtual methods

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1761,7 +1761,7 @@ App::~App()
 
 	// Unload all of the modules
 	for(;!module_list_.empty();module_list_.pop_back())
-		;
+		module_list_.back()->stop();
 
 	delete state_manager;
 

--- a/synfig-studio/src/gui/modules/module.cpp
+++ b/synfig-studio/src/gui/modules/module.cpp
@@ -51,7 +51,6 @@ Module::Module():status_(false)
 
 Module::~Module()
 {
-	stop();
 }
 
 bool


### PR DESCRIPTION
neither constructors.

The derived methods are not called, but those from the class itself.

https://scc.ustc.edu.cn/zlsc/sugon/intel/ssadiag_docs/pt_reference/references/sc_cpp_virtual_call_in_dtor.htm
https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP50-CPP.+Do+not+invoke+virtual+functions+from+constructors+or+destructors