### PR TITLE
[Autotools] Fixed `make distcheck`. Reduced build output for synfigstudio-release.sh script

### DIFF
--- a/ETL/ETL/_smart_ptr.h
+++ b/ETL/ETL/_smart_ptr.h
@@ -97,7 +97,7 @@ public:
 		smart_ptrs much like we would pointers. */
 #ifdef _WIN32
 	template <class U>
-	smart_ptr(const smart_ptr<U> &x):obj((pointer)&*x.obj),refcount(x.refcount())
+	smart_ptr(const smart_ptr<U> &x):obj((pointer)&*x.obj),refcount(x.refcount)
 		{ }
 #endif
 

--- a/ETL/Makefile.am
+++ b/ETL/Makefile.am
@@ -71,7 +71,7 @@ stats:
 	-@echo 
 
 ChangeLog:
-	../autobuild/git2cl > ChangeLog
+	cd $(top_srcdir) && ../autobuild/git2cl > ChangeLog
 
 listfixmes:
 	-@echo

--- a/ETL/test/benchmark.cpp
+++ b/ETL/test/benchmark.cpp
@@ -166,7 +166,7 @@ int hermite_int_test()
 	int i;
 
 	etl::clock timer;
-	etl::clock::value_type t;
+	float t;
 
 	Hermie.p1()=0;
 	Hermie.t1()=40000;

--- a/ETL/test/clock.cpp
+++ b/ETL/test/clock.cpp
@@ -23,6 +23,8 @@
 
 #include <ETL/clock>
 #include <stdio.h>
+#include <chrono>
+#include <thread>
 
 /* === M A C R O S ========================================================= */
 
@@ -36,12 +38,9 @@ using namespace etl;
 int basic_test(void)
 {
 	int ret=0;
-	fprintf(stderr,"default etl::clock precision:  %0.8f\n",etl::clock::precision());
-	fprintf(stderr,"realtime etl::clock precision: %0.8f\n",etl::clock_realtime::precision());
-	fprintf(stderr,"proctime etl::clock precision: %0.8f\n",etl::clock_proctime::precision());
 
-	etl::clock_realtime timer;
-	etl::clock::value_type amount,total;
+	etl::clock timer;
+	float amount, total;
 
 	for(amount=3.0;amount>=0.00015;amount/=2.0)
 	{
@@ -53,7 +52,7 @@ int basic_test(void)
 			fprintf(stderr,"waiting %f seconds...\n",amount);
 
 		timer.reset();
-		etl::clock::sleep(amount);
+		std::this_thread::sleep_for(std::chrono::microseconds ((std::int64_t)(amount*1000000.f)));
 		total=timer();
 		if((total-amount)*1000000.0<1000.0f)
 			fprintf(stderr," ** I waited %f seconds, error of %f microseconds\n",total,(total-amount)*1000000);

--- a/autobuild/synfigstudio-release.sh
+++ b/autobuild/synfigstudio-release.sh
@@ -22,6 +22,7 @@ set -e
 export SCRIPTPATH=$(cd `dirname "$0"`; pwd)
 export SRCPREFIX=`dirname "$SCRIPTPATH"`
 
+BUILD_RELEASE_DIR=${SRCPREFIX}/_release/
 
 export PREFIX="$HOME/local-synfig"
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig"
@@ -47,12 +48,17 @@ if [ -e /etc/debian_version ] && [ -z $with_boost_libdir ]; then
 	fi
 fi
 
+if [[ `uname` == "MINGW"* ]]; then # MacOS doesn't support `uname -o` flag
+	PATH="${MINGW_PREFIX}/lib/ccache/bin:${PATH}"
+	PKG_CONFIG_PATH="/opt/mlt-6.16.0/lib/pkgconfig:${PKG_CONFIG_PATH}"
+	echo "ccache enabled"
+fi
 
 if [ -z $THREADS ]; then
 	export THREADS=4
 fi
 
-start_stage() 
+start_stage()
 {
 	echo -e "Starting ${YLW}$1${NC} stage"
 }
@@ -87,22 +93,23 @@ pack-etl()
 	start_stage "Pack ETL"
 	cd $SRCPREFIX/ETL
 	autoreconf -if
-	./configure --prefix="$PREFIX"
-	make distcheck -j${THREADS}
-	mv ETL-${ETL_VERSION}.tar.gz ../../
+	mkdir -p ${BUILD_RELEASE_DIR}/ETL && cd $BUILD_RELEASE_DIR/ETL
+	$SRCPREFIX/ETL/configure --prefix="$PREFIX"
+	make V=0 CXXFLAGS="-w" distcheck -j${THREADS}
+	mv ETL-${ETL_VERSION}.tar.gz ${BUILD_RELEASE_DIR}
 	end_stage "Pack ETL"
 }
 
 test-etl()
 {
 	start_stage "Test ETL"
-	cd $SRCPREFIX/../
+	cd ${BUILD_RELEASE_DIR}
 	tar xf ETL-${ETL_VERSION}.tar.gz
 	cd ETL-${ETL_VERSION}
 	./configure --prefix="$PREFIX"
-	make install -j${THREADS}
+	make V=0 CXXFLAGS="-w" install -j${THREADS}
 	cd ..
-	rm -rf $SRCPREFIX/../ETL-${ETL_VERSION}
+	rm -rf ${BUILD_RELEASE_DIR}/ETL-${ETL_VERSION}
 	end_stage "Test ETL"
 }
 
@@ -118,24 +125,25 @@ pack-core()
 {
 	start_stage "Pack Synfig Core"
 	cd $SRCPREFIX/synfig-core
-    ./bootstrap.sh
-	./configure --prefix="$PREFIX"
+	./bootstrap.sh
+	mkdir -p ${BUILD_RELEASE_DIR}/synfig-core && cd $BUILD_RELEASE_DIR/synfig-core
+	$SRCPREFIX/synfig-core/configure --prefix="$PREFIX"
 	echo "------------------------------------- pack-core make"
-	make distcheck -j${THREADS}
-	mv synfig-${CORE_VERSION}.tar.gz ../../
+	make V=0 CXXFLAGS="-w" distcheck -j${THREADS}
+	mv synfig-${CORE_VERSION}.tar.gz ${BUILD_RELEASE_DIR}
 	end_stage "Pack Synfig Core"
 }
 
 test-core()
 {
 	start_stage "Test Synfig Core"
-	cd $SRCPREFIX/../
+	cd ${BUILD_RELEASE_DIR}
 	tar xf synfig-${CORE_VERSION}.tar.gz
 	cd synfig-${CORE_VERSION}
 	./configure --prefix="$PREFIX"
-	make install -j${THREADS}
+	make V=0 CXXFLAGS="-w" install -j${THREADS}
 	cd ..
-	rm -rf $SRCPREFIX/../synfig-${CORE_VERSION}
+	rm -rf ${BUILD_RELEASE_DIR}/synfig-${CORE_VERSION}
 	end_stage "Test Synfig Core"
 }
 
@@ -152,22 +160,23 @@ pack-studio()
 	start_stage "Pack Synfig Studio"
 	cd $SRCPREFIX/synfig-studio
 	./bootstrap.sh
-	./configure --prefix="$PREFIX"
-	make distcheck -j${THREADS}
-	mv synfigstudio-${STUDIO_VERSION}.tar.gz ../..
+	mkdir -p ${BUILD_RELEASE_DIR}/synfig-studio && cd $BUILD_RELEASE_DIR/synfig-studio
+	$SRCPREFIX/synfig-studio/configure --prefix="$PREFIX"
+	make V=0 CXXFLAGS="-w" distcheck -j${THREADS}
+	mv synfigstudio-${STUDIO_VERSION}.tar.gz ${BUILD_RELEASE_DIR}
 	end_stage "Pack Synfig Studio"
 }
 
 test-studio()
 {
 	start_stage "Test Synfig Studio"
-	cd $SRCPREFIX/../
+	cd ${BUILD_RELEASE_DIR}
 	tar xf synfigstudio-${STUDIO_VERSION}.tar.gz
 	cd synfigstudio-${STUDIO_VERSION}
 	./configure --prefix="$PREFIX"
 	make install -j${THREADS}
 	cd ..
-	rm -rf $SRCPREFIX/../synfigstudio-${STUDIO_VERSION}
+	rm -rf ${BUILD_RELEASE_DIR}/synfigstudio-${STUDIO_VERSION}
 	end_stage "Test Synfig Studio"
 }
 

--- a/synfig-core/Makefile.am
+++ b/synfig-core/Makefile.am
@@ -98,7 +98,7 @@ stats:
 	-@echo 
 
 ChangeLog:
-	../autobuild/git2cl > ChangeLog
+	cd $(top_srcdir) && ../autobuild/git2cl > ChangeLog
 
 listfixmes:
 	-@echo

--- a/synfig-core/bootstrap.sh
+++ b/synfig-core/bootstrap.sh
@@ -27,7 +27,7 @@ if [ -z $LIBTOOLIZE ]; then
         exit 1
 fi
 
-echo "running libtooize ($LIBTOOLIZE)..."
+echo "running libtoolize ($LIBTOOLIZE)..."
 $LIBTOOLIZE  --ltdl --copy --force
 
 echo "running autopoint..."

--- a/synfig-studio/Makefile.am
+++ b/synfig-studio/Makefile.am
@@ -89,7 +89,7 @@ SH=sh
 DOXYGEN=doxygen
 
 ChangeLog:
-	../autobuild/git2cl > ChangeLog
+	cd $(top_srcdir) && ../autobuild/git2cl > ChangeLog
 
 stats:
 	-@echo

--- a/synfig-studio/build_tools/Makefile.am
+++ b/synfig-studio/build_tools/Makefile.am
@@ -1,4 +1,4 @@
-dist_noinst_SCRIPTS = autorevision.sh
+dist_noinst_SCRIPTS = autorevision.sh sif2ico.sh
 
 if DEVELOPMENT_SNAPSHOT
 all-local:

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -429,12 +429,12 @@ win32icons_DATA = $(WIN32_ICONS)
 all: $(IMAGES) $(ICONS)
 
 .sifz.ico:
-	bash $(srcdir)/../build_tools/sif2ico.sh $<
+	bash $(top_srcdir)/build_tools/sif2ico.sh $<
 	echo "  File \"images\\$@\"" >>./icons.nsh
 	echo "  Delete \"\$$INSTDIR\\share\\pixmaps\\$@\"" >>./unicons.nsh
 
 .sif.ico:
-	bash $(srcdir)/../build_tools/sif2ico.sh $<
+	bash $(top_srcdir)/build_tools/sif2ico.sh $<
 	echo "  File \"images\\$@\"" >>./icons.nsh
 	echo "  Delete \"\$$INSTDIR\\share\\pixmaps\\$@\"" >>./unicons.nsh
 

--- a/synfig-studio/src/gui/Makefile.am
+++ b/synfig-studio/src/gui/Makefile.am
@@ -39,6 +39,7 @@ EVENTS_HH = \
 
 OTHER_HH = \
 	eventkey.h \
+	_smach.h \
 	smach.h \
 	timemodel.h \
 	app.h \


### PR DESCRIPTION
- Now `synfigstudio-release.sh` script can be run from any folder;
- `synfigstudio-release.sh` - creates `_release` folder and works inside it, this fixes error `configure: error: source directory already configured; run “make distclean” there first`, when you try to build Synfig after this script.

P.S.

There is still an error here: 
```
ERROR: files left after uninstall:
./share/pixmaps/sif_icon.ico
./share/pixmaps/synfig_icon.ico
./share/synfig/icons/classic/about_icon.png
./share/synfig/icons/classic/action_add_to_set_icon.png

...
./share/synfig/icons/classic/valuenode_icon.png
./share/synfig/images/installer_logo.bmp
./share/synfig/images/installer_logo_osx.png
./share/synfig/images/splash_screen.png
```

I don't know why they are not removed. 

@rodolforg Any ideas here?