### PR TITLE
[ETL] current_working_directory() function now works correctly with non-Latin filenames

### DIFF
--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -37,6 +37,7 @@
 #include <string>
 #include <cstdarg>
 #include <cstdlib>
+#include <glibmm/miscutils.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -49,15 +50,6 @@
 #endif
 
 /* === T Y P E D E F S ===================================================== */
-
-#ifdef _MSC_VER
-#include <direct.h> /* for _getcwd() and _chdir() */
-#define getcwd _getcwd
-#else
-extern "C" {
-#include <unistd.h>
-}
-#endif
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
@@ -247,12 +239,8 @@ unix_to_local_path(const std::string &path)
 }
 
 inline std::string
-current_working_directory()
-{
-	char dir[256];
-	// TODO: current_working_directory() should use Glib::locale_to_utf8()
-	std::string ret(getcwd(dir,sizeof(dir)));
-	return ret;
+current_working_directory() {
+	return Glib::get_current_dir();
 }
 
 inline std::string

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -55,6 +55,7 @@ using namespace synfig;
 
 #if defined(HAVE_FORK) && defined(HAVE_PIPE) && defined(HAVE_WAITPID)
  #define UNIX_PIPE_TO_PROCESSES
+ #include <unistd.h> // for popen
 #else
  #define WIN32_PIPE_TO_PROCESSES
 #endif
@@ -98,7 +99,7 @@ ffmpeg_trgt::~ffmpeg_trgt()
 	if(file)
 	{
 		std::this_thread::yield();
-		sleep(1);
+		std::this_thread::sleep_for(std::chrono::seconds(1));
 #if defined(WIN32_PIPE_TO_PROCESSES)
 		pclose(file);
 #elif defined(UNIX_PIPE_TO_PROCESSES)


### PR DESCRIPTION
This problem mentioned by @rodolforg here: https://github.com/synfig/synfig/pull/1952, so I fixed it.

> etl::absolute_path() trusting on getcwd(), that doesn't handle the famous encoding problems.

