### PR TITLE
[ETL/Core] Fixed warnings

### DIFF
--- a/ETL/ETL/_surface.h
+++ b/ETL/ETL/_surface.h
@@ -481,7 +481,7 @@ public:
 	{
 		assert(data_);
 		if(pitch_==(signed int)sizeof(value_type)*w_)
-			memset(data_,0,h_*pitch_);
+			memset(static_cast<void*>(data_), 0, h_*pitch_);
 		else
 			fill(value_type());
 	}

--- a/synfig-core/src/modules/mod_magickpp/trgt_magickpp.cpp
+++ b/synfig-core/src/modules/mod_magickpp/trgt_magickpp.cpp
@@ -252,7 +252,7 @@ magickpp_trgt::end_frame()
 }
 
 bool
-magickpp_trgt::start_frame(synfig::ProgressCallback *callback)
+magickpp_trgt::start_frame(synfig::ProgressCallback */*callback*/)
 {
 	if (start_pointer == buffer1)
 		start_pointer = buffer_pointer = buffer2;
@@ -266,7 +266,7 @@ magickpp_trgt::start_frame(synfig::ProgressCallback *callback)
 }
 
 Color*
-magickpp_trgt::start_scanline(int scanline)
+magickpp_trgt::start_scanline(int /*scanline*/)
 {
 	return color_buffer;
 }

--- a/synfig-core/src/modules/mod_mng/trgt_mng.cpp
+++ b/synfig-core/src/modules/mod_mng/trgt_mng.cpp
@@ -64,13 +64,13 @@ mng_alloc_proc(mng_size_t size)
 }
 
 static void MNG_DECL
-mng_free_proc(mng_ptr ptr, mng_size_t size)
+mng_free_proc(mng_ptr ptr, mng_size_t /*size*/)
 {
 	free(ptr); return;
 }
 
 static mng_bool MNG_DECL
-mng_null_proc(mng_handle mng)
+mng_null_proc(mng_handle /*mng*/)
 {
 	// synfig::info("%s:%d mng_trgt::mng_null_proc was called", __FILE__, __LINE__);
 	return MNG_TRUE;
@@ -85,10 +85,10 @@ mng_write_proc(mng_handle mng, mng_ptr buf, mng_uint32 size, mng_uint32* written
 }
 
 static mng_bool MNG_DECL
-mng_error_proc(mng_handle mng, mng_int32 error,
-			   mng_int8 severity, mng_chunkid chunkname,
-			   mng_uint32 chunkseq, mng_int32 extra1,
-			   mng_int32 extra2, mng_pchar errortext)
+mng_error_proc(mng_handle /*mng*/, mng_int32 /*error*/,
+			   mng_int8 /*severity*/, mng_chunkid /*chunkname*/,
+			   mng_uint32 /*chunkseq*/, mng_int32 /*extra1*/,
+			   mng_int32 /*extra2*/, mng_pchar errortext)
 {
 	synfig::error("%s:%d mng_trgt: error: %s", __FILE__, __LINE__, errortext);
 	return MNG_TRUE;
@@ -267,7 +267,7 @@ mng_trgt::end_frame()
 }
 
 bool
-mng_trgt::start_frame(synfig::ProgressCallback *callback)
+mng_trgt::start_frame(synfig::ProgressCallback */*callback*/)
 {
 	// synfig::info("%s:%d mng_trgt::start_frame()", __FILE__, __LINE__);
 
@@ -308,7 +308,7 @@ mng_trgt::start_frame(synfig::ProgressCallback *callback)
 }
 
 Color*
-mng_trgt::start_scanline(int scanline)
+mng_trgt::start_scanline(int /*scanline*/)
 {
 	return color_buffer;
 }

--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -171,7 +171,7 @@ static void GaussianBlur_2x2(etl::surface<T,AT,VP> &surface)
 	
 	AT *SC0=new AT[w];
 
-	memcpy(SC0,surface[0],w*sizeof(AT));
+	memcpy(static_cast<void*>(SC0), surface[0], w*sizeof(AT));
 
 	for(y=0;y<h;y++)
 	{

--- a/synfig-core/src/synfig/color/colormatrix.cpp
+++ b/synfig-core/src/synfig/color/colormatrix.cpp
@@ -241,9 +241,9 @@ ColorMatrix::BatchProcessor::process(Color *dest, int dest_stride, const Color *
 	{
 		if (dest_dr)
 			for(; dest != dest_end; dest += dest_stride)
-				memset(dest, 0, sizeof(*dest)*width);
+				memset(static_cast<void*>(dest), 0, sizeof(*dest)*width);
 		else
-			memset(dest, 0, sizeof(*dest)*width*height);
+			memset(static_cast<void*>(dest), 0, sizeof(*dest)*width*height);
 	}
 	else
 	if (copy_all)

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1378,8 +1378,8 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 
 	// don't call thread_init() if threads are already initialized
 	// on some machines bonobo_init() initialized threads before we get here
-	if (!g_thread_supported())
-		Glib::thread_init();
+	//if (!Glib::thread_supported())
+	//	Glib::thread_init();
 
 	distance_system=Distance::SYSTEM_PIXELS;
 	

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3713,7 +3713,7 @@ CanvasView::set_toolbar_id(Gtk::UIManager::ui_merge_id toolbar_id)
 }
 
 bool
-CanvasView::on_delete_event(GdkEventAny* event)
+CanvasView::on_delete_event(GdkEventAny* /*event*/)
 {
 	close_view();
 

--- a/synfig-studio/src/gui/trees/childrentreestore.cpp
+++ b/synfig-studio/src/gui/trees/childrentreestore.cpp
@@ -331,7 +331,7 @@ ChildrenTreeStore::on_value_node_changed(synfig::ValueNode::Handle value_node)
 }
 
 void
-ChildrenTreeStore::on_value_node_renamed(synfig::ValueNode::Handle value_node)
+ChildrenTreeStore::on_value_node_renamed(synfig::ValueNode::Handle /*value_node*/)
 {
 	rebuild_value_nodes();
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -1195,6 +1195,8 @@ void Widget_Timetrack::WaypointSD::on_modifier_keys_changed()
 	if (action != NONE) {
 		std::string action_name;
 		switch (action) {
+		case NONE:
+			return; // just to hide warning "enumeration value ‘NONE’ not handled in switch"
 		case MOVE:
 			action_name = _("Move waypoints");
 			break;

--- a/synfig-studio/src/synfigapp/actions/valuenodesetactivebone.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuenodesetactivebone.cpp
@@ -89,7 +89,7 @@ Action::ValueNodeSetActiveBone::get_param_vocab()
 }
 
 bool
-Action::ValueNodeSetActiveBone::is_candidate(const ParamList &x)
+Action::ValueNodeSetActiveBone::is_candidate(const ParamList &)
 {
 	return false;
 }

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinepolygonizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinepolygonizer.cpp
@@ -767,7 +767,7 @@ inline double penalty(RawBorder &path, int a, int b)
   synfig::PointInt p;
 
   int n = b - a + 1;
-  p = path[b == path.size() ? 0 : b].pos() - path[a].pos();
+  p = path[b == static_cast<std::int32_t>(path.size()) ? 0 : b].pos() - path[a].pos();
 
   synfig::Point v(-p[1],p[0]);//convert(rotate90(p))
   synfig::Point sum   = path.sums()[b] - path.sums()[a];


### PR DESCRIPTION
- static_cast<void*> used to disable warning "clearing an object of non-trivial type...". This can be removed after synfig::Color will be trivial;
- Removed unused variables;
- Fixed warning: comparison between signed and unsigned integer expressions.