### PR TITLE
[Synfig Studio] don't let inner layer be duplicated twice

### DIFF
--- a/synfig-studio/src/synfigapp/actions/layerduplicate.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerduplicate.cpp
@@ -30,18 +30,18 @@
 #	include <config.h>
 #endif
 
-#include <synfig/general.h>
-
 #include "layerduplicate.h"
-#include "layeradd.h"
-#include <synfig/context.h>
-#include <synfigapp/canvasinterface.h>
 
+#include <synfig/context.h>
+#include <synfig/general.h>
+#include <synfig/layers/layer_pastecanvas.h>
+
+#include <synfigapp/actions/layeradd.h>
+#include <synfigapp/canvasinterface.h>
 #include <synfigapp/localization.h>
 
 #endif
 
-using namespace std;
 using namespace etl;
 using namespace synfig;
 using namespace synfigapp;
@@ -95,6 +95,34 @@ static Canvas::Handle get_top_parent_if_inline_canvas(Canvas::Handle canvas)
 	if(canvas->is_inline() && canvas->parent())
 		return get_top_parent_if_inline_canvas(canvas->parent());
 	return canvas;
+}
+
+/// Remove the layers that are inside an already listed group-kind layer, as they would be duplicated twice
+static std::list<Layer::LooseHandle>
+remove_layers_inside_included_pastelayers(const std::list<Layer::Handle>& layer_list)
+{
+	std::vector<Layer::LooseHandle> layerpastecanvas_list;
+	for (const auto& layer : layer_list) {
+		if (Layer_PasteCanvas* pastecanvas = dynamic_cast<Layer_PasteCanvas*>(layer.get())) {
+			layerpastecanvas_list.push_back(layer);
+		}
+	}
+
+	std::list<Layer::LooseHandle> clean_layer_list;
+	for (const Layer::LooseHandle layer : layer_list) {
+		bool is_inside_a_selected_pastelayer = false;
+		auto pastelayer = layer->get_parent_paste_canvas_layer();
+		while (pastelayer) {
+			if (std::find(layerpastecanvas_list.begin(), layerpastecanvas_list.end(), pastelayer) != layerpastecanvas_list.end()) {
+				is_inside_a_selected_pastelayer = true;
+				break;
+			}
+			pastelayer = pastelayer->get_parent_paste_canvas_layer();
+		}
+		if (!is_inside_a_selected_pastelayer)
+			clean_layer_list.push_back(layer);
+	}
+	return clean_layer_list;
 }
 
 /* === M E T H O D S ======================================================= */
@@ -156,6 +184,9 @@ Action::LayerDuplicate::prepare()
 	if(!first_time())
 		return;
 
+	// remove layers that would be duplicated twice
+	std::list<Layer::LooseHandle> clean_layer_list = remove_layers_inside_included_pastelayers(layers);
+
 	// pair (original layer, cloned layer)
 	std::map<synfig::Layer::Handle,synfig::Layer::Handle> cloned_layer_map;
 	// pair (original special valuenode, cloned special valuenode)
@@ -163,7 +194,7 @@ Action::LayerDuplicate::prepare()
 	// pair (canvas, last exported valuenode "Index #" -> Layer_Duplicate parameter: index )
 	std::map<Canvas::LooseHandle, int> last_index;
 
-	for(auto layer : layers)
+	for(auto layer : clean_layer_list)
 	{
 		Canvas::Handle subcanvas(layer->get_canvas());
 

--- a/synfig-studio/test/app_layerduplicate.cpp
+++ b/synfig-studio/test/app_layerduplicate.cpp
@@ -560,7 +560,7 @@ static bool test_synfigapp_layerduplicate_two_layer_duplicate_in_different_group
 }
 
 // User try to duplicate a group AND an inner layer_duplicate
-// Check if it creates a new group with two layer_duplicate (with different Index parameters)
+// Check if it creates a new group and don't duplicate layer_duplicate
 static bool test_synfigapp_layerduplicate_encapsulated_and_inner_layer_duplicate()
 {
 	synfig::Canvas::Handle canvas = synfig::Canvas::create();
@@ -585,26 +585,24 @@ static bool test_synfigapp_layerduplicate_encapsulated_and_inner_layer_duplicate
 	action->perform();
 
 	ASSERT_EQUAL(2, canvas->size())
-	ASSERT_EQUAL(3, canvas->value_node_list().size())
+	ASSERT_EQUAL(2, canvas->value_node_list().size())
 
 	// - dup_group
-	//   - dup_layer_duplicate1
-	//   - dup_layer_duplicate2
+	//   - dup_layer_duplicate
 	// - group
 	//   - layer_duplicate
 	auto dup_group = canvas->front();
 	ASSERT_EQUAL("group", dup_group->get_name())
 	auto dup_child_canvas = dup_group->get_param("canvas").get(canvas);
+	ASSERT_EQUAL(1, dup_child_canvas->size())
+	ASSERT_EQUAL(1, child_canvas->size())
 	auto dup_layer_duplicate1 = dup_child_canvas->front();
 	ASSERT_EQUAL("duplicate", dup_layer_duplicate1->get_name())
-	auto dup_layer_duplicate2 = *std::next(dup_child_canvas->begin(), 1);
-	ASSERT_EQUAL("duplicate", dup_layer_duplicate2->get_name())
 
 	std::string new_id1 = dup_layer_duplicate1->dynamic_param_list().find("index")->second->get_id();
-	std::string new_id2 = dup_layer_duplicate2->dynamic_param_list().find("index")->second->get_id();
+	std::string id0 = duplicate_layer->dynamic_param_list().find("index")->second->get_id();
 	ASSERT_NOT_EQUAL("some_index1", new_id1)
-	ASSERT_NOT_EQUAL("some_index1", new_id2)
-	ASSERT_NOT_EQUAL(new_id2, new_id1)
+	ASSERT_EQUAL("some_index1", id0)
 
 	return false;
 }


### PR DESCRIPTION
If action LayerDuplicate has among the layers to be duplicated a
layer named "a" that is 'inside' of a group layer (pastecanvas)
named "g". In case of "g" is a layer included in the action layer
list too, don't duplicate the "a" twice, ie. the group and
its contents - including "a" - are duplicated, but "a" won't
be duplicated again.

It would clash the GUID of both "a" duplicates, and that leads
to crash.
A way to avoid it in a general way would be too troublesome :P
Many hierarchy levels and special GUIDs to handle.

Regular (and advanced) user normally won't need it, anyway.

Full description and minor discussion here:
https://forums.synfig.org/t/proposal-of-change-of-behavior-duplicating-both-group-and-an-inner-layer/11823