### PR TITLE
[Core] LinkableValueNode provides methods for inverse manipulation

### DIFF
--- a/synfig-core/src/synfig/value.cpp
+++ b/synfig-core/src/synfig/value.cpp
@@ -122,16 +122,14 @@ ValueBase::operator=(ValueBase x)
 	return *this;
 }
 
-#ifdef _DEBUG
 String
 ValueBase::get_string() const
 {
 	Operation::ToStringFunc func =
 		Type::get_operation<Operation::ToStringFunc>(
 			Operation::Description::get_to_string(type->identifier) );
-	return func == NULL ? "Invalid type" : func(data);
+	return func ? func(data) : "Invalid type";
 }
-#endif	// _DEBUG
 
 bool
 ValueBase::is_valid()const

--- a/synfig-core/src/synfig/value.h
+++ b/synfig-core/src/synfig/value.h
@@ -282,9 +282,7 @@ public:
 		*this = List(list.begin(), list.end());
 	}
 
-#ifdef _DEBUG
 	String get_string() const;
-#endif	// _DEBUG
 	// ========================================================================
 
 	//! Put template for any class

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -800,6 +800,18 @@ LinkableValueNode::set_root_canvas(etl::loose_handle<Canvas> x)
 		get_link(i)->set_root_canvas(x);
 }
 
+LinkableValueNode::InvertibleStatus LinkableValueNode::is_invertible(const Time& /*t*/, const ValueBase& /*target_value*/, int* link_index) const
+{
+	if (link_index)
+		*link_index = -1;
+	return INVERSE_NOT_SUPPORTED;
+}
+
+ValueBase LinkableValueNode::get_inverse(const Time& /*t*/, const ValueBase& /*target_value*/) const
+{
+	return ValueBase();
+}
+
 void
 LinkableValueNode::get_values_vfunc(std::map<Time, ValueBase> &x) const
 {

--- a/synfig-core/src/synfig/valuenode.h
+++ b/synfig-core/src/synfig/valuenode.h
@@ -422,6 +422,24 @@ public:
 
 	virtual void set_root_canvas(etl::loose_handle<Canvas> x);
 
+	//! If get_inverse() can be called
+	enum InvertibleStatus {
+		INVERSE_OK, ///< get_inverse() will return valid value
+		INVERSE_NOT_SUPPORTED, ///< valuenode does not support reverse function or does not implement it
+		INVERSE_ERROR_BAD_TYPE, ///< valuenode can't handle the target_value type
+		INVERSE_ERROR_BAD_VALUE, ///< the provided target_value does not allow a inverse function (e.g. leads to a division by zero)
+		INVERSE_ERROR_BAD_TIME, ///< time is invalid
+		INVERSE_ERROR_BAD_PARAMETER ///< another valuenode parameter does not allow a inverse function (e.g. leads to a division by zero)
+	};
+
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse().
+	//! If is_invertible returns INVERSE_ERROR_BAD_PARAMETER, link_index returns the invalid link index
+	//! Otherwise, link_index is invalid
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
+	//! Returns the Link value that leads this value node to match the target value at time t
+	virtual ValueBase get_inverse(const Time& t, const ValueBase& target_value) const;
+
 protected:
 	//! Member to store the children vocabulary
 	Vocab children_vocab;

--- a/synfig-core/src/synfig/valuenodes/valuenode_add.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_add.cpp
@@ -167,24 +167,6 @@ synfig::ValueNode_Add::operator()(Time t)const
 	return ValueBase();
 }
 
-ValueBase
-synfig::ValueNode_Add::get_inverse(Time t, const synfig::Real &target_value) const
-{
-	return target_value / (*scalar)(t).get(Real()) - (*ref_b)(t).get(Real());
-}
-
-ValueBase
-synfig::ValueNode_Add::get_inverse(Time t, const synfig::Angle &target_value) const
-{
-	return target_value / (*scalar)(t).get(Real()) - (*ref_b)(t).get(Angle());
-}
-
-ValueBase
-synfig::ValueNode_Add::get_inverse(Time t, const synfig::Vector &target_value) const
-{
-	return target_value / (*scalar)(t).get(Real()) - (*ref_b)(t).get(Vector());
-}
-
 bool
 ValueNode_Add::set_link_vfunc(int i,ValueNode::Handle value)
 {
@@ -246,4 +228,40 @@ ValueNode_Add::get_children_vocab_vfunc() const
 	);
 
 	return ret;
+}
+
+LinkableValueNode::InvertibleStatus
+ValueNode_Add::is_invertible(const Time& t, const ValueBase& target_value, int* link_index) const
+{
+	if (!t.is_valid())
+		return INVERSE_ERROR_BAD_TIME;
+	if (approximate_zero((*scalar)(t).get(Real()))) {
+		if (link_index)
+			*link_index = get_link_index_from_name("scalar");
+		return INVERSE_ERROR_BAD_PARAMETER;
+	}
+	const Type& type = target_value.get_type();
+	if (type != type_real && type != type_angle && type != type_vector)
+		return INVERSE_ERROR_BAD_TYPE;
+	if (link_index)
+		*link_index = get_link_index_from_name("lhs");
+	return INVERSE_OK;
+}
+
+ValueBase
+ValueNode_Add::get_inverse(const Time& t, const ValueBase& target_value) const
+{
+	Real scalar_value = (*scalar)(t).get(Real());
+
+	if (approximate_zero(scalar_value))
+		throw runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Scalar is zero")));
+
+	const Type& type = target_value.get_type();
+	if (type == type_real)
+		return target_value.get(Real()) / scalar_value - (*ref_b)(t).get(Real());
+	if (type == type_angle)
+		return target_value.get(Angle()) / scalar_value - (*ref_b)(t).get(Angle());
+	if (type == type_vector)
+		return target_value.get(Vector()) / scalar_value - (*ref_b)(t).get(Vector());
+	throw runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Invalid value type")));
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_add.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_add.h
@@ -62,10 +62,12 @@ public:
 	virtual String get_local_name()const;
 	static bool check_type(Type &type);
 	virtual Vocab get_children_vocab_vfunc()const;
+
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse()
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
 	//! Returns the modified Link to match the target value at time t
-	ValueBase get_inverse(Time t, const synfig::Real &target_value) const;
-	ValueBase get_inverse(Time t, const synfig::Angle &target_value) const;
-	ValueBase get_inverse(Time t, const synfig::Vector &target_value) const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
 	
 }; // END of class ValueNode_Add
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_integer.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_integer.h
@@ -55,9 +55,11 @@ public:
 	virtual String get_name()const;
 	virtual String get_local_name()const;
 
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse()
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
 	//! Returns the modified Link to match the target value at time t
-	ValueBase get_inverse(Time t, const synfig::Real &target_value) const;
-	ValueBase get_inverse(Time t, const synfig::Angle &target_value) const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
 
 	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
@@ -173,8 +173,34 @@ synfig::ValueNode_Range::operator()(Time t)const
 	return ValueBase();
 }
 
+LinkableValueNode::InvertibleStatus
+synfig::ValueNode_Range::is_invertible(const Time& t, const ValueBase& target_value, int* link_index) const
+{
+	if (!t.is_valid())
+		return INVERSE_ERROR_BAD_TIME;
+
+	const Type& type = target_value.get_type();
+	if (type != type_angle && type != type_vector)
+		return INVERSE_ERROR_BAD_TYPE;
+
+	if (link_index)
+		*link_index = get_link_index_from_name("link");
+	return INVERSE_OK;
+}
+
+ValueBase
+ValueNode_Range::get_inverse(const Time& t, const ValueBase& target_value) const
+{
+	const Type& type = target_value.get_type();
+	if (type == type_angle)
+		return get_inverse(t, target_value.get(Angle()));
+	if (type == type_vector)
+		return get_inverse(t, target_value.get(Vector()));
+	throw runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Invalid value type")));
+}
+
 synfig::ValueBase
-synfig::ValueNode_Range::get_inverse(Time t, const synfig::Vector &target_value) const
+synfig::ValueNode_Range::get_inverse(const Time& t, const synfig::Vector &target_value) const
 {
 	Type &type(get_type());
 	if (type == type_integer)
@@ -210,7 +236,7 @@ synfig::ValueNode_Range::get_inverse(Time t, const synfig::Vector &target_value)
 }
 
 synfig::ValueBase
-synfig::ValueNode_Range::get_inverse(Time t, const synfig::Angle &target_value) const
+synfig::ValueNode_Range::get_inverse(const Time& t, const synfig::Angle &target_value) const
 {
 	Angle minimum = (* min_)(t).get(Angle());
 	Angle maximum = (* max_)(t).get(Angle());

--- a/synfig-core/src/synfig/valuenodes/valuenode_range.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_range.h
@@ -44,6 +44,9 @@ class ValueNode_Range : public LinkableValueNode
 
 	ValueNode_Range(const ValueBase &value);
 
+	ValueBase get_inverse(const Time& t, const synfig::Vector &target_value) const;
+	ValueBase get_inverse(const Time& t, const synfig::Angle &target_value) const;
+
 public:
 
 	typedef etl::handle<ValueNode_Range> Handle;
@@ -56,9 +59,11 @@ public:
 	virtual String get_name()const;
 	virtual String get_local_name()const;
 
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse()
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
 	//! Returns the modified Link to match the target value at time t
-	ValueBase get_inverse(Time t, const synfig::Vector &target_value) const;
-	ValueBase get_inverse(Time t, const synfig::Angle &target_value) const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
 
 	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
@@ -38,6 +38,7 @@
 #include <synfig/localization.h>
 #include <synfig/valuenode_registry.h>
 #include <ETL/misc>
+#include <ETL/stringf>
 
 #endif
 
@@ -147,15 +148,29 @@ ValueNode_Real::operator()(Time t)const
 	throw runtime_error(get_local_name()+_(":Bad type ")+get_type().description.local_name);
 }
 
-synfig::ValueBase
-synfig::ValueNode_Real::get_inverse(Time /*t*/, const synfig::Angle &target_value) const
+LinkableValueNode::InvertibleStatus
+ValueNode_Real::is_invertible(const Time& t, const ValueBase& target_value, int* link_index) const
 {
-	return (float)Angle::deg(target_value).get();
+	if (!t.is_valid())
+		return INVERSE_ERROR_BAD_TIME;
+
+	const Type& type = target_value.get_type();
+	if (type != type_angle)
+		return INVERSE_ERROR_BAD_TYPE;
+
+	if (link_index)
+		*link_index = get_link_index_from_name("link");
+	return INVERSE_OK;
 }
 
-
-
-
+synfig::ValueBase
+synfig::ValueNode_Real::get_inverse(const Time& /*t*/, const synfig::ValueBase &target_value) const
+{
+	const Type& target_type = target_value.get_type();
+	if (target_type == type_angle)
+		return Angle::deg(target_value.get(Angle())).get();
+	throw runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Invalid value type")));
+}
 
 bool
 ValueNode_Real::check_type(Type &type)

--- a/synfig-core/src/synfig/valuenodes/valuenode_real.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.h
@@ -56,8 +56,11 @@ public:
 	virtual String get_name()const;
 	virtual String get_local_name()const;
 
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse()
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
 	//! Returns the modified Link to match the target value at time t
-	ValueBase get_inverse(Time t, const synfig::Angle &target_value) const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
 
 	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_scale.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_scale.cpp
@@ -148,49 +148,47 @@ synfig::ValueNode_Scale::operator()(Time t)const
 }
 
 synfig::ValueBase
-synfig::ValueNode_Scale::get_inverse(Time t, const synfig::Vector &target_value) const
+synfig::ValueNode_Scale::get_inverse(const Time& t, const synfig::ValueBase &target_value) const
 {
 	Real scalar_value((*scalar)(t).get(Real()));
-	if(scalar_value==0)
-			throw runtime_error(strprintf("ValueNode_Scale: %s",_("Attempting to get the inverse of a non invertible Valuenode")));
-	else
-		{
-			if (get_type() == type_real)
-				return target_value.mag() / scalar_value;
-			if (get_type() == type_angle)
-				return Angle::tan(target_value[1] / scalar_value ,target_value[0] / scalar_value);
-			return target_value / scalar_value;
-		}
-	return ValueBase();
+	if(approximate_zero(scalar_value))
+		throw runtime_error(strprintf("ValueNode_%s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Scalar is zero")));
+	const Type& target_type = target_value.get_type();
+	if (target_type == type_real)
+		return target_value.get(Real()) / scalar_value;
+	if (target_type == type_angle)
+		return target_value.get(Angle()) / scalar_value;
+	if (target_type == type_vector) {
+		Vector target_vector = target_value.get(Vector());
+		if (get_type() == type_real)
+			return target_vector.mag() / scalar_value;
+		if (get_type() == type_angle)
+			return Angle::tan(target_vector[1] / scalar_value ,target_vector[0] / scalar_value);
+		return target_vector / scalar_value;
+	}
+	throw runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Invalid value type")));
 }
 
-synfig::ValueBase
-synfig::ValueNode_Scale::get_inverse(Time t, const synfig::Angle &target_value) const
+LinkableValueNode::InvertibleStatus
+synfig::ValueNode_Scale::is_invertible(const Time& t, const ValueBase& target_value, int* link_index) const
 {
-	Real scalar_value((*scalar)(t).get(Real()));
-	if(scalar_value==0)
-		throw runtime_error(strprintf("ValueNode_Scale: %s",_("Attempting to get the inverse of a non invertible Valuenode")));
-	else
-		return target_value / scalar_value;
-	return ValueBase();
-}
+	if (!t.is_valid())
+		return INVERSE_ERROR_BAD_TIME;
 
-synfig::ValueBase
-synfig::ValueNode_Scale::get_inverse(Time t, const synfig::Real &target_value) const
-{
 	Real scalar_value((*scalar)(t).get(Real()));
-	if(scalar_value==0)
-		throw runtime_error(strprintf("ValueNode_Scale: %s",_("Attempting to get the inverse of a non invertible Valuenode")));
-	else
-		return target_value / scalar_value;
-	return ValueBase();
-}
+	if (approximate_zero(scalar_value)) {
+		if (link_index)
+			*link_index = get_link_index_from_name("scalar");
+		return INVERSE_ERROR_BAD_PARAMETER;
+	}
 
-bool
-synfig::ValueNode_Scale::is_invertible(Time t) const
-{
-	Real scalar_value((*scalar)(t).get(Real()));
-	return (!(scalar_value==0));
+	const Type& type = target_value.get_type();
+	if (type != type_real && type != type_angle && type != type_vector)
+		return INVERSE_ERROR_BAD_TYPE;
+
+	if (link_index)
+		*link_index = get_link_index_from_name("link");
+	return INVERSE_OK;
 }
 
 bool

--- a/synfig-core/src/synfig/valuenodes/valuenode_scale.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_scale.h
@@ -61,12 +61,11 @@ public:
 
 	virtual ValueBase operator()(Time t)const;
 
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse()
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
 	//! Returns the modified Link to match the target value at time t
-	ValueBase get_inverse(Time t, const synfig::Vector &target_value) const;
-	ValueBase get_inverse(Time t, const synfig::Angle &target_value) const;
-	ValueBase get_inverse(Time t, const synfig::Real &target_value) const;
-
-	bool is_invertible(Time t)const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
 
 	virtual String get_name()const;
 

--- a/synfig-studio/src/synfigapp/actions/valuedescset.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescset.cpp
@@ -543,77 +543,6 @@ Action::ValueDescSet::prepare()
 
 	// Perform reverse manipulations
 
-	// If we are a scale value node, then edit the link
-	// such that it will scale to our target value
-	if (ValueNode_Scale::Handle scale_value_node = ValueNode_Scale::Handle::cast_dynamic(value_desc.get_value_node()))
-	{
-		if(! scale_value_node->is_invertible(time))
-		{
-			synfig::warning(_("Attempt to edit scale ValueNode with a scale factor of zero."));
-			return;
-		}
-		ValueBase new_value;
-		if (value.get_type() == type_angle)
-			new_value = scale_value_node->get_inverse(time, value.get(Angle()));
-		else if(value.get_type() == type_vector)
-			new_value = scale_value_node->get_inverse(time, value.get(Vector()));
-		else if(value.get_type() == type_real)
-			new_value = scale_value_node->get_inverse(time, value.get(Real()));
-		else
-			throw Error(_("Inverse manipulation of %s scale values not implemented in core."), value.type_name().c_str());
-		add_action_valuedescset(new_value,ValueDesc(scale_value_node, scale_value_node->get_link_index_from_name("link")));
-		return;
-	}
-    // Range: disallow values outside the range
-	if (ValueNode_Range::Handle range_value_node = ValueNode_Range::Handle::cast_dynamic(value_desc.get_value_node()))
-	{
-		ValueBase new_value;
-		if (value.get_type() == type_angle)
-			new_value = range_value_node->get_inverse(time, value.get(Angle()));
-		else
-			throw Error(_("Inverse manipulation of %s range values not implemented in core."), value.type_name().c_str());
-		add_action_valuedescset(new_value,ValueDesc(range_value_node,range_value_node->get_link_index_from_name("link")));
-		return;
-	}
-	// Integer: integer values only
-	if (ValueNode_Integer::Handle integer_value_node = ValueNode_Integer::Handle::cast_dynamic(value_desc.get_value_node()))
-	{
-		ValueBase new_value;
-		if (value.get_type() == type_angle)
-			new_value = integer_value_node->get_inverse(time, value.get(Angle()));
-		else if(value.get_type() == type_real)
-			new_value = integer_value_node->get_inverse(time, value.get(Real()));
-		else
-			throw Error(_("Inverse manipulation of %s integer values not implemented in core."), value.type_name().c_str());
-		add_action_valuedescset(new_value,ValueDesc(integer_value_node,integer_value_node->get_link_index_from_name("link")));
-		return;
-	}
-	// Add value node
-	if (ValueNode_Add::Handle add_value_node = ValueNode_Add::Handle::cast_dynamic(value_desc.get_value_node()))
-	{
-		ValueBase new_value;
-		if (value.get_type() == type_angle)
-			new_value = add_value_node->get_inverse(time, value.get(Angle()));
-		else if(value.get_type() == type_real)
-			new_value = add_value_node->get_inverse(time, value.get(Real()));
-		else if(value.get_type() == type_vector)
-			new_value = add_value_node->get_inverse(time, value.get(Vector()));
-		else
-			throw Error(_("Inverse manipulation of %s add values not implemented in core."), value.type_name().c_str());
-		add_action_valuedescset(new_value,ValueDesc(add_value_node,add_value_node->get_link_index_from_name("lhs")));
-		return;
-	}
-	// Real: Reverse manipulations for Real->Angle convert
-	if (ValueNode_Real::Handle real_value_node = ValueNode_Real::Handle::cast_dynamic(value_desc.get_value_node()))
-	{
-		ValueBase new_value;
-		if (value.get_type() == type_angle)
-			new_value = real_value_node->get_inverse(time, value.get(Angle()));
-		else
-			throw Error(_("Inverse manipulation of %s real values not implemented in core."), value.type_name().c_str());
-		add_action_valuedescset(new_value,ValueDesc(real_value_node,real_value_node->get_link_index_from_name("link")));
-		return;
-	}
 	// BlineCalcWidth: modify the scale value node
 	// so that the target width is achieved
 	if (ValueNode_BLineCalcWidth::Handle bline_width = ValueNode_BLineCalcWidth::Handle::cast_dynamic(value_desc.get_value_node()))
@@ -785,6 +714,41 @@ Action::ValueDescSet::prepare()
 					return;
 				}
 			}
+		}
+	}
+
+	// Linkable value nodes has methods to do reverse manipulations
+	if (LinkableValueNode::Handle linkable_value_node = LinkableValueNode::Handle::cast_dynamic(value_desc.get_value_node()))
+	{
+		int link_index;
+		LinkableValueNode::InvertibleStatus invertible = linkable_value_node->is_invertible(time, value, &link_index);
+		switch (invertible) {
+		case synfig::LinkableValueNode::INVERSE_OK: {
+			ValueBase new_value = linkable_value_node->get_inverse(time, value);
+			add_action_valuedescset(new_value,ValueDesc(linkable_value_node, link_index));
+			return;
+		}
+		case synfig::LinkableValueNode::INVERSE_NOT_SUPPORTED:
+			throw Error(_("Inverse manipulation of valuenode '%s' is not supported."),
+			            linkable_value_node->get_type().description.local_name.c_str());
+		case synfig::LinkableValueNode::INVERSE_ERROR_BAD_TYPE:
+			throw Error(_("Inverse manipulation of valuenode '%s' with %s values is not implemented."),
+			            linkable_value_node->get_type().description.local_name.c_str(),
+			            value.type_name().c_str());
+		case synfig::LinkableValueNode::INVERSE_ERROR_BAD_VALUE:
+			throw Error(_("Inverse manipulation of valuenode '%s' is not possible for value %s."),
+			            linkable_value_node->get_type().description.local_name.c_str(),
+			            value.get_string().c_str());
+		case synfig::LinkableValueNode::INVERSE_ERROR_BAD_TIME:
+			throw Error(_("Inverse manipulation of valuenode '%s' is not possible at current time point %s."),
+			            linkable_value_node->get_type().description.local_name.c_str(),
+			            time.get_string(Time::FORMAT_NORMAL).c_str());
+		case synfig::LinkableValueNode::INVERSE_ERROR_BAD_PARAMETER:
+			throw Error(_("Attempt to edit valuenode '%s' is not possible due to another parameter of valuenode: %s."),
+			            linkable_value_node->get_type().description.local_name.c_str(),
+			            link_index >= 0 && link_index < linkable_value_node->link_count() ?
+			                linkable_value_node->link_local_name(link_index).c_str()
+			              : _("unknown parameter (please report)"));
 		}
 	}
 


### PR DESCRIPTION
Instead of limiting get_inverse() method to only a few valuenodes,
and to let synfigapp action ValueDescSet more generalistic,
LinkableValueNode now has to two methods to provide the inverse
transformation of a value.