### PR TITLE
Fix various typos

### DIFF
--- a/3-package-osx-dmg.sh
+++ b/3-package-osx-dmg.sh
@@ -354,7 +354,7 @@ get_version_release_string()
 		VERSION=${VERSION%%-*}
 	fi
 	if [ ! -z $BREED ]; then
-		BREED=`echo $BREED | tr _ . | tr - .`	# No "-" or "_" characters, becuse RPM and DEB complain
+		BREED=`echo $BREED | tr _ . | tr - .`	# No "-" or "_" characters, because RPM and DEB complain
 		BREED=.$BREED
 	fi
 	REVISION=`git show --pretty=format:%ci HEAD |  head -c 10 | tr -d '-'`

--- a/autobuild/fedora-crosscompile-linux.sh
+++ b/autobuild/fedora-crosscompile-linux.sh
@@ -140,7 +140,7 @@ if [[ ${VERSION##*-RC} != ${VERSION} ]]; then
 	VERSION=${VERSION%%-*}
 fi
 [[ $DEBUG == 1 ]] && BREED=${BREED}.dbg
-BREED=`echo $BREED | tr _ . | tr - .`	# No "-" or "_" characters, becuse RPM and DEB complain
+BREED=`echo $BREED | tr _ . | tr - .`	# No "-" or "_" characters, because RPM and DEB complain
 
 popd > /dev/null
 

--- a/autobuild/synfigstudio-osx-build.sh
+++ b/autobuild/synfigstudio-osx-build.sh
@@ -546,7 +546,7 @@ get_version_release_string()
 		VERSION=${VERSION%%-*}
 	fi
 	if [ ! -z $BREED ]; then
-		BREED=`echo $BREED | tr _ . | tr - .`	# No "-" or "_" characters, becuse RPM and DEB complain
+		BREED=`echo $BREED | tr _ . | tr - .`	# No "-" or "_" characters, because RPM and DEB complain
 		BREED=.$BREED
 	fi
 	REVISION=`git show --pretty=format:%ci HEAD |  head -c 10 | tr -d '-'`

--- a/synfig-core/NEWS
+++ b/synfig-core/NEWS
@@ -12,13 +12,13 @@
   * Major cleanup of code responsible for sound playback, fixed non-working volume parameter and eliminated synchronization issues.
   * Advanced Outline Layer: Added two new types of tips - "Off-Peak Stop" and "Inner Rounded Stop". They can be used to define outline start/end and dashes.
   * Switch Layer: Now it is possible to select visible layer by index (see "Active Layer Depth" parameter).
-  * Rectangle Layer: now it is posible to define two types of rounded corners and horizontal/vertical feather.
+  * Rectangle Layer: now it is possible to define two types of rounded corners and horizontal/vertical feather.
   * Filled Rectangle Layer deprecated.
   * Changed Gamma handling: Global Gamma option removed, Gamma is now defined on per-document basis, default gamma value = 1.0, for old documents it is set to 2.2.
   * Fixed behavior “Local Time” parameter of Time Loop layer (issue #479).
   * DashItem Offset and Length parameters now use consistent units when editing them (issue #1265).
   * Fixed issues opening and exporting of files with multibyte (i.e. Arabic) symbols in filename.
-  * Homogenous parameter of Advanced Outline is enabled and static by default.
+  * Homogeneous parameter of Advanced Outline is enabled and static by default.
   * Set Animation Speed parameter of Noise Distort Layer as static by default.
   * Fixed crash when exporting with “pngspritesheet” target (issue #356).
   * Fixed crash when removing spline vertex too fast.
@@ -115,7 +115,7 @@
  0.64.0 (git tag "synfig-0.64.0") - May 06 2013 - Major features, bug fixes.
  
   * New CLI based on boost libraries. 
-  * New pluging system
+  * New plugin system
   * New Cairo render engine
   * Terminology renaming
   * Keyframes can now be enabled and disabled
@@ -152,7 +152,7 @@
   * Support to create Advanced Outlines with the Draw Tool.
   * Fixed script to generate synfig API.
   * Added two new parameters to the WidthPoint class. Lower Boundary and Upper Boundary
-    They define the lower and upper boundaries value of the widhtpoint position
+    They define the lower and upper boundaries value of the widthpoint position
     When placed at start and end of the BLine. By default lower = 0.0 and upper = 1.0
     Lower boundary must be always smaller than Upper boundary.
     As parameters they cannot be exported, converted or animated.

--- a/synfig-core/m4/ax_boost_base.m4
+++ b/synfig-core/m4/ax_boost_base.m4
@@ -10,7 +10,7 @@
 #
 #   Test for the Boost C++ libraries of a particular version (or newer)
 #
-#   If no path to the installed boost library is given the macro searchs
+#   If no path to the installed boost library is given the macro searches
 #   under /usr, /usr/local, /opt and /opt/local and evaluates the
 #   $BOOST_ROOT environment variable. Further documentation is available at
 #   <http://randspringer.de/boost/index.html>.
@@ -98,7 +98,7 @@ if test "x$want_boost" = "xyes"; then
     esac
 
     dnl first we check the system location for boost libraries
-    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl this location is chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM
     if test "$ac_boost_path" != ""; then
         BOOST_CPPFLAGS="-I$ac_boost_path/include"

--- a/synfig-core/src/modules/lyr_std/perspective.cpp
+++ b/synfig-core/src/modules/lyr_std/perspective.cpp
@@ -799,7 +799,7 @@ namespace {
 					li->alpha_matrix
 				  * from_pixels_matrix;
 				
-				// trucate rect by sub_task rect
+				// truncate rect by sub_task rect
 				rect_float &= TransformationPerspective::transform_bounds_perspective(
 						matrix.get_inverted(),
 						rendering::Transformation::Bounds(

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -673,7 +673,7 @@ Layer::hit_check(synfig::Context context, const synfig::Point &pos)const
 	return context.hit_check(pos);
 }
 
-// Temporary function to render transformed layer for layers which yet not suppurt transformed rendering
+// Temporary function to render transformed layer for layers which yet not support transformed rendering
 #ifdef _DEBUG
 bool
 Layer::render_transformed(const Layer *layer, Context context,Surface *surface,int quality, const RendDesc &renddesc, ProgressCallback *cb, const char *file, int line)

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -585,7 +585,7 @@ public:
 	virtual Color get_color(Context context, const Point &pos)const;
 	virtual CairoColor get_cairocolor(Context context, const Point &pos)const;
 
-	// Temporary function to render transformed layer for leyers which yet not suppurt transformed rendering
+	// Temporary function to render transformed layer for layers which yet not support transformed rendering
 	static bool render_transformed(const Layer *layer, Context context,Surface *surface,int quality, const RendDesc &renddesc, ProgressCallback *cb, const char *file, int line);
 
 	//! Renders the Canvas to the given Surface in an accelerated manner

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -3015,7 +3015,7 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 					// the layer linked it
 					if(!layer->set_param(param_name,data))
 					{
-						// TODO(ice0): Add normal version comparision function (check glib)
+						// TODO(ice0): Add normal version comparison function (check glib)
 						// TODO(ice0): Remove stubs after updating image files (.sif)
 						if (param_name == "loopyness" && layer->get_name() == "outline" && (layer->get_version() == "0.3")) {
 							continue;

--- a/synfig-core/src/synfig/module.h
+++ b/synfig-core/src/synfig/module.h
@@ -214,7 +214,7 @@ class Module : public etl::shared_object
 public:
 	//! The initializer of the module. Default implementation does nothing
 	virtual bool constructor_(synfig::ProgressCallback */*cb*/) { return true; }
-	//! The module cleanup funtion
+	//! The module cleanup function
 	virtual void destructor_() { }
 
 	typedef etl::handle<Module> Handle;

--- a/synfig-core/src/synfig/target.h
+++ b/synfig-core/src/synfig/target.h
@@ -234,7 +234,7 @@ public:
 	//!	Sets the time for the next frame at \a time
 	/*! It modifies the curr_frame_ member which has to be set to zero when next_frame is called for the first time
 	 ** \param time The time reference to be modified
-	 **	\return The number of remainig frames to render
+	 **	\return The number of remaining frames to render
 	 **	\sa curr_frame_
 	*/
 	virtual int	next_frame(Time& time);

--- a/synfig-core/src/synfig/value.h
+++ b/synfig-core/src/synfig/value.h
@@ -141,7 +141,7 @@ public:
 
 public:
 
-	//! Template for the operator assigment operator for non ValueBase classes
+	//! Template for the operator assignment operator for non ValueBase classes
 	//! \see set()
 	template <class T> ValueBase& operator=(const T& x)
 		{ set(x); return *this; }

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -948,7 +948,7 @@ ValueNode_BLine::get_blinepoint(std::vector<ListEntry>::const_iterator current, 
 	Vector tt1,tt2; // Calculated tangents
 	Point v,vn,vp; // Transformed current Vertex, next Vertex, previous Vertex
 	Point vs,vns,vps; // Setup current Vertex, next Vertex, previous Vertex
-	Angle beta1,beta2; //Final angle of tangents (trasformed)
+	Angle beta1,beta2; //Final angle of tangents (transformed)
 	Angle beta01,beta02; //Original angle of tangnets (untransformed)
 	Angle alpha; // Increment of angle produced in the segment next-previous
 	Angle gamma; // Compensation due to the variation relative to the midpoint.

--- a/synfig-studio/NEWS
+++ b/synfig-studio/NEWS
@@ -13,7 +13,7 @@
   * Transformation widget got a special control point to easily change origin of transformation.
   * New "Bake" command allow to bake animation for any parameter.
   * Now it is possible to open images in external editor (right click -> "Edit image in external tool...").
-  * Workspace layout cna be saved ("Workspace" - "Save workspace"/"Edit workspace list..." menu commands).
+  * Workspace layout can be saved ("Workspace" - "Save workspace"/"Edit workspace list..." menu commands).
   * Hovering mouse cursor over timetrack now shows frame preview.
   * Now it is possible to select playback range on the timeline and make playback looped.
   * Workarea handles now hidden during playback.
@@ -98,7 +98,7 @@
   * Tooltips for group transformation widget. Thanks to Jerome Blanchi.
   * Completely reworked preferences dialogue. Thanks to Yu Chen (concept), Jerome Blanchi (implementation) and Caryoscelus (fixes).
   * Fixed behavior of “Insert Item” action for Splines (it should be different from “Insert item & Keep shape” action). Thanks to Ivan Mahonin.
-  * Fix crash when manipulating with guides. Alow to remove guides by dragging them back to onto rulers. Thanks to Jerome Blanchi.
+  * Fix crash when manipulating with guides. Allow to remove guides by dragging them back to onto rulers. Thanks to Jerome Blanchi.
   * Zoom level now can be edited via dedicated widget in the bottom-left corner of Canvas Window. Thanks to Caryoscelus.
   * Now it is possible to hide File buttons on the toolbar to save horizontal space. Available via “Edit” -> “Preferences” -> “Preferences”. Thanks to Caryoscelus.
   * Fixed readability of “Current Time” text widget when using dark theme. Thanks to Chris London.
@@ -120,7 +120,7 @@
  1.0.1 (git tag "1.0.1") - July 21, 2015 - Bugfix release.
  
   * Fix switching bone parent.
-  * Interactively highlight handles during bouding box selection.
+  * Interactively highlight handles during bounding box selection.
   * Update icons for "New", "Open", "Save/As/All" and "Undo/Redo".
   * Keyframes widget: Double click opens keyframe properties dialog box.
   * Keyframe properties dialog: Show keyframe description and active status.
@@ -189,10 +189,10 @@
 
  0.64.0 (git tag "synfigstudio-0.64.0") - May 06, 2013 - Major features, bug fixes.
 
-  * New pluging system
+  * New plugin system
   * New Cairo render engine
   * Terminology renaming
-  * Traslation is now handled by intltool
+  * Translation is now handled by intltool
   * Keyframes can now be enabled and disabled
   * New sequence separator option
   * Fix bug ID: 2684968: render is one frame short.
@@ -222,7 +222,7 @@
  ** Rewording some UI strings
  * New Outline Grow parameter on Paste Canvas layer. For inline canvases it increases (decreases) the width of the children layers by a exponential factor.
  * Support for load Gimp palettes. Patch thanks to Bretrand Gregoire.
- * Improve constrast on color sliders for Color Edit and Gradient Edit widgets. Patch thanks to Bertrand Gregoire
+ * Improve contrast on color sliders for Color Edit and Gradient Edit widgets. Patch thanks to Bertrand Gregoire
  * Rename icon source from zoom to scale. Patch thanks to Bertrand Gregoire
 
  0.63.04 (git tag: "synfigstudio-0.63.04") - February 08, 2012 - Features, bug fixes.
@@ -247,7 +247,7 @@
   * Fix bug https://pivotaltracker.com/story/show/18136743: BLine linked objects get wrong initial position
   * Use Gtk::Tooltip instead of deprecated Gtk::Tooltips. This fully fix tooltips for Layer parameter panel.
   * When modify a value that has a waypoint at the current time, don't modify its interpolations, only the value.
-  * Widhtpoint position duck now allows 'Edit Waypoint' contextual menu.
+  * Widthpoint position duck now allows 'Edit Waypoint' contextual menu.
   * Add feature to delete multiple vertices at the same time on blines and other list types.
   * Enum Widget allows icons now. Add icons to Default Interpolation widget.
   * Insert Item smart is allowed now over empty lists.
@@ -265,7 +265,7 @@
   * Add undo capability for guides.
   * Snap to guides is now relative to zoom.
   * OptionMenu (deprecatd) has been replaced by ComboBox.
-  * When change the Setup Dialog, spread it inmediately to the canvas's rules.
+  * When change the Setup Dialog, spread it immediately to the canvas's rules.
   * Circle, Rectangle, Star and Polygon Tools allows create Advanced Outlines Layers.
   * Linked to BLine has the option of be curve length based. On by default.
   * New icons for canvas navigation, preview, render and animate mode buttons.
@@ -277,7 +277,7 @@
  0.63.00 (git tag: "synfigstudio-0.63.00") - June 5, 2011 - Bug fixes, major features
 
   * Fix bug #31044763: fps rounding to integer.
-  * Fix bug: Change default bline width spin button widthout first focus a canvas
+  * Fix bug: Change default bline width spin button without first focus a canvas
     produces undesired changes to the width size.
   * Fix tool tips for layer parameters and add tool tip support for linkable
     value node parameters.
@@ -376,7 +376,7 @@
   * Input Device configuration can be saved/loaded now.
   * Fill/Outline instead of Background/Foreground.
   * Additions to the Canvas Window: Update Zoom Dial, Frame Dial, Keyframe Dial
-    Toogle Ducks Dial, Resolution Dial, Quality Butons, Show/Snap to Grid,
+    Toggle Ducks Dial, Resolution Dial, Quality Buttons, Show/Snap to Grid,
     Onion Skinning buttons.
   * Past and future onion skins enabled and selectable.
   * Improved UI on crash recovery dialog.

--- a/synfig-studio/plugins/lottie-exporter/common/Param.py
+++ b/synfig-studio/plugins/lottie-exporter/common/Param.py
@@ -212,7 +212,7 @@ class Param:
         if self.param.tag in settings.BONES or self.param[0].tag in settings.CONVERT_METHODS:
             self.extract_subparams()
 
-            if self.param.tag == "bone":  # Carefull about param[0] and param here
+            if self.param.tag == "bone":  # Careful about param[0] and param here
 
                 # Get the animation of this origin
                 bone_origin, eff_1 = self.subparams["origin"].recur_animate("vector")

--- a/synfig-studio/plugins/lottie-exporter/common/misc.py
+++ b/synfig-studio/plugins/lottie-exporter/common/misc.py
@@ -388,7 +388,7 @@ def get_vector(waypoint):
 
 def radial_to_tangent(radius, angle):
     """
-    Converts a tangent from radius and angle format to x, y axis co-ordinate
+    Converts a tangent from radius and angle format to x, y axis coordinate
     system
 
     Args:

--- a/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/offsetKeyframe.py
@@ -84,9 +84,9 @@ def clamped_vector(p1, p2, p3, animated, i, lottie, ease):
     when clamped waypoints are used
 
     Args:
-        p1       (common.Vector.Vector)         : First point in Co-ordinate System
-        p2       (common.Vector.Vector)         : Second point in Co-ordinate System
-        p3       (common.Vector.Vector)         : Third point in Co-ordinate System
+        p1       (common.Vector.Vector)         : First point in Coordinate System
+        p2       (common.Vector.Vector)         : Second point in Coordinate System
+        p3       (common.Vector.Vector)         : Third point in Coordinate System
         animated (lxml.etree._Element) : Synfig format animation
         i        (int)                 : Iterator over animation
         ease     (str)                 : Specifies if it is an ease in animation ease out

--- a/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/shapePropKeyframe/helper.py
@@ -237,7 +237,7 @@ def insert_dict_at(lottie, idx, fr, loop,constant=False):
 
     Args:
         lottie (dict) : Shape layer will be stored in this main dictionary
-        idx    (int)  : index at which dicionary needs to be stored
+        idx    (int)  : index at which dictionary needs to be stored
         fr     (int)  : frame number
         loop   (bool) : Specifies if the shape is loop or not
 

--- a/synfig-studio/plugins/lottie-exporter/properties/valueKeyframe.py
+++ b/synfig-studio/plugins/lottie-exporter/properties/valueKeyframe.py
@@ -16,8 +16,8 @@ def normalize_tangents(cur_pos, next_pos, t_in, t_out):
     Converts the tangents from arbitrary range to the range of 0-1
 
     Args:
-        cur_pos  (common.Vector.Vector) : Current position in co-ordinate system
-        next_pos (common.Vector.Vector) : Next position in co-ordinate system
+        cur_pos  (common.Vector.Vector) : Current position in coordinate system
+        next_pos (common.Vector.Vector) : Next position in coordinate system
         t_in     (dict)        : In tangent in Lottie format
         t_out    (dict)        : Out tangent in Lottie format
 
@@ -159,8 +159,8 @@ def set_tangents(out_val, in_val, cur_pos, next_pos, lottie, animated):
     Args:
         out_val   (common.Vector.Vector)         : Tangent out value
         in_val    (common.Vector.Vector)         : Tangent in value
-        cur_pos   (common.Vector.Vector)         : Current position in co-ordinate system
-        next_pos  (common.Vector.Vector)         : Next position in co-ordinate system
+        cur_pos   (common.Vector.Vector)         : Current position in coordinate system
+        next_pos  (common.Vector.Vector)         : Next position in coordinate system
         lottie    (dict)                : bezier interval in lottie format
         animation (lxml.etree._Element) : Synfig format animation
 

--- a/synfig-studio/plugins/lottie-exporter/shapes/gFill.py
+++ b/synfig-studio/plugins/lottie-exporter/shapes/gFill.py
@@ -15,7 +15,7 @@ sys.path.append("..")
 
 def gen_radial_gradient(lottie, layer, idx):
     """
-    Generates the dictionary correspnding to shapes/gFill.json but with radial gradient
+    Generates the dictionary corresponding to shapes/gFill.json but with radial gradient
 
     Args:
     """

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -152,7 +152,7 @@ private:
 	//static etl::handle<synfigapp::UIInterface> ui_interface_;
 	//static int max_recent_files;
 
-/*      //declated as globals in app.cpp
+/*      //declared as globals in app.cpp
 	static Dock_Keyframes *dock_keyframes;
 	static Dock_Layers *dock_layers;
 	static Dock_Params *dock_params;
@@ -250,7 +250,7 @@ public:
 	/*
  -- ** -- S I G N A L S -------------------------------------------------------
 	*/
-/*      //declated as globals in app.cpp
+/*      //declared as globals in app.cpp
 	static sigc::signal<
 		void,
 		etl::loose_handle<CanvasView>

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -644,7 +644,7 @@ public:
 	//! Toggle between none/last visible handles
 	//! \Sa             DuckMatic::set_type_mask_state(), DuckMatic::get_type_mask_state()
 	void toggle_duck_mask_all();
-	// Toogle displaybar according to App::enable_mainwin_toolbar
+	// Toggle displaybar according to App::enable_mainwin_toolbar
 	void toggle_show_toolbar();
 
 	/*

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -630,7 +630,7 @@ Dialog_Setup::create_interface_page(PageInfo pi)
 	toggle_handle_tooltip_transfo_value.set_halign(Gtk::ALIGN_START);
 	toggle_handle_tooltip_transfo_value.set_hexpand(false);
 
-	//! change resume signal connexion
+	//! change resume signal connection
 	ui_language_combo.signal_changed().connect(
 			sigc::bind<int> (sigc::mem_fun(*this, &Dialog_Setup::on_value_change), CHANGE_UI_LANGUAGE));
 	toggle_use_dark_theme.property_active().signal_changed().connect(

--- a/synfig-studio/src/gui/exception_guard.h
+++ b/synfig-studio/src/gui/exception_guard.h
@@ -31,7 +31,7 @@
 ///     SYNFIG_EXCEPTION_GUARD_BEGIN()
 ///     ... code
 ///     ... code
-///     SYNFIG_EXCEPTION_GUARD_END_BOOL(true) // return true if successfull, false if it caught any exception
+///     SYNFIG_EXCEPTION_GUARD_END_BOOL(true) // return true if successful, false if it caught any exception
 /// }
 ///
 

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -2659,7 +2659,7 @@ StateDraw_Context::extend_bline_from_begin(ValueNode_BLine::Handle value_node,st
 				}
 			}
 		} // endif wplist_value_node exists
-	} // endif is avanced outline
+	} // endif is advanced outline
 
 	if (complete_loop)
 	{
@@ -2850,7 +2850,7 @@ StateDraw_Context::extend_bline_from_end(ValueNode_BLine::Handle value_node,std:
 				}
 			}
 		} // endif wplist_value_node exists
-	} // endif is avanced outline
+	} // endif is advanced outline
 
 	if (complete_loop)
 	{

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -2593,7 +2593,7 @@ StateLasso_Context::extend_bline_from_begin(ValueNode_BLine::Handle value_node,s
 				}
 			}
 		} // endif wplist_value_node exists
-	} // endif is avanced outline
+	} // endif is advanced outline
 
 	if (complete_loop)
 	{
@@ -2784,7 +2784,7 @@ StateLasso_Context::extend_bline_from_end(ValueNode_BLine::Handle value_node,std
 				}
 			}
 		} // endif wplist_value_node exists
-	} // endif is avanced outline
+	} // endif is advanced outline
 
 	if (complete_loop)
 	{

--- a/synfig-studio/src/gui/timemodel.h
+++ b/synfig-studio/src/gui/timemodel.h
@@ -175,7 +175,7 @@ public:
 
 	sigc::signal<void> signal_bounds_changed()      { return signal_bounds_changed_; }      // raises on bounds changed
 	sigc::signal<void> signal_visible_changed()     { return signal_visible_changed_; }     // raises on visible bounds changed
-	sigc::signal<void> signal_play_bounds_changed() { return signal_play_bounds_changed_; } // raises on play bounsd changed
+	sigc::signal<void> signal_play_bounds_changed() { return signal_play_bounds_changed_; } // raises on play bounds changed
 	sigc::signal<void> signal_time_changed()        { return signal_time_changed_; }        // raises on current time changed
 	sigc::signal<void> signal_play_time_changed()   { return signal_play_time_changed_; }   // raises on play time changed
 

--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -1147,7 +1147,7 @@ void Widget_Curves::ChannelPointSD::delta_drag(int total_dx, int total_dy, bool 
 	const Time deltatime = next_time - base_time;
 
 	if (deltatime != 0) {
-		// new dragging position allow us to restore previouly overlapped waypoints
+		// new dragging position allow us to restore previously overlapped waypoints
 		auto waypoints_to_restore = widget.overlapped_waypoints;
 		// let it store new overlapped waypoints until next drag motion
 		widget.overlapped_waypoints.clear();

--- a/synfig-studio/src/synfigapp/actions/valuedescbonesetparent.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescbonesetparent.cpp
@@ -219,6 +219,6 @@ Action::ValueDescBoneSetParent::undo() {
 			child_bone->set_link("angle",ValueNode_Const::create(angle));
 		}
 	}else{
-		get_canvas_interface()->get_ui_interface()->error("Could'nt find parent to active bone");
+		get_canvas_interface()->get_ui_interface()->error("Couldn't find parent to active bone");
 	}
 }

--- a/synfig-studio/src/synfigapp/settings.h
+++ b/synfig-studio/src/synfigapp/settings.h
@@ -72,7 +72,7 @@ public:
 	//! \brief Load optionally filtered settings from given synfig settings format filename
 	//! \return false if file open failed, else true. If key_filter is set, return false if value could not be loaded.
 	//! \sa		set_value
-	//! \Param[in] filename, the synfig settings format filename. Should be aboslute path.
+	//! \Param[in] filename, the synfig settings format filename. Should be absolute path.
 	//! \Param[in] key_filter, optional, string use to filter the settings key. No wildcard only full equal string test.
 	bool load_from_file(const synfig::String& filename, const synfig::String& key_filter = "" );
 	bool save_to_file(const synfig::String& filename)const;

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
@@ -66,7 +66,7 @@ float h_factor = 1;
 float w_factor = 1;
 /* === P R O C E D U R E S ================================================= */
 
-// this function will be responsible for unit conversion and height, width tranformation
+// this function will be responsible for unit conversion and height, width transformation
 void PreProcessSegment(studio::PointList &segment)
 {
   int size = segment.size();

--- a/synfig-studio/test/app_layerduplicate.cpp
+++ b/synfig-studio/test/app_layerduplicate.cpp
@@ -856,9 +856,9 @@ int main()
 	}
 
 	if (exception_thrown)
-		synfig::error("Test interrupted due to an execption thrown (%i errors and %i successfull tests until then)", failures, successes);
+		synfig::error("Test interrupted due to an exception thrown (%i errors and %i successful tests until then)", failures, successes);
 	else if (failures)
-		synfig::error("Test finished with %i errors and %i successfull tests", failures, successes);
+		synfig::error("Test finished with %i errors and %i successful tests", failures, successes);
 	else
 		synfig::info("Success");
 


### PR DESCRIPTION
Found via `codespell -q 3 -L aline,ang,ba,childs,eiter,forse,objext,pevent,shouldbe,thru,uint,unselect,vertexes --skip="./synfig-studio/po,./synfig-core/po,/synfig-core/m4,./synfig-osx/,./gtkmm-osx,./bugs,.*.eps,*.sif"`