### PR TITLE
[Synfig Studio] Improve Skeleton toolbox layout

### DIFF
--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -109,7 +109,7 @@ class studio::StateBone_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	// holder of optons
-	Gtk::Grid options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -121,6 +121,7 @@ class studio::StateBone_Context : public sigc::trackable
 
 	//  bone width
 	Gtk::Label bone_width_label;
+	Gtk::HBox skel_box;
 	Widget_Distance skel_bone_width_dist;
 	Widget_Distance skel_deform_bone_width_dist;
 
@@ -363,7 +364,7 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	/*setting up the tool options menu*/
 
 	// 0, title
-	title_label.set_label(_("Skeleton Creation"));
+	title_label.set_label(_("Skeleton Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
@@ -373,6 +374,9 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
 	id_label.set_alignment(Gtk::ALIGN_START,Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
+	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
+	id_box.pack_start(id_entry);
 
 
 	// 2, Bone width
@@ -385,44 +389,44 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	skel_deform_bone_width_dist.set_range(0,10000000);
 	skel_deform_bone_width_dist.set_sensitive(true);
 
+	skel_box.pack_start(skel_bone_width_dist);
+	skel_box.pack_start(skel_deform_bone_width_dist);
+
 	load_settings();
 
 	// 4, Layer choice
-	layer_label.set_label(_("Layer to Create:"));
+	layer_label.set_label(_("Layer"));
 	layer_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-	layer_label.set_attributes(list);
-	layer_label.set_sensitive(true);
 	
 	create_layer.set_label(_("Create Layer"));
 	create_layer.set_alignment(Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
 	create_layer.set_sensitive(true);
 
 
-	// pack all options to the options_table
+	// pack all options to the options_grid
 
 	// 0, title
-	options_table.attach(title_label,0, 0,1,1);
+	options_grid.attach(title_label, 0, 0, 2, 1);
 	// 1, name
-	options_table.attach(id_label,0, 1,1,1);
-	options_table.attach(id_entry,2, 1,3,1);
+	options_grid.attach(id_box, 0, 1, 2, 1);
 	// 2, default bone width
-	options_table.attach(bone_width_label,0,2,1,1);
-	options_table.attach(skel_bone_width_dist,2, 2,3,1);
-	options_table.attach(skel_deform_bone_width_dist,2, 2,3,1);
+	options_grid.attach(bone_width_label, 0, 2);
+	options_grid.attach(skel_box, 1, 2);
 	// 3, Layer choice
-	options_table.attach(layer_label,0, 4,1,1);
-	options_table.attach(radiobutton_skel,0, 5,2,1);
-	options_table.attach(radiobutton_skel_deform,2, 5,2,1);
-	options_table.attach(create_layer,2,6,2,1);
+	options_grid.attach(layer_label, 0, 3, 2, 1);
+	options_grid.attach(radiobutton_skel, 0, 4, 2, 1);
+	options_grid.attach(radiobutton_skel_deform, 0, 5, 2, 1);
+	options_grid.attach(create_layer, 0, 6, 2, 1);
 
 	create_layer.signal_clicked().connect(sigc::mem_fun(*this,&StateBone_Context::make_layer));
 	radiobutton_skel.signal_toggled().connect(sigc::mem_fun(*this,&StateBone_Context::update_layer));
 
 	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacing(GAP); // row gap
-	options_table.set_margin_bottom(0);
-	options_table.show_all();
+	options_grid.set_hexpand();
+	options_grid.set_border_width(GAP*2); // border width
+	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
 	skel_deform_bone_width_dist.hide();
 
@@ -485,7 +489,7 @@ void
 StateBone_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Skeleton Tool"));
 	App::dialog_tool_options->set_name("bone");
 

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -310,6 +310,9 @@ StateBone_Context::load_settings()
 			set_skel_deform_bone_width(Distance(atof(value.c_str()),Distance::SYSTEM_UNITS));
 		else
 			set_skel_deform_bone_width(Distance(DEFAULT_WIDTH,Distance::SYSTEM_UNITS)); // default width
+
+		layer_skel_flag = get_layer_skel_flag();
+		layer_skel_deform_flag = get_layer_skel_deform_flag();
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -410,8 +410,8 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	// 1, name
 	options_grid.attach(id_box, 0, 1, 2, 1);
 	// 2, default bone width
-	options_grid.attach(bone_width_label, 0, 2);
-	options_grid.attach(skel_box, 1, 2);
+	options_grid.attach(bone_width_label, 0, 2, 1, 1);
+	options_grid.attach(skel_box, 1, 2, 1, 1);
 	// 3, Layer choice
 	options_grid.attach(layer_label, 0, 3, 2, 1);
 	options_grid.attach(radiobutton_skel, 0, 4, 2, 1);

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -123,28 +123,23 @@ class studio::StateBone_Context : public sigc::trackable
 	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of optons
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
+	Gtk::Box id_box;
 
-	//  bone width
 	Gtk::Label bone_width_label;
-	Gtk::HBox skel_box;
 	Widget_Distance skel_bone_width_dist;
 	Widget_Distance skel_deform_bone_width_dist;
+	Gtk::Box skel_box;
 
-	// Layer Type
 	Gtk::Label layer_label;
 	Gtk::ToggleButton layer_skel_togglebutton;
 	Gtk::ToggleButton layer_skel_deform_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Box layer_types_box;
 
 public:
 	synfig::String get_id() const { return id_entry.get_text();}
@@ -424,10 +419,9 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
-
-	id_box.pack_start(id_entry);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*id_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_label.set_label(_("Layer Type:"));
 	layer_label.set_halign(Gtk::ALIGN_START);
@@ -439,9 +433,9 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 		("synfig-encapsulate_filter"), _("Skeleton Deform Layer"));
 
 	SPACING(layer_types_indent, INDENTATION);
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_skel_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_skel_deform_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_skel_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_skel_deform_togglebutton, false, false, 0);
 
 	bone_width_label.set_label(_("Bone Width:"));
 	bone_width_label.set_halign(Gtk::ALIGN_START);
@@ -453,8 +447,8 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	skel_deform_bone_width_dist.set_range(0,10000000);
 	skel_deform_bone_width_dist.set_sensitive(true);
 
-	skel_box.pack_start(skel_bone_width_dist);
-	skel_box.pack_start(skel_deform_bone_width_dist);
+	skel_box.pack_start(skel_bone_width_dist, true, true, 0);
+	skel_box.pack_start(skel_deform_bone_width_dist, true, true, 0);
 
 	load_settings();
 
@@ -477,6 +471,7 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	layer_skel_deform_togglebutton.signal_toggled().connect(
 		sigc::mem_fun(*this,&StateBone_Context::toggle_layer_skel_deform));
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -361,9 +361,8 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 
 	get_canvas_interface()->set_state("bone");
 
-	/*setting up the tool options menu*/
-
-	// 0, title
+	// Set up state_bone Toolbox window
+	// Title
 	title_label.set_label(_("Skeleton Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -371,15 +370,18 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	title_label.set_attributes(list);
 	title_label.set_alignment(Gtk::ALIGN_START,Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
+	// Layer name
 	id_label.set_label(_("Name:"));
 	id_label.set_alignment(Gtk::ALIGN_START,Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(id_entry);
 
+	// Layer type
+	layer_label.set_label(_("Layer Type:"));
+	layer_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
-	// 2, Bone width
+	// Layer settings
 	bone_width_label.set_label(_("Bone Width:"));
 	bone_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 	skel_bone_width_dist.set_digits(2);
@@ -394,28 +396,24 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 
 	load_settings();
 
-	// 4, Layer choice
-	layer_label.set_label(_("Layer"));
-	layer_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-	
+	// Create button
 	create_layer.set_label(_("Create Layer"));
 	create_layer.set_alignment(Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
 	create_layer.set_sensitive(true);
 
-
-	// pack all options to the options_grid
-
-	// 0, title
+	// Layout widgets in options_grid
+	// Title
 	options_grid.attach(title_label, 0, 0, 2, 1);
-	// 1, name
+	// Layer name
 	options_grid.attach(id_box, 0, 1, 2, 1);
-	// 2, default bone width
-	options_grid.attach(bone_width_label, 0, 2, 1, 1);
-	options_grid.attach(skel_box, 1, 2, 1, 1);
-	// 3, Layer choice
-	options_grid.attach(layer_label, 0, 3, 2, 1);
-	options_grid.attach(radiobutton_skel, 0, 4, 2, 1);
-	options_grid.attach(radiobutton_skel_deform, 0, 5, 2, 1);
+	// Layer type
+	options_grid.attach(layer_label, 0, 2, 2, 1);
+	options_grid.attach(radiobutton_skel, 0, 3, 2, 1);
+	options_grid.attach(radiobutton_skel_deform, 0, 4, 2, 1);
+	// Layer settings
+	options_grid.attach(bone_width_label, 0, 5, 1, 1);
+	options_grid.attach(skel_box, 1, 5, 1, 1);
+	// Create button
 	options_grid.attach(create_layer, 0, 6, 2, 1);
 
 	create_layer.signal_clicked().connect(sigc::mem_fun(*this,&StateBone_Context::make_layer));

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -219,29 +219,6 @@ public:
 	bool egress_on_selection_change;
 	Smach::event_result event_layer_selection_changed_handler(const Smach::event& /*x*/);
 
-	bool get_layer_skel_flag() const
-	{
-		return layer_skel_togglebutton.get_active();
-	}
-
-	void set_layer_skel_flag(bool x)
-	{
-		return layer_skel_togglebutton.set_active(x);
-	}
-
-	bool get_layer_skel_deform_flag() const
-	{
-		return layer_skel_deform_togglebutton.get_active();
-	}
-
-	void set_layer_skel_deform_flag(bool x)
-	{
-		return layer_skel_deform_togglebutton.set_active(x);
-	}
-
-	bool layer_skel_flag;
-	bool layer_skel_deform_flag;
-
 	void toggle_layer_skel();
 	void toggle_layer_skel_deform();
 }; // END of class StateBone_Context
@@ -287,14 +264,14 @@ StateBone_Context::load_settings()
 		}
 
 		if(settings.get_value("bone.layer_skel",value) && value=="0")
-			set_layer_skel_flag(false);
+			layer_skel_togglebutton.set_active(false);
 		else
-			set_layer_skel_flag(true);
+			layer_skel_togglebutton.set_active(true);
 
-		if(settings.get_value("bone.layer_skel_deform",value) && value =="0")
-			set_layer_skel_deform_flag(false);
+		if(settings.get_value("bone.layer_skel_deform",value) && value =="1")
+			layer_skel_deform_togglebutton.set_active(true);
 		else
-			set_layer_skel_deform_flag(true);
+			layer_skel_deform_togglebutton.set_active(false);
 
 		if(settings.get_value("bone.skel_bone_width",value) && !value.empty())
 			set_skel_bone_width(Distance(atof(value.c_str()),Distance::SYSTEM_UNITS));
@@ -305,9 +282,6 @@ StateBone_Context::load_settings()
 			set_skel_deform_bone_width(Distance(atof(value.c_str()),Distance::SYSTEM_UNITS));
 		else
 			set_skel_deform_bone_width(Distance(DEFAULT_WIDTH,Distance::SYSTEM_UNITS)); // default width
-
-		layer_skel_flag = get_layer_skel_flag();
-		layer_skel_deform_flag = get_layer_skel_deform_flag();
 	}
 	catch(...)
 	{
@@ -326,8 +300,8 @@ StateBone_Context::save_settings()
 		else
 			settings.set_value("bone.skel_deform_id",get_id().c_str());
 
-		settings.set_value("bone.layer_skel", get_layer_skel_flag() ? "1" : "0");
-		settings.set_value("bone.layer_skel_deform", get_layer_skel_deform_flag() ? "1" : "0");
+		settings.set_value("bone.layer_skel", layer_skel_togglebutton.get_active() ? "1" : "0");
+		settings.set_value("bone.layer_skel_deform", layer_skel_deform_togglebutton.get_active() ? "1" : "0");
 		settings.set_value("bone.skel_bone_width",skel_bone_width_dist.get_value().get_string());
 		settings.set_value("bone.skel_deform_bone_width",skel_deform_bone_width_dist.get_value().get_string());
 	}
@@ -1340,13 +1314,9 @@ StateBone_Context::_on_signal_value_desc_set(ValueDesc value_desc,ValueBase valu
 void
 StateBone_Context::toggle_layer_skel()
 {
-	if(!layer_skel_flag)
+	if(layer_skel_togglebutton.get_active())
 	{
-		set_layer_skel_flag(true);
-		set_layer_skel_deform_flag(false);
-
-		layer_skel_flag = true;
-		layer_skel_deform_flag = false;
+		layer_skel_deform_togglebutton.set_active(false);
 
 		save_settings();
 		c_layer = 0;
@@ -1354,21 +1324,17 @@ StateBone_Context::toggle_layer_skel()
 		load_settings();
 	}
 
-	if(get_layer_skel_flag() +
-	   get_layer_skel_deform_flag() == 0)
-		set_layer_skel_flag(true);
+	if(layer_skel_togglebutton.get_active() +
+	   layer_skel_deform_togglebutton.get_active() == 0)
+		layer_skel_togglebutton.set_active(true);
 }
 
 void
 StateBone_Context::toggle_layer_skel_deform()
 {
-	if(!layer_skel_deform_flag)
+	if(layer_skel_deform_togglebutton.get_active())
 	{
-		set_layer_skel_flag(false);
-		set_layer_skel_deform_flag(true);
-
-		layer_skel_flag = false;
-		layer_skel_deform_flag = true;
+		layer_skel_togglebutton.set_active(false);
 
 		save_settings();
 		c_layer = 1;
@@ -1376,7 +1342,7 @@ StateBone_Context::toggle_layer_skel_deform()
 		load_settings();
 	}
 
-	if(get_layer_skel_flag() +
-	   get_layer_skel_deform_flag() == 0)
-		set_layer_skel_deform_flag(true);
+	if(layer_skel_togglebutton.get_active() +
+	   layer_skel_deform_togglebutton.get_active() == 0)
+		layer_skel_deform_togglebutton.set_active(true);
 }

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -73,8 +73,9 @@ using namespace synfigapp;
 	name->set_size_request(px)
 #endif
 
-#define GAP	(3)
 #define DEFAULT_WIDTH (0.1)
+
+const int GAP = 3;
 
 /* === G L O B A L S ======================================================= */
 
@@ -361,29 +362,32 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 
 	get_canvas_interface()->set_state("bone");
 
-	// Set up state_bone Toolbox window
-	// Title
+	// Toolbox widgets
 	title_label.set_label(_("Skeleton Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START,Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// Layer name
 	id_label.set_label(_("Name:"));
-	id_label.set_alignment(Gtk::ALIGN_START,Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
+	SPACING(id_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
+	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
+
 	id_box.pack_start(id_entry);
 
-	// Layer type
 	layer_label.set_label(_("Layer Type:"));
-	layer_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	layer_label.set_halign(Gtk::ALIGN_START);
+	layer_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// Layer settings
 	bone_width_label.set_label(_("Bone Width:"));
-	bone_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bone_width_label.set_halign(Gtk::ALIGN_START);
+	bone_width_label.set_valign(Gtk::ALIGN_CENTER);
 	skel_bone_width_dist.set_digits(2);
 	skel_bone_width_dist.set_range(0,10000000);
 	skel_bone_width_dist.set_sensitive(true);
@@ -396,33 +400,26 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 
 	load_settings();
 
-	// Create button
-	create_layer.set_label(_("Create Layer"));
-	create_layer.set_alignment(Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
-	create_layer.set_sensitive(true);
+	// Toolbox layout
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_label,
+		0, 2, 2, 1);
+	options_grid.attach(radiobutton_skel,
+		0, 3, 2, 1);
+	options_grid.attach(radiobutton_skel_deform,
+		0, 4, 2, 1);
+	options_grid.attach(bone_width_label,
+		0, 5, 1, 1);
+	options_grid.attach(skel_box,
+		1, 5, 1, 1);
 
-	// Layout widgets in options_grid
-	// Title
-	options_grid.attach(title_label, 0, 0, 2, 1);
-	// Layer name
-	options_grid.attach(id_box, 0, 1, 2, 1);
-	// Layer type
-	options_grid.attach(layer_label, 0, 2, 2, 1);
-	options_grid.attach(radiobutton_skel, 0, 3, 2, 1);
-	options_grid.attach(radiobutton_skel_deform, 0, 4, 2, 1);
-	// Layer settings
-	options_grid.attach(bone_width_label, 0, 5, 1, 1);
-	options_grid.attach(skel_box, 1, 5, 1, 1);
-	// Create button
-	options_grid.attach(create_layer, 0, 6, 2, 1);
-
-	create_layer.signal_clicked().connect(sigc::mem_fun(*this,&StateBone_Context::make_layer));
 	radiobutton_skel.signal_toggled().connect(sigc::mem_fun(*this,&StateBone_Context::update_layer));
 
-	// fine-tune options layout
-	options_grid.set_hexpand();
-	options_grid.set_border_width(GAP*2); // border width
-	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
 
@@ -490,6 +487,16 @@ StateBone_Context::refresh_tool_options()
 	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Skeleton Tool"));
 	App::dialog_tool_options->set_name("bone");
+
+	App::dialog_tool_options->add_button(
+			Gtk::StockID("gtk-add"),
+			_("Create Layer")
+	)->signal_clicked().connect(
+			sigc::mem_fun(
+					*this,
+					&StateBone_Context::make_layer
+			)
+	);
 
 	App::dialog_tool_options->add_button(
 			Gtk::StockID("gtk-clear"),


### PR DESCRIPTION
Original layout:
![skeleton_tool_current](https://user-images.githubusercontent.com/6705690/112046877-dad37a80-8b4c-11eb-8d44-03f7486669d5.png)

Proposed layout:
![skeleton_tool_update](https://user-images.githubusercontent.com/6705690/112046900-e32bb580-8b4c-11eb-854e-558eb1814211.png)

We need to update also other tools to use Gtk::Grid instead of Gtk::Table which is now deprecated.