### PR TITLE
Resolve issue #2014 (CanvasProperties did not properly reset on delete)

### DIFF
--- a/synfig-studio/src/gui/dialogs/canvasproperties.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasproperties.cpp
@@ -128,7 +128,8 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	ok_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::CanvasProperties::on_ok_pressed));
 
 	get_vbox()->show_all();
-	refresh();
+	//refresh();
+	signal_show().connect(sigc::mem_fun(*this, &studio::CanvasProperties::refresh));
 
 	update_title();
 }


### PR DESCRIPTION
Refresh was being called by CanvasProperties directly rather than being connected to signal_show() as demonstrated in CanvasOptions.

This is my first pull request, so any feedback is appreciated.