### PR TITLE
[Synfig Studio] The canvas properties dialog now displays values correctly after being closed with the window close button.

### DIFF
--- a/synfig-studio/src/gui/dialogs/canvasproperties.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasproperties.cpp
@@ -128,7 +128,8 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	ok_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::CanvasProperties::on_ok_pressed));
 
 	get_vbox()->show_all();
-	refresh();
+	//refresh();
+	signal_show().connect(sigc::mem_fun(*this, &studio::CanvasProperties::refresh));
 
 	update_title();
 }

--- a/synfig-studio/src/gui/dialogs/canvasproperties.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasproperties.cpp
@@ -128,7 +128,6 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	ok_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::CanvasProperties::on_ok_pressed));
 
 	get_vbox()->show_all();
-	//refresh();
 	signal_show().connect(sigc::mem_fun(*this, &studio::CanvasProperties::refresh));
 
 	update_title();


### PR DESCRIPTION
Refresh was being called by CanvasProperties directly rather than being connected to signal_show() as demonstrated in CanvasOptions.

This is my first pull request, so any feedback is appreciated.