### PR TITLE
[Synfig Studio] Stop rendering button has been moved to the right of the progress bar

### DIFF
--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -157,30 +157,30 @@ studio::Dock_Info::Dock_Info()
 	// Render Progress Bar
 	Gtk::HBox *render_box = manage(new Gtk::HBox());
 	Gtk::Label *render_progress_label = manage(new Gtk::Label());
-	Gtk::Label *left_spacer_label = manage(new Gtk::Label());
+	Gtk::Overlay *overlay = manage(new Gtk::Overlay());
+
 	render_progress_label->set_markup(etl::strprintf("<b>%s</b>", _("Render Progress:")));
-	grid->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8, 1);
 
 	// Render progress CSS ID
 	render_progress.set_name("render-progress");
 	render_progress.set_hexpand(true);
 	render_progress.set_vexpand(false);
-	render_progress.set_show_text(true);
-	render_progress.set_text(strprintf("%.1f%%", 0.0));
+	render_progress.set_margin_end(5);
+	render_progress.set_valign(Gtk::ALIGN_CENTER);
 	render_progress.set_fraction(0.0);
 
+	render_percentage.set_text(strprintf("%.1f%%", 0.0));
+
+	overlay->add_overlay(render_progress);
+	overlay->add_overlay(render_percentage);
+
 	stop_button.set_image_from_icon_name("process-stop", Gtk::IconSize::from_name("synfig-small_icon"));
-	stop_button.set_hexpand(false);
-	stop_button.set_vexpand(false);
-	stop_button.set_valign(Gtk::ALIGN_END);
+	stop_button.set_valign(Gtk::ALIGN_CENTER);
 	stop_button.signal_clicked().connect(sigc::mem_fun(*this, &studio::Dock_Info::on_stop_button_clicked));
 
-	// Use this label to make sure layout is symmetric, 30 is the value used for render_progress height
-	left_spacer_label->set_size_request(30, 0);
-
-	render_box->pack_start(*left_spacer_label, false, true, 0);
-	render_box->pack_start(render_progress);
+	render_box->pack_start(*overlay);
 	render_box->pack_start(stop_button, Gtk::PACK_SHRINK);
+	grid->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8, 1);
 	grid->attach_next_to(*render_box, *render_progress_label, Gtk::POS_BOTTOM, 7, 1);
 
 	grid->set_margin_start(5);
@@ -249,7 +249,7 @@ void studio::Dock_Info::set_render_progress(float value)
 	float already_done = coeff * (float)(n_passes_requested - n_passes_pending -1); 
 	float r            = ( coeff * value ) + already_done;
 
-	render_progress.set_text( strprintf( "%.1f%%", r*100 ));
+	render_percentage.set_text(strprintf("%.1f%%", r*100));
 	render_progress.set_fraction(r);
 
 	if(r > 0.0 && r < 1.0)

--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -95,31 +95,31 @@ studio::Dock_Info::Dock_Info()
 {
 	set_use_scrolled(false);
 
-	Gtk::Grid *table = manage(new Gtk::Grid);
-	table->set_column_spacing(3);
+	Gtk::Grid *grid = manage(new Gtk::Grid);
+	grid->set_column_spacing(3);
 
-	//pos labels
+	// X and Y position labels
 	Gtk::Label *x_label = manage(new Gtk::Label());
 	x_label->set_markup(etl::strprintf("<b>%s</b>", _("X: ")));
 	x_label->set_hexpand(false);
 	Gtk::Label *y_label = manage(new Gtk::Label());
 	y_label->set_markup(etl::strprintf("<b>%s</b>", _("Y: ")));
 	y_label->set_hexpand(false);
-	table->attach(*x_label, 0,0,1,1);
-	table->attach(*y_label, 0,1,1,1);
+	grid->attach(*x_label, 0, 0, 1, 1);
+	grid->attach(*y_label, 0, 1, 1, 1);
 
-	//pos
+	// X and Y position values
 	x.property_xalign() = 1.0;
 	y.property_xalign() = 1.0;
-	table->attach_next_to(x, *x_label, Gtk::POS_RIGHT, 1,1);
-	table->attach_next_to(y, *y_label, Gtk::POS_RIGHT, 1,1);
+	grid->attach_next_to(x, *x_label, Gtk::POS_RIGHT, 1, 1);
+	grid->attach_next_to(y, *y_label, Gtk::POS_RIGHT, 1, 1);
 
-	//separator
+	// Horizontal separator
 	Gtk::Label *separator1 = manage(new Gtk::Label("  "));
 	separator1->set_hexpand(true);
-	table->attach_next_to(*separator1, x, Gtk::POS_RIGHT, 1,4);
+	grid->attach_next_to(*separator1, x, Gtk::POS_RIGHT, 1, 4);
 
-	//color label
+	// Color labels
 	Gtk::Label *r_label = manage(new Gtk::Label());
 	r_label->set_markup(etl::strprintf("<b>%s</b>", _("R: ")));
 	r_label->set_hexpand(false);
@@ -132,12 +132,12 @@ studio::Dock_Info::Dock_Info()
 	Gtk::Label *a_label = manage(new Gtk::Label());
 	a_label->set_markup(etl::strprintf("<b>%s</b>", _("A: ")));
 	a_label->set_hexpand(false);
-	table->attach(*r_label, 3,0,1,1);
-	table->attach(*g_label, 3,1,1,1);
-	table->attach(*b_label, 3,2,1,1);
-	table->attach(*a_label, 3,3,1,1);
+	grid->attach(*r_label, 3, 0, 1, 1);
+	grid->attach(*g_label, 3, 1, 1, 1);
+	grid->attach(*b_label, 3, 2, 1, 1);
+	grid->attach(*a_label, 3, 3, 1, 1);
 
-	//color
+	// Color values
 	r.property_xalign() = 1.0f;
 	g.property_xalign() = 1.0f;
 	b.property_xalign() = 1.0f;
@@ -146,45 +146,52 @@ studio::Dock_Info::Dock_Info()
 	g.set_tooltip_text(_("Green component value of color\nThe value after gamma correction, if different, is given in brackets"));
 	b.set_tooltip_text(_("Blue component value of color\nThe value after gamma correction, if different, is given in brackets"));
 	a.set_tooltip_text(_("Alpha component value of color, i.e. opacity"));
-	table->attach_next_to(r, *r_label, Gtk::POS_RIGHT, 1,1);
-	table->attach_next_to(g, *g_label, Gtk::POS_RIGHT, 1,1);
-	table->attach_next_to(b, *b_label, Gtk::POS_RIGHT, 1,1);
-	table->attach_next_to(a, *a_label, Gtk::POS_RIGHT, 1,1);
+	grid->attach_next_to(r, *r_label, Gtk::POS_RIGHT, 1, 1);
+	grid->attach_next_to(g, *g_label, Gtk::POS_RIGHT, 1, 1);
+	grid->attach_next_to(b, *b_label, Gtk::POS_RIGHT, 1, 1);
+	grid->attach_next_to(a, *a_label, Gtk::POS_RIGHT, 1, 1);
 
 	Gtk::Label *separator2 = manage(new Gtk::Label(" "));
-	table->attach(*separator2, 0,4,8,1);
+	grid->attach(*separator2, 0, 4, 8, 1);
 
-	//Render Progress Bar
+	// Render Progress Bar
+	Gtk::HBox *render_box = manage(new Gtk::HBox());
 	Gtk::Label *render_progress_label = manage(new Gtk::Label());
-	render_progress_label->set_markup(etl::strprintf("<b>%s</b>", _("Render Progress: ")));
-	table->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8,1);
+	Gtk::Label *left_spacer_label = manage(new Gtk::Label());
+	render_progress_label->set_markup(etl::strprintf("<b>%s</b>", _("Render Progress:")));
+	grid->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8, 1);
 
 	// Render progress CSS ID
 	render_progress.set_name("render-progress");
-
-	table->attach_next_to(render_progress, *render_progress_label, Gtk::POS_BOTTOM, 7,1);
 	render_progress.set_hexpand(true);
 	render_progress.set_vexpand(false);
 	render_progress.set_show_text(true);
 	render_progress.set_text(strprintf("%.1f%%", 0.0));
 	render_progress.set_fraction(0.0);
 
-	stop_button.set_label(_("Stop rendering"));
+	stop_button.set_image_from_icon_name("process-stop", Gtk::IconSize::from_name("synfig-small_icon"));
+	stop_button.set_hexpand(false);
+	stop_button.set_vexpand(false);
+	stop_button.set_valign(Gtk::ALIGN_END);
 	stop_button.signal_clicked().connect(sigc::mem_fun(*this, &studio::Dock_Info::on_stop_button_clicked));
 
-	table->attach_next_to(stop_button, render_progress, Gtk::POS_BOTTOM, 7, 1);
+	// Use this label to make sure layout is symmetric, 30 is the value used for render_progress height
+	left_spacer_label->set_size_request(30, 0);
 
-	table->set_margin_start(5);
-	table->set_margin_end(5);
-	table->set_margin_top(5);
-	table->set_margin_bottom(5);
+	render_box->pack_start(*left_spacer_label, false, true, 0);
+	render_box->pack_start(render_progress);
+	render_box->pack_start(stop_button, Gtk::PACK_SHRINK);
+	grid->attach_next_to(*render_box, *render_progress_label, Gtk::POS_BOTTOM, 7, 1);
 
-	
-	table->show_all();
+	grid->set_margin_start(5);
+	grid->set_margin_end(5);
+	grid->set_margin_top(5);
+	grid->set_margin_bottom(5);
+	grid->show_all();
 
-	add(*table);
-	
-	//Render progress
+	add(*grid);
+
+	// Render progress
 	set_n_passes_requested(1); //Default
 	set_n_passes_pending  (0); //Default
 	set_render_progress (0.0); //Default, 0.0%

--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -171,7 +171,7 @@ studio::Dock_Info::Dock_Info()
 
 	render_percentage.set_text(strprintf("%.1f%%", 0.0));
 
-	overlay->add_overlay(render_progress);
+	overlay->add(render_progress);
 	overlay->add_overlay(render_percentage);
 
 	stop_button.set_image_from_icon_name("process-stop", Gtk::IconSize::from_name("synfig-small_icon"));

--- a/synfig-studio/src/gui/docks/dock_info.h
+++ b/synfig-studio/src/gui/docks/dock_info.h
@@ -47,6 +47,7 @@ class Dock_Info : public Dock_CanvasSpecific
 	Gtk::Label       r,g,b,a;
 	Gtk::Label       x,y;
 	Gtk::ProgressBar render_progress;
+	Gtk::Label       render_percentage;
 	Gtk::Button      stop_button;
 
 	etl::handle<AsyncRenderer> async_renderer;

--- a/synfig-studio/src/gui/docks/dock_info.h
+++ b/synfig-studio/src/gui/docks/dock_info.h
@@ -29,6 +29,7 @@
 
 #include <gtkmm/button.h>
 #include <gtkmm/label.h>
+#include <gtkmm/overlay.h>
 #include <gtkmm/progressbar.h>
 
 #include <gui/asyncrenderer.h>

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -1,5 +1,5 @@
 #render-progress * {
-	min-height: 20px;
+	min-height: 30px;
 }
 
 /*


### PR DESCRIPTION
Fix #2037

Before:
![Screenshot_106a](https://user-images.githubusercontent.com/5604544/112924464-5da29980-913a-11eb-9dd5-38468699ae34.png)

After:
![Screenshot_105a](https://user-images.githubusercontent.com/5604544/112924476-63987a80-913a-11eb-9c98-749c724fe8a4.png)


