### PR TITLE
[Synfig Studio] Toolbox migration from Gtk::Table to Gtk::Grid

### DIFF
--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -509,8 +509,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 {
 	egress_on_selection_change=true;
 
-	/* Set up the tool options dialog */
-
+	// Toolbox widgets
 	title_label.set_label(_("Spline Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -608,7 +607,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 
 	load_settings();
 
-
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(id_box,
@@ -638,9 +637,8 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	options_grid.attach(auto_export_box,
 		0, 9, 2, 1);
 
-	// fine-tune options layout
-	options_grid.set_border_width(GAP*2); // border width
-	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
 

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -142,7 +142,7 @@ class studio::StateBLine_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -511,39 +511,36 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 
 	/* Set up the tool options dialog */
 
-	// 0, title
 	title_label.set_label(_("Spline Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
-	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
 
-	// 2, layer types creation
 	layer_types_label.set_label(_("Layer Type:"));
-	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	layer_types_label.set_halign(Gtk::ALIGN_START);
+	layer_types_label.set_valign(Gtk::ALIGN_CENTER);
 
 	LAYER_CREATION(layer_region_togglebutton,
 		("synfig-layer_geometry_region"), _("Create a region layer"));
-
 	LAYER_CREATION(layer_outline_togglebutton,
 		("synfig-layer_geometry_outline"), _("Create an outline layer"));
-
 	LAYER_CREATION(layer_advanced_outline_togglebutton,
 		("synfig-layer_geometry_advanced_outline"), _("Create an advanced outline layer"));
-
 	LAYER_CREATION(layer_plant_togglebutton,
 		("synfig-layer_other_plant"), _("Create a plant layer"));
-
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
@@ -556,9 +553,9 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
 
-	// 3, blend method label and dropdown list
 	blend_label.set_label(_("Blend Method:"));
-	blend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	blend_label.set_halign(Gtk::ALIGN_START);
+	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
@@ -567,43 +564,43 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 		.set_local_name(_("Blend Method"))
 		.set_description(_("Defines the blend method to be used for splines")));
 
-	// 4, opacity label and slider
 	opacity_label.set_label(_("Opacity:"));
-	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	opacity_label.set_halign(Gtk::ALIGN_START);
+	opacity_label.set_valign(Gtk::ALIGN_CENTER);
 
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// 5, brush size
 	bline_width_label.set_label(_("Brush Size:"));
-	bline_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bline_width_label.set_halign(Gtk::ALIGN_START);
+	bline_width_label.set_valign(Gtk::ALIGN_CENTER);
 	bline_width_label.set_sensitive(false);
 
 	bline_width_dist.set_digits(2);
 	bline_width_dist.set_range(0,10000000);
 	bline_width_dist.set_sensitive(false);
 
-	// 6, feather
 	feather_label.set_label(_("Feather:"));
-	feather_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	feather_label.set_halign(Gtk::ALIGN_START);
+	feather_label.set_valign(Gtk::ALIGN_CENTER);
 	feather_label.set_sensitive(false);
 
 	feather_dist.set_digits(2);
 	feather_dist.set_range(0,10000000);
 	feather_dist.set_sensitive(false);
 
-	// 7, link origins
 	link_origins_label.set_label(_("Link Origins"));
-	link_origins_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	link_origins_label.set_halign(Gtk::ALIGN_START);
+	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 
 	link_origins_box.pack_start(link_origins_label);
 	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
 	link_origins_box.set_sensitive(false);
 
-	// 8, auto export
 	auto_export_label.set_label(_("Auto Export"));
-	auto_export_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	auto_export_label.set_halign(Gtk::ALIGN_START);
+	auto_export_label.set_valign(Gtk::ALIGN_CENTER);
 
 	auto_export_box.pack_start(auto_export_label);
 	auto_export_box.pack_end(auto_export_checkbutton, Gtk::PACK_SHRINK);
@@ -611,68 +608,41 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 
 	load_settings();
 
-	// pack all options to the options_table
 
-	// 0, title
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	options_table.attach(id_box,
-		0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 2, layer types creation
-	options_table.attach(layer_types_label,
-		0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(layer_types_box,
-		0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 3, blend method
-	options_table.attach(blend_box,
-		0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(blend_enum,
-		1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 4, opacity
-	options_table.attach(opacity_label,
-		0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(opacity_hscl,
-		1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 5, brush size
-	options_table.attach(bline_width_label,
-		0, 1, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(bline_width_dist,
-		1, 2, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 6, feather
-	options_table.attach(feather_label,
-		0, 1, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(feather_dist,
-		1, 2, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 7, link origins
-	options_table.attach(link_origins_box,
-		0, 2, 8, 9, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 8, auto export
-	options_table.attach(auto_export_box,
-		0, 2, 9, 10, Gtk::FILL, Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_types_label,
+		0, 2, 2, 1);
+	options_grid.attach(layer_types_box,
+		0, 3, 2, 1);
+	options_grid.attach(blend_box,
+		0, 4, 1, 1);
+	options_grid.attach(blend_enum,
+		1, 4, 1, 1);
+	options_grid.attach(opacity_label,
+		0, 5, 1, 1);
+	options_grid.attach(opacity_hscl,
+		1, 5, 1, 1);
+	options_grid.attach(bline_width_label,
+		0, 6, 1, 1);
+	options_grid.attach(bline_width_dist,
+		1, 6, 1, 1);
+	options_grid.attach(feather_label,
+		0, 7, 1, 1);
+	options_grid.attach(feather_dist,
+		1, 7, 1, 1);
+	options_grid.attach(link_origins_box,
+		0, 8, 2, 1);
+	options_grid.attach(auto_export_box,
+		0, 9, 2, 1);
 
 	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacings(GAP); // row gap
-	options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	//options_table.set_row_spacing(10, 0); //// the final row using border width of table
-	options_table.set_margin_bottom(0);
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2); // border width
+	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
 	refresh_tool_options();
 	App::dialog_tool_options->present();
@@ -702,7 +672,7 @@ void
 StateBLine_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Spline Tool"));
 	App::dialog_tool_options->set_name("bline");
 

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -117,7 +117,7 @@ class studio::StateCircle_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -536,42 +536,38 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 
 	/* Set up the tool options dialog */
 
-	// 0, title
 	title_label.set_label(_("Circle Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
-	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
 
-	// 2, layer types creation
 	layer_types_label.set_label(_("Layer Type:"));
-	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	layer_types_label.set_halign(Gtk::ALIGN_START);
+	layer_types_label.set_valign(Gtk::ALIGN_CENTER);
 
 	LAYER_CREATION(layer_circle_togglebutton,
 		("synfig-layer_geometry_circle"), _("Create a circle layer"));
-
 	LAYER_CREATION(layer_region_togglebutton,
 		("synfig-layer_geometry_region"), _("Create a region layer"));
-
 	LAYER_CREATION(layer_outline_togglebutton,
 		("synfig-layer_geometry_outline"), _("Create an outline layer"));
-
 	LAYER_CREATION(layer_advanced_outline_togglebutton,
 		("synfig-layer_geometry_advanced_outline"), _("Create an advanced outline layer"));
-
 	LAYER_CREATION(layer_plant_togglebutton,
 		("synfig-layer_other_plant"), _("Create a plant layer"));
-
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
@@ -585,9 +581,9 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
 
-	// 3, blend method label and dropdown list
 	blend_label.set_label(_("Blend Method:"));
-	blend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	blend_label.set_halign(Gtk::ALIGN_START);
+	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
@@ -596,32 +592,32 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 		.set_local_name(_("Blend Method"))
 		.set_description(_("Defines the blend method to be used for circles")));
 
-	// 4, opacity label and slider
 	opacity_label.set_label(_("Opacity:"));
-	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	opacity_label.set_halign(Gtk::ALIGN_START);
+	opacity_label.set_valign(Gtk::ALIGN_CENTER);
 
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// 5, brush size
 	bline_width_label.set_label(_("Brush Size:"));
-	bline_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bline_width_label.set_halign(Gtk::ALIGN_START);
+	bline_width_label.set_valign(Gtk::ALIGN_CENTER);
 	bline_width_label.set_sensitive(false);
 
 	bline_width_dist.set_digits(2);
 	bline_width_dist.set_range(0,10000000);
 	bline_width_dist.set_sensitive(false);
 
-	// 6, spline points
 	bline_points_label.set_label(_("Spline Points:"));
-	bline_points_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bline_points_label.set_halign(Gtk::ALIGN_START);
+	bline_points_label.set_valign(Gtk::ALIGN_CENTER);
 	bline_points_label.set_sensitive(false);
 	number_of_bline_points_spin.set_sensitive(false);
 
-	// 7, spline point angle offset
 	bline_point_angle_offset_label.set_label(_("Offset:"));
-	bline_point_angle_offset_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bline_point_angle_offset_label.set_halign(Gtk::ALIGN_START);
+	bline_point_angle_offset_label.set_valign(Gtk::ALIGN_CENTER);
 	bline_point_angle_offset_label.set_sensitive(false);
 	bline_point_angle_offset_spin.set_sensitive(false);
 
@@ -629,26 +625,26 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	bline_point_angle_offset_box.pack_start(*bline_point_angle_offset_indent, Gtk::PACK_SHRINK);
 	bline_point_angle_offset_box.pack_start(bline_point_angle_offset_label, Gtk::PACK_SHRINK);
 
-	// 8, invert
 	invert_label.set_label(_("Invert"));
-	invert_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	invert_label.set_halign(Gtk::ALIGN_START);
+	invert_label.set_valign(Gtk::ALIGN_CENTER);
 
 	invert_box.pack_start(invert_label);
 	invert_box.pack_end(invert_checkbutton, Gtk::PACK_SHRINK);
 	invert_box.set_sensitive(false);
 
-	// 9, feather
 	feather_label.set_label(_("Feather:"));
-	feather_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	feather_label.set_halign(Gtk::ALIGN_START);
+	feather_label.set_valign(Gtk::ALIGN_CENTER);
 	feather_label.set_sensitive(false);
 
 	feather_dist.set_digits(2);
 	feather_dist.set_range(0,10000000);
 	feather_dist.set_sensitive(false);
 
-	// 10, feather falloff for circle layer
 	falloff_label.set_label(_("Falloff:"));
-	falloff_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	falloff_label.set_halign(Gtk::ALIGN_START);
+	falloff_label.set_valign(Gtk::ALIGN_CENTER);
 	falloff_label.set_sensitive(false);
 	SPACING(falloff_indent, INDENTATION);
 	falloff_box.pack_start(*falloff_indent, Gtk::PACK_SHRINK);
@@ -665,17 +661,17 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 		.add_enum_value(CIRCLE_COSINE,"cosine",_("Cosine")));
 	falloff_enum.set_sensitive(false);
 
-	// 11, link origins
 	link_origins_label.set_label(_("Link Origins"));
-	link_origins_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	link_origins_label.set_halign(Gtk::ALIGN_START);
+	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 
 	link_origins_box.pack_start(link_origins_label);
 	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
 	link_origins_box.set_sensitive(false);
 
-	// 12, spline origins at center
 	origins_at_center_label.set_label(_("Spline Origins at Center"));
-	origins_at_center_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	origins_at_center_label.set_halign(Gtk::ALIGN_START);
+	origins_at_center_label.set_valign(Gtk::ALIGN_CENTER);
 
 	origins_at_center_box.pack_start(origins_at_center_label);
 	origins_at_center_box.pack_end(layer_origins_at_center_checkbutton, Gtk::PACK_SHRINK);
@@ -685,94 +681,54 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	load_settings();
 
 
-	// pack all options to the options_table
-
-	// 0, title
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	options_table.attach(id_box,
-		0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 2, layer types creation
-	options_table.attach(layer_types_label,
-		0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(layer_types_box,
-		0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 3, blend method
-	options_table.attach(blend_box,
-		0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(blend_enum,
-		1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 4, opacity
-	options_table.attach(opacity_label,
-		0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(opacity_hscl,
-		1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 5, brush size
-	options_table.attach(bline_width_label,
-		0, 1, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(bline_width_dist,
-		1, 2, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 6, spline points
-	options_table.attach(bline_points_label,
-		0, 1, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(number_of_bline_points_spin,
-		1, 2, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 7, spline points offset
-	options_table.attach(bline_point_angle_offset_box,
-		0, 1, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(bline_point_angle_offset_spin,
-		1, 2, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 8, invert
-	options_table.attach(invert_box,
-		0, 2, 9, 10, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 9, feather
-	options_table.attach(feather_label,
-		0, 1, 10, 11, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(feather_dist,
-		1, 2, 10, 11, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-  // 10, falloff
-  options_table.attach(falloff_box,
-		0, 1, 11, 12, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(falloff_enum,
-		1, 2, 11, 12, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 11, link origins
-	options_table.attach(link_origins_box,
-		0, 2, 12, 13, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 12, origins at center
-	options_table.attach(origins_at_center_box,
-		0, 2, 13, 14, Gtk::FILL, Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_types_label,
+		0, 2, 2, 1);
+	options_grid.attach(layer_types_box,
+		0, 3, 2, 1);
+	options_grid.attach(blend_box,
+		0, 4, 1, 1);
+	options_grid.attach(blend_enum,
+		1, 4, 1, 1);
+	options_grid.attach(opacity_label,
+		0, 5, 1, 1);
+	options_grid.attach(opacity_hscl,
+		1, 5, 1, 1);
+	options_grid.attach(bline_width_label,
+		0, 6, 1, 1);
+	options_grid.attach(bline_width_dist,
+		1, 6, 1, 1);
+	options_grid.attach(bline_points_label,
+		0, 7, 1, 1);
+	options_grid.attach(number_of_bline_points_spin,
+		1, 7, 1, 1);
+	options_grid.attach(bline_point_angle_offset_box,
+		0, 8, 1, 1);
+	options_grid.attach(bline_point_angle_offset_spin,
+		1, 8, 1, 1);
+	options_grid.attach(invert_box,
+		0, 9, 2, 1);
+	options_grid.attach(feather_label,
+		0, 10, 1, 1);
+	options_grid.attach(feather_dist,
+		1, 10, 1, 1);
+	options_grid.attach(falloff_box,
+		0, 11, 1, 1);
+	options_grid.attach(falloff_enum,
+		1, 11, 1, 1);
+	options_grid.attach(link_origins_box,
+		0, 12, 2, 1);
+	options_grid.attach(origins_at_center_box,
+		0, 13, 2, 1);
 
 	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacings(GAP); // row gap
-	options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	//options_table.set_row_spacing(13, 0); // the final row using border width of table
-	options_table.set_margin_bottom(0);
-
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2); // border width
+	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
 	refresh_tool_options();
 	App::dialog_tool_options->present();
@@ -795,7 +751,7 @@ void
 StateCircle_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Circle Tool"));
 	App::dialog_tool_options->set_name("circle");
 }

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -533,9 +533,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 {
 	egress_on_selection_change=true;
 
-
-	/* Set up the tool options dialog */
-
+	// Toolbox widgets
 	title_label.set_label(_("Circle Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -677,10 +675,9 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	origins_at_center_box.pack_end(layer_origins_at_center_checkbutton, Gtk::PACK_SHRINK);
 	origins_at_center_box.set_sensitive(false);
 
-
 	load_settings();
 
-
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(id_box,
@@ -724,9 +721,8 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	options_grid.attach(origins_at_center_box,
 		0, 13, 2, 1);
 
-	// fine-tune options layout
-	options_grid.set_border_width(GAP*2); // border width
-	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
 

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -626,8 +626,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	width_max_error_spin(width_max_error_adj, 0.01, 2),
 	fill_last_stroke_button(_("Fill Last Stroke"))
 {
-	/* Set up the tool options dialog */
-
+	// Toolbox widgets
 	title_label.set_label(_("Draw Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -783,7 +782,6 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	auto_export_box.pack_start(auto_export_label, Gtk::PACK_SHRINK);
 	auto_export_box.pack_end(auto_export_checkbutton, Gtk::PACK_SHRINK);
 
-
 	nested=0;
 	load_settings();
 
@@ -791,7 +789,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	UpdateCreateAdvancedOutline();
 	UpdateSmoothness();
 
-
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(id_box,
@@ -849,7 +847,6 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	options_grid.attach(auto_export_box,
 		0, 19, 2, 1);
 
-	// fine-tune options layout
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
@@ -865,7 +862,6 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 		&StateDraw_Context::UpdateSmoothness));
 	globalthres_spin.signal_value_changed().connect(sigc::mem_fun(*this,
 		&StateDraw_Context::UpdateSmoothness));
-
 
 	refresh_tool_options();
 	App::dialog_tool_options->present();

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -146,7 +146,7 @@ class studio::StateDraw_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -628,33 +628,32 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 {
 	/* Set up the tool options dialog */
 
-	// 0, title
 	title_label.set_label(_("Draw Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
-	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
 
-	// 2, layer types creation
 	layer_types_label.set_label(_("Layer Type:"));
-	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	layer_types_label.set_halign(Gtk::ALIGN_START);
+	layer_types_label.set_valign(Gtk::ALIGN_CENTER);
 
 	LAYER_CREATION(layer_region_togglebutton,
 		("synfig-layer_geometry_region"), _("Create a region layer"));
-
 	LAYER_CREATION(layer_outline_togglebutton,
 		("synfig-layer_geometry_outline"), _("Create an outline layer"));
-
 	LAYER_CREATION(layer_advanced_outline_togglebutton,
 		("synfig-layer_geometry_advanced_outline"), _("Create an advanced outline layer"));
 
@@ -665,9 +664,9 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
 
-	// 3, blend method label and dropdown list
 	blend_label.set_label(_("Blend Method:"));
-	blend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	blend_label.set_halign(Gtk::ALIGN_START);
+	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
@@ -676,33 +675,33 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 		.set_local_name(_("Blend Method"))
 		.set_description(_("Defines the blend method to be used for draws")));
 
-	// 4, opacity label and slider
 	opacity_label.set_label(_("Opacity:"));
-	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	opacity_label.set_halign(Gtk::ALIGN_START);
+	opacity_label.set_valign(Gtk::ALIGN_CENTER);
 
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// 5, brush size
 	bline_width_label.set_label(_("Brush Size:"));
-	bline_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bline_width_label.set_halign(Gtk::ALIGN_START);
+	bline_width_label.set_valign(Gtk::ALIGN_CENTER);
 
 	bline_width_dist.set_digits(2);
 	bline_width_dist.set_range(0,10000000);
 
-	// 6, pressure width
 	pressure_width_label.set_label(_("Pressure Sensitive"));
-	pressure_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	pressure_width_label.set_halign(Gtk::ALIGN_START);
+	pressure_width_label.set_valign(Gtk::ALIGN_CENTER);
 
 	pressure_width_box.pack_start(pressure_width_label, Gtk::PACK_SHRINK);
 	pressure_width_box.pack_end(pressure_width_checkbutton, Gtk::PACK_SHRINK);
 
-	// 7, min pressure, sub option of pressure width
 	SPACING(min_pressure_indent, INDENTATION);
 	SPACING(min_pressure_gap, GAP);
 	min_pressure_label.set_label(_("Min Width:"));
-	min_pressure_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	min_pressure_label.set_halign(Gtk::ALIGN_START);
+	min_pressure_label.set_valign(Gtk::ALIGN_CENTER);
 	min_pressure_label_box.pack_start(*min_pressure_indent, Gtk::PACK_SHRINK);
 	min_pressure_label_box.pack_start(min_pressure_label, Gtk::PACK_SHRINK);
 
@@ -710,17 +709,15 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	min_pressure_box.pack_end(*min_pressure_gap, Gtk::PACK_SHRINK);
 	min_pressure_box.pack_end(min_pressure_spin);
 
-	// 8, Smoothness
 	smoothness_label.set_label(_("Smoothness"));
-	smoothness_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	smoothness_label.set_halign(Gtk::ALIGN_START);
+	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 9, local threshold
 	SPACING(localthres_indent, INDENTATION);
 	localthres_box.pack_start(*localthres_indent, Gtk::PACK_SHRINK);
 	localthres_box.pack_start(localthres_radiobutton, Gtk::PACK_SHRINK);
 	localthres_radiobutton.set_label(_("Local:"));
 
-	// 10, global threshold
 	SPACING(globalthres_indent, INDENTATION);
 	globalthres_box.pack_start(*globalthres_indent, Gtk::PACK_SHRINK);
 	globalthres_box.pack_start(globalthres_radiobutton, Gtk::PACK_SHRINK);
@@ -729,59 +726,59 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	smoothness_group = localthres_radiobutton.get_group();
 	globalthres_radiobutton.set_group(smoothness_group);
 
-	// 11, width max error of advanced outline layer
 	width_max_error_label.set_label(_("Width Max Error:"));
 	SPACING(width_max_error_gap, GAP);
-	width_max_error_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	width_max_error_label.set_halign(Gtk::ALIGN_START);
+	width_max_error_label.set_valign(Gtk::ALIGN_CENTER);
 	width_max_error_box.pack_start(width_max_error_label, Gtk::PACK_SHRINK);
 	width_max_error_box.pack_start(*width_max_error_gap, Gtk::PACK_SHRINK);
 
-	// 12, round ends
 	round_ends_label.set_label(_("Round Ends"));
-	round_ends_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	round_ends_label.set_halign(Gtk::ALIGN_START);
+	round_ends_label.set_valign(Gtk::ALIGN_CENTER);
 
 	round_ends_box.pack_start(round_ends_label, Gtk::PACK_SHRINK);
 	round_ends_box.pack_end(round_ends_checkbutton, Gtk::PACK_SHRINK);
 
-	// 13, auto loop
 	auto_loop_label.set_label(_("Auto Loop"));
-	auto_loop_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	auto_loop_label.set_halign(Gtk::ALIGN_START);
+	auto_loop_label.set_valign(Gtk::ALIGN_CENTER);
 
 	auto_loop_box.pack_start(auto_loop_label, Gtk::PACK_SHRINK);
 	auto_loop_box.pack_end(auto_loop_checkbutton, Gtk::PACK_SHRINK);
 
-	// 14, auto extend
 	auto_extend_label.set_label(_("Auto Extend"));
-	auto_extend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	auto_extend_label.set_halign(Gtk::ALIGN_START);
+	auto_extend_label.set_valign(Gtk::ALIGN_CENTER);
 
 	auto_extend_box.pack_start(auto_extend_label, Gtk::PACK_SHRINK);
 	auto_extend_box.pack_end(auto_extend_checkbutton, Gtk::PACK_SHRINK);
 
-	// 15, auto link
 	auto_link_label.set_label(_("Auto Link"));
-	auto_link_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	auto_link_label.set_halign(Gtk::ALIGN_START);
+	auto_link_label.set_valign(Gtk::ALIGN_CENTER);
 
 	auto_link_box.pack_start(auto_link_label, Gtk::PACK_SHRINK);
 	auto_link_box.pack_end(auto_link_checkbutton, Gtk::PACK_SHRINK);
 
-	// 16, feather
 	feather_label.set_label(_("Feather:"));
-	feather_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	feather_label.set_halign(Gtk::ALIGN_START);
+	feather_label.set_valign(Gtk::ALIGN_CENTER);
 
 	feather_dist.set_digits(2);
 	feather_dist.set_range(0,10000000);
 
-	// 17, link origins
 	link_origins_label.set_label(_("Link Origins"));
-	link_origins_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	link_origins_label.set_halign(Gtk::ALIGN_START);
+	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 
 	link_origins_box.pack_start(link_origins_label);
 	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
 	link_origins_box.set_sensitive(false);
 
-	// 18, auto export
 	auto_export_label.set_label(_("Auto Export"));
-	auto_export_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	auto_export_label.set_halign(Gtk::ALIGN_START);
+	auto_export_label.set_valign(Gtk::ALIGN_CENTER);
 
 	auto_export_box.pack_start(auto_export_label, Gtk::PACK_SHRINK);
 	auto_export_box.pack_end(auto_export_checkbutton, Gtk::PACK_SHRINK);
@@ -795,122 +792,68 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	UpdateSmoothness();
 
 
-	// pack all options to the options_table
-
-	// 0, title
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	options_table.attach(id_box,
-		0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 2, layer types creation
-	options_table.attach(layer_types_label,
-		0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(layer_types_box,
-		0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 3, blend method
-	options_table.attach(blend_box,
-		0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(blend_enum,
-		1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 4, opacity
-	options_table.attach(opacity_label,
-		0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(opacity_hscl,
-		1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 5, brush size
-	options_table.attach(bline_width_label,
-		0, 1, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(bline_width_dist,
-		1, 2, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 6, pressure width
-	options_table.attach(pressure_width_box,
-		0, 2, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 7, min pressure, sub-option of pressure width
-	options_table.attach(min_pressure_label_box,
-		0, 1, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(min_pressure_box,
-		1, 2, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 8, smoothness
-	options_table.attach(smoothness_label,
-		0, 2, 9, 10, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 9, local threshold
-	options_table.attach(localthres_box,
-		0, 1, 10, 11, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(localthres_spin,
-		1, 2, 10, 11, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 10, global threshold
-	options_table.attach(globalthres_box,
-		0, 1, 11, 12, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(globalthres_spin,
-		1, 2, 11, 12, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 11, width max error of advanced outline layer
-	options_table.attach(width_max_error_box,
-		0, 1, 12, 13, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(width_max_error_spin,
-		1, 2, 12, 13, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 12, round ends
-	options_table.attach(round_ends_box,
-		0, 2, 13, 14, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 13, auto loop
-	options_table.attach(auto_loop_box,
-		0, 2, 14, 15, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 14, auto extend
-	options_table.attach(auto_extend_box,
-		0, 2, 15, 16, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 15, auto link
-	options_table.attach(auto_link_box,
-		0, 2, 16, 17, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 16, feather
-	options_table.attach(feather_label,
-		0, 1, 17, 18, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(feather_dist,
-		1, 2, 17, 18, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 17, link origins
-	options_table.attach(link_origins_box,
-		0, 2, 18, 19, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 18, auto export
-	options_table.attach(auto_export_box,
-		0, 2, 19, 20, Gtk::FILL, Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_types_label,
+		0, 2, 2, 1);
+	options_grid.attach(layer_types_box,
+		0, 3, 2, 1);
+	options_grid.attach(blend_box,
+		0, 4, 1, 1);
+	options_grid.attach(blend_enum,
+		1, 4, 1, 1);
+	options_grid.attach(opacity_label,
+		0, 5, 1, 1);
+	options_grid.attach(opacity_hscl,
+		1, 5, 1, 1);
+	options_grid.attach(bline_width_label,
+		0, 6, 1, 1);
+	options_grid.attach(bline_width_dist,
+		1, 6, 1, 1);
+	options_grid.attach(pressure_width_box,
+		0, 7, 2, 1);
+	options_grid.attach(min_pressure_label_box,
+		0, 8, 1, 1);
+	options_grid.attach(min_pressure_box,
+		1, 8, 1, 1);
+	options_grid.attach(smoothness_label,
+		0, 9, 2, 1);
+	options_grid.attach(localthres_box,
+		0, 10, 1, 1);
+	options_grid.attach(localthres_spin,
+		1, 10, 1, 1);
+	options_grid.attach(globalthres_box,
+		0, 11, 1, 1);
+	options_grid.attach(globalthres_spin,
+		1, 11, 1, 1);
+	options_grid.attach(width_max_error_box,
+		0, 12, 1, 1);
+	options_grid.attach(width_max_error_spin,
+		1, 12, 1, 1);
+	options_grid.attach(round_ends_box,
+		0, 13, 2, 1);
+	options_grid.attach(auto_loop_box,
+		0, 14, 2, 1);
+	options_grid.attach(auto_extend_box,
+		0, 15, 2, 1);
+	options_grid.attach(auto_link_box,
+		0, 16, 2, 1);
+	options_grid.attach(feather_label,
+		0, 17, 1, 1);
+	options_grid.attach(feather_dist,
+		1, 17, 1, 1);
+	options_grid.attach(link_origins_box,
+		0, 18, 2, 1);
+	options_grid.attach(auto_export_box,
+		0, 19, 2, 1);
 
 	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacings(GAP); // row gap
-	options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	//options_table.set_row_spacing(19, 0); // the final row using border width of table
-	options_table.set_margin_bottom(0);
-
-	options_table.show_all();
-
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
 	fill_last_stroke_button.signal_pressed().connect(
 		sigc::mem_fun(*this, &StateDraw_Context::fill_last_stroke));
@@ -984,7 +927,7 @@ void
 StateDraw_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Draw Tool"));
 	App::dialog_tool_options->set_name("draw");
 

--- a/synfig-studio/src/gui/states/state_eyedrop.cpp
+++ b/synfig-studio/src/gui/states/state_eyedrop.cpp
@@ -112,7 +112,7 @@ StateEyedrop_Context::StateEyedrop_Context(CanvasView *canvasView):
 	synfig::info("Entered Eyedrop State");
 	canvas_view->get_work_area()->set_cursor(Gdk::Cursor::create(Gdk::CROSSHAIR));
 
-	// Setup Eyedrop options dialog
+	// Toolbox widgets
 	title_label.set_label(_("Eyedrop Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -122,6 +122,7 @@ StateEyedrop_Context::StateEyedrop_Context(CanvasView *canvasView):
 	title_label.set_halign(Gtk::ALIGN_START);
 	title_label.set_valign(Gtk::ALIGN_CENTER);
 
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(*manage(new Gtk::Label(_("Click to assign Outline Color"), Gtk::ALIGN_START)),

--- a/synfig-studio/src/gui/states/state_eyedrop.cpp
+++ b/synfig-studio/src/gui/states/state_eyedrop.cpp
@@ -63,7 +63,7 @@ class studio::StateEyedrop_Context : public sigc::trackable
 	CanvasView *canvas_view;
 	CanvasView::IsWorking is_working;
 
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 
 public:
@@ -118,21 +118,23 @@ StateEyedrop_Context::StateEyedrop_Context(CanvasView *canvasView):
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0);
-	options_table.attach(*manage(new Gtk::Label(_("Click to assign Outline Color"), Gtk::ALIGN_START)),
-		0, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
-	options_table.attach(*manage(new Gtk::Label(_("Ctrl + Click to assign Fill Color"), Gtk::ALIGN_START)),
-		0, 2, 2, 3, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(*manage(new Gtk::Label(_("Click to assign Outline Color"), Gtk::ALIGN_START)),
+		0, 1, 2, 1);
+	options_grid.attach(*manage(new Gtk::Label(_("Ctrl + Click to assign Fill Color"), Gtk::ALIGN_START)),
+		0, 2, 2, 1);
 
-	options_table.set_border_width(GAP*2);
-	options_table.set_row_spacings(GAP);
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
-	options_table.show_all();
 	refresh_tool_options();
-
 	App::dock_toolbox->refresh();
 }
 
@@ -149,7 +151,7 @@ void
 StateEyedrop_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Eyedrop Tool"));
 	App::dialog_tool_options->set_name("eyedrop");
 }

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -389,8 +389,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 {
 	egress_on_selection_change=true;
 
-	// Set up the tool options dialog
-
+	// Toolbox widgets
 	title_label.set_label(_("Gradient Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -404,6 +403,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(name_gap, GAP);
+
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*name_gap, Gtk::PACK_SHRINK);
 	id_box.pack_start(id_entry, Gtk::PACK_EXPAND_WIDGET);
@@ -428,28 +428,29 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	layer_types_box.pack_start(layer_conical_gradient_togglebutton, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_spiral_gradient_togglebutton, Gtk::PACK_SHRINK);
 
-	// blend method label
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
+
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
-	// blend method
+
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
 		.set_description(_("Defines the blend method to be used for gradients")));
 
-	// opacity label
 	opacity_label.set_label(_("Opacity:"));
 	opacity_label.set_halign(Gtk::ALIGN_START);
 	opacity_label.set_valign(Gtk::ALIGN_CENTER);
-	// opacity
+
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
+	load_settings();
 
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(id_box,
@@ -467,16 +468,13 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	options_grid.attach(opacity_hscl,
 		1, 5, 1, 1);
 
-	// fine-tune options layout
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
 
-	load_settings();
 	refresh_tool_options();
 	App::dialog_tool_options->present();
-
 
 	// Turn off layer clicking
 	get_work_area()->set_allow_layer_clicks(false);

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -106,7 +106,7 @@ class studio::StateGradient_Context : public sigc::trackable
 	bool prev_workarea_layer_status_;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -391,25 +391,27 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 
 	// Set up the tool options dialog
 
-	// title
 	title_label.set_label(_("Gradient Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// layer name
 	id_label.set_label(_("Name:"));
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(name_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*name_gap, Gtk::PACK_SHRINK);
 	id_box.pack_start(id_entry, Gtk::PACK_EXPAND_WIDGET);
 
-	// layer (gradient) creation label
 	layer_types_label.set_label(_("Layer Type:"));
-	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-	// layer creation buttons
+	layer_types_label.set_halign(Gtk::ALIGN_START);
+	layer_types_label.set_valign(Gtk::ALIGN_CENTER);
+
 	LAYER_CREATION(layer_linear_gradient_togglebutton, toggle_layer_linear_gradient,
 		("synfig-layer_gradient_linear"), _("Create a linear gradient"));
 	LAYER_CREATION(layer_radial_gradient_togglebutton, toggle_layer_radial_gradient,
@@ -428,7 +430,8 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 
 	// blend method label
 	blend_label.set_label(_("Blend Method:"));
-	blend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	blend_label.set_halign(Gtk::ALIGN_START);
+	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
@@ -439,51 +442,36 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 
 	// opacity label
 	opacity_label.set_label(_("Opacity:"));
-	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	opacity_label.set_halign(Gtk::ALIGN_START);
+	opacity_label.set_valign(Gtk::ALIGN_CENTER);
 	// opacity
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// options table
-	// 0, title
-	options_table.attach(title_label,
-		0, 2,  0,  1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	options_table.attach(id_box,
-		0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 2, layer types creation
-	options_table.attach(layer_types_label,
-		0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(layer_types_box,
-		0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 3, blend method
-	options_table.attach(blend_box,
-		0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(blend_enum,
-		1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 4, opacity
-	options_table.attach(opacity_label,
-		0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(opacity_hscl,
-		1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
+
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_types_label,
+		0, 2, 2, 1);
+	options_grid.attach(layer_types_box,
+		0, 3, 2, 1);
+	options_grid.attach(blend_box,
+		0, 4, 1, 1);
+	options_grid.attach(blend_enum,
+		1, 4, 1, 1);
+	options_grid.attach(opacity_label,
+		0, 5, 1, 1);
+	options_grid.attach(opacity_hscl,
+		1, 5, 1, 1);
 
 	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacings(GAP); // row gap
-	options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	//options_table.set_row_spacing(6, 0); // the final row using border width of table
-	options_table.set_margin_bottom(0);
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
 	load_settings();
 	refresh_tool_options();
@@ -519,7 +507,7 @@ void
 StateGradient_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Gradient Tool"));
 	App::dialog_tool_options->set_name("gradient");
 }

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -604,9 +604,7 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	width_max_error_spin(width_max_error_adj, 0.01, 2),
 	fill_last_stroke_button(_("Fill Last Stroke"))
 {
-	/* Set up the tool options dialog */
-
-	// 0, title
+	// Toolbox widgets
 	title_label.set_label(_("Cutout Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -616,7 +614,6 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	title_label.set_halign(Gtk::ALIGN_START);
 	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
 	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
@@ -625,7 +622,6 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 
 	id_box.pack_start(id_entry);
 
-	// 2, layer types creation
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
@@ -633,18 +629,15 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 		("synfig-layer_geometry_region"), _("Create a region layer"));
 
 	
-
 	SPACING(layer_types_indent, INDENTATION);
 
 	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
-//	layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
+	//layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
 	//layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
 
-	// 3, blend method label and dropdown list
 	SPACING(blend_gap, GAP);
 	
-	// 4, opacity label and slider
 	opacity_label.set_label(_("Opacity:"));
 	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
@@ -652,21 +645,18 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// 5, brush size
 	bline_width_label.set_label(_("Brush Size:"));
 	bline_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
 	bline_width_dist.set_digits(2);
 	bline_width_dist.set_range(0,10000000);
 
-	// 6, pressure width
 	pressure_width_label.set_label(_("Pressure Sensitive"));
 	pressure_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
 	pressure_width_box.pack_start(pressure_width_label, Gtk::PACK_SHRINK);
 	pressure_width_box.pack_end(pressure_width_checkbutton, Gtk::PACK_SHRINK);
 
-	// 7, min pressure, sub option of pressure width
 	SPACING(min_pressure_indent, INDENTATION);
 	SPACING(min_pressure_gap, GAP);
 	min_pressure_label.set_label(_("Min Width:"));
@@ -678,18 +668,15 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	min_pressure_box.pack_end(*min_pressure_gap, Gtk::PACK_SHRINK);
 	min_pressure_box.pack_end(min_pressure_spin);
 
-	// 8, Smoothness
 	smoothness_label.set_label(_("Smoothness"));
 	smoothness_label.set_halign(Gtk::ALIGN_START);
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 9, local threshold
 	SPACING(localthres_indent, INDENTATION);
 	localthres_box.pack_start(*localthres_indent, Gtk::PACK_SHRINK);
 	localthres_box.pack_start(localthres_radiobutton, Gtk::PACK_SHRINK);
 	localthres_radiobutton.set_label("Local:");
 
-	// 10, global threshold
 	SPACING(globalthres_indent, INDENTATION);
 	globalthres_box.pack_start(*globalthres_indent, Gtk::PACK_SHRINK);
 	globalthres_box.pack_start(globalthres_radiobutton, Gtk::PACK_SHRINK);
@@ -698,42 +685,36 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	smoothness_group = localthres_radiobutton.get_group();
 	globalthres_radiobutton.set_group(smoothness_group);
 
-	// 11, width max error of advanced outline layer
 	width_max_error_label.set_label(_("Width Max Error:"));
 	SPACING(width_max_error_gap, GAP);
 	width_max_error_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 	width_max_error_box.pack_start(width_max_error_label, Gtk::PACK_SHRINK);
 	width_max_error_box.pack_start(*width_max_error_gap, Gtk::PACK_SHRINK);
 
-	// 12, round ends
 	round_ends_label.set_label(_("Round Ends"));
 	round_ends_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
 	round_ends_box.pack_start(round_ends_label, Gtk::PACK_SHRINK);
 	round_ends_box.pack_end(round_ends_checkbutton, Gtk::PACK_SHRINK);
 
-	// 13, auto loop
 	auto_loop_label.set_label(_("Auto Loop"));
 	auto_loop_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
 	auto_loop_box.pack_start(auto_loop_label, Gtk::PACK_SHRINK);
 	auto_loop_box.pack_end(auto_loop_checkbutton, Gtk::PACK_SHRINK);
 
-	// 14, auto extend
 	auto_extend_label.set_label(_("Auto Extend"));
 	auto_extend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
 	auto_extend_box.pack_start(auto_extend_label, Gtk::PACK_SHRINK);
 	auto_extend_box.pack_end(auto_extend_checkbutton, Gtk::PACK_SHRINK);
 
-	// 15, auto link
 	auto_link_label.set_label(_("Auto Link"));
 	auto_link_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
 	auto_link_box.pack_start(auto_link_label, Gtk::PACK_SHRINK);
 	auto_link_box.pack_end(auto_link_checkbutton, Gtk::PACK_SHRINK);
 
-	// 16, feather
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
 	feather_label.set_valign(Gtk::ALIGN_CENTER);
@@ -741,13 +722,11 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	feather_dist.set_digits(2);
 	feather_dist.set_range(0,10000000);
 
-	// 17, auto export
 	auto_export_label.set_label(_("Auto Export"));
 	auto_export_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
 	auto_export_box.pack_start(auto_export_label, Gtk::PACK_SHRINK);
 	auto_export_box.pack_end(auto_export_checkbutton, Gtk::PACK_SHRINK);
-
 
 	nested=0;
 	load_settings();
@@ -756,8 +735,7 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	UpdateCreateAdvancedOutline();
 	UpdateSmoothness();
 
-
-	// pack all options to the options_grid
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(smoothness_label,
@@ -780,18 +758,16 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
 
-
 	fill_last_stroke_button.signal_pressed().connect(
 		sigc::mem_fun(*this, &StateLasso_Context::fill_last_stroke));
 	pressure_width_checkbutton.signal_toggled().connect(
 		sigc::mem_fun(*this, &StateLasso_Context::UpdateUsePressure));
-//	layer_advanced_outline_togglebutton.signal_toggled().connect(
+	//layer_advanced_outline_togglebutton.signal_toggled().connect(
 	//	sigc::mem_fun(*this, &StateLasso_Context::UpdateCreateAdvancedOutline));
 	localthres_spin.signal_value_changed().connect(sigc::mem_fun(*this,
 		&StateLasso_Context::UpdateSmoothness));
 	globalthres_spin.signal_value_changed().connect(sigc::mem_fun(*this,
 		&StateLasso_Context::UpdateSmoothness));
-
 
 	refresh_tool_options();
 	App::dialog_tool_options->present();

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -143,7 +143,7 @@ class studio::StateLasso_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -612,7 +612,9 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
 	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
@@ -678,7 +680,8 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 
 	// 8, Smoothness
 	smoothness_label.set_label(_("Smoothness"));
-	smoothness_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	smoothness_label.set_halign(Gtk::ALIGN_START);
+	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
 	// 9, local threshold
 	SPACING(localthres_indent, INDENTATION);
@@ -732,7 +735,8 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 
 	// 16, feather
 	feather_label.set_label(_("Feather:"));
-	feather_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	feather_label.set_halign(Gtk::ALIGN_START);
+	feather_label.set_valign(Gtk::ALIGN_CENTER);
 
 	feather_dist.set_digits(2);
 	feather_dist.set_range(0,10000000);
@@ -753,113 +757,28 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	UpdateSmoothness();
 
 
-	// pack all options to the options_table
+	// pack all options to the options_grid
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(smoothness_label,
+		0, 1, 2, 1);
+	options_grid.attach(localthres_box,
+		0, 2, 1, 1);
+	options_grid.attach(localthres_spin,
+		1, 2, 1, 1);
+	options_grid.attach(globalthres_box,
+		0, 3, 1, 1);
+	options_grid.attach(globalthres_spin,
+		1, 3, 1, 1);
+	options_grid.attach(feather_label,
+		0, 4, 1, 1);
+	options_grid.attach(feather_dist,
+		1, 4, 1, 1);
 
-	// 0, title
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	//options_table.attach(id_box,
-	////	0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 2, layer types creation
-	//options_table.attach(layer_types_label,
-	////	0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	//options_table.attach(layer_types_box,
-	//	0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 3, blend method
-	
-	// 4, opacity
-	//options_table.attach(opacity_label,
-	//	0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	//options_table.attach(opacity_hscl,
-	//	1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 5, brush size
-	//options_table.attach(bline_width_label,
-	//	0, 1, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	//options_table.attach(bline_width_dist,
-	//	1, 2, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 6, pressure width
-	//options_table.attach(pressure_width_box,
-	///	0, 2, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 7, min pressure, sub-option of pressure width
-	//options_table.attach(min_pressure_label_box,
-	//	0, 1, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	//options_table.attach(min_pressure_box,
-	//	1, 2, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 8, smoothness
-	options_table.attach(smoothness_label,
-		0, 2, 9, 10, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 9, local threshold
-	options_table.attach(localthres_box,
-		0, 1, 10, 11, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(localthres_spin,
-		1, 2, 10, 11, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 10, global threshold
-	options_table.attach(globalthres_box,
-		0, 1, 11, 12, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(globalthres_spin,
-		1, 2, 11, 12, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 11, width max error of advanced outline layer
-	//options_table.attach(width_max_error_box,
-	//	0, 1, 12, 13, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	//options_table.attach(width_max_error_spin,
-	//	1, 2, 12, 13, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 12, round ends
-	//options_table.attach(round_ends_box,
-	///	0, 2, 13, 14, Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 13, auto loop
-	//options_table.attach(auto_loop_box,
-	//	0, 2, 14, 15, Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 14, auto extend
-	//options_table.attach(auto_extend_box,
-	//	0, 2, 15, 16, Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 15, auto link
-	//options_table.attach(auto_link_box,
-	//	0, 2, 16, 17, Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-	// 16, feather
-	options_table.attach(feather_label,
-		0, 1, 17, 18, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(feather_dist,
-		1, 2, 17, 18, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 17, auto export
-	//options_table.attach(auto_export_box,
-	//	0, 2, 18, 19, Gtk::FILL, Gtk::FILL, 0, 0
-	//	);
-
-	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	//options_table.set_row_spacings(GAP); // row gap
-	//options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	//options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	options_table.set_row_spacing(16, GAP*2);
-	//options_table.set_row_spacing(19, 0); // the final row using border width of table
-	options_table.set_margin_bottom(0);
-
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
 
 	fill_last_stroke_button.signal_pressed().connect(
@@ -934,7 +853,7 @@ void
 StateLasso_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Cutout Tool"));
 	App::dialog_tool_options->set_name("lasso");
 

--- a/synfig-studio/src/gui/states/state_mirror.cpp
+++ b/synfig-studio/src/gui/states/state_mirror.cpp
@@ -88,7 +88,7 @@ class studio::StateMirror_Context : public sigc::trackable
 
 	etl::handle<DuckDrag_Mirror> duck_dragger_;
 
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 
 	sigc::connection keypress_connect;
@@ -171,16 +171,18 @@ StateMirror_Context::StateMirror_Context(CanvasView* canvas_view):
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 	
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0);
-	options_table.attach(radiobutton_axis_x,
-		0, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
-	options_table.attach(radiobutton_axis_y,
-		0, 2, 2, 3, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
-	options_table.attach(*manage(new Gtk::Label(_("(Shift key toggles axis)"))),
-		0, 2, 3, 4, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(radiobutton_axis_x,
+		0, 1, 1, 1);
+	options_grid.attach(radiobutton_axis_y,
+		0, 2, 1, 1);
+	options_grid.attach(*manage(new Gtk::Label(_("(Shift key toggles axis)"))),
+		0, 3, 2, 1);
 
 	radiobutton_axis_x.signal_toggled().connect(sigc::mem_fun(*this,&StateMirror_Context::update_axes));
 	radiobutton_axis_y.signal_toggled().connect(sigc::mem_fun(*this,&StateMirror_Context::update_axes));
@@ -188,9 +190,9 @@ StateMirror_Context::StateMirror_Context(CanvasView* canvas_view):
 	keypress_connect=get_work_area()->signal_key_press_event().connect(sigc::mem_fun(*this,&StateMirror_Context::key_press_event),false);
 	keyrelease_connect=get_work_area()->signal_key_release_event().connect(sigc::mem_fun(*this,&StateMirror_Context::key_release_event),false);
 
-	options_table.set_border_width(GAP*2);
-	options_table.set_row_spacings(GAP);
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.show_all();
 	refresh_tool_options();
 	App::dialog_tool_options->present();
 
@@ -241,7 +243,7 @@ void
 StateMirror_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Mirror Tool"));
 	App::dialog_tool_options->set_name("mirror");
 }

--- a/synfig-studio/src/gui/states/state_mirror.cpp
+++ b/synfig-studio/src/gui/states/state_mirror.cpp
@@ -165,7 +165,7 @@ StateMirror_Context::StateMirror_Context(CanvasView* canvas_view):
 	radiobutton_axis_x(radiobutton_group,_("Horizontal")),
 	radiobutton_axis_y(radiobutton_group,_("Vertical"))
 {
-	// Set up the tool options dialog
+	// Toolbox widgets
 	title_label.set_label(_("Mirror Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -174,7 +174,8 @@ StateMirror_Context::StateMirror_Context(CanvasView* canvas_view):
 	title_label.set_hexpand();
 	title_label.set_halign(Gtk::ALIGN_START);
 	title_label.set_valign(Gtk::ALIGN_CENTER);
-	
+
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(radiobutton_axis_x,
@@ -184,15 +185,16 @@ StateMirror_Context::StateMirror_Context(CanvasView* canvas_view):
 	options_grid.attach(*manage(new Gtk::Label(_("(Shift key toggles axis)"))),
 		0, 3, 2, 1);
 
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.show_all();
+
 	radiobutton_axis_x.signal_toggled().connect(sigc::mem_fun(*this,&StateMirror_Context::update_axes));
 	radiobutton_axis_y.signal_toggled().connect(sigc::mem_fun(*this,&StateMirror_Context::update_axes));
 	shift_is_pressed=false;
 	keypress_connect=get_work_area()->signal_key_press_event().connect(sigc::mem_fun(*this,&StateMirror_Context::key_press_event),false);
 	keyrelease_connect=get_work_area()->signal_key_release_event().connect(sigc::mem_fun(*this,&StateMirror_Context::key_release_event),false);
 
-	options_grid.set_border_width(GAP*2);
-	options_grid.set_row_spacing(GAP);
-	options_grid.show_all();
 	refresh_tool_options();
 	App::dialog_tool_options->present();
 

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -283,7 +283,9 @@ StateNormal_Context::StateNormal_Context(CanvasView* canvas_view):
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 	
 	options_grid.attach(title_label,
 		0, 0, 1, 1);

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -46,6 +46,7 @@
 #include <synfig/angle.h>
 
 #include <synfigapp/main.h>
+#include <gtkmm-3.0/gtkmm/widget.h>
 
 #endif
 
@@ -109,7 +110,7 @@ class studio::StateNormal_Context : public sigc::trackable
 
 	etl::handle<DuckDrag_Combo> duck_dragger_;
 
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 
 	bool ctrl_pressed;
@@ -285,22 +286,20 @@ StateNormal_Context::StateNormal_Context(CanvasView* canvas_view):
 	title_label.set_attributes(list);
 	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 	
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0);
-	options_table.attach(*manage(new Gtk::Label(_("Ctrl to rotate"), Gtk::ALIGN_START)),
-		0, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
-	options_table.attach(*manage(new Gtk::Label(_("Alt to scale"), Gtk::ALIGN_START)),
-		0, 2, 2, 3, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
-	options_table.attach(*manage(new Gtk::Label(_("Shift to constrain"), Gtk::ALIGN_START)),
-		0, 2, 3, 4, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
+	options_grid.attach(title_label,
+		0, 0, 1, 1);
+	options_grid.attach(*manage(new Gtk::Label(_("Ctrl to rotate"), Gtk::ALIGN_START)),
+		0, 1, 1, 1);
+	options_grid.attach(*manage(new Gtk::Label(_("Alt to scale"), Gtk::ALIGN_START)),
+		0, 2, 1, 1);
+	options_grid.attach(*manage(new Gtk::Label(_("Shift to constrain"), Gtk::ALIGN_START)),
+		0, 3, 1, 1);
 
-	options_table.set_border_width(GAP*2);
-	options_table.set_row_spacings(GAP);
-
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 	refresh_tool_options();
-	//App::dialog_tool_options->set_widget(options_table);
-	//App::dialog_tool_options->present();
 
 	get_work_area()->set_allow_layer_clicks(true);
 	get_work_area()->set_duck_dragger(duck_dragger_);
@@ -316,7 +315,7 @@ void
 StateNormal_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Transform Tool"));
 	App::dialog_tool_options->set_name("normal");
 }

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -46,7 +46,6 @@
 #include <synfig/angle.h>
 
 #include <synfigapp/main.h>
-#include <gtkmm-3.0/gtkmm/widget.h>
 
 #endif
 

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -277,7 +277,7 @@ StateNormal_Context::StateNormal_Context(CanvasView* canvas_view):
 {
 	duck_dragger_->canvas_view_=get_canvas_view();
 
-	// Set up the tool options dialog
+	// Toolbox widgets
 	title_label.set_label(_("Transform Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -286,7 +286,8 @@ StateNormal_Context::StateNormal_Context(CanvasView* canvas_view):
 	title_label.set_hexpand();
 	title_label.set_halign(Gtk::ALIGN_START);
 	title_label.set_valign(Gtk::ALIGN_CENTER);
-	
+
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 1, 1);
 	options_grid.attach(*manage(new Gtk::Label(_("Ctrl to rotate"), Gtk::ALIGN_START)),
@@ -300,14 +301,11 @@ StateNormal_Context::StateNormal_Context(CanvasView* canvas_view):
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
+
 	refresh_tool_options();
 
 	get_work_area()->set_allow_layer_clicks(true);
 	get_work_area()->set_duck_dragger(duck_dragger_);
-
-	//these will segfault
-//	get_work_area()->set_cursor(Gdk::CROSSHAIR);
-//	get_work_area()->reset_cursor();
 
 	App::dock_toolbox->refresh();
 }

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -469,9 +469,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 {
 	egress_on_selection_change=true;
 
-
-	/* Set up the tool options dialog */
-
+	// Toolbox widgets
 	title_label.set_label(_("Polygon Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -508,7 +506,6 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
 	SPACING(layer_types_indent, INDENTATION);
-
 	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_polygon_togglebutton, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
@@ -572,7 +569,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 
 	load_settings();
 
-
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(id_box,
@@ -602,16 +599,13 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	options_grid.attach(link_origins_box,
 		0, 9, 2, 1);
 
-	// fine-tune options layout
-	options_grid.set_border_width(GAP*2); // border width
-	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
-	
 	options_grid.show_all();
 
 	refresh_tool_options();
 	App::dialog_tool_options->present();
-
 
 	// Turn off layer clicking
 	get_work_area()->set_allow_layer_clicks(false);

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -113,7 +113,7 @@ class studio::StatePolygon_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -472,42 +472,38 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 
 	/* Set up the tool options dialog */
 
-	// 0, title
 	title_label.set_label(_("Polygon Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
-	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
 
-	// 2, layer types creation
 	layer_types_label.set_label(_("Layer Type:"));
-	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	layer_types_label.set_halign(Gtk::ALIGN_START);
+	layer_types_label.set_valign(Gtk::ALIGN_CENTER);
 
 	LAYER_CREATION(layer_polygon_togglebutton,
 		("synfig-layer_geometry_polygon"), _("Create a polygon layer"));
-
 	LAYER_CREATION(layer_region_togglebutton,
 		("synfig-layer_geometry_region"), _("Create a region layer"));
-
 	LAYER_CREATION(layer_outline_togglebutton,
 		("synfig-layer_geometry_outline"), _("Create an outline layer"));
-
 	LAYER_CREATION(layer_advanced_outline_togglebutton,
 		("synfig-layer_geometry_advanced_outline"), _("Create an advanced outline layer"));
-
 	LAYER_CREATION(layer_plant_togglebutton,
 		("synfig-layer_other_plant"), _("Create a plant layer"));
-
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
@@ -521,9 +517,9 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
 
-	// 3, blend method label and dropdown list
 	blend_label.set_label(_("Blend Method:"));
-	blend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	blend_label.set_halign(Gtk::ALIGN_START);
+	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
@@ -532,43 +528,43 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 		.set_local_name(_("Blend Method"))
 		.set_description(_("Defines the blend method to be used for polygons")));
 
-	// 4, opacity label and slider
 	opacity_label.set_label(_("Opacity:"));
-	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	opacity_label.set_halign(Gtk::ALIGN_START);
+	opacity_label.set_valign(Gtk::ALIGN_CENTER);
 
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// 5, brush size
 	bline_width_label.set_label(_("Brush Size:"));
-	bline_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bline_width_label.set_halign(Gtk::ALIGN_START);
+	bline_width_label.set_valign(Gtk::ALIGN_CENTER);
 	bline_width_label.set_sensitive(false);
 
 	bline_width_dist.set_digits(2);
 	bline_width_dist.set_range(0,10000000);
 	bline_width_dist.set_sensitive(false);
 
-	// 6, invert
 	invert_label.set_label(_("Invert"));
-	invert_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	invert_label.set_halign(Gtk::ALIGN_START);
+	invert_label.set_valign(Gtk::ALIGN_CENTER);
 
 	invert_box.pack_start(invert_label);
 	invert_box.pack_end(invert_checkbutton, Gtk::PACK_SHRINK);
 	invert_box.set_sensitive(false);
 
-	// 7, feather
 	feather_label.set_label(_("Feather:"));
-	feather_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	feather_label.set_halign(Gtk::ALIGN_START);
+	feather_label.set_valign(Gtk::ALIGN_CENTER);
 	feather_label.set_sensitive(false);
 
 	feather_dist.set_digits(2);
 	feather_dist.set_range(0,10000000);
 	feather_dist.set_sensitive(false);
 
-	// 8, link origins
 	link_origins_label.set_label(_("Link Origins"));
-	link_origins_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	link_origins_label.set_halign(Gtk::ALIGN_START);
+	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 
 	link_origins_box.pack_start(link_origins_label);
 	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
@@ -576,69 +572,42 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 
 	load_settings();
 
-	// pack all options to the options_table
 
-	// 0, title
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	options_table.attach(id_box,
-		0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 2, layer types creation
-	options_table.attach(layer_types_label,
-		0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(layer_types_box,
-		0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 3, blend method
-	options_table.attach(blend_box,
-		0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(blend_enum,
-		1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 4, opacity
-	options_table.attach(opacity_label,
-		0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(opacity_hscl,
-		1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 5, brush size
-	options_table.attach(bline_width_label,
-		0, 1, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(bline_width_dist,
-		1, 2, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 6, invert
-	options_table.attach(invert_box,
-		0, 2, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 7, feather
-	options_table.attach(feather_label,
-		0, 1, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(feather_dist,
-		1, 2, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 8, link origins
-	options_table.attach(link_origins_box,
-		0, 2, 9, 10, Gtk::FILL, Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_types_label,
+		0, 2, 2, 1);
+	options_grid.attach(layer_types_box,
+		0, 3, 2, 1);
+	options_grid.attach(blend_box,
+		0, 4, 1, 1);
+	options_grid.attach(blend_enum,
+		1, 4, 1, 1);
+	options_grid.attach(opacity_label,
+		0, 5, 1, 1);
+	options_grid.attach(opacity_hscl,
+		1, 5, 1, 1);
+	options_grid.attach(bline_width_label,
+		0, 6, 1, 1);
+	options_grid.attach(bline_width_dist,
+		1, 6, 1, 1);
+	options_grid.attach(invert_box,
+		0, 7, 2, 1);
+	options_grid.attach(feather_label,
+		0, 8, 1, 1);
+	options_grid.attach(feather_dist,
+		1, 8, 1, 1);
+	options_grid.attach(link_origins_box,
+		0, 9, 2, 1);
 
 	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacings(GAP); // row gap
-	options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	//options_table.set_row_spacing(9, 0); // the final row using border width of table
-	options_table.set_margin_bottom(0);
+	options_grid.set_border_width(GAP*2); // border width
+	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_margin_bottom(0);
 	
-	options_table.show_all();
+	options_grid.show_all();
 
 	refresh_tool_options();
 	App::dialog_tool_options->present();
@@ -669,7 +638,7 @@ void
 StatePolygon_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 
 	App::dialog_tool_options->set_local_name(_("Polygon Tool"));
 	App::dialog_tool_options->set_name("polygon");

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -111,7 +111,7 @@ class studio::StateRectangle_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -484,42 +484,38 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 
 	/* Set up the tool options dialog */
 
-	// 0, title
 	title_label.set_label(_("Rectangle Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
-	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
 
-	// 2, layer types creation
 	layer_types_label.set_label(_("Layer Type:"));
-	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	layer_types_label.set_halign(Gtk::ALIGN_START);
+	layer_types_label.set_valign(Gtk::ALIGN_CENTER);
 
 	LAYER_CREATION(layer_rectangle_togglebutton,
 		("synfig-layer_geometry_rectangle"), _("Create a rectangle layer"));
-
 	LAYER_CREATION(layer_region_togglebutton,
 		("synfig-layer_geometry_region"), _("Create a region layer"));
-
 	LAYER_CREATION(layer_outline_togglebutton,
 		("synfig-layer_geometry_outline"), _("Create an outline layer"));
-
 	LAYER_CREATION(layer_advanced_outline_togglebutton,
 		("synfig-layer_geometry_advanced_outline"), _("Create an advanced outline layer"));
-
 	LAYER_CREATION(layer_plant_togglebutton,
 		("synfig-layer_other_plant"), _("Create a plant layer"));
-
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
@@ -533,9 +529,9 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
 
-	// 3, blend method label and dropdown list
 	blend_label.set_label(_("Blend Method:"));
-	blend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	blend_label.set_halign(Gtk::ALIGN_START);
+	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
@@ -544,51 +540,51 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 		.set_local_name(_("Blend Method"))
 		.set_description(_("Defines the blend method to be used for rectangles")));
 
-	// 4, opacity label and slider
 	opacity_label.set_label(_("Opacity:"));
-	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	opacity_label.set_halign(Gtk::ALIGN_START);
+	opacity_label.set_valign(Gtk::ALIGN_CENTER);
 
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// 5, bline width
 	bline_width_label.set_label(_("Brush Size:"));
-	bline_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bline_width_label.set_halign(Gtk::ALIGN_START);
+	bline_width_label.set_valign(Gtk::ALIGN_CENTER);
 	bline_width_label.set_sensitive(false);
 
 	bline_width_dist.set_tooltip_text(_("Brush size"));
 	bline_width_dist.set_sensitive(false);
 
-	// 6, invert
 	invert_label.set_label(_("Invert"));
-	invert_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	invert_label.set_halign(Gtk::ALIGN_START);
+	invert_label.set_valign(Gtk::ALIGN_CENTER);
 
 	invert_box.pack_start(invert_label);
 	invert_box.pack_end(invert_checkbutton, Gtk::PACK_SHRINK);
 	invert_box.set_sensitive(false);
 
-	// 7, feather
 	feather_label.set_label(_("Feather:"));
-	feather_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	feather_label.set_halign(Gtk::ALIGN_START);
+	feather_label.set_valign(Gtk::ALIGN_CENTER);
 	feather_label.set_sensitive(false);
 
 	feather_dist.set_digits(2);
 	feather_dist.set_range(0,10000000);
 	feather_dist.set_sensitive(false);
 
-	// 8, expansion
 	expand_label.set_label(_("Expansion:"));
-	expand_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	expand_label.set_halign(Gtk::ALIGN_START);
+	expand_label.set_valign(Gtk::ALIGN_CENTER);
 	expand_label.set_sensitive(false);
 
 	expand_dist.set_digits(2);
 	expand_dist.set_range(0, 1000000);
 	expand_dist.set_sensitive(false);
 
-	// 9, link origins
 	link_origins_label.set_label(_("Link Origins"));
-	link_origins_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	link_origins_label.set_halign(Gtk::ALIGN_START);
+	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 
 	link_origins_box.pack_start(link_origins_label);
 	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
@@ -596,76 +592,45 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 
 	load_settings();
 
-	// pack all options to the options_table
 
-	// 0, title
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	options_table.attach(id_box,
-		0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 2, layer types creation
-	options_table.attach(layer_types_label,
-		0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(layer_types_box,
-		0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 3, blend method
-	options_table.attach(blend_box,
-		0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(blend_enum,
-		1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 4, opacity
-	options_table.attach(opacity_label,
-		0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(opacity_hscl,
-		1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 5, brush size
-	options_table.attach(bline_width_label,
-		0, 1, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(bline_width_dist,
-		1, 2, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 6, invert
-	options_table.attach(invert_box,
-		0, 2, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 7, feather
-	options_table.attach(feather_label,
-		0, 1, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(feather_dist,
-		1, 2, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 8, expansion
-	options_table.attach(expand_label,
-		0, 1, 9, 10, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(expand_dist,
-		1, 2, 9, 10, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 9, link origins
-	options_table.attach(link_origins_box,
-		0, 2, 10, 11, Gtk::FILL, Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_types_label,
+		0, 2, 2, 1);
+	options_grid.attach(layer_types_box,
+		0, 3, 2, 1);
+	options_grid.attach(blend_box,
+		0, 4, 1, 1);
+	options_grid.attach(blend_enum,
+		1, 4, 1, 1);
+	options_grid.attach(opacity_label,
+		0, 5, 1, 1);
+	options_grid.attach(opacity_hscl,
+		1, 5, 1, 1);
+	options_grid.attach(bline_width_label,
+		0, 6, 1, 1);
+	options_grid.attach(bline_width_dist,
+		1, 6, 1, 1);
+	options_grid.attach(invert_box,
+		0, 7, 2, 1);
+	options_grid.attach(feather_label,
+		0, 8, 1, 1);
+	options_grid.attach(feather_dist,
+		1, 8, 1, 1);
+	options_grid.attach(expand_label,
+		0, 9, 1, 1);
+	options_grid.attach(expand_dist,
+		1, 9, 1, 1);
+	options_grid.attach(link_origins_box,
+		0, 10, 2, 1);
 
 	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacings(GAP); // row gap
-	options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	//options_table.set_row_spacing(10, 0); // the final row using border width of table
-	options_table.set_margin_bottom(0);
-
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2); // border width
+	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
 	refresh_tool_options();
 	App::dialog_tool_options->present();
@@ -688,7 +653,7 @@ void
 StateRectangle_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Rectangle Tool"));
 	App::dialog_tool_options->set_name("rectangle");
 }

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -482,8 +482,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 {
 	egress_on_selection_change=true;
 
-	/* Set up the tool options dialog */
-
+	// Toolbox widgets
 	title_label.set_label(_("Rectangle Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -592,7 +591,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 
 	load_settings();
 
-
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(id_box,
@@ -626,9 +625,8 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	options_grid.attach(link_origins_box,
 		0, 10, 2, 1);
 
-	// fine-tune options layout
-	options_grid.set_border_width(GAP*2); // border width
-	options_grid.set_row_spacing(GAP); // row gap
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
 

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -107,7 +107,7 @@ class studio::StateRotate_Context : public sigc::trackable
 
 	etl::handle<DuckDrag_Rotate> duck_dragger_;
 
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 
 	Gtk::Label scale_label;
@@ -204,28 +204,30 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 	
 	scale_label.set_label(_("Allow Scale"));
-	scale_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	scale_label.set_hexpand();
+	scale_label.set_halign(Gtk::ALIGN_START);
+	scale_label.set_valign(Gtk::ALIGN_CENTER);
 	
 	scale_box.pack_start(scale_label);
 	scale_box.pack_end(scale_checkbutton, Gtk::PACK_SHRINK);
 	
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(scale_box,
-		0, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(scale_box,
+		0, 1, 2, 1);
 
 	scale_checkbutton.signal_toggled().connect(sigc::mem_fun(*this,&StateRotate_Context::refresh_scale_flag));
 
-	options_table.set_border_width(GAP*2);
-	options_table.set_row_spacings(GAP);
-	options_table.show_all();
+	options_grid.set_hexpand();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.show_all();
 	refresh_tool_options();
-	//App::dialog_tool_options->set_widget(options_table);
 	App::dialog_tool_options->present();
 
 	get_work_area()->set_allow_layer_clicks(true);
@@ -244,7 +246,7 @@ void
 StateRotate_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Rotate Tool"));
 	App::dialog_tool_options->set_name("rotate");
 }

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -198,7 +198,7 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 {
 	duck_dragger_->canvas_view_=get_canvas_view();
 
-	// Set up the tool options dialog
+	// Toolbox widgets
 	title_label.set_label(_("Rotate Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -207,15 +207,16 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 	title_label.set_hexpand();
 	title_label.set_halign(Gtk::ALIGN_START);
 	title_label.set_valign(Gtk::ALIGN_CENTER);
-	
+
 	scale_label.set_label(_("Allow Scale"));
 	scale_label.set_hexpand();
 	scale_label.set_halign(Gtk::ALIGN_START);
 	scale_label.set_valign(Gtk::ALIGN_CENTER);
-	
+
 	scale_box.pack_start(scale_label);
 	scale_box.pack_end(scale_checkbutton, Gtk::PACK_SHRINK);
-	
+
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(scale_box,
@@ -227,6 +228,7 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.show_all();
+
 	refresh_tool_options();
 	App::dialog_tool_options->present();
 
@@ -234,7 +236,6 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 	get_work_area()->set_duck_dragger(duck_dragger_);
 
 	get_work_area()->set_cursor(Gdk::EXCHANGE);
-//	get_work_area()->reset_cursor();
 
 	App::dock_toolbox->refresh();
 

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -184,7 +184,7 @@ StateScale_Context::StateScale_Context(CanvasView* canvas_view):
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
 	duck_dragger_(new DuckDrag_Scale())
 {
-	// Set up the tool options dialog
+	// Toolbox widgets
 	title_label.set_label(_("Scale Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -198,10 +198,10 @@ StateScale_Context::StateScale_Context(CanvasView* canvas_view):
 	aspect_lock_label.set_hexpand();
 	aspect_lock_label.set_halign(Gtk::ALIGN_START);
 	aspect_lock_label.set_valign(Gtk::ALIGN_CENTER);
-
 	aspect_lock_box.pack_start(aspect_lock_label);
 	aspect_lock_box.pack_end(aspect_lock_checkbutton, Gtk::PACK_SHRINK);
-	
+
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(aspect_lock_box,
@@ -209,10 +209,10 @@ StateScale_Context::StateScale_Context(CanvasView* canvas_view):
 
 	aspect_lock_checkbutton.signal_toggled().connect(sigc::mem_fun(*this,&StateScale_Context::refresh_aspect_lock_flag));
 
-	options_grid.set_hexpand();
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.show_all();
+
 	refresh_tool_options();
 	App::dialog_tool_options->present();
 

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -95,7 +95,7 @@ class studio::StateScale_Context : public sigc::trackable
 
 	etl::handle<DuckDrag_Scale> duck_dragger_;
 
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 
 	Gtk::Label aspect_lock_label;
@@ -190,26 +190,29 @@ StateScale_Context::StateScale_Context(CanvasView* canvas_view):
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
 	aspect_lock_label.set_label(_("Lock Aspect Ratio"));
-	aspect_lock_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	aspect_lock_label.set_hexpand();
+	aspect_lock_label.set_halign(Gtk::ALIGN_START);
+	aspect_lock_label.set_valign(Gtk::ALIGN_CENTER);
 
 	aspect_lock_box.pack_start(aspect_lock_label);
 	aspect_lock_box.pack_end(aspect_lock_checkbutton, Gtk::PACK_SHRINK);
 	
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(aspect_lock_box,
-		0, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(aspect_lock_box,
+		0, 1, 2, 1);
 
 	aspect_lock_checkbutton.signal_toggled().connect(sigc::mem_fun(*this,&StateScale_Context::refresh_aspect_lock_flag));
 
-	options_table.set_border_width(GAP*2);
-	options_table.set_row_spacings(GAP);
-	options_table.show_all();
+	options_grid.set_hexpand();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.show_all();
 	refresh_tool_options();
 	App::dialog_tool_options->present();
 
@@ -229,7 +232,7 @@ void
 StateScale_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Scale Tool"));
 	App::dialog_tool_options->set_name("scale");
 }

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -76,7 +76,7 @@ class studio::StateSketch_Context : public sigc::trackable
 
 	bool prev_table_status;
 
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 	Gtk::Button button_clear_sketch;
 	Gtk::Button button_undo_stroke;
@@ -239,28 +239,27 @@ StateSketch_Context::StateSketch_Context(CanvasView* canvas_view):
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 	
 	show_sketch_label.set_label(_("Show Sketch"));
-	show_sketch_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	show_sketch_label.set_halign(Gtk::ALIGN_START);
+	show_sketch_label.set_valign(Gtk::ALIGN_CENTER);
 
 	show_sketch_box.pack_start(show_sketch_label);
 	show_sketch_box.pack_end(show_sketch_checkbutton, Gtk::PACK_SHRINK);
 	
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(show_sketch_box,
-		0, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0
-		);
-	//options_table.attach(button_undo_stroke, 0, 2, 2, 3, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
-	//options_table.attach(button_clear_sketch, 0, 2, 3, 4, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
-	//options_table.attach(button_save_sketch, 0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
-	//options_table.attach(button_load_sketch, 1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(show_sketch_box,
+		0, 1, 2, 1);
 
-	options_table.set_border_width(GAP*2);
-	options_table.set_row_spacings(GAP);
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
+
 	refresh_tool_options();
 	App::dialog_tool_options->present();
 
@@ -313,7 +312,7 @@ void
 StateSketch_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Sketch Tool"));
 	App::dialog_tool_options->set_name("sketch");
 

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -234,6 +234,7 @@ StateSketch_Context::StateSketch_Context(CanvasView* canvas_view):
 	button_load_sketch.signal_clicked().connect(sigc::mem_fun(*this,&studio::StateSketch_Context::load_sketch));
 	show_sketch_checkbutton.signal_clicked().connect(sigc::mem_fun(*this,&studio::StateSketch_Context::toggle_show_sketch));
 
+	// Toolbox widgets
 	title_label.set_label(_("Sketch Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -249,7 +250,8 @@ StateSketch_Context::StateSketch_Context(CanvasView* canvas_view):
 
 	show_sketch_box.pack_start(show_sketch_label);
 	show_sketch_box.pack_end(show_sketch_checkbutton, Gtk::PACK_SHRINK);
-	
+
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(show_sketch_box,

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -47,8 +47,6 @@
 #include <synfig/general.h>
 
 #include <synfigapp/main.h>
-#include <gtkmm-3.0/gtkmm/widget.h>
-#include <gtkmm-3.0/gtkmm/enums.h>
 
 #endif
 

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -195,7 +195,7 @@ StateSmoothMove_Context::StateSmoothMove_Context(CanvasView* canvas_view):
 {
 	pressure=1.0f;
 
-	// Set up the tool options dialog
+	// Toolbox widgets
 	title_label.set_label(_("SmoothMove Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -212,6 +212,9 @@ StateSmoothMove_Context::StateSmoothMove_Context(CanvasView* canvas_view):
 	spin_radius.set_halign(Gtk::ALIGN_END);
 	spin_radius.set_valign(Gtk::ALIGN_CENTER);
 
+	load_settings();
+
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(spin_label,
@@ -221,11 +224,11 @@ StateSmoothMove_Context::StateSmoothMove_Context(CanvasView* canvas_view):
 
 	spin_radius.signal_value_changed().connect(sigc::mem_fun(*this,&StateSmoothMove_Context::refresh_radius));
 
-	options_grid.set_hexpand();
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
+
 	refresh_tool_options();
 	App::dialog_tool_options->present();
 
@@ -236,8 +239,6 @@ StateSmoothMove_Context::StateSmoothMove_Context(CanvasView* canvas_view):
 
 	get_work_area()->set_cursor(Gdk::FLEUR);
 	//get_work_area()->reset_cursor();
-
-	load_settings();
 }
 
 void

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -47,6 +47,8 @@
 #include <synfig/general.h>
 
 #include <synfigapp/main.h>
+#include <gtkmm-3.0/gtkmm/widget.h>
+#include <gtkmm-3.0/gtkmm/enums.h>
 
 #endif
 
@@ -99,7 +101,7 @@ class studio::StateSmoothMove_Context : public sigc::trackable
 
 	etl::handle<DuckDrag_SmoothMove> duck_dragger_;
 
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 
 	Glib::RefPtr<Gtk::Adjustment> adj_radius;
@@ -196,34 +198,37 @@ StateSmoothMove_Context::StateSmoothMove_Context(CanvasView* canvas_view):
 	pressure=1.0f;
 
 	// Set up the tool options dialog
-	
 	title_label.set_label(_("SmoothMove Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
 	spin_label.set_label(_("Radius:"));
-	spin_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-	
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(spin_label,
-		0, 1, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(spin_radius,
-		1, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
+	spin_label.set_halign(Gtk::ALIGN_START);
+	spin_label.set_valign(Gtk::ALIGN_CENTER);
+
+	spin_radius.set_halign(Gtk::ALIGN_END);
+	spin_radius.set_valign(Gtk::ALIGN_CENTER);
+
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(spin_label,
+		0, 1, 1, 1);
+	options_grid.attach(spin_radius,
+		1, 1, 1, 1);
 
 	spin_radius.signal_value_changed().connect(sigc::mem_fun(*this,&StateSmoothMove_Context::refresh_radius));
 
-	options_table.set_border_width(GAP*2);
-	options_table.set_row_spacings(GAP);
-	options_table.show_all();
+	options_grid.set_hexpand();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 	refresh_tool_options();
-	//App::dialog_tool_options->set_widget(options_table);
 	App::dialog_tool_options->present();
 
 	get_work_area()->set_allow_layer_clicks(true);
@@ -241,7 +246,7 @@ void
 StateSmoothMove_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Smooth Move"));
 	App::dialog_tool_options->set_name("smooth_move");
 }

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -111,7 +111,7 @@ class studio::StateStar_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -606,42 +606,38 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 
 	/* Set up the tool options dialog */
 
-	// 0, title
 	title_label.set_label(_("Star Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
-	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
 
-	// 2, layer types creation
 	layer_types_label.set_label(_("Layer Type:"));
-	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	layer_types_label.set_halign(Gtk::ALIGN_START);
+	layer_types_label.set_valign(Gtk::ALIGN_CENTER);
 
 	LAYER_CREATION(layer_star_togglebutton,
 		("synfig-layer_geometry_star"), _("Create a star layer"));
-
 	LAYER_CREATION(layer_region_togglebutton,
 		("synfig-layer_geometry_region"), _("Create a region layer"));
-
 	LAYER_CREATION(layer_outline_togglebutton,
 		("synfig-layer_geometry_outline"), _("Create an outline layer"));
-
 	LAYER_CREATION(layer_advanced_outline_togglebutton,
 		("synfig-layer_geometry_advanced_outline"), _("Create an advanced outline layer"));
-
 	LAYER_CREATION(layer_plant_togglebutton,
 		("synfig-layer_other_plant"), _("Create a plant layer"));
-
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
@@ -655,9 +651,9 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
 
-	// 3, blend method label and dropdown list
 	blend_label.set_label(_("Blend Method:"));
-	blend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	blend_label.set_halign(Gtk::ALIGN_START);
+	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
@@ -666,86 +662,86 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 		.set_local_name(_("Blend Method"))
 		.set_description(_("Defines the blend method to be used for stars")));
 
-	// 4, opacity label and slider
 	opacity_label.set_label(_("Opacity:"));
-	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	opacity_label.set_halign(Gtk::ALIGN_START);
+	opacity_label.set_valign(Gtk::ALIGN_CENTER);
 
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// 5, brush size
 	bline_width_label.set_label(_("Brush Size:"));
-	bline_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	bline_width_label.set_halign(Gtk::ALIGN_START);
+	bline_width_label.set_valign(Gtk::ALIGN_CENTER);
 	bline_width_label.set_sensitive(false);
 
 	bline_width_dist.set_digits(2);
 	bline_width_dist.set_range(0,10000000);
 	bline_width_dist.set_sensitive(false);
 
-	// 6, star points
 	number_of_points_label.set_label(_("Star Points:"));
-	number_of_points_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	number_of_points_label.set_halign(Gtk::ALIGN_START);
+	number_of_points_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 7, angle offset
 	angle_offset_label.set_label(_("Offset:"));
-	angle_offset_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	angle_offset_label.set_halign(Gtk::ALIGN_START);
+	angle_offset_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 8, radius ratio
 	radius_ratio_label.set_label(_("Radius Ratio:"));
-	radius_ratio_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	radius_ratio_label.set_halign(Gtk::ALIGN_START);
+	radius_ratio_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 9, regular polygon
 	regular_polygon_label.set_label(_("Regular Polygon"));
-	regular_polygon_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	regular_polygon_label.set_halign(Gtk::ALIGN_START);
+	regular_polygon_label.set_valign(Gtk::ALIGN_CENTER);
 
 	regular_polygon_box.pack_start(regular_polygon_label);
 	regular_polygon_box.pack_end(regular_polygon_checkbutton, Gtk::PACK_SHRINK);
 
-	// 10, inner width
 	inner_width_label.set_label(_("Inner Width:"));
-	inner_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	inner_width_label.set_halign(Gtk::ALIGN_START);
+	inner_width_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 11, inner tangent
 	inner_tangent_label.set_label(_("Inner Tangent:"));
-	inner_tangent_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	inner_tangent_label.set_halign(Gtk::ALIGN_START);
+	inner_tangent_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 12, outer width
 	outer_width_label.set_label(_("Outer Width:"));
-	outer_width_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	outer_width_label.set_halign(Gtk::ALIGN_START);
+	outer_width_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 13, outer tangent
 	outer_tangent_label.set_label(_("Outer Tangent:"));
-	outer_tangent_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	outer_tangent_label.set_halign(Gtk::ALIGN_START);
+	outer_tangent_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 14, invert
 	invert_label.set_label(_("Invert"));
-	invert_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	invert_label.set_halign(Gtk::ALIGN_START);
+	invert_label.set_valign(Gtk::ALIGN_CENTER);
 
 	invert_box.pack_start(invert_label);
 	invert_box.pack_end(invert_checkbutton, Gtk::PACK_SHRINK);
 	invert_box.set_sensitive(false);
 
-	// 15, feather
 	feather_label.set_label(_("Feather:"));
-	feather_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	feather_label.set_halign(Gtk::ALIGN_START);
+	feather_label.set_valign(Gtk::ALIGN_CENTER);
 	feather_label.set_sensitive(false);
 
 	feather_dist.set_digits(2);
 	feather_dist.set_range(0,10000000);
 	feather_dist.set_sensitive(false);
 
-	// 16, link origins
 	link_origins_label.set_label(_("Link Origins"));
-	link_origins_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	link_origins_label.set_halign(Gtk::ALIGN_START);
+	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 
 	link_origins_box.pack_start(link_origins_label);
 	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
 	link_origins_box.set_sensitive(false);
 
-	// 17, spline origins at center
 	origins_at_center_label.set_label(_("Spline Origins at Center"));
-	origins_at_center_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	origins_at_center_label.set_halign(Gtk::ALIGN_START);
+	origins_at_center_label.set_valign(Gtk::ALIGN_CENTER);
 
 	origins_at_center_box.pack_start(origins_at_center_label);
 	origins_at_center_box.pack_end(layer_origins_at_center_checkbutton, Gtk::PACK_SHRINK);
@@ -753,126 +749,73 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 
 	load_settings();
 
-	// pack all options to the options_table
-
-	// 0, title
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	options_table.attach(id_box,
-		0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 2, layer types creation
-	options_table.attach(layer_types_label,
-		0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(layer_types_box,
-		0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 3, blend method
-	options_table.attach(blend_box,
-		0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(blend_enum,
-		1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 4, opacity
-	options_table.attach(opacity_label,
-		0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(opacity_hscl,
-		1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 5, brush size
-	options_table.attach(bline_width_label,
-		0, 1, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(bline_width_dist,
-		1, 2, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 6, star points
-	options_table.attach(number_of_points_label,
-		0, 1, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(number_of_points_spin,
-		1, 2, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 7, star points offset
-	options_table.attach(angle_offset_label,
-		0, 1, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(angle_offset_spin,
-		1, 2, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 8, radius ratio
-	options_table.attach(radius_ratio_label,
-		0, 1, 9, 10, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(radius_ratio_spin,
-		1, 2, 9, 10, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 9, regular polygon
-	options_table.attach(regular_polygon_box,
-		0, 2, 10, 11, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 10, inner width
-	options_table.attach(inner_width_label,
-		0, 1, 11, 12, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(inner_width_spin,
-		1, 2, 11, 12, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 11, inner tangent
-	options_table.attach(inner_tangent_label,
-		0, 1, 12, 13, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(inner_tangent_spin,
-		1, 2, 12, 13, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 12, outer width
-	options_table.attach(outer_width_label,
-		0, 1, 13, 14, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(outer_width_spin,
-		1, 2, 13, 14, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 13, outer tangent
-	options_table.attach(outer_tangent_label,
-		0, 1, 14, 15, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(outer_tangent_spin,
-		1, 2, 14, 15, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 14, invert
-	options_table.attach(invert_box,
-		0, 2, 15, 16, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 15, feather
-	options_table.attach(feather_label,
-		0, 1, 16, 17, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(feather_dist,
-		1, 2, 16, 17, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 16, link origins
-	options_table.attach(link_origins_box,
-		0, 2, 17, 18, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 17, origins at center
-	options_table.attach(origins_at_center_box,
-		0, 2, 18, 19, Gtk::FILL, Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_types_label,
+		0, 2, 2, 1);
+	options_grid.attach(layer_types_box,
+		0, 3, 2, 1);
+	options_grid.attach(blend_box,
+		0, 4, 1, 1);
+	options_grid.attach(blend_enum,
+		1, 4, 1, 1);
+	options_grid.attach(opacity_label,
+		0, 5, 1, 1);
+	options_grid.attach(opacity_hscl,
+		1, 5, 1, 1);
+	options_grid.attach(bline_width_label,
+		0, 6, 1, 1);
+	options_grid.attach(bline_width_dist,
+		1, 6, 1, 1);
+	options_grid.attach(number_of_points_label,
+		0, 7, 1, 1);
+	options_grid.attach(number_of_points_spin,
+		1, 7, 1, 1);
+	options_grid.attach(angle_offset_label,
+		0, 8, 1, 1);
+	options_grid.attach(angle_offset_spin,
+		1, 8, 1, 1);
+	options_grid.attach(radius_ratio_label,
+		0, 9, 1, 1);
+	options_grid.attach(radius_ratio_spin,
+		1, 9, 1, 1);
+	options_grid.attach(regular_polygon_box,
+		0, 10, 2, 1);
+	options_grid.attach(inner_width_label,
+		0, 11, 1, 1);
+	options_grid.attach(inner_width_spin,
+		1, 11, 1, 1);
+	options_grid.attach(inner_tangent_label,
+		0, 12, 1, 1);
+	options_grid.attach(inner_tangent_spin,
+		1, 12, 1, 1);
+	options_grid.attach(outer_width_label,
+		0, 13, 1, 1);
+	options_grid.attach(outer_width_spin,
+		1, 13, 1, 1);
+	options_grid.attach(outer_tangent_label,
+		0, 14, 1, 1);
+	options_grid.attach(outer_tangent_spin,
+		1, 14, 1, 1);
+	options_grid.attach(invert_box,
+		0, 15, 2, 1);
+	options_grid.attach(feather_label,
+		0, 16, 1, 1);
+	options_grid.attach(feather_dist,
+		1, 16, 1, 1);
+	options_grid.attach(link_origins_box,
+		0, 17, 2, 1);
+	options_grid.attach(origins_at_center_box,
+		0, 18, 2, 1);
 
 	// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacings(GAP); // row gap
-	options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	//options_table.set_row_spacing(19, 0); // the final row using border width of table
-	options_table.set_margin_bottom(0);
+	options_grid.set_border_width(GAP*2); // border width
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
 
-	options_table.show_all();
+	options_grid.show_all();
 
 	refresh_tool_options();
 	App::dialog_tool_options->present();
@@ -895,7 +838,7 @@ void
 StateStar_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Star Tool"));
 	App::dialog_tool_options->set_name("star");
 }

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -604,8 +604,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 {
 	egress_on_selection_change=true;
 
-	/* Set up the tool options dialog */
-
+	// Toolbox widgets
 	title_label.set_label(_("Star Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -749,6 +748,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 
 	load_settings();
 
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(id_box,
@@ -810,11 +810,9 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	options_grid.attach(origins_at_center_box,
 		0, 18, 2, 1);
 
-	// fine-tune options layout
-	options_grid.set_border_width(GAP*2); // border width
+	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
-
 	options_grid.show_all();
 
 	refresh_tool_options();

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -106,7 +106,7 @@ class studio::StateText_Context
 	synfigapp::Settings& settings;
 
 	// holder of options
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 
 	// title
 	Gtk::Label title_label;
@@ -392,26 +392,27 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 
 	/* Set up the tool options dialog */
 
-	// 0, title
 	title_label.set_label(_("Text Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// 1, layer name label and entry
 	id_label.set_label(_("Name:"));
-	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	id_label.set_halign(Gtk::ALIGN_START);
+	id_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(id_gap, GAP);
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
 
-	// 2, layer types creation
 	layer_types_label.set_label(_("Layer Type:"));
-	layer_types_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	layer_types_label.set_halign(Gtk::ALIGN_START);
+	layer_types_label.set_valign(Gtk::ALIGN_CENTER);
 
 	LAYER_CREATION(layer_text_togglebutton,
 		("synfig-layer_other_text"), _("Create a text layer"));
@@ -421,9 +422,9 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
 	layer_types_box.pack_start(layer_text_togglebutton, Gtk::PACK_SHRINK);
 
-	// 3, blend method label and dropdown list
 	blend_label.set_label(_("Blend Method:"));
-	blend_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	blend_label.set_halign(Gtk::ALIGN_START);
+	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	SPACING(blend_gap, GAP);
 	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
 	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
@@ -432,102 +433,74 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 		.set_local_name(_("Blend Method"))
 		.set_description(_("Defines the blend method to be used for texts")));
 
-	// 4, opacity label and slider
 	opacity_label.set_label(_("Opacity:"));
-	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	opacity_label.set_halign(Gtk::ALIGN_START);
+	opacity_label.set_valign(Gtk::ALIGN_CENTER);
 
 	opacity_hscl.set_digits(2);
 	opacity_hscl.set_value_pos(Gtk::POS_LEFT);
 	opacity_hscl.set_tooltip_text(_("Opacity"));
 
-	// 5, paragraph
 	paragraph_label.set_label(_("Multiline Text"));
-	paragraph_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	paragraph_label.set_halign(Gtk::ALIGN_START);
+	paragraph_label.set_valign(Gtk::ALIGN_CENTER);
 	paragraph_box.pack_start(paragraph_label, Gtk::PACK_SHRINK);
 	paragraph_box.pack_end(paragraph_checkbutton, Gtk::PACK_SHRINK);
 
-	// 6, size
 	size_label.set_label(_("Size:"));
-	size_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	size_label.set_halign(Gtk::ALIGN_START);
+	size_label.set_valign(Gtk::ALIGN_CENTER);
 
 	size_widget.set_digits(2);
 	size_widget.set_canvas(canvas_view->get_canvas());
 
-	// 7, orientation
 	orientation_label.set_label(_("Orientation:"));
-	orientation_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	orientation_label.set_halign(Gtk::ALIGN_START);
+	orientation_label.set_valign(Gtk::ALIGN_CENTER);
 
 	orientation_widget.set_digits(2);
 
-	// 8, family
 	family_label.set_label(_("Family:"));
-	family_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	family_label.set_halign(Gtk::ALIGN_START);
+	family_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// pack all options to the options_table
+	// pack all options to the options_grid
 
-	// 0, title
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 1, name
-	options_table.attach(id_box,
-		0, 2, 1, 2, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 2, layer types creation
-	options_table.attach(layer_types_label,
-		0, 2, 2, 3, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(layer_types_box,
-		0, 2, 3, 4, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 3, blend method
-	options_table.attach(blend_box,
-		0, 1, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(blend_enum,
-		1, 2, 4, 5, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 4, opacity
-	options_table.attach(opacity_label,
-		0, 1, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(opacity_hscl,
-		1, 2, 5, 6, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 5, paragraph
-	options_table.attach(paragraph_box,
-		0, 2, 6, 7, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 6, size
-	options_table.attach(size_label,
-		0, 1, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(size_widget,
-		1, 2, 7, 8, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 7, orientation
-	options_table.attach(orientation_label,
-		0, 1, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(orientation_widget,
-		1, 2, 8, 9, Gtk::EXPAND|Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	// 8, family
-	options_table.attach(family_label,
-		0, 1, 9, 10, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(family_entry,
-		1, 2, 9, 10, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-		// fine-tune options layout
-	options_table.set_border_width(GAP*2); // border width
-	options_table.set_row_spacings(GAP); // row gap
-	options_table.set_row_spacing(0, GAP*2); // the gap between first and second row.
-	options_table.set_row_spacing(2, 1); // row gap between label and icon of layer type
-	//options_table.set_row_spacing(9, 0); // the final row using border width of table
-	options_table.set_margin_bottom(0);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(id_box,
+		0, 1, 2, 1);
+	options_grid.attach(layer_types_label,
+		0, 2, 2, 1);
+	options_grid.attach(layer_types_box,
+		0, 3, 2, 1);
+	options_grid.attach(blend_box,
+		0, 4, 1, 1);
+	options_grid.attach(blend_enum,
+		1, 4, 1, 1);
+	options_grid.attach(opacity_label,
+		0, 5, 1, 1);
+	options_grid.attach(opacity_hscl,
+		1, 5, 1, 1);
+	options_grid.attach(paragraph_box,
+		0, 6, 2, 1);
+	options_grid.attach(size_label,
+		0, 7, 1, 1);
+	options_grid.attach(size_widget,
+		1, 7, 1, 1);
+	options_grid.attach(orientation_label,
+		0, 8, 1, 1);
+	options_grid.attach(orientation_widget,
+		1, 8, 1, 1);
+	options_grid.attach(family_label,
+		0, 9, 1, 1);
+	options_grid.attach(family_entry,
+		1, 9, 1, 1);
 
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.set_margin_bottom(0);
+	options_grid.show_all();
 
 	load_settings();
 
@@ -561,7 +534,7 @@ void
 StateText_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Text Tool"));
 	App::dialog_tool_options->set_name("text");
 }

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -389,9 +389,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 {
 	egress_on_selection_change=true;
 
-
-	/* Set up the tool options dialog */
-
+	// Toolbox widgets
 	title_label.set_label(_("Text Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -464,8 +462,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	family_label.set_halign(Gtk::ALIGN_START);
 	family_label.set_valign(Gtk::ALIGN_CENTER);
 
-	// pack all options to the options_grid
-
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(id_box,

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -97,7 +97,7 @@ class studio::StateWidth_Context : public sigc::trackable
 	synfigapp::Settings& settings;
 
 	//Toolbox display
-	Gtk::Table options_table;
+	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 
 	Glib::RefPtr<Gtk::Adjustment> adj_delta;
@@ -247,42 +247,43 @@ StateWidth_Context::StateWidth_Context(CanvasView* canvas_view):
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
 	title_label.set_attributes(list);
-	title_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	title_label.set_hexpand();
+	title_label.set_halign(Gtk::ALIGN_START);
+	title_label.set_valign(Gtk::ALIGN_CENTER);
 	
 	relative_label.set_label(_("Relative Growth"));
-	relative_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	relative_label.set_halign(Gtk::ALIGN_START);
+	relative_label.set_valign(Gtk::ALIGN_CENTER);
 	
 	relative_box.pack_start(relative_label);
 	relative_box.pack_end(relative_checkbutton, Gtk::PACK_SHRINK);
 
 	growth_label.set_label(_("Growth:"));
-	growth_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	growth_label.set_halign(Gtk::ALIGN_START);
+	growth_label.set_valign(Gtk::ALIGN_CENTER);
 
 	radius_label.set_label(_("Radius:"));
-	radius_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	radius_label.set_halign(Gtk::ALIGN_START);
+	radius_label.set_valign(Gtk::ALIGN_CENTER);
 	
-	options_table.attach(title_label,
-		0, 2, 0, 1, Gtk::FILL, Gtk::FILL, 0, 0
-		);
-	options_table.attach(growth_label,
-		0, 1, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0
-		);
-	options_table.attach(spin_delta,
-		1, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0
-		);
-	options_table.attach(radius_label,
-		0, 1, 2, 3, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0
-		);
-	options_table.attach(*influence_radius,
-		1, 2, 2, 3, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0
-		);
-	options_table.attach(relative_box,
-		0, 2, 3, 4, Gtk::EXPAND|Gtk::FILL, Gtk::EXPAND|Gtk::FILL, 0, 0
-		);
+	options_grid.attach(title_label,
+		0, 0, 2, 1);
+	options_grid.attach(growth_label,
+		0, 1, 1, 1);
+	options_grid.attach(spin_delta,
+		1, 1, 1, 1);
+	options_grid.attach(radius_label,
+		0, 2, 1, 1);
+	options_grid.attach(*influence_radius,
+		1, 2, 1, 1);
+	options_grid.attach(relative_box,
+		0, 3, 2, 1);
 
-	options_table.set_border_width(GAP*2);
-	options_table.set_row_spacings(GAP);
-	options_table.show_all();
+	options_grid.set_border_width(GAP*2);
+	options_grid.set_row_spacing(GAP);
+	options_grid.show_all();
+	options_grid.set_margin_bottom(0);
+
 	refresh_tool_options();
 	App::dialog_tool_options->present();
 	// Turn off layer clicking
@@ -329,7 +330,7 @@ void
 StateWidth_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
-	App::dialog_tool_options->set_widget(options_table);
+	App::dialog_tool_options->set_widget(options_grid);
 	App::dialog_tool_options->set_local_name(_("Width Tool"));
 	App::dialog_tool_options->set_name("width");
 }

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -233,15 +233,7 @@ StateWidth_Context::StateWidth_Context(CanvasView* canvas_view):
 	adj_delta(Gtk::Adjustment::create(6,0,20,0.01,0.1)),
 	spin_delta(adj_delta,0.01,3)
 {
-	influence_radius=manage(new Widget_Distance());
-	influence_radius->show();
-	influence_radius->set_digits(0);
-	influence_radius->set_range(0,10000000);
-	influence_radius->set_size_request(24,-1);
-
-	load_settings();
-
-	// Set up the tool options dialog
+	// Toolbox widgets
 	title_label.set_label(_("Width Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
@@ -265,7 +257,16 @@ StateWidth_Context::StateWidth_Context(CanvasView* canvas_view):
 	radius_label.set_label(_("Radius:"));
 	radius_label.set_halign(Gtk::ALIGN_START);
 	radius_label.set_valign(Gtk::ALIGN_CENTER);
-	
+
+	influence_radius=manage(new Widget_Distance());
+	influence_radius->show();
+	influence_radius->set_digits(0);
+	influence_radius->set_range(0,10000000);
+	influence_radius->set_size_request(24,-1);
+
+	load_settings();
+
+	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
 	options_grid.attach(growth_label,


### PR DESCRIPTION
Migrate toolbox layouts from `Gtk::Table` (deprecated) to `Gtk::Grid`.