### PR TITLE
[Synfig Studio] Exported canvas can be reopened after closing

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -733,6 +733,7 @@ void CanvasView::deactivate()
 
 void CanvasView::present()
 {
+	show(); // gtk_widget_show also checks visibility, so there is no need to call `is_visible()`
 	App::set_selected_canvas_view(this);
 	update_title();
 	Dockable::present();


### PR DESCRIPTION
Fixes https://github.com/synfig/synfig/issues/2087