### PR TITLE
[MSVC] Fixed unresolved external symbol error when building `lyr_std`

### DIFF
--- a/synfig-core/src/modules/mod_particle/plant.cpp
+++ b/synfig-core/src/modules/mod_particle/plant.cpp
@@ -96,7 +96,7 @@ Plant::Plant():
 	param_random_factor(ValueBase(Real(0.2))),
 	param_drag(ValueBase(Real(0.1))),
 	param_use_width(ValueBase(true)),
-	version(version__)
+	version(get_register_version())
 {
 	bounding_rect=Rect::zero();
 	Random random;

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -114,12 +114,12 @@ Layer::subsys_init()
 	_layer_book=new Book();
 
 #define INCLUDE_LAYER(class)									\
-	synfig::Layer::book() [synfig::String(class::name__)] =		\
+	synfig::Layer::book() [class::get_register_name()] =		\
 		BookEntry(class::create,								\
-				  class::name__,								\
-				   _(class::local_name__),		\
-				  class::category__,							\
-				  class::version__)
+				  class::get_register_name(),					\
+				   _(class::get_register_local_name()),			\
+				  class::get_register_category(),				\
+				  class::get_register_version())
 
 #define LAYER_ALIAS(class,alias)								\
 	synfig::Layer::book()[synfig::String(alias)] =				\
@@ -127,7 +127,7 @@ Layer::subsys_init()
 				  alias,										\
 				  alias,										\
 				  CATEGORY_DO_NOT_USE,							\
-				  class::version__)
+				  class::get_register_version())
 
 	INCLUDE_LAYER(Layer_SolidColor);
 		LAYER_ALIAS(Layer_SolidColor,	"solid_color");

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -60,26 +60,31 @@
 
 //! Defines various variables and the create method, common for all importers.
 //! To be used in the private part of the importer class definition.
+// Static `name`, `local_name`, `version`, and `category` is needed to register layer.
+// We also have non-static versions of these methods in order to be able to change the
+// layer name (visual presentation) at runtime depending on its parameters.
 #define SYNFIG_LAYER_MODULE_EXT \
 	public: \
-	static const char name__[], version__[], local_name__[], category__[]; \
+	static const char* get_register_name(); \
+	static const char* get_register_version(); \
+	static const char* get_register_local_name(); \
+	static const char* get_register_category(); \
 	static Layer *create();
-
 //! Sets the name of the layer
 #define SYNFIG_LAYER_SET_NAME(class,x) \
-	const char class::name__[]=x
+	const char* class::get_register_name() { return x; }
 
 //! Sets the local name of the layer
 #define SYNFIG_LAYER_SET_LOCAL_NAME(class,x) \
-	const char class::local_name__[]=x;
+	const char* class::get_register_local_name() { return x; }
 
 //! Sets the category of the layer
 #define SYNFIG_LAYER_SET_CATEGORY(class,x) \
-	const char class::category__[]=x
+	const char* class::get_register_category() { return x; }
 
 //! Sets the version string for the layer
 #define SYNFIG_LAYER_SET_VERSION(class,x) \
-	const char class::version__[]=x
+	const char* class::get_register_version() { return x; }
 
 //! Defines de implementation of the create method for the importer
 #define SYNFIG_LAYER_INIT(class) \
@@ -126,14 +131,14 @@
 //! Exports the name or the local name of the layer
 #define EXPORT_NAME() \
 	if (param=="Name" || param=="name" || param=="name__") \
-		return name__; \
+		return get_register_name(); \
 	else if (param=="local_name__") \
-		return synfigcore_localize(local_name__);
+		return synfigcore_localize(get_register_local_name());
 
 //! Exports the version of the layer
 #define EXPORT_VERSION() \
 	if (param=="Version" || param=="version" || param=="version__") \
-		return version__;
+		return get_register_version();
 
 //! This is used as the category for layer book entries which represent aliases of layers.
 //! It prevents these layers showing up in the menu.

--- a/synfig-core/src/synfig/module.h
+++ b/synfig-core/src/synfig/module.h
@@ -87,10 +87,10 @@
 #define LAYER(class)																			\
 	synfig::Layer::register_in_book(															\
 		synfig::Layer::BookEntry(class::create,													\
-								 class::name__,													\
-								 synfigcore_localize(class::local_name__),		\
-								 class::category__,												\
-								 class::version__));
+								 class::get_register_name(),													\
+								 synfigcore_localize(class::get_register_local_name()),		\
+								 class::get_register_category(),												\
+								 class::get_register_version()));
 
 //! Register a Layer class in the book of layers with an alias
 #define LAYER_ALIAS(class,alias)																\
@@ -99,7 +99,7 @@
 								 alias,															\
 								 alias,															\
 								 CATEGORY_DO_NOT_USE,											\
-								 class::version__));
+								 class::get_register_version()));
 
 //! Marks the end of the layers in the module's inventory
 #define END_LAYERS }


### PR DESCRIPTION
Fixed: LNK2001 Unresolved external symbol "public: static char const *
 const synfig::Layer_Shape::name__"
- Global static symbols must be properly exported for the MSVC compiler to find them (functions are exported/imported automatically).

 Also there is a problem here to declare these symbols as imported/exported.
The base `Layer` class should export these fields, but the derived `Layer_Shape` should import them from the `Base` class and
export them again.
So the simplest solution here is to switch from static symbols to functions.