### PR TITLE
[Synfig Studio] Replace deprecated Gtk::HScale with Gtk::Scale

### DIFF
--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -168,7 +168,7 @@ class studio::StateBLine_Context : public sigc::trackable
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 	// brush size
 	Gtk::Label bline_width_label;
@@ -505,7 +505,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	depth(-1),
 	duckmatic_push(get_work_area()),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f)
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1))
 {
 	egress_on_selection_change=true;
 

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -144,7 +144,7 @@ class studio::StateCircle_Context : public sigc::trackable
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 	// brush size
 	Gtk::Label bline_width_label;
@@ -525,7 +525,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	duckmatic_push(get_work_area()),
 	prev_workarea_layer_status_(get_work_area()->get_allow_layer_clicks()),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f),
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1)),
 	number_of_bline_points_adj(Gtk::Adjustment::create(0, 2, 120, 1, 1)),
 	number_of_bline_points_spin(number_of_bline_points_adj, 1, 0),
 	bline_point_angle_offset_adj(Gtk::Adjustment::create(0, -360, 360, 0.1, 1)),

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -170,7 +170,7 @@ class studio::StateDraw_Context : public sigc::trackable
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 	// brush size
 	Gtk::Label bline_width_label;
@@ -615,7 +615,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	push_state(*get_work_area()),
 	//loop_(false),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f),
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1)),
 	min_pressure_adj(Gtk::Adjustment::create(0,0,1,0.01,0.1)),
 	min_pressure_spin(min_pressure_adj,0.1,3),
 	localthres_adj(Gtk::Adjustment::create(20, 1, 100000, 0.1, 1)),

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -132,7 +132,7 @@ class studio::StateGradient_Context : public sigc::trackable
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 
 public:
@@ -384,8 +384,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	duckmatic_push(get_work_area()),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
 	prev_workarea_layer_status_(get_work_area()->get_allow_layer_clicks()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f)
-
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1))
 {
 	egress_on_selection_change=true;
 

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -167,7 +167,7 @@ class studio::StateLasso_Context : public sigc::trackable
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 	// brush size
 	Gtk::Label bline_width_label;
@@ -593,7 +593,7 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	push_state(*get_work_area()),
 	//loop_(false),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f),
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1)),
 	min_pressure_adj(Gtk::Adjustment::create(0,0,1,0.01,0.1)),
 	min_pressure_spin(min_pressure_adj,0.1,3),
 	localthres_adj(Gtk::Adjustment::create(20, 1, 100000, 0.1, 1)),

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -140,7 +140,7 @@ class studio::StatePolygon_Context : public sigc::trackable
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 	// brush size
 	Gtk::Label bline_width_label;
@@ -465,7 +465,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	prev_workarea_layer_status_(get_work_area()->get_allow_layer_clicks()),
 	duckmatic_push(get_work_area()),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f)
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1))
 {
 	egress_on_selection_change=true;
 

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -138,7 +138,7 @@ class studio::StateRectangle_Context : public sigc::trackable
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 	// brush size
 	Gtk::Label bline_width_label;
@@ -478,7 +478,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	duckmatic_push(get_work_area()),
 	prev_workarea_layer_status_(get_work_area()->get_allow_layer_clicks()),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f)
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1))
 {
 	egress_on_selection_change=true;
 

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -138,7 +138,7 @@ class studio::StateStar_Context : public sigc::trackable
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 	// brush size
 	Gtk::Label bline_width_label;
@@ -586,7 +586,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	duckmatic_push(get_work_area()),
 	prev_workarea_layer_status_(get_work_area()->get_allow_layer_clicks()),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f),
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1)),
 	number_of_points_adj(Gtk::Adjustment::create(0, 2, 120, 1, 1)),
 	number_of_points_spin(number_of_points_adj,1,0),
 	radius_ratio_adj(Gtk::Adjustment::create(0, -10, 10, 0.01, 0.1)),

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -128,7 +128,7 @@ class studio::StateText_Context
 
 	// opacity
 	Gtk::Label opacity_label;
-	Gtk::HScale opacity_hscl;
+	Gtk::Scale opacity_hscl;
 
 	// paragraph
 	Gtk::Label paragraph_label;
@@ -385,7 +385,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	duckmatic_push(get_work_area()),
 	prev_workarea_layer_status_(get_work_area()->get_allow_layer_clicks()),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	opacity_hscl(0.0f, 1.0125f, 0.0125f)
+	opacity_hscl(Gtk::Adjustment::create(1.0, 0.0, 1.0, 0.01, 0.1))
 {
 	egress_on_selection_change=true;
 


### PR DESCRIPTION
Replace deprecated `Gtk::HScale` used in toolboxes with `Gtk::Scale`.

Also fine-tuned step increment so that with mouse scroll the step is of 0.1, with arrows 0.01 and with Ctrl+arrows is 0.1 instead of some predefined step increment.
