### PR TITLE
[Synfig Studio] Replace Render and Preview dialogs deprecated methods

### DIFF
--- a/synfig-studio/src/gui/dialogs/dialog_preview.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_preview.cpp
@@ -60,15 +60,16 @@ using namespace studio;
 
 //dialog_preview stuff...
 Dialog_Preview::Dialog_Preview():
-	settings(this, "preview"),
-	preview_table(1, 1, true)
+	settings(this, "preview")
 {
 	set_title(_("Preview"));
 	set_transient_for(*App::main_window);
-	add(preview_table);
-	preview_table.attach(preview, 0, 1, 0, 1);
+	add(preview_grid);
+	preview_grid.set_row_homogeneous(true);
+	preview_grid.set_column_homogeneous(true);
+	preview_grid.attach(preview, 0, 0, 1, 1);
 	preview.show();
-	preview_table.show();
+	preview_grid.show();
 
 	//catch key press event
 	signal_key_press_event().connect(sigc::mem_fun(*this, &Dialog_Preview::on_key_pressed));

--- a/synfig-studio/src/gui/dialogs/dialog_preview.h
+++ b/synfig-studio/src/gui/dialogs/dialog_preview.h
@@ -66,7 +66,7 @@ public:
 	Dialog_Preview();
 	~Dialog_Preview();
 
-    void set_preview(etl::handle<Preview> prev);
+	void set_preview(etl::handle<Preview> prev);
 
 	Widget_Preview &get_widget() {return preview;}
 	const Widget_Preview &get_widget() const {return preview;}
@@ -82,7 +82,7 @@ private:
 	void close_window_handler();
 
 protected:
-	Gtk::Table preview_table;
+	Gtk::Grid preview_grid;
 
 }; // END of Dialog_Preview
 

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -42,7 +42,7 @@
 
 #include <gtkmm/alignment.h>
 #include <gtkmm/frame.h>
-#include <gtkmm/table.h>
+#include <gtkmm/grid.h>
 
 #include <gui/app.h>
 #include <gui/asyncrenderer.h>
@@ -88,6 +88,7 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	toggle_extract_alpha(_("Extract alpha"), true),
 	tparam("mpeg4",6000)
 {
+	this->set_resizable(false);
 	progress_logger.reset(new ProgressLogger());
 	tparam.sequence_separator=App::sequence_separator;
 	widget_rend_desc.show();
@@ -112,8 +113,9 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	dialogPadding->set_padding(12, 12, 12, 12);
 	get_vbox()->pack_start(*dialogPadding, false, false, 0);
 
-	Gtk::VBox *dialogBox = manage(new Gtk::VBox(false, 12));
-	dialogPadding->add(*dialogBox);
+	Gtk::Grid *dialogGrid = manage(new Gtk::Grid());
+	dialogGrid->set_row_spacing(12);
+	dialogPadding->add(*dialogGrid);
 
 	Gtk::Button *choose_button(manage(new class Gtk::Button(Gtk::StockID(_("Choose...")))));
 	choose_button->show();
@@ -127,67 +129,77 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	Gtk::Frame *target_frame=manage(new Gtk::Frame(_("Target")));
 	target_frame->set_shadow_type(Gtk::SHADOW_NONE);
 	((Gtk::Label *) target_frame->get_label_widget())->set_markup(_("<b>Target</b>"));
-	dialogBox->pack_start(*target_frame);
+	dialogGrid->attach(*target_frame, 0, 0, 1, 1);
 	Gtk::Alignment *targetPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
 	targetPadding->set_padding(6, 0, 24, 0);
 	target_frame->add(*targetPadding);
 
-	Gtk::Table *target_table = manage(new Gtk::Table(2, 3, false));
-	target_table->set_row_spacings(6);
-	target_table->set_col_spacings(12);
-	targetPadding->add(*target_table);
+	Gtk::Grid *target_grid = manage(new Gtk::Grid());
+	target_grid->set_row_spacing(6);
+	target_grid->set_column_spacing(12);
+	targetPadding->add(*target_grid);
 
 	Gtk::Label *filenameLabel = manage(new Gtk::Label(_("_Filename"), true));
-	filenameLabel->set_alignment(0, 0.5);
+	filenameLabel->set_halign(Gtk::ALIGN_START);
+	filenameLabel->set_valign(Gtk::ALIGN_CENTER);
 	filenameLabel->set_mnemonic_widget(entry_filename);
-	target_table->attach(*filenameLabel, 0, 1, 0, 1, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
-	target_table->attach(entry_filename, 1, 2, 0, 1, Gtk::EXPAND|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
-	target_table->attach(*choose_button, 2, 3, 0, 1, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
+	entry_filename.set_hexpand();
+	target_grid->attach(*filenameLabel, 0, 0, 1, 1);
+	target_grid->attach(entry_filename, 1, 0, 1, 1);
+	target_grid->attach(*choose_button, 2, 0, 1, 1);
 
 	Gtk::Label *targetLabel = manage(new Gtk::Label(_("_Target"), true));
-	targetLabel->set_alignment(0, 0.5);
+	targetLabel->set_halign(Gtk::ALIGN_START);
+	targetLabel->set_valign(Gtk::ALIGN_CENTER);
 	targetLabel->set_mnemonic_widget(comboboxtext_target);
-	target_table->attach(*targetLabel, 0, 1, 1, 2, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
-	target_table->attach(comboboxtext_target, 1, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
-	target_table->attach(*tparam_button, 2, 3, 1, 2, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
+	comboboxtext_target.set_hexpand();
+	target_grid->attach(*targetLabel, 0, 1, 1, 1);
+	target_grid->attach(comboboxtext_target, 1, 1, 1, 1);
+	target_grid->attach(*tparam_button, 2, 1, 1, 1);
 
 	toggle_single_frame.signal_toggled().connect(sigc::mem_fun(*this, &studio::RenderSettings::on_single_frame_toggle));
 
 	Gtk::Frame *settings_frame=manage(new Gtk::Frame(_("Settings")));
 	settings_frame->set_shadow_type(Gtk::SHADOW_NONE);
 	((Gtk::Label *) settings_frame->get_label_widget())->set_markup(_("<b>Settings</b>"));
-	dialogBox->pack_start(*settings_frame);
+	dialogGrid->attach(*settings_frame, 0, 1, 1, 1);
 
 	Gtk::Alignment *settingsPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
 	settingsPadding->set_padding(6, 0, 24, 0);
 	settings_frame->add(*settingsPadding);
 
-	Gtk::Table *settings_table=manage(new Gtk::Table(3,2,false));
-	settings_table->set_row_spacings(6);
-	settings_table->set_col_spacings(12);
-	settingsPadding->add(*settings_table);
+	Gtk::Grid *settings_grid = manage(new Gtk::Grid());
+	settings_grid->set_row_spacing(6);
+	settings_grid->set_column_spacing(12);
+	settingsPadding->add(*settings_grid);
 
 	Gtk::Label *qualityLabel = manage(new Gtk::Label(_("_Quality"), true));
-	qualityLabel->set_alignment(0, 0.5);
+	qualityLabel->set_halign(Gtk::ALIGN_START);
+	qualityLabel->set_valign(Gtk::ALIGN_CENTER);
 	qualityLabel->set_mnemonic_widget(entry_quality);
-	settings_table->attach(*qualityLabel, 0, 1, 0, 1, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
-	settings_table->attach(entry_quality, 1, 2, 0, 1, Gtk::EXPAND|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
+	entry_quality.set_hexpand();
+	settings_grid->attach(*qualityLabel, 0, 0, 1, 1);
+	settings_grid->attach(entry_quality, 1, 0, 1, 1);
 
 	Gtk::Label *antiAliasLabel = manage(new Gtk::Label(_("_Anti-Aliasing"), true));
-	antiAliasLabel->set_alignment(0, 0.5);
+	antiAliasLabel->set_halign(Gtk::ALIGN_START);
+	antiAliasLabel->set_valign(Gtk::ALIGN_CENTER);
 	antiAliasLabel->set_mnemonic_widget(entry_antialias);
-	settings_table->attach(*antiAliasLabel, 0, 1, 1, 2, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
-	settings_table->attach(entry_antialias, 1, 2, 1, 2, Gtk::EXPAND|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
+	entry_antialias.set_hexpand();
+	settings_grid->attach(*antiAliasLabel, 0, 1, 1, 1);
+	settings_grid->attach(entry_antialias, 1, 1, 1, 1);
 
-	toggle_single_frame.set_alignment(0, 0.5);
-	settings_table->attach(toggle_single_frame, 2, 3, 0, 1, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
+	toggle_single_frame.set_halign(Gtk::ALIGN_START);
+	toggle_single_frame.set_valign(Gtk::ALIGN_CENTER);
+	settings_grid->attach(toggle_single_frame, 2, 0, 1, 1);
 	toggle_single_frame.set_active(false);
 
-	toggle_extract_alpha.set_alignment(0, 0.5);
-	settings_table->attach(toggle_extract_alpha, 2, 3, 1, 2, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL, 0, 0);
+	toggle_extract_alpha.set_halign(Gtk::ALIGN_START);
+	toggle_extract_alpha.set_valign(Gtk::ALIGN_CENTER);
+	settings_grid->attach(toggle_extract_alpha, 2, 1, 1, 1);
 	toggle_extract_alpha.set_active(false);
 
-	dialogBox->pack_start(widget_rend_desc);
+	dialogGrid->attach(widget_rend_desc, 0, 2, 1, 1);
 
 
 	Gtk::Button *cancel_button(manage(new class Gtk::Button(Gtk::StockID("gtk-cancel"))));


### PR DESCRIPTION
Replaced the following deprecated stuff:
- `Gtk::Table`
- `Gtk::VBox`
- `set_alignment()`