### PR TITLE
[Synfig Studio] Sometimes Widget_Vector didn't use locale for decimal separator

### DIFF
--- a/synfig-core/src/synfig/string_helper.cpp
+++ b/synfig-core/src/synfig/string_helper.cpp
@@ -36,7 +36,7 @@
 #endif
 
 std::string
-synfig::remove_trailing_zeroes(const std::string& text)
+synfig::remove_trailing_zeroes(const std::string& text, bool force_decimal_point)
 {
 	std::string result(text);
 	std::locale l(setlocale(LC_NUMERIC, nullptr));
@@ -44,10 +44,16 @@ synfig::remove_trailing_zeroes(const std::string& text)
 	const size_t decimal_point_pos = text.find(decimal_point);
 
 	if (decimal_point_pos == text.npos) {
-		result += decimal_point + '0';
+		if (force_decimal_point)
+			result += decimal_point + std::string("0");
+	} else if (decimal_point_pos == text.length()-1) {
+		if (force_decimal_point)
+			result += '0';
+		else
+			result.pop_back();
 	} else {
 		const size_t last_non_zero_pos = result.find_last_not_of('0');
-		result = result.substr(0, std::max(decimal_point_pos, last_non_zero_pos) + 1);
+		result = result.substr(0, std::max(decimal_point_pos+1, last_non_zero_pos) + 1);
 	}
 	return result;
 }

--- a/synfig-core/src/synfig/string_helper.h
+++ b/synfig-core/src/synfig/string_helper.h
@@ -31,7 +31,8 @@ namespace synfig
 
 /// Remove trailing zeroes of a string with a real number.
 /// It respects decimal point defined by locale and leave at least one decimal place
-std::string remove_trailing_zeroes(const std::string& text);
+/// \param force_decimal_point The result string will always show the decimal point even if it isn't needed (e.g. 4 -> 4.0)
+std::string remove_trailing_zeroes(const std::string& text, bool force_decimal_point = true);
 
 /// Remove whitespaces from both ends of a string
 std::string trim(const std::string& text);

--- a/synfig-studio/src/gui/widgets/widget_vector.cpp
+++ b/synfig-studio/src/gui/widgets/widget_vector.cpp
@@ -36,6 +36,7 @@
 #include <gui/app.h>
 #include <gui/widgets/widget_distance.h>
 #include <synfig/general.h>
+#include <synfig/string_helper.h>
 
 #endif
 
@@ -197,19 +198,10 @@ Widget_Vector::set_value(const synfig::Vector &data)
 		spinbutton_x->set_value(vector[0]);
 		spinbutton_y->set_value(vector[1]);
 		
-		String str;
-		std::ostringstream sstream_x;
-		sstream_x << spinbutton_x->get_value();
-		str=sstream_x.str();
-		while (*str.rbegin() == '0' && str.length() > 1)
-			str=str.substr(0, str.size()-1);
-		entry_x->set_text(str);
-		std::ostringstream sstream_y;
-		sstream_y << spinbutton_y->get_value();
-		str=sstream_y.str();
-		while (*str.rbegin() == '0' && str.length() > 1)
-			str=str.substr(0, str.size()-1);
-		entry_y->set_text(str);
+		String str = std::to_string(spinbutton_x->get_value());
+		entry_x->set_text(remove_trailing_zeroes(str));
+		str = std::to_string(spinbutton_y->get_value());
+		entry_y->set_text(remove_trailing_zeroes(str));
 		
 		//distance_x->hide();
 		//distance_y->hide();


### PR DESCRIPTION
Example:
 In Canvas Properties dialog, we have the Image Area delimited by two points:
the top left corner and the bottom right corner.
Both points use Widget_Vector to edit it.
There, you could only type real numbers by using 'dot' (.) to separate
integer from the fractional part (e.g. 4.5). However, this character
depends on locale. Brazil and Germany, for example, use 'comma' (,).
 Another case: on the same dialog, the Focus Point field.

This commit also fixes synfig::remove_trailing_zeroes() - I accidentally
let two chars to be summed instead of appending them to string