### PR TITLE
[Synfig Studio] Replace set_alignment and set_padding deprecated methods

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -102,7 +102,10 @@ using namespace studio;
 		icon=manage(new Gtk::Image(Gtk::StockID(stockid),iconsize)); \
 		button->add(*icon); \
 		button->set_tooltip_text(tooltip); \
-		icon->set_padding(0,0); \
+		icon->set_margin_start(0); \
+		icon->set_margin_end(0); \
+		icon->set_margin_top(0); \
+		icon->set_margin_bottom(0); \
 		icon->show(); \
 		button->set_relief(Gtk::RELIEF_NONE); \
 		button->show() \
@@ -116,7 +119,10 @@ using namespace studio;
 		icon=manage(new Gtk::Image(Gtk::StockID(stockid),Gtk::ICON_SIZE_BUTTON)); \
 		button->add(*icon); \
 		button->set_tooltip_text(tooltip); \
-		icon->set_padding(0,0); \
+		icon->set_margin_start(0); \
+		icon->set_margin_end(0); \
+		icon->set_margin_top(0); \
+		icon->set_margin_bottom(0); \
 		icon->show(); \
 		/*button->set_relief(Gtk::RELIEF_NONE);*/ \
 		button->show(); \
@@ -807,7 +813,10 @@ void CanvasView::set_jack_enabled(bool value)
 			jackbutton->remove();
 			jackbutton->add(*icon);
 			jackbutton->set_tooltip_text(_("Disable JACK"));
-			icon->set_padding(0,0);
+			icon->set_margin_start(0);
+			icon->set_margin_end(0);
+			icon->set_margin_top(0);
+			icon->set_margin_bottom(0);
 			icon->show();
 			offset_widget->show();
 		}
@@ -817,7 +826,10 @@ void CanvasView::set_jack_enabled(bool value)
 			jackbutton->remove();
 			jackbutton->add(*icon);
 			jackbutton->set_tooltip_text(_("Enable JACK"));
-			icon->set_padding(0,0);
+			icon->set_margin_start(0);
+			icon->set_margin_end(0);
+			icon->set_margin_top(0);
+			icon->set_margin_bottom(0);
 			icon->show();
 			offset_widget->hide();
 		}

--- a/synfig-studio/src/gui/dialogs/canvasproperties.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasproperties.cpp
@@ -36,6 +36,7 @@
 #include <gtkmm/frame.h>
 #include <gtkmm/label.h>
 #include <gtkmm/grid.h>
+#include <gtkmm/stylecontext.h>
 
 #include <gui/localization.h>
 
@@ -67,13 +68,10 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	widget_rend_desc.signal_changed().connect(sigc::mem_fun(*this,&studio::CanvasProperties::on_rend_desc_changed));
 
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	dialogPadding->set_margin_start(12);
-	dialogPadding->set_margin_end(12);
-	dialogPadding->set_margin_top(12);
-	dialogPadding->set_margin_bottom(12);
 	get_vbox()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Grid *dialogGrid = manage(new Gtk::Grid());
+	dialogGrid->get_style_context()->add_class("dialog-main-content");
 	dialogGrid->set_row_spacing(12);
 	dialogPadding->add(*dialogGrid);
 
@@ -83,13 +81,10 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	dialogGrid->attach(*info_frame, 0, 0, 1, 1);
 
 	Gtk::Alignment *infoPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	infoPadding->set_margin_start(24);
-	infoPadding->set_margin_end(0);
-	infoPadding->set_margin_top(6);
-	infoPadding->set_margin_bottom(0);
 	info_frame->add(*infoPadding);
 
 	Gtk::Grid *info_grid = manage(new Gtk::Grid());
+	info_grid->get_style_context()->add_class("dialog-secondary-content");
 	info_grid->set_row_spacing(6);
 	info_grid->set_column_spacing(12);
 	infoPadding->add(*info_grid);

--- a/synfig-studio/src/gui/dialogs/canvasproperties.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasproperties.cpp
@@ -67,7 +67,10 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	widget_rend_desc.signal_changed().connect(sigc::mem_fun(*this,&studio::CanvasProperties::on_rend_desc_changed));
 
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	dialogPadding->set_padding(12, 12, 12, 12);
+	dialogPadding->set_margin_start(12);
+	dialogPadding->set_margin_end(12);
+	dialogPadding->set_margin_top(12);
+	dialogPadding->set_margin_bottom(12);
 	get_vbox()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Grid *dialogGrid = manage(new Gtk::Grid());
@@ -80,7 +83,10 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	dialogGrid->attach(*info_frame, 0, 0, 1, 1);
 
 	Gtk::Alignment *infoPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	infoPadding->set_padding(6, 0, 24, 0);
+	infoPadding->set_margin_start(24);
+	infoPadding->set_margin_end(0);
+	infoPadding->set_margin_top(6);
+	infoPadding->set_margin_bottom(0);
 	info_frame->add(*infoPadding);
 
 	Gtk::Grid *info_grid = manage(new Gtk::Grid());

--- a/synfig-studio/src/gui/dialogs/dialog_ffmpegparam.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_ffmpegparam.cpp
@@ -90,13 +90,16 @@ const char* allowed_video_codecs_description[] =
 Dialog_FFmpegParam::Dialog_FFmpegParam(Gtk::Window &parent):
 	Dialog_TargetParam(parent, _("FFmpeg parameters"))
 {
+	this->set_resizable(false);
 	// Custom Video Codec Entry
 	Gtk::Label* custom_label(manage(new Gtk::Label(std::string(CUSTOM_VCODEC_DESCRIPTION)+":")));
-	custom_label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	custom_label->set_halign(Gtk::ALIGN_START);
+	custom_label->set_valign(Gtk::ALIGN_CENTER);
 	customvcodec=Gtk::manage(new Gtk::Entry());
 	// Available Video Codecs Combo Box Text.
 	Gtk::Label* label(manage(new Gtk::Label(_("Available Video Codecs:"))));
-	label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	label->set_halign(Gtk::ALIGN_START);
+	label->set_valign(Gtk::ALIGN_CENTER);
 	vcodec = Gtk::manage(new Gtk::ComboBoxText());
 	// Appends the codec descriptions to the Combo Box
 	for (int i = 0; allowed_video_codecs[i] != NULL &&
@@ -114,7 +117,8 @@ Dialog_FFmpegParam::Dialog_FFmpegParam(Gtk::Window &parent):
 	//Bitrate Spin Button
 	bitrate = Gtk::manage(new Gtk::SpinButton(Gtk::Adjustment::create(0.0, 10.0,100000.0)));
 	Gtk::Label* label2(manage(new Gtk::Label(_("Video Bit Rate:"))));
-	label2->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	label2->set_halign(Gtk::ALIGN_START);
+	label2->set_valign(Gtk::ALIGN_CENTER);
 	get_vbox()->pack_start(*label2, true, true, 0);
 	get_vbox()->pack_start(*bitrate,true, true, 0);
 

--- a/synfig-studio/src/gui/dialogs/dialog_soundselect.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_soundselect.cpp
@@ -60,7 +60,10 @@ studio::Dialog_SoundSelect::Dialog_SoundSelect(Gtk::Window &parent, etl::handle<
 canvas_interface(ci)
 {
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	dialogPadding->set_padding(12, 12, 12, 12);
+	dialogPadding->set_margin_start(12);
+	dialogPadding->set_margin_end(12);
+	dialogPadding->set_margin_top(12);
+	dialogPadding->set_margin_bottom(12);
 	get_vbox()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Frame *soundFrame = manage(new Gtk::Frame(_("Sound Parameters")));
@@ -69,14 +72,19 @@ canvas_interface(ci)
 	dialogPadding->add(*soundFrame);
 
 	Gtk::Alignment *framePadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	framePadding->set_padding(6, 0, 24, 0);
+	framePadding->set_margin_start(24);
+	framePadding->set_margin_end(0);
+	framePadding->set_margin_top(6);
+	framePadding->set_margin_bottom(0);
 	soundFrame->add(*framePadding);
 
 	Gtk::Label *fileLabel = manage(new Gtk::Label(_("_Sound File"), true));
-	fileLabel->set_alignment(0, 0.5);
+	fileLabel->set_halign(Gtk::ALIGN_START);
+	fileLabel->set_valign(Gtk::ALIGN_CENTER);
 	fileLabel->set_mnemonic_widget(soundfile);
 	Gtk::Label *offsetLabel = manage(new Gtk::Label(_("Time _Offset"), true));
-	offsetLabel->set_alignment(0, 0.5);
+	offsetLabel->set_halign(Gtk::ALIGN_START);
+	offsetLabel->set_valign(Gtk::ALIGN_CENTER);
 	offsetLabel->set_mnemonic_widget(offset);
 
 	Gtk::Table *table = manage(new Gtk::Table(2, 2, false));

--- a/synfig-studio/src/gui/dialogs/dialog_soundselect.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_soundselect.cpp
@@ -60,22 +60,15 @@ studio::Dialog_SoundSelect::Dialog_SoundSelect(Gtk::Window &parent, etl::handle<
 canvas_interface(ci)
 {
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	dialogPadding->set_margin_start(12);
-	dialogPadding->set_margin_end(12);
-	dialogPadding->set_margin_top(12);
-	dialogPadding->set_margin_bottom(12);
 	get_vbox()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Frame *soundFrame = manage(new Gtk::Frame(_("Sound Parameters")));
 	((Gtk::Label *) soundFrame->get_label_widget())->set_markup(_("<b>Sound Parameters</b>"));
+	soundFrame->get_style_context()->add_class("dialog-main-content");
 	soundFrame->set_shadow_type(Gtk::SHADOW_NONE);
 	dialogPadding->add(*soundFrame);
 
 	Gtk::Alignment *framePadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	framePadding->set_margin_start(24);
-	framePadding->set_margin_end(0);
-	framePadding->set_margin_top(6);
-	framePadding->set_margin_bottom(0);
 	soundFrame->add(*framePadding);
 
 	Gtk::Label *fileLabel = manage(new Gtk::Label(_("_Sound File"), true));
@@ -88,6 +81,7 @@ canvas_interface(ci)
 	offsetLabel->set_mnemonic_widget(offset);
 
 	Gtk::Table *table = manage(new Gtk::Table(2, 2, false));
+	table->get_style_context()->add_class("dialog-secondary-content");
 	table->set_row_spacings(6);
 	table->set_col_spacings(12);
 	framePadding->add(*table);

--- a/synfig-studio/src/gui/dialogs/dialog_spritesheetparam.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_spritesheetparam.cpp
@@ -35,23 +35,27 @@ namespace studio
 Dialog_SpriteSheetParam::Dialog_SpriteSheetParam(Gtk::Window &parent):
 	Dialog_TargetParam(parent, _("Sprite sheet parameters")), 
 	frame_count(0)
-{	
+{
+	this->set_resizable(false);
 	//Checkbox
-	check_button = Gtk::manage(new Gtk::CheckButton(_("Add into an existing file."),true));
+	check_button = Gtk::manage(new Gtk::CheckButton(_("Add into an existing file"),true));
 
 	//Offset X
 	Gtk::Label* offset_x_label(manage(new Gtk::Label(_("Offset X:"))));
-	offset_x_label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	offset_x_label->set_halign(Gtk::ALIGN_START);
+	offset_x_label->set_valign(Gtk::ALIGN_CENTER);
 	offset_x_box = Gtk::manage(new Gtk::SpinButton(Gtk::Adjustment::create(0.0, 0.0,10000.0)));
 
 	//Offset Y
 	Gtk::Label* offset_y_label(manage(new Gtk::Label(_("Offset Y:"))));
-	offset_y_label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	offset_y_label->set_halign(Gtk::ALIGN_START);
+	offset_y_label->set_valign(Gtk::ALIGN_CENTER);
 	offset_y_box = Gtk::manage(new Gtk::SpinButton(Gtk::Adjustment::create(0.0, 0.0,10000.0)));
 
 	//Dirrection
 	Gtk::Label* direction_label(manage(new Gtk::Label(_("Direction:"))));
-	direction_label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	direction_label->set_halign(Gtk::ALIGN_START);
+	direction_label->set_valign(Gtk::ALIGN_CENTER);
 	direction_box = Gtk::manage(new Gtk::ComboBoxText());
 	direction_box->append("horizontal");
 	direction_box->append("vertical");
@@ -60,13 +64,15 @@ Dialog_SpriteSheetParam::Dialog_SpriteSheetParam(Gtk::Window &parent):
 	
 	//Row count
 	Gtk::Label* rows_label(manage(new Gtk::Label(_("Rows:"))));
-	rows_label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	rows_label->set_halign(Gtk::ALIGN_START);
+	rows_label->set_valign(Gtk::ALIGN_CENTER);
 	rows_box = Gtk::manage(new Gtk::SpinButton(Gtk::Adjustment::create(0.0, 1.0,1000.0)));
 	rows_box->signal_value_changed().connect(sigc::mem_fun(*this, &Dialog_SpriteSheetParam::on_rows_change));
 
 	//Column count
 	Gtk::Label* columns_label(manage(new Gtk::Label(_("Columns:"))));
-	columns_label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	columns_label->set_halign(Gtk::ALIGN_START);
+	columns_label->set_valign(Gtk::ALIGN_CENTER);
 	columns_box = Gtk::manage(new Gtk::SpinButton(Gtk::Adjustment::create(0.0, 1.0,1000.0)));
 	columns_box->signal_value_changed().connect(sigc::mem_fun(*this, &Dialog_SpriteSheetParam::on_cols_change));
 

--- a/synfig-studio/src/gui/dialogs/dialog_template.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_template.cpp
@@ -164,7 +164,8 @@ void
 Dialog_Template::attach_label(Gtk::Grid *grid, synfig::String str, guint row)
 {
 	Gtk::Label* label(manage(new Gtk::Label((str + ":").c_str())));
-	label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	label->set_halign(Gtk::ALIGN_START);
+	label->set_valign(Gtk::ALIGN_CENTER);
 	label->set_margin_start(10);
 	grid->attach(*label, 0, row, 1, 1);
 }
@@ -174,7 +175,8 @@ Dialog_Template::attach_label_section(Gtk::Grid *grid, synfig::String str, guint
 {
 	Gtk::Label* label(manage(new Gtk::Label(str)));
 	label->set_attributes(section_attrlist);
-	label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	label->set_halign(Gtk::ALIGN_START);
+	label->set_valign(Gtk::ALIGN_CENTER);
 	grid->attach(*label, 0, row, 1, 1);
 }
 
@@ -183,7 +185,8 @@ Dialog_Template::attach_label_title(Gtk::Grid *grid, synfig::String str)
 {
 	Gtk::Label* label(manage(new Gtk::Label(str)));
 	label->set_attributes(title_attrlist);
-	label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	label->set_halign(Gtk::ALIGN_START);
+	label->set_valign(Gtk::ALIGN_CENTER);
 	label->set_margin_start(20);
 	Gtk::EventBox* box(manage(new Gtk::EventBox()));
 	box->add(*label);
@@ -196,7 +199,8 @@ Dialog_Template::attach_label(Gtk::Grid *grid, synfig::String str, guint row, gu
 {
 	str = endstring?str+":":str;
 	Gtk::Label* label(manage(new Gtk::Label(str)));
-	label->set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+	label->set_halign(Gtk::ALIGN_START);
+	label->set_valign(Gtk::ALIGN_CENTER);
 	grid->attach(*label, col, row, 1, 1);
 	return label;
 }

--- a/synfig-studio/src/gui/dialogs/dialog_waypoint.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_waypoint.cpp
@@ -53,6 +53,7 @@ Dialog_Waypoint::Dialog_Waypoint(Gtk::Window& parent,etl::handle<synfig::Canvas>
 	Dialog(_("Waypoint Editor"),parent),
 	canvas(canvas)
 {
+	this->set_resizable(false);
 	assert(canvas);
     waypointwidget=manage(new class Widget_Waypoint(canvas));
 	get_vbox()->pack_start(*waypointwidget);

--- a/synfig-studio/src/gui/dials/framedial.cpp
+++ b/synfig-studio/src/gui/dials/framedial.cpp
@@ -98,7 +98,10 @@ FrameDial::init_button(Gtk::Button &button, const char *stockid, const char *too
 	Gtk::IconSize iconsize = Gtk::IconSize::from_name("synfig-small_icon_16x16");
 
 	Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID(stockid), iconsize));
-	icon->set_padding(0, 0);
+	icon->set_margin_start(0);
+	icon->set_margin_end(0);
+	icon->set_margin_top(0);
+	icon->set_margin_bottom(0);
 	icon->show();
 
 	button.add(*icon);

--- a/synfig-studio/src/gui/dials/jackdial.cpp
+++ b/synfig-studio/src/gui/dials/jackdial.cpp
@@ -81,7 +81,10 @@ JackDial::create_icon(Gtk::IconSize iconsize, const char *stockid, const char *t
 	Gtk::ToggleButton *button = manage(new class Gtk::ToggleButton());
 	button->add(*icon);
 	button->set_tooltip_text(tooltip);
-	icon->set_padding(0, 0);
+	icon->set_margin_start(0);
+	icon->set_margin_end(0);
+	icon->set_margin_top(0);
+	icon->set_margin_bottom(0);
 	icon->show();
 	button->set_relief(Gtk::RELIEF_NONE);
 	button->show();

--- a/synfig-studio/src/gui/dials/keyframedial.cpp
+++ b/synfig-studio/src/gui/dials/keyframedial.cpp
@@ -70,7 +70,10 @@ KeyFrameDial::create_icon(Gtk::IconSize iconsize, const char * stockid,
 	Gtk::ToggleButton *button = manage(new class Gtk::ToggleButton());
 	button->add(*icon);
 	button->set_tooltip_text(tooltip);
-	icon->set_padding(0, 0);
+	icon->set_margin_start(0);
+	icon->set_margin_end(0);
+	icon->set_margin_top(0);
+	icon->set_margin_bottom(0);
 	icon->show();
 	button->set_relief(Gtk::RELIEF_NONE);
 	button->set_active();

--- a/synfig-studio/src/gui/dials/resolutiondial.cpp
+++ b/synfig-studio/src/gui/dials/resolutiondial.cpp
@@ -83,7 +83,10 @@ void
 ResolutionDial::init_button(Gtk::ToolButton &button, Gtk::IconSize size, const Gtk::StockID & stockid, const char *label, const char *tooltip)
 {
 	Gtk::Image *icon = manage(new Gtk::Image(stockid, size));
-	icon->set_padding(0, 0);
+	icon->set_margin_start(0);
+	icon->set_margin_end(0);
+	icon->set_margin_top(0);
+	icon->set_margin_bottom(0);
 	icon->show();
 
 	button.set_icon_widget(*icon);

--- a/synfig-studio/src/gui/dials/toggleducksdial.cpp
+++ b/synfig-studio/src/gui/dials/toggleducksdial.cpp
@@ -92,7 +92,10 @@ void
 ToggleDucksDial::init_label_button(Gtk::ToggleToolButton &button, Gtk::IconSize iconsize, const char *stockid, const char *label, const char *tooltip)
 {
 	Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID(stockid), iconsize));
-	icon->set_padding(0, 0);
+	icon->set_margin_start(0);
+	icon->set_margin_end(0);
+	icon->set_margin_top(0);
+	icon->set_margin_bottom(0);
 	icon->show();
 
 	button.set_label(label);

--- a/synfig-studio/src/gui/dials/zoomdial.cpp
+++ b/synfig-studio/src/gui/dials/zoomdial.cpp
@@ -118,7 +118,10 @@ ZoomDial::create_icon(Gtk::IconSize size, const Gtk::BuiltinStockID & stockid,
 	Gtk::Image *icon = manage(new Gtk::Image(stockid, size));
 	button->add(*icon);
 	button->set_tooltip_text(tooltip);
-	icon->set_padding(0, 0);
+	icon->set_margin_start(0);
+	icon->set_margin_end(0);
+	icon->set_margin_top(0);
+	icon->set_margin_bottom(0);
 	icon->show();
 	button->set_relief(Gtk::RELIEF_NONE);
 	button->show();

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -311,12 +311,15 @@ void studio::Preview::frame_finish(const Preview_Target *targ)
 }
 
 #define IMAGIFY_BUTTON(button,stockid,tooltip) \
-        icon = manage(new Gtk::Image(Gtk::StockID(stockid), Gtk::ICON_SIZE_BUTTON)); \
+	icon = manage(new Gtk::Image(Gtk::StockID(stockid), Gtk::ICON_SIZE_BUTTON)); \
 	button->set_tooltip_text(tooltip); \
-        button->add(*icon); \
-        button->set_relief(Gtk::RELIEF_NONE); \
-        button->show(); \
-	icon->set_padding(0,0); \
+	button->add(*icon); \
+	button->set_relief(Gtk::RELIEF_NONE); \
+	button->show(); \
+	icon->set_margin_start(0); \
+	icon->set_margin_end(0); \
+	icon->set_margin_top(0); \
+	icon->set_margin_bottom(0); \
 	icon->show();
 
 Widget_Preview::Widget_Preview():
@@ -391,7 +394,10 @@ Widget_Preview::Widget_Preview():
 	Gtk::Image *icon0 = manage(new Gtk::Image(Gtk::StockID("synfig-animate_seek_prev_frame"), Gtk::ICON_SIZE_BUTTON));
 	prev_framebutton = manage(new class Gtk::Button());
 	prev_framebutton->set_tooltip_text(_("Seek to previous frame"));
-	icon0->set_padding(0,0);
+	icon0->set_margin_start(0);
+	icon0->set_margin_end(0);
+	icon0->set_margin_top(0);
+	icon0->set_margin_bottom(0);
 	icon0->show();
 	prev_framebutton->add(*icon0);
 	prev_framebutton->set_relief(Gtk::RELIEF_NONE);
@@ -404,7 +410,10 @@ Widget_Preview::Widget_Preview():
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-animate_play"), Gtk::ICON_SIZE_BUTTON));
 		play_button = manage(new class Gtk::Button());
 		play_button->set_tooltip_text(_("Play"));
-		icon->set_padding(0,0);
+		icon->set_margin_start(0);
+		icon->set_margin_end(0);
+		icon->set_margin_top(0);
+		icon->set_margin_bottom(0);
 		icon->show();
 		play_button->add(*icon);
 		play_button->set_relief(Gtk::RELIEF_NONE);
@@ -417,7 +426,10 @@ Widget_Preview::Widget_Preview():
 		Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID("synfig-animate_pause"), Gtk::ICON_SIZE_BUTTON));
 		pause_button = manage(new class Gtk::Button());
 		pause_button->set_tooltip_text(_("Pause"));
-		icon->set_padding(0,0);
+		icon->set_margin_start(0);
+		icon->set_margin_end(0);
+		icon->set_margin_top(0);
+		icon->set_margin_bottom(0);
 		icon->show();
 		pause_button->add(*icon);
 		pause_button->set_relief(Gtk::RELIEF_NONE);
@@ -431,7 +443,10 @@ Widget_Preview::Widget_Preview():
 	Gtk::Image *icon2 = manage(new Gtk::Image(Gtk::StockID("synfig-animate_seek_next_frame"), Gtk::ICON_SIZE_BUTTON));
 	next_framebutton = manage(new class Gtk::Button());
 	next_framebutton->set_tooltip_text(_("Seek to next frame"));
-	icon2->set_padding(0,0);
+	icon2->set_margin_start(0);
+	icon2->set_margin_end(0);
+	icon2->set_margin_top(0);
+	icon2->set_margin_bottom(0);
 	icon2->show();
 	next_framebutton->add(*icon2);
 	next_framebutton->set_relief(Gtk::RELIEF_NONE);
@@ -1326,7 +1341,10 @@ void Widget_Preview::set_jack_enabled(bool value) {
 		jackbutton->remove();
 		jackbutton->add(*icon);
 		jackbutton->set_tooltip_text(_("Disable JACK"));
-		icon->set_padding(0,0);
+		icon->set_margin_start(0);
+		icon->set_margin_end(0);
+		icon->set_margin_top(0);
+		icon->set_margin_bottom(0);
 		icon->show();
 
 		offset_widget->show();
@@ -1337,7 +1355,10 @@ void Widget_Preview::set_jack_enabled(bool value) {
 		jackbutton->remove();
 		jackbutton->add(*icon);
 		jackbutton->set_tooltip_text(_("Enable JACK"));
-		icon->set_padding(0,0);
+		icon->set_margin_start(0);
+		icon->set_margin_end(0);
+		icon->set_margin_top(0);
+		icon->set_margin_bottom(0);
 		icon->show();
 
 		offset_widget->hide();

--- a/synfig-studio/src/gui/renddesc.cpp
+++ b/synfig-studio/src/gui/renddesc.cpp
@@ -571,19 +571,26 @@ Widget_RendDesc::create_widgets()
 	scale_gamma_g=manage(new Gtk::Scale(adjustment_gamma_g));
 	scale_gamma_b=manage(new Gtk::Scale(adjustment_gamma_b));
 	toggle_px_aspect=manage(new Gtk::CheckButton(_("_Pixel Aspect"), true));
-	toggle_px_aspect->set_alignment(0, 0.5);
+	toggle_px_aspect->set_halign(Gtk::ALIGN_START);
+	toggle_px_aspect->set_valign(Gtk::ALIGN_CENTER);
 	toggle_px_width=manage(new Gtk::CheckButton(_("Pi_xel Width"), true));
-	toggle_px_width->set_alignment(0, 0.5);
+	toggle_px_width->set_halign(Gtk::ALIGN_START);
+	toggle_px_width->set_valign(Gtk::ALIGN_CENTER);
 	toggle_px_height=manage(new Gtk::CheckButton(_("Pix_el Height"), true));
-	toggle_px_height->set_alignment(0, 0.5);
+	toggle_px_height->set_halign(Gtk::ALIGN_START);
+	toggle_px_height->set_valign(Gtk::ALIGN_CENTER);
 	toggle_im_aspect=manage(new Gtk::CheckButton(_("Image _Aspect"), true));
-	toggle_im_aspect->set_alignment(0, 0.5);
+	toggle_im_aspect->set_halign(Gtk::ALIGN_START);
+	toggle_im_aspect->set_valign(Gtk::ALIGN_CENTER);
 	toggle_im_width=manage(new Gtk::CheckButton(_("Image _Width"), true));
-	toggle_im_width->set_alignment(0, 0.5);
+	toggle_im_width->set_halign(Gtk::ALIGN_START);
+	toggle_im_width->set_valign(Gtk::ALIGN_CENTER);
 	toggle_im_height=manage(new Gtk::CheckButton(_("Image _Height"), true));
-	toggle_im_height->set_alignment(0, 0.5);
+	toggle_im_height->set_halign(Gtk::ALIGN_START);
+	toggle_im_height->set_valign(Gtk::ALIGN_CENTER);
 	toggle_im_span=manage(new Gtk::CheckButton(_("Image _Span"), true));
-	toggle_im_span->set_alignment(0, 0.5);
+	toggle_im_span->set_halign(Gtk::ALIGN_START);
+	toggle_im_span->set_valign(Gtk::ALIGN_CENTER);
 
 	toggle_wh_ratio=manage(new Widget_Link(_("Link width and height"), _("Unlink width and height")));
 	toggle_res_ratio=manage(new Widget_Link(_("Link x and y resolution"), _("Unlink x and y resolution")));
@@ -627,7 +634,10 @@ Gtk::Widget *
 Widget_RendDesc::create_image_tab()
 {
 	Gtk::Alignment *paddedPanel = manage(new Gtk::Alignment(0, 0, 1, 1));
-	paddedPanel->set_padding(12, 12, 12, 12);
+	paddedPanel->set_margin_start(12);
+	paddedPanel->set_margin_end(12);
+	paddedPanel->set_margin_top(12);
+	paddedPanel->set_margin_bottom(12);
 
 	Gtk::Box *panelBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 12));
 	panelBox->set_homogeneous(false);
@@ -640,7 +650,10 @@ Widget_RendDesc::create_image_tab()
 	panelBox->pack_start(*imageSizeFrame, Gtk::PACK_SHRINK);
 
 	Gtk::Alignment *tableSizePadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	tableSizePadding->set_padding(6, 0, 24, 0);
+	tableSizePadding->set_margin_start(24);
+	tableSizePadding->set_margin_end(0);
+	tableSizePadding->set_margin_top(6);
+	tableSizePadding->set_margin_bottom(0);
 	Gtk::Grid *imageSizeGrid = manage(new Gtk::Grid());
 
 	tableSizePadding->add(*imageSizeGrid);
@@ -700,7 +713,10 @@ Widget_RendDesc::create_image_tab()
 	panelBox->pack_start(*imageAreaFrame, Gtk::PACK_SHRINK);
 
 	Gtk::Alignment *imageAreaPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	imageAreaPadding->set_padding(6, 0, 24, 0);
+	imageAreaPadding->set_margin_start(24);
+	imageAreaPadding->set_margin_end(0);
+	imageAreaPadding->set_margin_top(6);
+	imageAreaPadding->set_margin_bottom(0);
 	imageAreaFrame->add(*imageAreaPadding);
 
 	Gtk::Box *imageAreaBox = manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL,12));
@@ -738,7 +754,10 @@ Gtk::Widget *
 Widget_RendDesc::create_time_tab()
 {
 	Gtk::Alignment *paddedPanel = manage(new Gtk::Alignment(0, 0, 1, 1));
-	paddedPanel->set_padding(12, 12, 12, 12);
+	paddedPanel->set_margin_start(12);
+	paddedPanel->set_margin_end(12);
+	paddedPanel->set_margin_top(12);
+	paddedPanel->set_margin_bottom(12);
 	
 	Gtk::Box *panelBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 12));  // for future widgets
 	panelBox->set_homogeneous(false);
@@ -752,7 +771,10 @@ Widget_RendDesc::create_time_tab()
 		time_frame = frame;
 		
 		Gtk::Alignment *framePadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-		framePadding->set_padding(6, 0, 24, 0);
+		framePadding->set_margin_start(24);
+		framePadding->set_margin_end(0);
+		framePadding->set_margin_top(6);
+		framePadding->set_margin_bottom(0);
 		frame->add(*framePadding);
 		
 		Gtk::Grid *frameGrid = manage(new Gtk::Grid());
@@ -799,7 +821,10 @@ Gtk::Widget *
 Widget_RendDesc::create_gamma_tab()
 {
 	Gtk::Alignment *paddedPanel = manage(new Gtk::Alignment(0, 0, 1, 1));
-	paddedPanel->set_padding(12, 12, 12, 12);
+	paddedPanel->set_margin_start(12);
+	paddedPanel->set_margin_end(12);
+	paddedPanel->set_margin_top(12);
+	paddedPanel->set_margin_bottom(12);
 
 	Gtk::Box *panelBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 12));
 	panelBox->set_homogeneous(false);
@@ -812,7 +837,10 @@ Widget_RendDesc::create_gamma_tab()
 		panelBox->pack_start(*frame, Gtk::PACK_SHRINK);
 
 		Gtk::Alignment *framePadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-		framePadding->set_padding(6, 0, 6, 0);
+		framePadding->set_margin_start(6);
+		framePadding->set_margin_end(0);
+		framePadding->set_margin_top(6);
+		framePadding->set_margin_bottom(0);
 		frame->add(*framePadding);
 		gamma_frame = frame;
 		
@@ -883,7 +911,10 @@ Gtk::Widget *
 Widget_RendDesc::create_other_tab()
 {
 	Gtk::Alignment *paddedPanel = manage(new Gtk::Alignment(0, 0, 1, 1));
-	paddedPanel->set_padding(12, 12, 12, 12);
+	paddedPanel->set_margin_start(12);
+	paddedPanel->set_margin_end(12);
+	paddedPanel->set_margin_top(12);
+	paddedPanel->set_margin_bottom(12);
 
 	Gtk::Box *panelBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 12));
 	panelBox->set_homogeneous(false);
@@ -895,7 +926,10 @@ Widget_RendDesc::create_other_tab()
 	panelBox->pack_start(*lockFrame, Gtk::PACK_SHRINK);
 
 	Gtk::Alignment *lockPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	lockPadding->set_padding(6, 0, 24, 0);
+	lockPadding->set_margin_start(24);
+	lockPadding->set_margin_end(0);
+	lockPadding->set_margin_top(6);
+	lockPadding->set_margin_bottom(0);
 	lockFrame->add(*lockPadding);
 
 	Gtk::Grid *lockGrid = manage(new Gtk::Grid());
@@ -922,7 +956,10 @@ Widget_RendDesc::create_other_tab()
 	panelBox->pack_start(*focusFrame, Gtk::PACK_SHRINK);
 
 	Gtk::Alignment *focusPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	focusPadding->set_padding(6, 0, 24, 0);
+	focusPadding->set_margin_start(24);
+	focusPadding->set_margin_end(0);
+	focusPadding->set_margin_top(6);
+	focusPadding->set_margin_bottom(0);
 	focusFrame->add(*focusPadding);
 
 	Gtk::Box *focusBox = manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 12));

--- a/synfig-studio/src/gui/renddesc.cpp
+++ b/synfig-studio/src/gui/renddesc.cpp
@@ -40,6 +40,7 @@
 #include <gtkmm/drawingarea.h>
 #include <gtkmm/grid.h>
 #include <gtkmm/label.h>
+#include <gtkmm/stylecontext.h>
 
 #include <gui/localization.h>
 
@@ -634,12 +635,9 @@ Gtk::Widget *
 Widget_RendDesc::create_image_tab()
 {
 	Gtk::Alignment *paddedPanel = manage(new Gtk::Alignment(0, 0, 1, 1));
-	paddedPanel->set_margin_start(12);
-	paddedPanel->set_margin_end(12);
-	paddedPanel->set_margin_top(12);
-	paddedPanel->set_margin_bottom(12);
 
 	Gtk::Box *panelBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 12));
+	panelBox->get_style_context()->add_class("dialog-main-content");
 	panelBox->set_homogeneous(false);
 	paddedPanel->add(*panelBox);
 
@@ -650,11 +648,8 @@ Widget_RendDesc::create_image_tab()
 	panelBox->pack_start(*imageSizeFrame, Gtk::PACK_SHRINK);
 
 	Gtk::Alignment *tableSizePadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	tableSizePadding->set_margin_start(24);
-	tableSizePadding->set_margin_end(0);
-	tableSizePadding->set_margin_top(6);
-	tableSizePadding->set_margin_bottom(0);
 	Gtk::Grid *imageSizeGrid = manage(new Gtk::Grid());
+	imageSizeGrid->get_style_context()->add_class("dialog-secondary-content");
 
 	tableSizePadding->add(*imageSizeGrid);
 	imageSizeFrame->add(*tableSizePadding);
@@ -709,20 +704,16 @@ Widget_RendDesc::create_image_tab()
 	Gtk::Frame *imageAreaFrame = manage(new Gtk::Frame(_("Image Area")));
 	imageAreaFrame->set_shadow_type(Gtk::SHADOW_NONE);
 	((Gtk::Label *) imageAreaFrame->get_label_widget())->set_markup(_("<b>Image Area</b>"));
-	//panelBox->pack_start(*imageAreaFrame, false, false, 0);
 	panelBox->pack_start(*imageAreaFrame, Gtk::PACK_SHRINK);
 
 	Gtk::Alignment *imageAreaPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	imageAreaPadding->set_margin_start(24);
-	imageAreaPadding->set_margin_end(0);
-	imageAreaPadding->set_margin_top(6);
-	imageAreaPadding->set_margin_bottom(0);
 	imageAreaFrame->add(*imageAreaPadding);
 
 	Gtk::Box *imageAreaBox = manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL,12));
 	Gtk::Box *imageAreaTlbrLabelBox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL,6));
 	Gtk::Box *imageAreaTlbrBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL,6));
 	Gtk::Box *imageAreaSpanBox = manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL,6));
+	imageAreaBox->get_style_context()->add_class("dialog-secondary-content");
 	imageAreaPadding->add(*imageAreaBox);
 
 	Gtk::Label *imageAreaTopLeftLabel = manage(new Gtk::Label(_("_Top Left"), 0, 0.5, true));
@@ -754,12 +745,9 @@ Gtk::Widget *
 Widget_RendDesc::create_time_tab()
 {
 	Gtk::Alignment *paddedPanel = manage(new Gtk::Alignment(0, 0, 1, 1));
-	paddedPanel->set_margin_start(12);
-	paddedPanel->set_margin_end(12);
-	paddedPanel->set_margin_top(12);
-	paddedPanel->set_margin_bottom(12);
 	
 	Gtk::Box *panelBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 12));  // for future widgets
+	panelBox->get_style_context()->add_class("dialog-main-content");
 	panelBox->set_homogeneous(false);
 	paddedPanel->add(*panelBox);
 	
@@ -771,16 +759,13 @@ Widget_RendDesc::create_time_tab()
 		time_frame = frame;
 		
 		Gtk::Alignment *framePadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-		framePadding->set_margin_start(24);
-		framePadding->set_margin_end(0);
-		framePadding->set_margin_top(6);
-		framePadding->set_margin_bottom(0);
 		frame->add(*framePadding);
 		
 		Gtk::Grid *frameGrid = manage(new Gtk::Grid());
-		framePadding->add(*frameGrid);
+		frameGrid->get_style_context()->add_class("dialog-secondary-content");
 		frameGrid->set_row_spacing(6);
 		frameGrid->set_column_spacing(250);
+		framePadding->add(*frameGrid);
 		int row = 0;
 		
 		{
@@ -821,12 +806,9 @@ Gtk::Widget *
 Widget_RendDesc::create_gamma_tab()
 {
 	Gtk::Alignment *paddedPanel = manage(new Gtk::Alignment(0, 0, 1, 1));
-	paddedPanel->set_margin_start(12);
-	paddedPanel->set_margin_end(12);
-	paddedPanel->set_margin_top(12);
-	paddedPanel->set_margin_bottom(12);
 
 	Gtk::Box *panelBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 12));
+	panelBox->get_style_context()->add_class("dialog-main-content");
 	panelBox->set_homogeneous(false);
 	paddedPanel->add(*panelBox);
 	
@@ -911,12 +893,9 @@ Gtk::Widget *
 Widget_RendDesc::create_other_tab()
 {
 	Gtk::Alignment *paddedPanel = manage(new Gtk::Alignment(0, 0, 1, 1));
-	paddedPanel->set_margin_start(12);
-	paddedPanel->set_margin_end(12);
-	paddedPanel->set_margin_top(12);
-	paddedPanel->set_margin_bottom(12);
 
 	Gtk::Box *panelBox = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 12));
+	panelBox->get_style_context()->add_class("dialog-main-content");
 	panelBox->set_homogeneous(false);
 	paddedPanel->add(*panelBox);
 
@@ -926,13 +905,10 @@ Widget_RendDesc::create_other_tab()
 	panelBox->pack_start(*lockFrame, Gtk::PACK_SHRINK);
 
 	Gtk::Alignment *lockPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	lockPadding->set_margin_start(24);
-	lockPadding->set_margin_end(0);
-	lockPadding->set_margin_top(6);
-	lockPadding->set_margin_bottom(0);
 	lockFrame->add(*lockPadding);
 
 	Gtk::Grid *lockGrid = manage(new Gtk::Grid());
+	lockGrid->get_style_context()->add_class("dialog-secondary-content");
 	lockGrid->set_row_spacing(6);
 	lockGrid->set_column_spacing(12);
 	lockPadding->add(*lockGrid);
@@ -956,13 +932,10 @@ Widget_RendDesc::create_other_tab()
 	panelBox->pack_start(*focusFrame, Gtk::PACK_SHRINK);
 
 	Gtk::Alignment *focusPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	focusPadding->set_margin_start(24);
-	focusPadding->set_margin_end(0);
-	focusPadding->set_margin_top(6);
-	focusPadding->set_margin_bottom(0);
 	focusFrame->add(*focusPadding);
 
 	Gtk::Box *focusBox = manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 12));
+	focusBox->get_style_context()->add_class("dialog-secondary-content");
 	focusPadding->add(*focusBox);
 
 	Gtk::Label *focusLabel = manage(new Gtk::Label(_("_Focus Point"), 0, 0.5, true));

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -110,7 +110,10 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	comboboxtext_target.signal_changed().connect(sigc::mem_fun(this, &RenderSettings::on_comboboxtext_target_changed));
 
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	dialogPadding->set_padding(12, 12, 12, 12);
+	dialogPadding->set_margin_start(12);
+	dialogPadding->set_margin_end(12);
+	dialogPadding->set_margin_top(12);
+	dialogPadding->set_margin_bottom(12);
 	get_vbox()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Grid *dialogGrid = manage(new Gtk::Grid());
@@ -131,7 +134,10 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	((Gtk::Label *) target_frame->get_label_widget())->set_markup(_("<b>Target</b>"));
 	dialogGrid->attach(*target_frame, 0, 0, 1, 1);
 	Gtk::Alignment *targetPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	targetPadding->set_padding(6, 0, 24, 0);
+	targetPadding->set_margin_start(24);
+	targetPadding->set_margin_end(0);
+	targetPadding->set_margin_top(6);
+	targetPadding->set_margin_bottom(0);
 	target_frame->add(*targetPadding);
 
 	Gtk::Grid *target_grid = manage(new Gtk::Grid());
@@ -165,7 +171,10 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	dialogGrid->attach(*settings_frame, 0, 1, 1, 1);
 
 	Gtk::Alignment *settingsPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	settingsPadding->set_padding(6, 0, 24, 0);
+	settingsPadding->set_margin_start(24);
+	settingsPadding->set_margin_end(0);
+	settingsPadding->set_margin_top(6);
+	settingsPadding->set_margin_bottom(0);
 	settings_frame->add(*settingsPadding);
 
 	Gtk::Grid *settings_grid = manage(new Gtk::Grid());

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -110,13 +110,10 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	comboboxtext_target.signal_changed().connect(sigc::mem_fun(this, &RenderSettings::on_comboboxtext_target_changed));
 
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	dialogPadding->set_margin_start(12);
-	dialogPadding->set_margin_end(12);
-	dialogPadding->set_margin_top(12);
-	dialogPadding->set_margin_bottom(12);
 	get_vbox()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Grid *dialogGrid = manage(new Gtk::Grid());
+	dialogGrid->get_style_context()->add_class("dialog-main-content");
 	dialogGrid->set_row_spacing(12);
 	dialogPadding->add(*dialogGrid);
 
@@ -134,13 +131,10 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	((Gtk::Label *) target_frame->get_label_widget())->set_markup(_("<b>Target</b>"));
 	dialogGrid->attach(*target_frame, 0, 0, 1, 1);
 	Gtk::Alignment *targetPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	targetPadding->set_margin_start(24);
-	targetPadding->set_margin_end(0);
-	targetPadding->set_margin_top(6);
-	targetPadding->set_margin_bottom(0);
 	target_frame->add(*targetPadding);
 
 	Gtk::Grid *target_grid = manage(new Gtk::Grid());
+	target_grid->get_style_context()->add_class("dialog-secondary-content");
 	target_grid->set_row_spacing(6);
 	target_grid->set_column_spacing(12);
 	targetPadding->add(*target_grid);
@@ -171,13 +165,10 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	dialogGrid->attach(*settings_frame, 0, 1, 1, 1);
 
 	Gtk::Alignment *settingsPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	settingsPadding->set_margin_start(24);
-	settingsPadding->set_margin_end(0);
-	settingsPadding->set_margin_top(6);
-	settingsPadding->set_margin_bottom(0);
 	settings_frame->add(*settingsPadding);
 
 	Gtk::Grid *settings_grid = manage(new Gtk::Grid());
+	settings_grid->get_style_context()->add_class("dialog-secondary-content");
 	settings_grid->set_row_spacing(6);
 	settings_grid->set_column_spacing(12);
 	settingsPadding->add(*settings_grid);

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -70,3 +70,14 @@
 	margin-top   : 12px;
 	margin-bottom: 12px;
 }
+
+/*
+ * Synfig Studio options in dialogs
+ * Slightly moved to the right
+ */
+.dialog-secondary-content {
+	margin-left  : 24px;
+	margin-right : 0px;
+	margin-top   : 6px;
+	margin-bottom: 0px;
+}

--- a/synfig-studio/src/gui/splash.cpp
+++ b/synfig-studio/src/gui/splash.cpp
@@ -150,8 +150,12 @@ Splash::Splash():
 	splash_image->set(imagepath+"splash_screen"+strprintf("%d",number)+"." IMAGE_EXT);
 	*/
 	splash_image->set(imagepath + "splash_screen." IMAGE_EXT);
-	splash_image->set_alignment(0.5,0.5);
-	splash_image->set_padding(0,0);
+	splash_image->set_halign(Gtk::ALIGN_CENTER);
+	splash_image->set_halign(Gtk::ALIGN_CENTER);
+	splash_image->set_margin_start(0);
+	splash_image->set_margin_end(0);
+	splash_image->set_margin_top(0);
+	splash_image->set_margin_bottom(0);
 
 	// Get the image size
 	int image_w = 350; int image_h = 0;

--- a/synfig-studio/src/gui/widgets/widget_defaults.cpp
+++ b/synfig-studio/src/gui/widgets/widget_defaults.cpp
@@ -219,7 +219,10 @@ Widget_Defaults::Widget_Defaults():
 		_button_swap->set_border_width(0);
 		icon = manage(new Gtk::Image(Gtk::StockID("synfig-swap_colors"), iconsize));
 		_button_swap->add(*icon);
-		dynamic_cast<Gtk::Misc*>(_button_swap->get_child())->set_padding(0, 0);
+		dynamic_cast<Gtk::Misc*>(_button_swap->get_child())->set_margin_start(0);
+		dynamic_cast<Gtk::Misc*>(_button_swap->get_child())->set_margin_end(0);
+		dynamic_cast<Gtk::Misc*>(_button_swap->get_child())->set_margin_top(0);
+		dynamic_cast<Gtk::Misc*>(_button_swap->get_child())->set_margin_bottom(0);
 		_button_swap->signal_clicked().connect(sigc::mem_fun(*this,&Widget_Defaults::on_swap_color_clicked));
 		_button_swap->set_tooltip_text(_("Swap Fill and\nOutline Colors"));
 
@@ -232,7 +235,10 @@ Widget_Defaults::Widget_Defaults():
 		_button_reset->set_border_width(0);
 		icon = manage(new Gtk::Image(Gtk::StockID("synfig-reset_colors"), iconsize));
 		_button_reset->add(*icon);
-		dynamic_cast<Gtk::Misc*>(_button_reset->get_child())->set_padding(0, 0);
+		dynamic_cast<Gtk::Misc*>(_button_reset->get_child())->set_margin_start(0);
+		dynamic_cast<Gtk::Misc*>(_button_reset->get_child())->set_margin_end(0);
+		dynamic_cast<Gtk::Misc*>(_button_reset->get_child())->set_margin_top(0);
+		dynamic_cast<Gtk::Misc*>(_button_reset->get_child())->set_margin_bottom(0);
 		_button_reset->signal_clicked().connect(sigc::mem_fun(*this,&Widget_Defaults::on_reset_color_clicked));
 		_button_reset->set_tooltip_text(_("Reset Colors to Black and White"));
 

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -73,7 +73,8 @@ Widget_Keyframe_List::Widget_Keyframe_List():
 
 	// Window of the moving tooltip
 
-	moving_tooltip_label.set_alignment(0.5, 0.5);
+	moving_tooltip_label.set_halign(Gtk::ALIGN_CENTER);
+	moving_tooltip_label.set_valign(Gtk::ALIGN_CENTER);
 	moving_tooltip_label.show();
 
 	moving_tooltip.set_resizable(false);

--- a/synfig-studio/src/gui/widgets/widget_link.cpp
+++ b/synfig-studio/src/gui/widgets/widget_link.cpp
@@ -68,8 +68,14 @@ Widget_Link::Widget_Link(const std::string &tlt_inactive, const std::string &tlt
 	// not use manage() otherwise the not-shown icon at exit wouldn't be deleted...
 	icon_on_ = new Gtk::Image(chain_icon_pixbuff_scaled);
 
-	icon_off_->set_padding(0,0);
-	icon_on_->set_padding(0,0);
+	icon_off_->set_margin_start(0);
+	icon_off_->set_margin_end(0);
+	icon_off_->set_margin_top(0);
+	icon_off_->set_margin_bottom(0);
+	icon_on_->set_margin_start(0);
+	icon_on_->set_margin_end(0);
+	icon_on_->set_margin_top(0);
+	icon_on_->set_margin_bottom(0);
 
 	icon_off_->show();
 	add(*icon_off_);

--- a/synfig-studio/src/gui/widgets/widget_waypoint.cpp
+++ b/synfig-studio/src/gui/widgets/widget_waypoint.cpp
@@ -194,6 +194,8 @@ Widget_Waypoint::Widget_Waypoint(etl::handle<synfig::Canvas> canvas):
 	tcbGrid->attach(*temporalTensionLabel,  0, 4, 1, 1);
 	tcbGrid->attach(*spin_temporal_tension, 1, 4, 1, 1);
 
+	tcbFrame->add(*tcbGrid);
+
 	set_canvas(canvas);
 
 	add(*waypointFrame);
@@ -201,7 +203,6 @@ Widget_Waypoint::Widget_Waypoint(etl::handle<synfig::Canvas> canvas):
 	add(*interpolationFrame);
 	add(*interpolationGrid);
 	add(*tcbFrame);
-	add(*tcbGrid);
 }
 
 void
@@ -287,7 +288,6 @@ Widget_Waypoint::config_tcb_params(bool show_params)
 	}
 
 	tcbFrame->set_visible(show_params);
-	tcbGrid->set_visible(show_params);
 }
 void
 Widget_Waypoint::update_tcb_params_visibility()

--- a/synfig-studio/src/gui/widgets/widget_waypoint.cpp
+++ b/synfig-studio/src/gui/widgets/widget_waypoint.cpp
@@ -34,6 +34,7 @@
 #include <gui/widgets/widget_waypoint.h>
 
 #include <gtkmm/label.h>
+#include <gtkmm/stylecontext.h>
 
 #include <gui/localization.h>
 #include <gui/widgets/widget_enum.h>
@@ -61,12 +62,8 @@ Widget_Waypoint::Widget_Waypoint(etl::handle<synfig::Canvas> canvas):
 	adj_bias(Gtk::Adjustment::create(0.0,-20,20,0.1,1)),
 	adj_temporal_tension(Gtk::Adjustment::create(0.0,-20,20,0.1,1))
 {
+	get_style_context()->add_class("dialog-main-content");
 	set_spacing(12);
-
-	set_margin_start (12);
-	set_margin_end   (12);
-	set_margin_top   (12);
-	set_margin_bottom(12);
 
 	value_widget=manage(new Widget_ValueBase());
 	value_widget->set_canvas(canvas);
@@ -128,20 +125,17 @@ Widget_Waypoint::Widget_Waypoint(etl::handle<synfig::Canvas> canvas):
 	((Gtk::Label *) waypointFrame->get_label_widget())->set_markup(_("<b>Waypoint</b>"));
 
 	auto waypointGrid = manage(new Gtk::Grid());
+	waypointGrid->get_style_context()->add_class("dialog-secondary-content");
 	waypointGrid->set_row_spacing(6);
 	waypointGrid->set_column_spacing(12);
 
 	Gtk::Label *waypointValueLabel = manage(new Gtk::Label(_("_Value"), true));
-	waypointValueLabel->set_margin_top(6);
-	waypointValueLabel->set_margin_start(24);
 	waypointValueLabel->set_mnemonic_widget(*value_widget);
 	waypointGrid->attach(*waypointValueLabel, 0, 0, 1, 1);
 	waypointGrid->attach(*value_widget      , 1, 0, 1, 1);
 	waypointGrid->attach(*value_node_label  , 2, 0, 1, 1);
 
 	Gtk::Label *waypointTimeLabel = manage(new Gtk::Label(_("_Time"), true));
-	waypointTimeLabel->set_margin_top(6);
-	waypointTimeLabel->set_margin_start(24);
 	waypointTimeLabel->set_mnemonic_widget(*time_widget);
 	waypointGrid->attach(*waypointTimeLabel, 0, 1, 1, 1);
 	waypointGrid->attach(*time_widget,       1, 1, 1, 1);
@@ -151,21 +145,18 @@ Widget_Waypoint::Widget_Waypoint(etl::handle<synfig::Canvas> canvas):
 	((Gtk::Label *) interpolationFrame->get_label_widget())->set_markup(_("<b>Interpolation</b>"));
 
 	auto interpolationGrid = manage(new Gtk::Grid());
+	interpolationGrid->get_style_context()->add_class("dialog-secondary-content");
 	interpolationGrid->set_row_spacing(6);
 	interpolationGrid->set_column_spacing(12);
 
 	Gtk::Label *interpolationInLabel = manage(new Gtk::Label(_("_In Interpolation"), true));
 	interpolationInLabel->set_halign(Gtk::ALIGN_START);
-	interpolationInLabel->set_margin_top(6);
-	interpolationInLabel->set_margin_start(24);
 	interpolationInLabel->set_mnemonic_widget(*before_options);
 	interpolationGrid->attach(*interpolationInLabel, 0, 0, 1, 1);
 	interpolationGrid->attach(*before_options,       1, 0, 1, 1);
 
 	Gtk::Label *interpolationOutLabel = manage(new Gtk::Label(_("O_ut Interpolation"), true));
 	interpolationOutLabel->set_halign(Gtk::ALIGN_START);
-	interpolationOutLabel->set_margin_top(6);
-	interpolationOutLabel->set_margin_start(24);
 	interpolationOutLabel->set_mnemonic_widget(*after_options);
 	interpolationGrid->attach(*interpolationOutLabel, 0, 1, 1, 1);
 	interpolationGrid->attach(*after_options,         1, 1, 1, 1);
@@ -175,38 +166,30 @@ Widget_Waypoint::Widget_Waypoint(etl::handle<synfig::Canvas> canvas):
 	((Gtk::Label *) tcbFrame->get_label_widget())->set_markup(_("<b>TCB Parameter</b>"));
 
 	tcbGrid = manage(new Gtk::Grid());
+	tcbGrid->get_style_context()->add_class("dialog-secondary-content");
 	tcbGrid->set_row_spacing(6);
 	tcbGrid->set_column_spacing(12);
-	tcbGrid->add(*tcbFrame);
 
 	Gtk::Label *tensionLabel = manage(new Gtk::Label(_("T_ension"), true));
 	tensionLabel->set_halign(Gtk::ALIGN_START);
-	tensionLabel->set_margin_top(6);
-	tensionLabel->set_margin_start(24);
 	tensionLabel->set_mnemonic_widget(*spin_tension);
 	tcbGrid->attach(*tensionLabel, 0, 1, 1, 1);
 	tcbGrid->attach(*spin_tension, 1, 1, 1, 1);
 
 	Gtk::Label *continuityLabel = manage(new Gtk::Label(_("Continuit_y"), true));
 	continuityLabel->set_halign(Gtk::ALIGN_START);
-	continuityLabel->set_margin_top(6);
-	continuityLabel->set_margin_start(24);
 	continuityLabel->set_mnemonic_widget(*spin_continuity);
 	tcbGrid->attach(*continuityLabel, 0, 2, 1, 1);
 	tcbGrid->attach(*spin_continuity, 1, 2, 1, 1);
 
 	Gtk::Label *biasLabel = manage(new Gtk::Label(_("_Bias"), true));
 	biasLabel->set_halign(Gtk::ALIGN_START);
-	biasLabel->set_margin_top(6);
-	biasLabel->set_margin_start(24);
 	biasLabel->set_mnemonic_widget(*spin_bias);
 	tcbGrid->attach(*biasLabel, 0, 3, 1, 1);
 	tcbGrid->attach(*spin_bias, 1, 3, 1, 1);
 
 	Gtk::Label *temporalTensionLabel = manage(new Gtk::Label(_("Te_mporal Tension"), true));
 	temporalTensionLabel->set_halign(Gtk::ALIGN_START);
-	temporalTensionLabel->set_margin_top(6);
-	temporalTensionLabel->set_margin_start(24);
 	temporalTensionLabel->set_mnemonic_widget(*spin_temporal_tension);
 	tcbGrid->attach(*temporalTensionLabel,  0, 4, 1, 1);
 	tcbGrid->attach(*spin_temporal_tension, 1, 4, 1, 1);
@@ -217,6 +200,7 @@ Widget_Waypoint::Widget_Waypoint(etl::handle<synfig::Canvas> canvas):
 	add(*waypointGrid);
 	add(*interpolationFrame);
 	add(*interpolationGrid);
+	add(*tcbFrame);
 	add(*tcbGrid);
 }
 
@@ -302,6 +286,7 @@ Widget_Waypoint::config_tcb_params(bool show_params)
 		adj_temporal_tension->set_value(waypoint.get_temporal_tension());
 	}
 
+	tcbFrame->set_visible(show_params);
 	tcbGrid->set_visible(show_params);
 }
 void


### PR DESCRIPTION
Replaced the following deprecated stuff:
- `set_alignment()`
- `set_padding()`