### PR TITLE
[Synfig Studio] 'Undock Panel' menu item is no longer visible for already undocked panels

### DIFF
--- a/synfig-studio/src/gui/docks/dockbook.cpp
+++ b/synfig-studio/src/gui/docks/dockbook.cpp
@@ -269,12 +269,14 @@ DockBook::tab_button_pressed(GdkEventButton* event, Dockable* dockable)
 	Gtk::Menu *tabmenu=manage(new class Gtk::Menu());
 	tabmenu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), tabmenu));
 
-	Gtk::MenuItem *item = manage(new Gtk::MenuItem(_("Undock panel")));
-	item->signal_activate().connect(sigc::mem_fun(*dockable, &Dockable::detach_to_pointer));
-	item->show();
-	tabmenu->append(*item);
+	if (get_n_pages() > 1 || (get_parent() && get_parent()->get_children().size() > 1)) {
+		Gtk::MenuItem *item = manage(new Gtk::MenuItem(_("Undock panel")));
+		item->signal_activate().connect(sigc::mem_fun(*dockable, &Dockable::detach_to_pointer));
+		item->show();
+		tabmenu->append(*item);
+	}
 
-	item = manage(new Gtk::ImageMenuItem(Gtk::StockID("gtk-close")));
+	Gtk::MenuItem *item = manage(new Gtk::ImageMenuItem(Gtk::StockID("gtk-close")));
 	item->signal_activate().connect(
 		sigc::bind(sigc::ptr_fun(&DockManager::remove_widget_by_pointer_recursive), dockable) );
 	item->show();


### PR DESCRIPTION
even when it's a solo panel in a floating window.

Related to #2047