### PR TITLE
[Synfig Studio] Replace deprecated get_vbox() method

### DIFF
--- a/synfig-studio/src/gui/dialogs/canvasproperties.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasproperties.cpp
@@ -68,7 +68,7 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	widget_rend_desc.signal_changed().connect(sigc::mem_fun(*this,&studio::CanvasProperties::on_rend_desc_changed));
 
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	get_vbox()->pack_start(*dialogPadding, false, false, 0);
+	get_content_area()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Grid *dialogGrid = manage(new Gtk::Grid());
 	dialogGrid->get_style_context()->add_class("dialog-main-content");
@@ -135,7 +135,7 @@ CanvasProperties::CanvasProperties(Gtk::Window& parent,etl::handle<synfigapp::Ca
 	add_action_widget(*ok_button,2);
 	ok_button->signal_clicked().connect(sigc::mem_fun(*this, &studio::CanvasProperties::on_ok_pressed));
 
-	get_vbox()->show_all();
+	get_content_area()->show_all();
 	signal_show().connect(sigc::mem_fun(*this, &studio::CanvasProperties::refresh));
 
 	update_title();

--- a/synfig-studio/src/gui/dialogs/dialog_color.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_color.cpp
@@ -95,7 +95,7 @@ Dialog_Color::create_color_edit_widget()
 	color_edit_widget = manage(new Widget_ColorEdit());
 	color_edit_widget->signal_value_changed().connect(sigc::mem_fun(*this,
 			&studio::Dialog_Color::on_color_changed));
-	get_vbox()->pack_start(*color_edit_widget);
+	get_content_area()->pack_start(*color_edit_widget);
 }
 
 void

--- a/synfig-studio/src/gui/dialogs/dialog_ffmpegparam.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_ffmpegparam.cpp
@@ -105,11 +105,11 @@ Dialog_FFmpegParam::Dialog_FFmpegParam(Gtk::Window &parent):
 	for (int i = 0; allowed_video_codecs[i] != NULL &&
 					allowed_video_codecs_description[i] != NULL; i++)
 		vcodec->append(allowed_video_codecs_description[i]);
-	//Adds the Combo Box and the Custom Video Codec entry to the vertical box
-	get_vbox()->pack_start(*label, true, true, 0);
-	get_vbox()->pack_start(*vcodec, true, true, 0);
-	get_vbox()->pack_start(*custom_label, true, true, 0);
-	get_vbox()->pack_start(*customvcodec, true, true, 0);
+	//Adds the Combo Box and the Custom Video Codec entry to the box
+	get_content_area()->pack_start(*label, true, true, 0);
+	get_content_area()->pack_start(*vcodec, true, true, 0);
+	get_content_area()->pack_start(*custom_label, true, true, 0);
+	get_content_area()->pack_start(*customvcodec, true, true, 0);
 
 	// Connect the signal change to the handler
 	vcodec->signal_changed().connect(sigc::mem_fun(*this, &Dialog_FFmpegParam::on_vcodec_change));
@@ -119,10 +119,10 @@ Dialog_FFmpegParam::Dialog_FFmpegParam(Gtk::Window &parent):
 	Gtk::Label* label2(manage(new Gtk::Label(_("Video Bit Rate:"))));
 	label2->set_halign(Gtk::ALIGN_START);
 	label2->set_valign(Gtk::ALIGN_CENTER);
-	get_vbox()->pack_start(*label2, true, true, 0);
-	get_vbox()->pack_start(*bitrate,true, true, 0);
+	get_content_area()->pack_start(*label2, true, true, 0);
+	get_content_area()->pack_start(*bitrate,true, true, 0);
 
-	get_vbox()->show_all();
+	get_content_area()->show_all();
 }
 
 

--- a/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
@@ -78,7 +78,7 @@ Dialog_Gradient::Dialog_Gradient():
 	set_default_button->signal_clicked().connect(sigc::mem_fun(*this, &Dialog_Gradient::on_set_default_pressed));
 
 	Gtk::Table* table(manage(new Gtk::Table(2,2,false)));
-	get_vbox()->pack_start(*table);
+	get_content_area()->pack_start(*table);
 
 	widget_gradient=manage(new Widget_Gradient());
 	widget_gradient->set_editable();

--- a/synfig-studio/src/gui/dialogs/dialog_soundselect.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_soundselect.cpp
@@ -60,7 +60,7 @@ studio::Dialog_SoundSelect::Dialog_SoundSelect(Gtk::Window &parent, etl::handle<
 canvas_interface(ci)
 {
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	get_vbox()->pack_start(*dialogPadding, false, false, 0);
+	get_content_area()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Frame *soundFrame = manage(new Gtk::Frame(_("Sound Parameters")));
 	((Gtk::Label *) soundFrame->get_label_widget())->set_markup(_("<b>Sound Parameters</b>"));
@@ -94,7 +94,7 @@ canvas_interface(ci)
 	okbutton = manage(new Gtk::Button(Gtk::StockID("gtk-ok")));
 	add_action_widget(*okbutton, 0);
 
-	get_vbox()->show_all();
+	get_content_area()->show_all();
 
 	offset.set_value(0);
 

--- a/synfig-studio/src/gui/dialogs/dialog_template.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_template.cpp
@@ -133,8 +133,8 @@ Dialog_Template::Dialog_Template(Gtk::Window& parent, synfig::String dialog_titl
 	//! TODO create a warning zone to push message on rare events (like no brush path, zero fps ...)
 	//! this warning zone could also hold normal message like : "x change to come"  (and a link to "Changes summary" page)
 
-	get_vbox()->pack_start(main_grid);
-	get_vbox()->set_border_width(12);
+	get_content_area()->pack_start(main_grid);
+	get_content_area()->set_border_width(12);
 
 	show_all_children();
 }

--- a/synfig-studio/src/gui/dialogs/dialog_waypoint.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_waypoint.cpp
@@ -56,7 +56,7 @@ Dialog_Waypoint::Dialog_Waypoint(Gtk::Window& parent,etl::handle<synfig::Canvas>
 	this->set_resizable(false);
 	assert(canvas);
     waypointwidget=manage(new class Widget_Waypoint(canvas));
-	get_vbox()->pack_start(*waypointwidget);
+	get_content_area()->pack_start(*waypointwidget);
 
 	Gtk::Button *delete_button(manage(new class Gtk::Button(Gtk::StockID("gtk-delete"))));
 	delete_button->show();

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1366,7 +1366,7 @@ edit_several_waypoints(etl::handle<CanvasView> canvas_view, std::list<synfigapp:
 	Widget_WaypointModel widget_waypoint_model;
 	widget_waypoint_model.show();
 
-	dialog.get_vbox()->pack_start(widget_waypoint_model);
+	dialog.get_content_area()->pack_start(widget_waypoint_model);
 
 	dialog.add_button(_("Cancel"), 0);
 	dialog.add_button(_("Apply"), 1);

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -114,7 +114,7 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	comboboxtext_target.signal_changed().connect(sigc::mem_fun(this, &RenderSettings::on_comboboxtext_target_changed));
 
 	Gtk::Alignment *dialogPadding = manage(new Gtk::Alignment(0, 0, 1, 1));
-	get_vbox()->pack_start(*dialogPadding, false, false, 0);
+	get_content_area()->pack_start(*dialogPadding, false, false, 0);
 
 	Gtk::Grid *dialogGrid = manage(new Gtk::Grid());
 	dialogGrid->get_style_context()->add_class("dialog-main-content");
@@ -222,7 +222,7 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 
 	set_entry_filename();
 
-	get_vbox()->show_all();
+	get_content_area()->show_all();
 }
 
 RenderSettings::~RenderSettings()


### PR DESCRIPTION
Replaced the following deprecated stuff:
- `get_vbox()`

Didn't replace the method in vectorizersettings.cpp as it will be replaced in #2080