### PR TITLE
[Synfig Studio] Replace some other deprecated Gtk libraries

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -862,7 +862,7 @@ CanvasView::create_time_bar()
 	timeslider->show();
 
 	// Setup Time Scroll
-	Gtk::HScrollbar *time_window_scroll = manage(new class Gtk::HScrollbar(time_model()->scroll_time_adjustment()));
+	Gtk::Scrollbar *time_window_scroll = manage(new class Gtk::Scrollbar(time_model()->scroll_time_adjustment()));
 	time_window_scroll->set_tooltip_text(_("Moves the time window"));
 	//time_window_scroll->set_can_focus(true); // Uncomment this produce bad render of the HScroll
 	time_window_scroll->show();
@@ -981,7 +981,7 @@ CanvasView::create_time_bar()
 		sigc::mem_fun(*time_model(), &TimeModel::set_play_bounds_upper_to_current) );
 	framedial->show();
 
-	Gtk::HSeparator *separator = manage(new Gtk::HSeparator());
+	Gtk::Separator *separator = manage(new Gtk::Separator());
 	separator->show();
 
 	//Setup the KeyFrameDial widget

--- a/synfig-studio/src/gui/dialogs/dialog_input.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_input.cpp
@@ -191,7 +191,7 @@ void Dialog_Input::create_widgets()
 			table->attach(*comboboxtext, 1, 2, row, row+1, Gtk::EXPAND | Gtk::FILL, Gtk::SHRINK | Gtk::FILL);
 		}
 
-		table->attach( *manage(new class Gtk::HSeparator()),
+		table->attach( *manage(new class Gtk::Separator()),
 					   0,
 					   2,
 					   (int)options->devices.size(),

--- a/synfig-studio/src/gui/docks/dock_curves.cpp
+++ b/synfig-studio/src/gui/docks/dock_curves.cpp
@@ -55,7 +55,9 @@ Dock_Curves::Dock_Curves():
 	Dock_CanvasSpecific("curves",_("Graphs"),Gtk::StockID("synfig-curves")),
 	table_(),
 	last_widget_curves_()
-{ }
+{
+	vscrollbar_.set_orientation(Gtk::ORIENTATION_VERTICAL);
+}
 
 Dock_Curves::~Dock_Curves()
 {

--- a/synfig-studio/src/gui/docks/dock_curves.h
+++ b/synfig-studio/src/gui/docks/dock_curves.h
@@ -46,8 +46,8 @@ class Widget_Curves;
 
 class Dock_Curves : public Dock_CanvasSpecific
 {
-	Gtk::HScrollbar hscrollbar_;
-	Gtk::VScrollbar vscrollbar_;
+	Gtk::Scrollbar hscrollbar_;
+	Gtk::Scrollbar vscrollbar_;
 
 	Widget_CanvasTimeslider widget_timeslider_;
 	Widget_Keyframe_List widget_kf_list_;

--- a/synfig-studio/src/gui/docks/dock_layergroups.h
+++ b/synfig-studio/src/gui/docks/dock_layergroups.h
@@ -36,8 +36,6 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-namespace Gtk { class HScale; }
-
 namespace studio {
 
 class GroupActionManager ;

--- a/synfig-studio/src/gui/docks/dock_layers.h
+++ b/synfig-studio/src/gui/docks/dock_layers.h
@@ -36,8 +36,6 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
-namespace Gtk { class HScale; }
-
 namespace studio {
 
 class LayerActionManager;
@@ -49,7 +47,7 @@ class Dock_Layers : public Dock_CanvasSpecific
 
 	Glib::RefPtr<Gtk::Action> action_new_layer;
 
-	//Gtk::HScale *layer_amount_hscale;
+	//Gtk::Scale *layer_amount_hscale;
 
 	LayerActionManager* layer_action_manager;
 

--- a/synfig-studio/src/gui/docks/dock_navigator.cpp
+++ b/synfig-studio/src/gui/docks/dock_navigator.cpp
@@ -69,10 +69,10 @@ Widget_NavView::Widget_NavView():
 {
 	//zooming stuff
 	zoom_print.set_size_request(40,-1);
-	Gtk::HScale *hs = manage(new Gtk::HScale(adj_zoom));
+	Gtk::Scale *hs = manage(new Gtk::Scale(adj_zoom));
 	hs->set_draw_value(false);
 
-	Gtk::HSeparator *sep = manage(new Gtk::HSeparator());
+	Gtk::Separator *sep = manage(new Gtk::Separator());
 
 	attach(drawto,     0, 4, 0, 1);
 	attach(*sep,       0, 4, 1, 2, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL);

--- a/synfig-studio/src/gui/docks/dock_navigator.cpp
+++ b/synfig-studio/src/gui/docks/dock_navigator.cpp
@@ -67,17 +67,23 @@ Widget_NavView::Widget_NavView():
 	adj_zoom(Gtk::Adjustment::create(0, -4, 4, 1, 2)),
 	scrolling(0)
 {
-	//zooming stuff
-	zoom_print.set_size_request(40,-1);
-	Gtk::Scale *hs = manage(new Gtk::Scale(adj_zoom));
-	hs->set_draw_value(false);
+	drawto.set_hexpand();
+	drawto.set_vexpand();
 
 	Gtk::Separator *sep = manage(new Gtk::Separator());
 
-	attach(drawto,     0, 4, 0, 1);
-	attach(*sep,       0, 4, 1, 2, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL);
-	attach(zoom_print, 0, 1, 2, 3, Gtk::SHRINK|Gtk::FILL, Gtk::SHRINK|Gtk::FILL);
-	attach(*hs,        1, 4, 2, 3, Gtk::EXPAND|Gtk::FILL, Gtk::SHRINK|Gtk::FILL);
+	zoom_print.set_size_request(60,-1);
+	zoom_print.set_margin_start(5);
+	zoom_print.set_margin_end(5);
+
+	Gtk::Scale *hs = manage(new Gtk::Scale(adj_zoom));
+	hs->set_draw_value(false);
+	hs->set_hexpand();
+
+	attach(drawto,     0, 0, 2, 1);
+	attach(*sep,       0, 1, 2, 1);
+	attach(zoom_print, 0, 2, 1, 1);
+	attach(*hs,        1, 2, 1, 1);
 	show_all();
 
 	adj_zoom->signal_value_changed().connect(sigc::mem_fun(*this, &Widget_NavView::on_number_modify));

--- a/synfig-studio/src/gui/docks/dock_navigator.h
+++ b/synfig-studio/src/gui/docks/dock_navigator.h
@@ -33,7 +33,7 @@
 #include <gtkmm/drawingarea.h>
 #include <gtkmm/adjustment.h>
 #include <gtkmm/label.h>
-#include <gtkmm/table.h>
+#include <gtkmm/grid.h>
 
 #include <gui/docks/dock_canvasspecific.h>
 
@@ -47,7 +47,7 @@ namespace studio {
 
 class CanvasView;
 
-class Widget_NavView : public Gtk::Table
+class Widget_NavView : public Gtk::Grid
 {
 	etl::loose_handle<CanvasView> canvas_view;
 	Cairo::RefPtr<Cairo::ImageSurface> surface;

--- a/synfig-studio/src/gui/docks/dock_soundwave.cpp
+++ b/synfig-studio/src/gui/docks/dock_soundwave.cpp
@@ -461,6 +461,7 @@ Dock_SoundWave::Dock_SoundWave()
 
 	vscrollbar.set_vexpand();
 	vscrollbar.set_hexpand(false);
+	vscrollbar.set_orientation(Gtk::ORIENTATION_VERTICAL);
 	vscrollbar.show();
 	hscrollbar.set_hexpand();
 	hscrollbar.show();

--- a/synfig-studio/src/gui/docks/dock_soundwave.h
+++ b/synfig-studio/src/gui/docks/dock_soundwave.h
@@ -55,8 +55,8 @@ private:
 	Widget_Keyframe_List widget_kf_list;
 	Widget_CanvasTimeslider widget_timeslider;
 	Grid_SoundWave *current_grid_sound;
-	Gtk::VScrollbar vscrollbar;
-	Gtk::HScrollbar hscrollbar;
+	Gtk::Scrollbar vscrollbar;
+	Gtk::Scrollbar hscrollbar;
 };
 
 }

--- a/synfig-studio/src/gui/docks/dock_timetrack.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack.cpp
@@ -350,6 +350,7 @@ Dock_Timetrack_Old::Dock_Timetrack_Old():
 	grid_()
 {
 	set_use_scrolled(false);
+	vscrollbar_.set_orientation(Gtk::ORIENTATION_VERTICAL);
 }
 
 Dock_Timetrack_Old::~Dock_Timetrack_Old()

--- a/synfig-studio/src/gui/docks/dock_timetrack.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack.h
@@ -45,8 +45,8 @@ namespace studio {
 
 class Dock_Timetrack_Old : public Dock_CanvasSpecific
 {
-	Gtk::HScrollbar hscrollbar_;
-	Gtk::VScrollbar vscrollbar_;
+	Gtk::Scrollbar hscrollbar_;
+	Gtk::Scrollbar vscrollbar_;
 	Widget_CanvasTimeslider widget_timeslider_;
 	Widget_Keyframe_List widget_kf_list_;
 	Gtk::Grid *grid_;

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -52,6 +52,7 @@ Dock_Timetrack2::Dock_Timetrack2()
 
 	vscrollbar.set_vexpand();
 	vscrollbar.set_hexpand(false);
+	vscrollbar.set_orientation(Gtk::ORIENTATION_VERTICAL);
 	vscrollbar.show();
 	hscrollbar.set_hexpand();
 	hscrollbar.show();

--- a/synfig-studio/src/gui/docks/dock_timetrack2.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.h
@@ -51,8 +51,8 @@ private:
 	Widget_Keyframe_List widget_kf_list;
 	Widget_CanvasTimeslider widget_timeslider;
 	Widget_Timetrack *current_widget_timetrack;
-	Gtk::VScrollbar vscrollbar;
-	Gtk::HScrollbar hscrollbar;
+	Gtk::Scrollbar vscrollbar;
+	Gtk::Scrollbar hscrollbar;
 	Gtk::ToolPalette tool_palette;
 
 	void on_update_header_height(int height);

--- a/synfig-studio/src/gui/docks/dock_toolbox.h
+++ b/synfig-studio/src/gui/docks/dock_toolbox.h
@@ -59,7 +59,6 @@ class Dock_Toolbox : public Dockable
 	friend class studio::StateManager;
 
 	Gtk::ToolItemGroup *tool_item_group;
-	Gtk::VBox *tool_box;
 	Gtk::Paned *tool_box_paned;
 
 	std::map<synfig::String,Gtk::ToggleToolButton *> state_button_map;

--- a/synfig-studio/src/gui/preview.h
+++ b/synfig-studio/src/gui/preview.h
@@ -191,7 +191,7 @@ class Widget_Preview : public Gtk::Table
 {
 	Gtk::DrawingArea	draw_area;
 	Glib::RefPtr<Gtk::Adjustment> adj_time_scrub; //the adjustment for the managed scrollbar
-	Gtk::HScale		scr_time_scrub;
+	Gtk::Scale		scr_time_scrub;
 	Gtk::ToggleButton	b_loop;
 	Gtk::ScrolledWindow	preview_window;
 	//Glib::RefPtr<Gdk::GC>		gc_area;

--- a/synfig-studio/src/gui/widgets/widget_defaults.cpp
+++ b/synfig-studio/src/gui/widgets/widget_defaults.cpp
@@ -324,7 +324,7 @@ Widget_Defaults::Widget_Defaults():
 	//widget_blend_method->set_tooltip_text(_("Default Blend Method"));
 
 	// widget opacity
-	//widget_opacity = manage(new Gtk::HScale(0.0f,1.01f,0.01f));
+	//widget_opacity = manage(new Gtk::Scale(0.0f,1.01f,0.01f));
 	//widget_opacity->set_digits(2);
 	//widget_opacity->set_value_pos(Gtk::POS_LEFT);
 	//widget_opacity->signal_value_changed().connect(sigc::mem_fun(*this,&studio::Widget_Defaults::on_opacity_changed));

--- a/synfig-studio/src/gui/widgets/widget_defaults.h
+++ b/synfig-studio/src/gui/widgets/widget_defaults.h
@@ -72,7 +72,7 @@ class Widget_Defaults : public Gtk::Box
 
 	//Widget_Enum	*widget_blend_method;
 
-	//Gtk::HScale 	*widget_opacity;
+	//Gtk::Scale 	*widget_opacity;
 
 	void otln_color_refresh();
 	void fill_color_refresh();


### PR DESCRIPTION
Replaced the following deprecated stuff:
- `Gtk::HScale`
- `Gtk::HSeparator`
- `Gtk::HScrollbar`
- `Gtk::VScrollbar`