### PR TITLE
[Synfig Studio] Replacing Gtk::HBox with Gtk::Box

### DIFF
--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -178,7 +178,7 @@ studio::Dock_Info::Dock_Info()
 	stop_button.set_valign(Gtk::ALIGN_CENTER);
 	stop_button.signal_clicked().connect(sigc::mem_fun(*this, &studio::Dock_Info::on_stop_button_clicked));
 
-	render_grid->attach(*overlay, 0, 0);
+	render_grid->attach(*overlay, 0, 0, 1, 1);
 	render_grid->attach_next_to(stop_button, Gtk::POS_RIGHT, 1, 1);
 	grid->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8, 1);
 	grid->attach_next_to(*render_grid, *render_progress_label, Gtk::POS_BOTTOM, 7, 1);

--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -155,7 +155,7 @@ studio::Dock_Info::Dock_Info()
 	grid->attach(*separator2, 0, 4, 8, 1);
 
 	// Render Progress Bar
-	Gtk::HBox *render_box = manage(new Gtk::HBox());
+	Gtk::Grid *render_grid = manage(new Gtk::Grid());
 	Gtk::Label *render_progress_label = manage(new Gtk::Label());
 	Gtk::Overlay *overlay = manage(new Gtk::Overlay());
 
@@ -178,10 +178,10 @@ studio::Dock_Info::Dock_Info()
 	stop_button.set_valign(Gtk::ALIGN_CENTER);
 	stop_button.signal_clicked().connect(sigc::mem_fun(*this, &studio::Dock_Info::on_stop_button_clicked));
 
-	render_box->pack_start(*overlay);
-	render_box->pack_start(stop_button, Gtk::PACK_SHRINK);
+	render_grid->attach(*overlay, 0, 0);
+	render_grid->attach_next_to(stop_button, Gtk::POS_RIGHT, 1, 1);
 	grid->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8, 1);
-	grid->attach_next_to(*render_box, *render_progress_label, Gtk::POS_BOTTOM, 7, 1);
+	grid->attach_next_to(*render_grid, *render_progress_label, Gtk::POS_BOTTOM, 7, 1);
 
 	grid->set_margin_start(5);
 	grid->set_margin_end(5);

--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -155,7 +155,7 @@ studio::Dock_Info::Dock_Info()
 	grid->attach(*separator2, 0, 4, 8, 1);
 
 	// Render Progress Bar
-	Gtk::Grid *render_grid = manage(new Gtk::Grid());
+	Gtk::Box *render_box = manage(new Gtk::Box());
 	Gtk::Label *render_progress_label = manage(new Gtk::Label());
 	Gtk::Overlay *overlay = manage(new Gtk::Overlay());
 
@@ -178,10 +178,10 @@ studio::Dock_Info::Dock_Info()
 	stop_button.set_valign(Gtk::ALIGN_CENTER);
 	stop_button.signal_clicked().connect(sigc::mem_fun(*this, &studio::Dock_Info::on_stop_button_clicked));
 
-	render_grid->attach(*overlay, 0, 0, 1, 1);
-	render_grid->attach_next_to(stop_button, Gtk::POS_RIGHT, 1, 1);
+	render_box->pack_start(*overlay, true, true, 0);
+	render_box->pack_start(stop_button, false, false, 0);
 	grid->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8, 1);
-	grid->attach_next_to(*render_grid, *render_progress_label, Gtk::POS_BOTTOM, 7, 1);
+	grid->attach_next_to(*render_box, *render_progress_label, Gtk::POS_BOTTOM, 7, 1);
 
 	grid->set_margin_start(5);
 	grid->set_margin_end(5);

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -514,7 +514,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0);
+	id_grid.attach(id_label, 0, 0, 1, 1);
 	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
 	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
@@ -535,7 +535,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
 	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
@@ -547,7 +547,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach(blend_label, 0, 0, 1, 1);
 	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -585,7 +585,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
 	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	link_origins_grid.set_sensitive(false);
 
@@ -594,7 +594,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	auto_export_label.set_valign(Gtk::ALIGN_CENTER);
 	auto_export_label.set_hexpand();
 
-	auto_export_grid.attach(auto_export_label, 0, 0);
+	auto_export_grid.attach(auto_export_label, 0, 0, 1, 1);
 	auto_export_grid.attach_next_to(auto_export_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	auto_export_grid.set_sensitive(true);
 

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -138,55 +138,45 @@ class studio::StateBLine_Context : public sigc::trackable
 
 	void refresh_ducks(bool x=true);
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
+	Gtk::Grid id_grid;
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
 
-	// layer types to create:
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_region_togglebutton;
 	Gtk::ToggleButton layer_outline_togglebutton;
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Grid layer_types_grid;
 
-	// blend method
 	Gtk::Label blend_label;
-	Gtk::HBox blend_box;
 	Widget_Enum blend_enum;
+	Gtk::Grid blend_grid;
 
-	// opacity
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
-	// brush size
 	Gtk::Label bline_width_label;
 	Widget_Distance bline_width_dist;
 
-	// feather size
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
-	// link origins
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::HBox link_origins_box;
+	Gtk::Grid link_origins_grid;
 
-	// auto export
 	Gtk::Label auto_export_label;
 	Gtk::CheckButton auto_export_checkbutton;
-	Gtk::HBox auto_export_box;
+	Gtk::Grid auto_export_grid;
 
 public:
 
@@ -522,11 +512,11 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
-
-	id_box.pack_start(id_entry);
+	id_grid.attach(id_label, 0, 0);
+	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
+	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -545,19 +535,20 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
+	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
-	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
+	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -592,31 +583,33 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
+	link_origins_label.set_hexpand();
 
-	link_origins_box.pack_start(link_origins_label);
-	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
-	link_origins_box.set_sensitive(false);
+	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	link_origins_grid.set_sensitive(false);
 
 	auto_export_label.set_label(_("Auto Export"));
 	auto_export_label.set_halign(Gtk::ALIGN_START);
 	auto_export_label.set_valign(Gtk::ALIGN_CENTER);
+	auto_export_label.set_hexpand();
 
-	auto_export_box.pack_start(auto_export_label);
-	auto_export_box.pack_end(auto_export_checkbutton, Gtk::PACK_SHRINK);
-	auto_export_box.set_sensitive(true);
+	auto_export_grid.attach(auto_export_label, 0, 0);
+	auto_export_grid.attach_next_to(auto_export_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	auto_export_grid.set_sensitive(true);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_box,
+	options_grid.attach(id_grid,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_box,
+	options_grid.attach(layer_types_grid,
 		0, 3, 2, 1);
-	options_grid.attach(blend_box,
+	options_grid.attach(blend_grid,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -632,11 +625,12 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 		0, 7, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 7, 1, 1);
-	options_grid.attach(link_origins_box,
+	options_grid.attach(link_origins_grid,
 		0, 8, 2, 1);
-	options_grid.attach(auto_export_box,
+	options_grid.attach(auto_export_grid,
 		0, 9, 2, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
@@ -2017,9 +2011,9 @@ StateBLine_Context::toggle_layer_creation()
 		get_layer_plant_flag() +
 		get_layer_curve_gradient_flag() >= 2)
 		{
-			link_origins_box.set_sensitive(true);
+			link_origins_grid.set_sensitive(true);
 		}
-	else link_origins_box.set_sensitive(false);
+	else link_origins_grid.set_sensitive(false);
 
   // update layer flags
   layer_region_flag = get_layer_region_flag();

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -145,9 +145,9 @@ class studio::StateBLine_Context : public sigc::trackable
 
 	Gtk::Label title_label;
 
-	Gtk::Grid id_grid;
 	Gtk::Label id_label;
 	Gtk::Entry id_entry;
+	Gtk::Box id_box;
 
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_region_togglebutton;
@@ -155,11 +155,11 @@ class studio::StateBLine_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::Grid layer_types_grid;
+	Gtk::Box layer_types_box;
 
 	Gtk::Label blend_label;
 	Widget_Enum blend_enum;
-	Gtk::Grid blend_grid;
+	Gtk::Box blend_box;
 
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
@@ -172,11 +172,11 @@ class studio::StateBLine_Context : public sigc::trackable
 
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::Grid link_origins_grid;
+	Gtk::Box link_origins_box;
 
 	Gtk::Label auto_export_label;
 	Gtk::CheckButton auto_export_checkbutton;
-	Gtk::Grid auto_export_grid;
+	Gtk::Box auto_export_box;
 
 public:
 
@@ -512,11 +512,10 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0, 1, 1);
-	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
-	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*id_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -535,20 +534,19 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
-	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_advanced_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_plant_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_curve_gradient_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0, 1, 1);
-	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
+	blend_box.pack_start(blend_label, false, false, 0);
+	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -583,33 +581,31 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
-	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
-	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	link_origins_grid.set_sensitive(false);
+	link_origins_box.pack_start(link_origins_label, true, true, 0);
+	link_origins_box.pack_start(layer_link_origins_checkbutton, false, false, 0);
+	link_origins_box.set_sensitive(false);
 
 	auto_export_label.set_label(_("Auto Export"));
 	auto_export_label.set_halign(Gtk::ALIGN_START);
 	auto_export_label.set_valign(Gtk::ALIGN_CENTER);
-	auto_export_label.set_hexpand();
 
-	auto_export_grid.attach(auto_export_label, 0, 0, 1, 1);
-	auto_export_grid.attach_next_to(auto_export_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	auto_export_grid.set_sensitive(true);
+	auto_export_box.pack_start(auto_export_label, true, true, 0);
+	auto_export_box.pack_start(auto_export_checkbutton, false, false, 0);
+	auto_export_box.set_sensitive(true);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_grid,
+	options_grid.attach(id_box,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_grid,
+	options_grid.attach(layer_types_box,
 		0, 3, 2, 1);
-	options_grid.attach(blend_grid,
+	options_grid.attach(blend_box,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -625,9 +621,9 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 		0, 7, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 7, 1, 1);
-	options_grid.attach(link_origins_grid,
+	options_grid.attach(link_origins_box,
 		0, 8, 2, 1);
-	options_grid.attach(auto_export_grid,
+	options_grid.attach(auto_export_box,
 		0, 9, 2, 1);
 
 	options_grid.set_vexpand(false);
@@ -2011,9 +2007,9 @@ StateBLine_Context::toggle_layer_creation()
 		get_layer_plant_flag() +
 		get_layer_curve_gradient_flag() >= 2)
 		{
-			link_origins_grid.set_sensitive(true);
+			link_origins_box.set_sensitive(true);
 		}
-	else link_origins_grid.set_sensitive(false);
+	else link_origins_box.set_sensitive(false);
 
   // update layer flags
   layer_region_flag = get_layer_region_flag();

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -534,7 +534,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0);
+	id_grid.attach(id_label, 0, 0, 1, 1);
 	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
 	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
@@ -557,7 +557,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
 	layer_types_grid.attach_next_to(layer_circle_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
@@ -570,7 +570,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach(blend_label, 0, 0, 1, 1);
 	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -609,7 +609,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	bline_point_angle_offset_spin.set_sensitive(false);
 
 	SPACING(bline_point_angle_offset_indent, INDENTATION);
-	bline_point_angle_offset_grid.attach(*bline_point_angle_offset_indent, 0, 0);
+	bline_point_angle_offset_grid.attach(*bline_point_angle_offset_indent, 0, 0, 1, 1);
 	bline_point_angle_offset_grid.attach_next_to(bline_point_angle_offset_label, Gtk::POS_RIGHT, 1, 1);
 
 	invert_label.set_label(_("Invert"));
@@ -617,7 +617,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
 	invert_label.set_hexpand();
 
-	invert_grid.attach(invert_label, 0, 0);
+	invert_grid.attach(invert_label, 0, 0, 1, 1);
 	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	invert_grid.set_sensitive(false);
 
@@ -636,7 +636,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	falloff_label.set_vexpand();
 	falloff_label.set_sensitive(false);
 	SPACING(falloff_indent, INDENTATION);
-	falloff_grid.attach(*falloff_indent, 0, 0);
+	falloff_grid.attach(*falloff_indent, 0, 0, 1, 1);
 	falloff_grid.attach_next_to(falloff_label, Gtk::POS_RIGHT, 1, 1);
 
 	falloff_enum.set_param_desc(ParamDesc("falloff")
@@ -655,7 +655,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
 	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	link_origins_grid.set_sensitive(false);
 
@@ -664,7 +664,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	origins_at_center_label.set_valign(Gtk::ALIGN_CENTER);
 	origins_at_center_label.set_hexpand();
 
-	origins_at_center_grid.attach(origins_at_center_label, 0, 0);
+	origins_at_center_grid.attach(origins_at_center_label, 0, 0, 1, 1);
 	origins_at_center_grid.attach_next_to(layer_origins_at_center_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	origins_at_center_grid.set_sensitive(false);
 

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -122,7 +122,7 @@ class studio::StateCircle_Context : public sigc::trackable
 
 	Gtk::Label id_label;
 	Gtk::Entry id_entry;
-	Gtk::Grid id_grid;
+	Gtk::Box id_box;
 
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_circle_togglebutton;
@@ -131,11 +131,11 @@ class studio::StateCircle_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::Grid layer_types_grid;
+	Gtk::Box layer_types_box;
 
 	Gtk::Label blend_label;
 	Widget_Enum blend_enum;
-	Gtk::Grid blend_grid;
+	Gtk::Box blend_box;
 
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
@@ -150,26 +150,26 @@ class studio::StateCircle_Context : public sigc::trackable
 	Gtk::Label bline_point_angle_offset_label;
 	Glib::RefPtr<Gtk::Adjustment> bline_point_angle_offset_adj;
 	Gtk::SpinButton	bline_point_angle_offset_spin;
-	Gtk::Grid bline_point_angle_offset_grid;
+	Gtk::Box bline_point_angle_offset_box;
 
 	Gtk::Label invert_label;
 	Gtk::CheckButton invert_checkbutton;
-	Gtk::Grid invert_grid;
+	Gtk::Box invert_box;
 
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
 	Gtk::Label falloff_label;
 	Widget_Enum falloff_enum;
-	Gtk::Grid falloff_grid;
+	Gtk::Box falloff_box;
 
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::Grid link_origins_grid;
+	Gtk::Box link_origins_box;
 
 	Gtk::Label origins_at_center_label;
 	Gtk::CheckButton layer_origins_at_center_checkbutton;
-	Gtk::Grid origins_at_center_grid;
+	Gtk::Box origins_at_center_box;
 
 public:
 
@@ -532,11 +532,10 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0, 1, 1);
-	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
-	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*id_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -557,21 +556,20 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
-	layer_types_grid.attach_next_to(layer_circle_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_circle_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_advanced_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_plant_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_curve_gradient_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0, 1, 1);
-	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
+	blend_box.pack_start(blend_label, false, false, 0);
+	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -597,29 +595,26 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	bline_points_label.set_label(_("Spline Points:"));
 	bline_points_label.set_halign(Gtk::ALIGN_START);
 	bline_points_label.set_valign(Gtk::ALIGN_CENTER);
-	bline_points_label.set_vexpand();
 	bline_points_label.set_sensitive(false);
 	number_of_bline_points_spin.set_sensitive(false);
 
 	bline_point_angle_offset_label.set_label(_("Offset:"));
 	bline_point_angle_offset_label.set_halign(Gtk::ALIGN_START);
 	bline_point_angle_offset_label.set_valign(Gtk::ALIGN_CENTER);
-	bline_point_angle_offset_label.set_vexpand();
 	bline_point_angle_offset_label.set_sensitive(false);
 	bline_point_angle_offset_spin.set_sensitive(false);
 
 	SPACING(bline_point_angle_offset_indent, INDENTATION);
-	bline_point_angle_offset_grid.attach(*bline_point_angle_offset_indent, 0, 0, 1, 1);
-	bline_point_angle_offset_grid.attach_next_to(bline_point_angle_offset_label, Gtk::POS_RIGHT, 1, 1);
+	bline_point_angle_offset_box.pack_start(*bline_point_angle_offset_indent, false, false, 0);
+	bline_point_angle_offset_box.pack_start(bline_point_angle_offset_label, false, false, 0);
 
 	invert_label.set_label(_("Invert"));
 	invert_label.set_halign(Gtk::ALIGN_START);
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
-	invert_label.set_hexpand();
 
-	invert_grid.attach(invert_label, 0, 0, 1, 1);
-	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	invert_grid.set_sensitive(false);
+	invert_box.pack_start(invert_label, true, true, 0);
+	invert_box.pack_start(invert_checkbutton, false, false, 0);
+	invert_box.set_sensitive(false);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -633,11 +628,10 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	falloff_label.set_label(_("Falloff:"));
 	falloff_label.set_halign(Gtk::ALIGN_START);
 	falloff_label.set_valign(Gtk::ALIGN_CENTER);
-	falloff_label.set_vexpand();
 	falloff_label.set_sensitive(false);
 	SPACING(falloff_indent, INDENTATION);
-	falloff_grid.attach(*falloff_indent, 0, 0, 1, 1);
-	falloff_grid.attach_next_to(falloff_label, Gtk::POS_RIGHT, 1, 1);
+	falloff_box.pack_start(*falloff_indent, false, false, 0);
+	falloff_box.pack_start(falloff_label, false, false, 0);
 
 	falloff_enum.set_param_desc(ParamDesc("falloff")
 		.set_local_name(_("Falloff"))
@@ -653,33 +647,31 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
-	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
-	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	link_origins_grid.set_sensitive(false);
+	link_origins_box.pack_start(link_origins_label, true, true, 0);
+	link_origins_box.pack_start(layer_link_origins_checkbutton, false, false, 0);
+	link_origins_box.set_sensitive(false);
 
 	origins_at_center_label.set_label(_("Spline Origins at Center"));
 	origins_at_center_label.set_halign(Gtk::ALIGN_START);
 	origins_at_center_label.set_valign(Gtk::ALIGN_CENTER);
-	origins_at_center_label.set_hexpand();
 
-	origins_at_center_grid.attach(origins_at_center_label, 0, 0, 1, 1);
-	origins_at_center_grid.attach_next_to(layer_origins_at_center_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	origins_at_center_grid.set_sensitive(false);
+	origins_at_center_box.pack_start(origins_at_center_label, true, true, 0);
+	origins_at_center_box.pack_start(layer_origins_at_center_checkbutton, false, false, 0);
+	origins_at_center_box.set_sensitive(false);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_grid,
+	options_grid.attach(id_box,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_grid,
+	options_grid.attach(layer_types_box,
 		0, 3, 2, 1);
-	options_grid.attach(blend_grid,
+	options_grid.attach(blend_box,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -695,23 +687,23 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 		0, 7, 1, 1);
 	options_grid.attach(number_of_bline_points_spin,
 		1, 7, 1, 1);
-	options_grid.attach(bline_point_angle_offset_grid,
+	options_grid.attach(bline_point_angle_offset_box,
 		0, 8, 1, 1);
 	options_grid.attach(bline_point_angle_offset_spin,
 		1, 8, 1, 1);
-	options_grid.attach(invert_grid,
+	options_grid.attach(invert_box,
 		0, 9, 2, 1);
 	options_grid.attach(feather_label,
 		0, 10, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 10, 1, 1);
-	options_grid.attach(falloff_grid,
+	options_grid.attach(falloff_box,
 		0, 11, 1, 1);
 	options_grid.attach(falloff_enum,
 		1, 11, 1, 1);
-	options_grid.attach(link_origins_grid,
+	options_grid.attach(link_origins_box,
 		0, 12, 2, 1);
-	options_grid.attach(origins_at_center_grid,
+	options_grid.attach(origins_at_center_box,
 		0, 13, 2, 1);
 
 	options_grid.set_vexpand(false);
@@ -1467,10 +1459,10 @@ StateCircle_Context::toggle_layer_creation()
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag())
 	{
-		invert_grid.set_sensitive(true);
+		invert_box.set_sensitive(true);
 	}
 	else
-		invert_grid.set_sensitive(false);
+		invert_box.set_sensitive(false);
 
 	// feather size
 	if (get_layer_circle_flag() ||
@@ -1510,10 +1502,10 @@ StateCircle_Context::toggle_layer_creation()
 		get_layer_plant_flag() ||
 		get_layer_curve_gradient_flag())
 	{
-		origins_at_center_grid.set_sensitive(true);
+		origins_at_center_box.set_sensitive(true);
 	}
 	else
-		origins_at_center_grid.set_sensitive(false);
+		origins_at_center_box.set_sensitive(false);
 
 	// link origins
 	if (get_layer_region_flag() +
@@ -1523,9 +1515,9 @@ StateCircle_Context::toggle_layer_creation()
 		get_layer_curve_gradient_flag() +
 		get_layer_circle_flag() >= 2)
 		{
-			link_origins_grid.set_sensitive(true);
+			link_origins_box.set_sensitive(true);
 		}
-	else link_origins_grid.set_sensitive(false);
+	else link_origins_box.set_sensitive(false);
 
   // update layer flags
   layer_circle_flag = get_layer_circle_flag();

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -113,21 +113,17 @@ class studio::StateCircle_Context : public sigc::trackable
 
 	bool prev_workarea_layer_status_;
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
+	Gtk::Grid id_grid;
 
-	// layer types to create:
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_circle_togglebutton;
 	Gtk::ToggleButton layer_region_togglebutton;
@@ -135,55 +131,45 @@ class studio::StateCircle_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Grid layer_types_grid;
 
-	// blend method
 	Gtk::Label blend_label;
-	Gtk::HBox blend_box;
 	Widget_Enum blend_enum;
+	Gtk::Grid blend_grid;
 
-	// opacity
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
-	// brush size
 	Gtk::Label bline_width_label;
 	Widget_Distance bline_width_dist;
 
-	// spline points
 	Gtk::Label bline_points_label;
 	Glib::RefPtr<Gtk::Adjustment> number_of_bline_points_adj;
 	Gtk::SpinButton	number_of_bline_points_spin;
 
-	// spline point angle offset
 	Gtk::Label bline_point_angle_offset_label;
 	Glib::RefPtr<Gtk::Adjustment> bline_point_angle_offset_adj;
 	Gtk::SpinButton	bline_point_angle_offset_spin;
-	Gtk::HBox bline_point_angle_offset_box;
+	Gtk::Grid bline_point_angle_offset_grid;
 
-	// invert
 	Gtk::Label invert_label;
 	Gtk::CheckButton invert_checkbutton;
-	Gtk::HBox invert_box;
+	Gtk::Grid invert_grid;
 
-	// feather size
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
-	// falloff of feather of circle layer
 	Gtk::Label falloff_label;
-	Gtk::HBox falloff_box;
 	Widget_Enum falloff_enum;
+	Gtk::Grid falloff_grid;
 
-	// link origins
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::HBox link_origins_box;
+	Gtk::Grid link_origins_grid;
 
-	// spline origins at center
 	Gtk::Label origins_at_center_label;
 	Gtk::CheckButton layer_origins_at_center_checkbutton;
-	Gtk::HBox origins_at_center_box;
+	Gtk::Grid origins_at_center_grid;
 
 public:
 
@@ -546,11 +532,11 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
-
-	id_box.pack_start(id_entry);
+	id_grid.attach(id_label, 0, 0);
+	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
+	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -571,20 +557,21 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_circle_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach_next_to(layer_circle_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
+	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
-	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
+	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -610,26 +597,29 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	bline_points_label.set_label(_("Spline Points:"));
 	bline_points_label.set_halign(Gtk::ALIGN_START);
 	bline_points_label.set_valign(Gtk::ALIGN_CENTER);
+	bline_points_label.set_vexpand();
 	bline_points_label.set_sensitive(false);
 	number_of_bline_points_spin.set_sensitive(false);
 
 	bline_point_angle_offset_label.set_label(_("Offset:"));
 	bline_point_angle_offset_label.set_halign(Gtk::ALIGN_START);
 	bline_point_angle_offset_label.set_valign(Gtk::ALIGN_CENTER);
+	bline_point_angle_offset_label.set_vexpand();
 	bline_point_angle_offset_label.set_sensitive(false);
 	bline_point_angle_offset_spin.set_sensitive(false);
 
 	SPACING(bline_point_angle_offset_indent, INDENTATION);
-	bline_point_angle_offset_box.pack_start(*bline_point_angle_offset_indent, Gtk::PACK_SHRINK);
-	bline_point_angle_offset_box.pack_start(bline_point_angle_offset_label, Gtk::PACK_SHRINK);
+	bline_point_angle_offset_grid.attach(*bline_point_angle_offset_indent, 0, 0);
+	bline_point_angle_offset_grid.attach_next_to(bline_point_angle_offset_label, Gtk::POS_RIGHT, 1, 1);
 
 	invert_label.set_label(_("Invert"));
 	invert_label.set_halign(Gtk::ALIGN_START);
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
+	invert_label.set_hexpand();
 
-	invert_box.pack_start(invert_label);
-	invert_box.pack_end(invert_checkbutton, Gtk::PACK_SHRINK);
-	invert_box.set_sensitive(false);
+	invert_grid.attach(invert_label, 0, 0);
+	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	invert_grid.set_sensitive(false);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -643,10 +633,11 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	falloff_label.set_label(_("Falloff:"));
 	falloff_label.set_halign(Gtk::ALIGN_START);
 	falloff_label.set_valign(Gtk::ALIGN_CENTER);
+	falloff_label.set_vexpand();
 	falloff_label.set_sensitive(false);
 	SPACING(falloff_indent, INDENTATION);
-	falloff_box.pack_start(*falloff_indent, Gtk::PACK_SHRINK);
-	falloff_box.pack_start(falloff_label, Gtk::PACK_SHRINK);
+	falloff_grid.attach(*falloff_indent, 0, 0);
+	falloff_grid.attach_next_to(falloff_label, Gtk::POS_RIGHT, 1, 1);
 
 	falloff_enum.set_param_desc(ParamDesc("falloff")
 		.set_local_name(_("Falloff"))
@@ -662,31 +653,33 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
+	link_origins_label.set_hexpand();
 
-	link_origins_box.pack_start(link_origins_label);
-	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
-	link_origins_box.set_sensitive(false);
+	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	link_origins_grid.set_sensitive(false);
 
 	origins_at_center_label.set_label(_("Spline Origins at Center"));
 	origins_at_center_label.set_halign(Gtk::ALIGN_START);
 	origins_at_center_label.set_valign(Gtk::ALIGN_CENTER);
+	origins_at_center_label.set_hexpand();
 
-	origins_at_center_box.pack_start(origins_at_center_label);
-	origins_at_center_box.pack_end(layer_origins_at_center_checkbutton, Gtk::PACK_SHRINK);
-	origins_at_center_box.set_sensitive(false);
+	origins_at_center_grid.attach(origins_at_center_label, 0, 0);
+	origins_at_center_grid.attach_next_to(layer_origins_at_center_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	origins_at_center_grid.set_sensitive(false);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_box,
+	options_grid.attach(id_grid,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_box,
+	options_grid.attach(layer_types_grid,
 		0, 3, 2, 1);
-	options_grid.attach(blend_box,
+	options_grid.attach(blend_grid,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -702,25 +695,26 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 		0, 7, 1, 1);
 	options_grid.attach(number_of_bline_points_spin,
 		1, 7, 1, 1);
-	options_grid.attach(bline_point_angle_offset_box,
+	options_grid.attach(bline_point_angle_offset_grid,
 		0, 8, 1, 1);
 	options_grid.attach(bline_point_angle_offset_spin,
 		1, 8, 1, 1);
-	options_grid.attach(invert_box,
+	options_grid.attach(invert_grid,
 		0, 9, 2, 1);
 	options_grid.attach(feather_label,
 		0, 10, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 10, 1, 1);
-	options_grid.attach(falloff_box,
+	options_grid.attach(falloff_grid,
 		0, 11, 1, 1);
 	options_grid.attach(falloff_enum,
 		1, 11, 1, 1);
-	options_grid.attach(link_origins_box,
+	options_grid.attach(link_origins_grid,
 		0, 12, 2, 1);
-	options_grid.attach(origins_at_center_box,
+	options_grid.attach(origins_at_center_grid,
 		0, 13, 2, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
@@ -1473,10 +1467,10 @@ StateCircle_Context::toggle_layer_creation()
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag())
 	{
-		invert_box.set_sensitive(true);
+		invert_grid.set_sensitive(true);
 	}
 	else
-		invert_box.set_sensitive(false);
+		invert_grid.set_sensitive(false);
 
 	// feather size
 	if (get_layer_circle_flag() ||
@@ -1516,10 +1510,10 @@ StateCircle_Context::toggle_layer_creation()
 		get_layer_plant_flag() ||
 		get_layer_curve_gradient_flag())
 	{
-		origins_at_center_box.set_sensitive(true);
+		origins_at_center_grid.set_sensitive(true);
 	}
 	else
-		origins_at_center_box.set_sensitive(false);
+		origins_at_center_grid.set_sensitive(false);
 
 	// link origins
 	if (get_layer_region_flag() +
@@ -1529,9 +1523,9 @@ StateCircle_Context::toggle_layer_creation()
 		get_layer_curve_gradient_flag() +
 		get_layer_circle_flag() >= 2)
 		{
-			link_origins_box.set_sensitive(true);
+			link_origins_grid.set_sensitive(true);
 		}
-	else link_origins_box.set_sensitive(false);
+	else link_origins_grid.set_sensitive(false);
 
   // update layer flags
   layer_circle_flag = get_layer_circle_flag();

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -142,112 +142,90 @@ class studio::StateDraw_Context : public sigc::trackable
 
 	bool link_layer_origin(Layer::Handle& layer, ValueNode::Handle &value_node) const;
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
+	Gtk::Grid id_grid;
 
-	// layer types to create:
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_region_togglebutton;
 	Gtk::ToggleButton layer_outline_togglebutton;
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Grid layer_types_grid;
 
-	// blend method
 	Gtk::Label blend_label;
-	Gtk::HBox blend_box;
 	Widget_Enum blend_enum;
+	Gtk::Grid blend_grid;
 
-	// opacity
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
-	// brush size
 	Gtk::Label bline_width_label;
 	Widget_Distance bline_width_dist;
 
-	// pressure width
 	Gtk::Label pressure_width_label;
 	Gtk::CheckButton pressure_width_checkbutton;
-	Gtk::HBox pressure_width_box;
+	Gtk::Grid pressure_width_grid;
 
-	// min pressure, sub option of pressure width
 	Gtk::Label min_pressure_label;
-	Gtk::HBox min_pressure_label_box;
+	Gtk::Grid min_pressure_label_grid;
 
 	Gtk::CheckButton min_pressure_checkbutton;
 	Glib::RefPtr<Gtk::Adjustment> min_pressure_adj;
 	Gtk::SpinButton  min_pressure_spin;
-	Gtk::HBox min_pressure_box;
+	Gtk::Grid min_pressure_grid;
 
-	// smoothness
 	Gtk::Label smoothness_label;
 	Gtk::RadioButton::Group smoothness_group;
 
-	// local threshold
 	Gtk::RadioButton localthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> localthres_adj;
 	Gtk::SpinButton localthres_spin;
-	Gtk::HBox localthres_box;
+	Gtk::Grid localthres_grid;
 
-	// global threshold
 	Gtk::RadioButton globalthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> globalthres_adj;
 	Gtk::SpinButton globalthres_spin;
-	Gtk::HBox globalthres_box;
+	Gtk::Grid globalthres_grid;
 
-	// width max error advanced outline layer
 	Gtk::Label width_max_error_label;
-	Gtk::HBox width_max_error_box;
+	Gtk::Grid width_max_error_grid;
 	Glib::RefPtr<Gtk::Adjustment> width_max_error_adj;
 	Gtk::SpinButton width_max_error_spin;
 
-	// constructing control
-	// round ends
 	Gtk::Label round_ends_label;
 	Gtk::CheckButton round_ends_checkbutton;
-	Gtk::HBox round_ends_box;
+	Gtk::Grid round_ends_grid;
 
-	// whether to loop new strokes which start and end in the same place
 	Gtk::Label auto_loop_label;
 	Gtk::CheckButton auto_loop_checkbutton;
-	Gtk::HBox auto_loop_box;
+	Gtk::Grid auto_loop_grid;
 
-	// whether to extend existing lines
 	Gtk::Label auto_extend_label;
 	Gtk::CheckButton auto_extend_checkbutton;
-	Gtk::HBox auto_extend_box;
+	Gtk::Grid auto_extend_grid;
 
-	// whether to link new ducks to existing ducks
 	Gtk::Label auto_link_label;
 	Gtk::CheckButton auto_link_checkbutton;
-	Gtk::HBox auto_link_box;
+	Gtk::Grid auto_link_grid;
 
-	// feather size
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
-	// link origins
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::HBox link_origins_box;
+	Gtk::Grid link_origins_grid;
 
-	// auto export
 	Gtk::Label auto_export_label;
 	Gtk::CheckButton auto_export_checkbutton;
-	Gtk::HBox auto_export_box;
+	Gtk::Grid auto_export_grid;
 
-	// toolbar buttons
 	Gtk::Button fill_last_stroke_button;
 
 
@@ -639,11 +617,11 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
-
-	id_box.pack_start(id_entry);
+	id_grid.attach(id_label, 0, 0);
+	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
+	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -658,17 +636,18 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
+	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
-	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
+	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -685,6 +664,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	bline_width_label.set_label(_("Brush Size:"));
 	bline_width_label.set_halign(Gtk::ALIGN_START);
 	bline_width_label.set_valign(Gtk::ALIGN_CENTER);
+	bline_width_label.set_vexpand();
 
 	bline_width_dist.set_digits(2);
 	bline_width_dist.set_range(0,10000000);
@@ -692,35 +672,40 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	pressure_width_label.set_label(_("Pressure Sensitive"));
 	pressure_width_label.set_halign(Gtk::ALIGN_START);
 	pressure_width_label.set_valign(Gtk::ALIGN_CENTER);
+	pressure_width_label.set_hexpand();
 
-	pressure_width_box.pack_start(pressure_width_label, Gtk::PACK_SHRINK);
-	pressure_width_box.pack_end(pressure_width_checkbutton, Gtk::PACK_SHRINK);
+	pressure_width_grid.attach(pressure_width_label, 0, 0);
+	pressure_width_grid.attach_next_to(pressure_width_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	SPACING(min_pressure_indent, INDENTATION);
 	SPACING(min_pressure_gap, GAP);
 	min_pressure_label.set_label(_("Min Width:"));
 	min_pressure_label.set_halign(Gtk::ALIGN_START);
 	min_pressure_label.set_valign(Gtk::ALIGN_CENTER);
-	min_pressure_label_box.pack_start(*min_pressure_indent, Gtk::PACK_SHRINK);
-	min_pressure_label_box.pack_start(min_pressure_label, Gtk::PACK_SHRINK);
+	min_pressure_label.set_vexpand();
+	min_pressure_label_grid.attach(*min_pressure_indent, 0, 0);
+	min_pressure_label_grid.attach_next_to(min_pressure_label, Gtk::POS_RIGHT, 1, 1);
 
-	min_pressure_box.pack_end(min_pressure_checkbutton, Gtk::PACK_SHRINK);
-	min_pressure_box.pack_end(*min_pressure_gap, Gtk::PACK_SHRINK);
-	min_pressure_box.pack_end(min_pressure_spin);
+	min_pressure_spin.set_hexpand();
+	min_pressure_grid.attach(min_pressure_spin, 0, 0);
+	min_pressure_grid.attach_next_to(*min_pressure_gap, Gtk::POS_RIGHT, 1, 1);
+	min_pressure_grid.attach_next_to(min_pressure_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	smoothness_label.set_label(_("Smoothness"));
 	smoothness_label.set_halign(Gtk::ALIGN_START);
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
 	SPACING(localthres_indent, INDENTATION);
-	localthres_box.pack_start(*localthres_indent, Gtk::PACK_SHRINK);
-	localthres_box.pack_start(localthres_radiobutton, Gtk::PACK_SHRINK);
+	localthres_grid.attach(*localthres_indent, 0, 0);
+	localthres_grid.attach_next_to(localthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
 	localthres_radiobutton.set_label(_("Local:"));
+	localthres_radiobutton.set_vexpand();
 
 	SPACING(globalthres_indent, INDENTATION);
-	globalthres_box.pack_start(*globalthres_indent, Gtk::PACK_SHRINK);
-	globalthres_box.pack_start(globalthres_radiobutton, Gtk::PACK_SHRINK);
+	globalthres_grid.attach(*globalthres_indent, 0, 0);
+	globalthres_grid.attach_next_to(globalthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
 	globalthres_radiobutton.set_label(_("Global:"));
+	globalthres_radiobutton.set_vexpand();
 
 	smoothness_group = localthres_radiobutton.get_group();
 	globalthres_radiobutton.set_group(smoothness_group);
@@ -729,36 +714,41 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	SPACING(width_max_error_gap, GAP);
 	width_max_error_label.set_halign(Gtk::ALIGN_START);
 	width_max_error_label.set_valign(Gtk::ALIGN_CENTER);
-	width_max_error_box.pack_start(width_max_error_label, Gtk::PACK_SHRINK);
-	width_max_error_box.pack_start(*width_max_error_gap, Gtk::PACK_SHRINK);
+	width_max_error_label.set_vexpand();
+	width_max_error_grid.attach(width_max_error_label, 0, 0);
+	width_max_error_grid.attach_next_to(*width_max_error_gap, Gtk::POS_RIGHT, 1, 1);
 
 	round_ends_label.set_label(_("Round Ends"));
 	round_ends_label.set_halign(Gtk::ALIGN_START);
 	round_ends_label.set_valign(Gtk::ALIGN_CENTER);
+	round_ends_label.set_hexpand();
 
-	round_ends_box.pack_start(round_ends_label, Gtk::PACK_SHRINK);
-	round_ends_box.pack_end(round_ends_checkbutton, Gtk::PACK_SHRINK);
+	round_ends_grid.attach(round_ends_label, 0, 0);
+	round_ends_grid.attach_next_to(round_ends_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	auto_loop_label.set_label(_("Auto Loop"));
 	auto_loop_label.set_halign(Gtk::ALIGN_START);
 	auto_loop_label.set_valign(Gtk::ALIGN_CENTER);
+	auto_loop_label.set_hexpand();
 
-	auto_loop_box.pack_start(auto_loop_label, Gtk::PACK_SHRINK);
-	auto_loop_box.pack_end(auto_loop_checkbutton, Gtk::PACK_SHRINK);
+	auto_loop_grid.attach(auto_loop_label, 0, 0);
+	auto_loop_grid.attach_next_to(auto_loop_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	auto_extend_label.set_label(_("Auto Extend"));
 	auto_extend_label.set_halign(Gtk::ALIGN_START);
 	auto_extend_label.set_valign(Gtk::ALIGN_CENTER);
+	auto_extend_label.set_hexpand();
 
-	auto_extend_box.pack_start(auto_extend_label, Gtk::PACK_SHRINK);
-	auto_extend_box.pack_end(auto_extend_checkbutton, Gtk::PACK_SHRINK);
+	auto_extend_grid.attach(auto_extend_label, 0, 0);
+	auto_extend_grid.attach_next_to(auto_extend_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	auto_link_label.set_label(_("Auto Link"));
 	auto_link_label.set_halign(Gtk::ALIGN_START);
 	auto_link_label.set_valign(Gtk::ALIGN_CENTER);
+	auto_link_label.set_hexpand();
 
-	auto_link_box.pack_start(auto_link_label, Gtk::PACK_SHRINK);
-	auto_link_box.pack_end(auto_link_checkbutton, Gtk::PACK_SHRINK);
+	auto_link_grid.attach(auto_link_label, 0, 0);
+	auto_link_grid.attach_next_to(auto_link_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -770,17 +760,19 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
+	link_origins_label.set_hexpand();
 
-	link_origins_box.pack_start(link_origins_label);
-	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
-	link_origins_box.set_sensitive(false);
+	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	link_origins_grid.set_sensitive(false);
 
 	auto_export_label.set_label(_("Auto Export"));
 	auto_export_label.set_halign(Gtk::ALIGN_START);
 	auto_export_label.set_valign(Gtk::ALIGN_CENTER);
+	auto_export_label.set_hexpand();
 
-	auto_export_box.pack_start(auto_export_label, Gtk::PACK_SHRINK);
-	auto_export_box.pack_end(auto_export_checkbutton, Gtk::PACK_SHRINK);
+	auto_export_grid.attach(auto_export_label, 0, 0);
+	auto_export_grid.attach_next_to(auto_export_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	nested=0;
 	load_settings();
@@ -792,13 +784,13 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_box,
+	options_grid.attach(id_grid,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_box,
+	options_grid.attach(layer_types_grid,
 		0, 3, 2, 1);
-	options_grid.attach(blend_box,
+	options_grid.attach(blend_grid,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -810,43 +802,44 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 		0, 6, 1, 1);
 	options_grid.attach(bline_width_dist,
 		1, 6, 1, 1);
-	options_grid.attach(pressure_width_box,
+	options_grid.attach(pressure_width_grid,
 		0, 7, 2, 1);
-	options_grid.attach(min_pressure_label_box,
+	options_grid.attach(min_pressure_label_grid,
 		0, 8, 1, 1);
-	options_grid.attach(min_pressure_box,
+	options_grid.attach(min_pressure_grid,
 		1, 8, 1, 1);
 	options_grid.attach(smoothness_label,
 		0, 9, 2, 1);
-	options_grid.attach(localthres_box,
+	options_grid.attach(localthres_grid,
 		0, 10, 1, 1);
 	options_grid.attach(localthres_spin,
 		1, 10, 1, 1);
-	options_grid.attach(globalthres_box,
+	options_grid.attach(globalthres_grid,
 		0, 11, 1, 1);
 	options_grid.attach(globalthres_spin,
 		1, 11, 1, 1);
-	options_grid.attach(width_max_error_box,
+	options_grid.attach(width_max_error_grid,
 		0, 12, 1, 1);
 	options_grid.attach(width_max_error_spin,
 		1, 12, 1, 1);
-	options_grid.attach(round_ends_box,
+	options_grid.attach(round_ends_grid,
 		0, 13, 2, 1);
-	options_grid.attach(auto_loop_box,
+	options_grid.attach(auto_loop_grid,
 		0, 14, 2, 1);
-	options_grid.attach(auto_extend_box,
+	options_grid.attach(auto_extend_grid,
 		0, 15, 2, 1);
-	options_grid.attach(auto_link_box,
+	options_grid.attach(auto_link_grid,
 		0, 16, 2, 1);
 	options_grid.attach(feather_label,
 		0, 17, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 17, 1, 1);
-	options_grid.attach(link_origins_box,
+	options_grid.attach(link_origins_grid,
 		0, 18, 2, 1);
-	options_grid.attach(auto_export_box,
+	options_grid.attach(auto_export_grid,
 		0, 19, 2, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
@@ -2985,7 +2978,7 @@ StateDraw_Context::toggle_layer_creation()
 		get_layer_outline_flag() +
 		get_layer_advanced_outline_flag() >= 2)
 		{
-			link_origins_box.set_sensitive(true);
+			link_origins_grid.set_sensitive(true);
 		}
-	else link_origins_box.set_sensitive(false);
+	else link_origins_grid.set_sensitive(false);
 }

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -151,17 +151,17 @@ class studio::StateDraw_Context : public sigc::trackable
 
 	Gtk::Label id_label;
 	Gtk::Entry id_entry;
-	Gtk::Grid id_grid;
+	Gtk::Box id_box;
 
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_region_togglebutton;
 	Gtk::ToggleButton layer_outline_togglebutton;
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
-	Gtk::Grid layer_types_grid;
+	Gtk::Box layer_types_box;
 
 	Gtk::Label blend_label;
 	Widget_Enum blend_enum;
-	Gtk::Grid blend_grid;
+	Gtk::Box blend_box;
 
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
@@ -171,15 +171,15 @@ class studio::StateDraw_Context : public sigc::trackable
 
 	Gtk::Label pressure_width_label;
 	Gtk::CheckButton pressure_width_checkbutton;
-	Gtk::Grid pressure_width_grid;
+	Gtk::Box pressure_width_box;
 
 	Gtk::Label min_pressure_label;
-	Gtk::Grid min_pressure_label_grid;
+	Gtk::Box min_pressure_label_box;
 
 	Gtk::CheckButton min_pressure_checkbutton;
 	Glib::RefPtr<Gtk::Adjustment> min_pressure_adj;
 	Gtk::SpinButton  min_pressure_spin;
-	Gtk::Grid min_pressure_grid;
+	Gtk::Box min_pressure_box;
 
 	Gtk::Label smoothness_label;
 	Gtk::RadioButton::Group smoothness_group;
@@ -187,44 +187,44 @@ class studio::StateDraw_Context : public sigc::trackable
 	Gtk::RadioButton localthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> localthres_adj;
 	Gtk::SpinButton localthres_spin;
-	Gtk::Grid localthres_grid;
+	Gtk::Box localthres_box;
 
 	Gtk::RadioButton globalthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> globalthres_adj;
 	Gtk::SpinButton globalthres_spin;
-	Gtk::Grid globalthres_grid;
+	Gtk::Box globalthres_box;
 
 	Gtk::Label width_max_error_label;
-	Gtk::Grid width_max_error_grid;
+	Gtk::Box width_max_error_box;
 	Glib::RefPtr<Gtk::Adjustment> width_max_error_adj;
 	Gtk::SpinButton width_max_error_spin;
 
 	Gtk::Label round_ends_label;
 	Gtk::CheckButton round_ends_checkbutton;
-	Gtk::Grid round_ends_grid;
+	Gtk::Box round_ends_box;
 
 	Gtk::Label auto_loop_label;
 	Gtk::CheckButton auto_loop_checkbutton;
-	Gtk::Grid auto_loop_grid;
+	Gtk::Box auto_loop_box;
 
 	Gtk::Label auto_extend_label;
 	Gtk::CheckButton auto_extend_checkbutton;
-	Gtk::Grid auto_extend_grid;
+	Gtk::Box auto_extend_box;
 
 	Gtk::Label auto_link_label;
 	Gtk::CheckButton auto_link_checkbutton;
-	Gtk::Grid auto_link_grid;
+	Gtk::Box auto_link_box;
 
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::Grid link_origins_grid;
+	Gtk::Box link_origins_box;
 
 	Gtk::Label auto_export_label;
 	Gtk::CheckButton auto_export_checkbutton;
-	Gtk::Grid auto_export_grid;
+	Gtk::Box auto_export_box;
 
 	Gtk::Button fill_last_stroke_button;
 
@@ -617,11 +617,10 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0, 1, 1);
-	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
-	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*id_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -636,18 +635,17 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
-	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_advanced_outline_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0, 1, 1);
-	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
+	blend_box.pack_start(blend_label, false, false, 0);
+	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -664,7 +662,6 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	bline_width_label.set_label(_("Brush Size:"));
 	bline_width_label.set_halign(Gtk::ALIGN_START);
 	bline_width_label.set_valign(Gtk::ALIGN_CENTER);
-	bline_width_label.set_vexpand();
 
 	bline_width_dist.set_digits(2);
 	bline_width_dist.set_range(0,10000000);
@@ -672,40 +669,35 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	pressure_width_label.set_label(_("Pressure Sensitive"));
 	pressure_width_label.set_halign(Gtk::ALIGN_START);
 	pressure_width_label.set_valign(Gtk::ALIGN_CENTER);
-	pressure_width_label.set_hexpand();
 
-	pressure_width_grid.attach(pressure_width_label, 0, 0, 1, 1);
-	pressure_width_grid.attach_next_to(pressure_width_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	pressure_width_box.pack_start(pressure_width_label, true, true, 0);
+	pressure_width_box.pack_start(pressure_width_checkbutton, false, false, 0);
 
 	SPACING(min_pressure_indent, INDENTATION);
 	SPACING(min_pressure_gap, GAP);
 	min_pressure_label.set_label(_("Min Width:"));
 	min_pressure_label.set_halign(Gtk::ALIGN_START);
 	min_pressure_label.set_valign(Gtk::ALIGN_CENTER);
-	min_pressure_label.set_vexpand();
-	min_pressure_label_grid.attach(*min_pressure_indent, 0, 0, 1, 1);
-	min_pressure_label_grid.attach_next_to(min_pressure_label, Gtk::POS_RIGHT, 1, 1);
+	min_pressure_label_box.pack_start(*min_pressure_indent, false, false, 0);
+	min_pressure_label_box.pack_start(min_pressure_label, false, false, 0);
 
-	min_pressure_spin.set_hexpand();
-	min_pressure_grid.attach(min_pressure_spin, 0, 0, 1, 1);
-	min_pressure_grid.attach_next_to(*min_pressure_gap, Gtk::POS_RIGHT, 1, 1);
-	min_pressure_grid.attach_next_to(min_pressure_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	min_pressure_box.pack_start(min_pressure_spin, true, true, 0);
+	min_pressure_box.pack_start(*min_pressure_gap, false, false, 0);
+	min_pressure_box.pack_start(min_pressure_checkbutton, false, false, 0);
 
 	smoothness_label.set_label(_("Smoothness"));
 	smoothness_label.set_halign(Gtk::ALIGN_START);
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
 	SPACING(localthres_indent, INDENTATION);
-	localthres_grid.attach(*localthres_indent, 0, 0, 1, 1);
-	localthres_grid.attach_next_to(localthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
+	localthres_box.pack_start(*localthres_indent, false, false, 0);
+	localthres_box.pack_start(localthres_radiobutton, false, false, 0);
 	localthres_radiobutton.set_label(_("Local:"));
-	localthres_radiobutton.set_vexpand();
 
 	SPACING(globalthres_indent, INDENTATION);
-	globalthres_grid.attach(*globalthres_indent, 0, 0, 1, 1);
-	globalthres_grid.attach_next_to(globalthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
+	globalthres_box.pack_start(*globalthres_indent, false, false, 0);
+	globalthres_box.pack_start(globalthres_radiobutton, false, false, 0);
 	globalthres_radiobutton.set_label(_("Global:"));
-	globalthres_radiobutton.set_vexpand();
 
 	smoothness_group = localthres_radiobutton.get_group();
 	globalthres_radiobutton.set_group(smoothness_group);
@@ -714,41 +706,36 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	SPACING(width_max_error_gap, GAP);
 	width_max_error_label.set_halign(Gtk::ALIGN_START);
 	width_max_error_label.set_valign(Gtk::ALIGN_CENTER);
-	width_max_error_label.set_vexpand();
-	width_max_error_grid.attach(width_max_error_label, 0, 0, 1, 1);
-	width_max_error_grid.attach_next_to(*width_max_error_gap, Gtk::POS_RIGHT, 1, 1);
+	width_max_error_box.pack_start(width_max_error_label, false, false, 0);
+	width_max_error_box.pack_start(*width_max_error_gap, false, false, 0);
 
 	round_ends_label.set_label(_("Round Ends"));
 	round_ends_label.set_halign(Gtk::ALIGN_START);
 	round_ends_label.set_valign(Gtk::ALIGN_CENTER);
-	round_ends_label.set_hexpand();
 
-	round_ends_grid.attach(round_ends_label, 0, 0, 1, 1);
-	round_ends_grid.attach_next_to(round_ends_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	round_ends_box.pack_start(round_ends_label, true, true, 0);
+	round_ends_box.pack_start(round_ends_checkbutton, false, false, 0);
 
 	auto_loop_label.set_label(_("Auto Loop"));
 	auto_loop_label.set_halign(Gtk::ALIGN_START);
 	auto_loop_label.set_valign(Gtk::ALIGN_CENTER);
-	auto_loop_label.set_hexpand();
 
-	auto_loop_grid.attach(auto_loop_label, 0, 0, 1, 1);
-	auto_loop_grid.attach_next_to(auto_loop_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	auto_loop_box.pack_start(auto_loop_label, true, true, 0);
+	auto_loop_box.pack_start(auto_loop_checkbutton, false, false, 0);
 
 	auto_extend_label.set_label(_("Auto Extend"));
 	auto_extend_label.set_halign(Gtk::ALIGN_START);
 	auto_extend_label.set_valign(Gtk::ALIGN_CENTER);
-	auto_extend_label.set_hexpand();
 
-	auto_extend_grid.attach(auto_extend_label, 0, 0, 1, 1);
-	auto_extend_grid.attach_next_to(auto_extend_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	auto_extend_box.pack_start(auto_extend_label, true, true, 0);
+	auto_extend_box.pack_start(auto_extend_checkbutton, false, false, 0);
 
 	auto_link_label.set_label(_("Auto Link"));
 	auto_link_label.set_halign(Gtk::ALIGN_START);
 	auto_link_label.set_valign(Gtk::ALIGN_CENTER);
-	auto_link_label.set_hexpand();
 
-	auto_link_grid.attach(auto_link_label, 0, 0, 1, 1);
-	auto_link_grid.attach_next_to(auto_link_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	auto_link_box.pack_start(auto_link_label, true, true, 0);
+	auto_link_box.pack_start(auto_link_checkbutton, false, false, 0);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -760,19 +747,17 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
-	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
-	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	link_origins_grid.set_sensitive(false);
+	link_origins_box.pack_start(link_origins_label, true, true, 0);
+	link_origins_box.pack_start(layer_link_origins_checkbutton, false, false, 0);
+	link_origins_box.set_sensitive(false);
 
 	auto_export_label.set_label(_("Auto Export"));
 	auto_export_label.set_halign(Gtk::ALIGN_START);
 	auto_export_label.set_valign(Gtk::ALIGN_CENTER);
-	auto_export_label.set_hexpand();
 
-	auto_export_grid.attach(auto_export_label, 0, 0, 1, 1);
-	auto_export_grid.attach_next_to(auto_export_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	auto_export_box.pack_start(auto_export_label, true, true, 0);
+	auto_export_box.pack_start(auto_export_checkbutton, false, false, 0);
 
 	nested=0;
 	load_settings();
@@ -784,13 +769,13 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_grid,
+	options_grid.attach(id_box,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_grid,
+	options_grid.attach(layer_types_box,
 		0, 3, 2, 1);
-	options_grid.attach(blend_grid,
+	options_grid.attach(blend_box,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -802,41 +787,41 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 		0, 6, 1, 1);
 	options_grid.attach(bline_width_dist,
 		1, 6, 1, 1);
-	options_grid.attach(pressure_width_grid,
+	options_grid.attach(pressure_width_box,
 		0, 7, 2, 1);
-	options_grid.attach(min_pressure_label_grid,
+	options_grid.attach(min_pressure_label_box,
 		0, 8, 1, 1);
-	options_grid.attach(min_pressure_grid,
+	options_grid.attach(min_pressure_box,
 		1, 8, 1, 1);
 	options_grid.attach(smoothness_label,
 		0, 9, 2, 1);
-	options_grid.attach(localthres_grid,
+	options_grid.attach(localthres_box,
 		0, 10, 1, 1);
 	options_grid.attach(localthres_spin,
 		1, 10, 1, 1);
-	options_grid.attach(globalthres_grid,
+	options_grid.attach(globalthres_box,
 		0, 11, 1, 1);
 	options_grid.attach(globalthres_spin,
 		1, 11, 1, 1);
-	options_grid.attach(width_max_error_grid,
+	options_grid.attach(width_max_error_box,
 		0, 12, 1, 1);
 	options_grid.attach(width_max_error_spin,
 		1, 12, 1, 1);
-	options_grid.attach(round_ends_grid,
+	options_grid.attach(round_ends_box,
 		0, 13, 2, 1);
-	options_grid.attach(auto_loop_grid,
+	options_grid.attach(auto_loop_box,
 		0, 14, 2, 1);
-	options_grid.attach(auto_extend_grid,
+	options_grid.attach(auto_extend_box,
 		0, 15, 2, 1);
-	options_grid.attach(auto_link_grid,
+	options_grid.attach(auto_link_box,
 		0, 16, 2, 1);
 	options_grid.attach(feather_label,
 		0, 17, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 17, 1, 1);
-	options_grid.attach(link_origins_grid,
+	options_grid.attach(link_origins_box,
 		0, 18, 2, 1);
-	options_grid.attach(auto_export_grid,
+	options_grid.attach(auto_export_box,
 		0, 19, 2, 1);
 
 	options_grid.set_vexpand(false);
@@ -2978,7 +2963,7 @@ StateDraw_Context::toggle_layer_creation()
 		get_layer_outline_flag() +
 		get_layer_advanced_outline_flag() >= 2)
 		{
-			link_origins_grid.set_sensitive(true);
+			link_origins_box.set_sensitive(true);
 		}
-	else link_origins_grid.set_sensitive(false);
+	else link_origins_box.set_sensitive(false);
 }

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -619,7 +619,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0);
+	id_grid.attach(id_label, 0, 0, 1, 1);
 	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
 	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
@@ -636,7 +636,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
 	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
@@ -646,7 +646,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach(blend_label, 0, 0, 1, 1);
 	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -674,7 +674,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	pressure_width_label.set_valign(Gtk::ALIGN_CENTER);
 	pressure_width_label.set_hexpand();
 
-	pressure_width_grid.attach(pressure_width_label, 0, 0);
+	pressure_width_grid.attach(pressure_width_label, 0, 0, 1, 1);
 	pressure_width_grid.attach_next_to(pressure_width_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	SPACING(min_pressure_indent, INDENTATION);
@@ -683,11 +683,11 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	min_pressure_label.set_halign(Gtk::ALIGN_START);
 	min_pressure_label.set_valign(Gtk::ALIGN_CENTER);
 	min_pressure_label.set_vexpand();
-	min_pressure_label_grid.attach(*min_pressure_indent, 0, 0);
+	min_pressure_label_grid.attach(*min_pressure_indent, 0, 0, 1, 1);
 	min_pressure_label_grid.attach_next_to(min_pressure_label, Gtk::POS_RIGHT, 1, 1);
 
 	min_pressure_spin.set_hexpand();
-	min_pressure_grid.attach(min_pressure_spin, 0, 0);
+	min_pressure_grid.attach(min_pressure_spin, 0, 0, 1, 1);
 	min_pressure_grid.attach_next_to(*min_pressure_gap, Gtk::POS_RIGHT, 1, 1);
 	min_pressure_grid.attach_next_to(min_pressure_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
@@ -696,13 +696,13 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
 	SPACING(localthres_indent, INDENTATION);
-	localthres_grid.attach(*localthres_indent, 0, 0);
+	localthres_grid.attach(*localthres_indent, 0, 0, 1, 1);
 	localthres_grid.attach_next_to(localthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
 	localthres_radiobutton.set_label(_("Local:"));
 	localthres_radiobutton.set_vexpand();
 
 	SPACING(globalthres_indent, INDENTATION);
-	globalthres_grid.attach(*globalthres_indent, 0, 0);
+	globalthres_grid.attach(*globalthres_indent, 0, 0, 1, 1);
 	globalthres_grid.attach_next_to(globalthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
 	globalthres_radiobutton.set_label(_("Global:"));
 	globalthres_radiobutton.set_vexpand();
@@ -715,7 +715,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	width_max_error_label.set_halign(Gtk::ALIGN_START);
 	width_max_error_label.set_valign(Gtk::ALIGN_CENTER);
 	width_max_error_label.set_vexpand();
-	width_max_error_grid.attach(width_max_error_label, 0, 0);
+	width_max_error_grid.attach(width_max_error_label, 0, 0, 1, 1);
 	width_max_error_grid.attach_next_to(*width_max_error_gap, Gtk::POS_RIGHT, 1, 1);
 
 	round_ends_label.set_label(_("Round Ends"));
@@ -723,7 +723,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	round_ends_label.set_valign(Gtk::ALIGN_CENTER);
 	round_ends_label.set_hexpand();
 
-	round_ends_grid.attach(round_ends_label, 0, 0);
+	round_ends_grid.attach(round_ends_label, 0, 0, 1, 1);
 	round_ends_grid.attach_next_to(round_ends_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	auto_loop_label.set_label(_("Auto Loop"));
@@ -731,7 +731,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	auto_loop_label.set_valign(Gtk::ALIGN_CENTER);
 	auto_loop_label.set_hexpand();
 
-	auto_loop_grid.attach(auto_loop_label, 0, 0);
+	auto_loop_grid.attach(auto_loop_label, 0, 0, 1, 1);
 	auto_loop_grid.attach_next_to(auto_loop_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	auto_extend_label.set_label(_("Auto Extend"));
@@ -739,7 +739,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	auto_extend_label.set_valign(Gtk::ALIGN_CENTER);
 	auto_extend_label.set_hexpand();
 
-	auto_extend_grid.attach(auto_extend_label, 0, 0);
+	auto_extend_grid.attach(auto_extend_label, 0, 0, 1, 1);
 	auto_extend_grid.attach_next_to(auto_extend_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	auto_link_label.set_label(_("Auto Link"));
@@ -747,7 +747,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	auto_link_label.set_valign(Gtk::ALIGN_CENTER);
 	auto_link_label.set_hexpand();
 
-	auto_link_grid.attach(auto_link_label, 0, 0);
+	auto_link_grid.attach(auto_link_label, 0, 0, 1, 1);
 	auto_link_grid.attach_next_to(auto_link_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	feather_label.set_label(_("Feather:"));
@@ -762,7 +762,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
 	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	link_origins_grid.set_sensitive(false);
 
@@ -771,7 +771,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	auto_export_label.set_valign(Gtk::ALIGN_CENTER);
 	auto_export_label.set_hexpand();
 
-	auto_export_grid.attach(auto_export_label, 0, 0);
+	auto_export_grid.attach(auto_export_label, 0, 0, 1, 1);
 	auto_export_grid.attach_next_to(auto_export_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	nested=0;

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -105,32 +105,26 @@ class studio::StateGradient_Context : public sigc::trackable
 
 	bool prev_workarea_layer_status_;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
+	Gtk::Grid id_grid;
 
-	// layer types to create:
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_circle_togglebutton;
 	Gtk::ToggleButton layer_linear_gradient_togglebutton;
 	Gtk::ToggleButton layer_radial_gradient_togglebutton;
 	Gtk::ToggleButton layer_conical_gradient_togglebutton;
 	Gtk::ToggleButton layer_spiral_gradient_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Grid layer_types_grid;
 
-	// blend method
 	Gtk::Label blend_label;
-	Gtk::HBox blend_box;
 	Widget_Enum blend_enum;
+	Gtk::Grid blend_grid;
 
-	// opacity
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
@@ -401,11 +395,11 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
 	SPACING(name_gap, GAP);
-
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*name_gap, Gtk::PACK_SHRINK);
-	id_box.pack_start(id_entry, Gtk::PACK_EXPAND_WIDGET);
+	id_grid.attach(id_label, 0, 0);
+	id_grid.attach_next_to(*name_gap, Gtk::POS_RIGHT, 1, 1);
+	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -421,19 +415,20 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 		("synfig-layer_gradient_spiral"), _("Create a spiral gradient"));
 
 	SPACING(layer_types_indent, INDENTATION);
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_linear_gradient_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_radial_gradient_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_conical_gradient_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_spiral_gradient_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach_next_to(layer_linear_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_radial_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_conical_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_spiral_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
+	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
 
-	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
-	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
+	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -452,13 +447,13 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_box,
+	options_grid.attach(id_grid,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_box,
+	options_grid.attach(layer_types_grid,
 		0, 3, 2, 1);
-	options_grid.attach(blend_box,
+	options_grid.attach(blend_grid,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -467,6 +462,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	options_grid.attach(opacity_hscl,
 		1, 5, 1, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -111,7 +111,7 @@ class studio::StateGradient_Context : public sigc::trackable
 
 	Gtk::Label id_label;
 	Gtk::Entry id_entry;
-	Gtk::Grid id_grid;
+	Gtk::Box id_box;
 
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_circle_togglebutton;
@@ -119,11 +119,11 @@ class studio::StateGradient_Context : public sigc::trackable
 	Gtk::ToggleButton layer_radial_gradient_togglebutton;
 	Gtk::ToggleButton layer_conical_gradient_togglebutton;
 	Gtk::ToggleButton layer_spiral_gradient_togglebutton;
-	Gtk::Grid layer_types_grid;
+	Gtk::Box layer_types_box;
 
 	Gtk::Label blend_label;
 	Widget_Enum blend_enum;
-	Gtk::Grid blend_grid;
+	Gtk::Box blend_box;
 
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
@@ -395,11 +395,10 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
 	SPACING(name_gap, GAP);
-	id_grid.attach(id_label, 0, 0, 1, 1);
-	id_grid.attach_next_to(*name_gap, Gtk::POS_RIGHT, 1, 1);
-	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*name_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -415,20 +414,19 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 		("synfig-layer_gradient_spiral"), _("Create a spiral gradient"));
 
 	SPACING(layer_types_indent, INDENTATION);
-	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
-	layer_types_grid.attach_next_to(layer_linear_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_radial_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_conical_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_spiral_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_linear_gradient_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_radial_gradient_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_conical_gradient_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_spiral_gradient_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
 
-	blend_grid.attach(blend_label, 0, 0, 1, 1);
-	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
+	blend_box.pack_start(blend_label, false, false, 0);
+	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -447,13 +445,13 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_grid,
+	options_grid.attach(id_box,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_grid,
+	options_grid.attach(layer_types_box,
 		0, 3, 2, 1);
-	options_grid.attach(blend_grid,
+	options_grid.attach(blend_box,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -397,7 +397,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	SPACING(name_gap, GAP);
-	id_grid.attach(id_label, 0, 0);
+	id_grid.attach(id_label, 0, 0, 1, 1);
 	id_grid.attach_next_to(*name_gap, Gtk::POS_RIGHT, 1, 1);
 	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
@@ -415,7 +415,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 		("synfig-layer_gradient_spiral"), _("Create a spiral gradient"));
 
 	SPACING(layer_types_indent, INDENTATION);
-	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
 	layer_types_grid.attach_next_to(layer_linear_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_radial_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_conical_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
@@ -427,7 +427,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
 
-	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach(blend_label, 0, 0, 1, 1);
 	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -192,12 +192,12 @@ class studio::StateLasso_Context : public sigc::trackable
 	Gtk::RadioButton localthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> localthres_adj;
 	Gtk::SpinButton localthres_spin;
-	Gtk::Grid localthres_grid;
+	Gtk::Box localthres_box;
 
 	Gtk::RadioButton globalthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> globalthres_adj;
 	Gtk::SpinButton globalthres_spin;
-	Gtk::Grid globalthres_grid;
+	Gtk::Box globalthres_box;
 
 	// width max error advanced outline layer
 	Gtk::Label width_max_error_label;
@@ -669,13 +669,13 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
 	SPACING(localthres_indent, INDENTATION);
-	localthres_grid.attach(*localthres_indent, 0, 0, 1, 1);
-	localthres_grid.attach_next_to(localthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
+	localthres_box.pack_start(*localthres_indent, false, false, 0);
+	localthres_box.pack_start(localthres_radiobutton, false, false, 0);
 	localthres_radiobutton.set_label("Local:");
 
 	SPACING(globalthres_indent, INDENTATION);
-	globalthres_grid.attach(*globalthres_indent, 0, 0, 1, 1);
-	globalthres_grid.attach_next_to(globalthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
+	globalthres_box.pack_start(*globalthres_indent, false, false, 0);
+	globalthres_box.pack_start(globalthres_radiobutton, false, false, 0);
 	globalthres_radiobutton.set_label("Global:");
 
 	smoothness_group = localthres_radiobutton.get_group();
@@ -736,11 +736,11 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 		0, 0, 2, 1);
 	options_grid.attach(smoothness_label,
 		0, 1, 2, 1);
-	options_grid.attach(localthres_grid,
+	options_grid.attach(localthres_box,
 		0, 2, 1, 1);
 	options_grid.attach(localthres_spin,
 		1, 2, 1, 1);
-	options_grid.attach(globalthres_grid,
+	options_grid.attach(globalthres_box,
 		0, 3, 1, 1);
 	options_grid.attach(globalthres_spin,
 		1, 3, 1, 1);

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -139,13 +139,11 @@ class studio::StateLasso_Context : public sigc::trackable
 	void reverse_bline(std::list<synfig::BLinePoint> &bline);
 	void reverse_wplist(std::list<synfig::WidthPoint> &wplist);
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
 	// layer name:
@@ -191,17 +189,15 @@ class studio::StateLasso_Context : public sigc::trackable
 	Gtk::Label smoothness_label;
 	Gtk::RadioButton::Group smoothness_group;
 
-	// local threshold
 	Gtk::RadioButton localthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> localthres_adj;
 	Gtk::SpinButton localthres_spin;
-	Gtk::HBox localthres_box;
+	Gtk::Grid localthres_grid;
 
-	// global threshold
 	Gtk::RadioButton globalthres_radiobutton;
 	Glib::RefPtr<Gtk::Adjustment> globalthres_adj;
 	Gtk::SpinButton globalthres_spin;
-	Gtk::HBox globalthres_box;
+	Gtk::Grid globalthres_grid;
 
 	// width max error advanced outline layer
 	Gtk::Label width_max_error_label;
@@ -673,13 +669,13 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
 	SPACING(localthres_indent, INDENTATION);
-	localthres_box.pack_start(*localthres_indent, Gtk::PACK_SHRINK);
-	localthres_box.pack_start(localthres_radiobutton, Gtk::PACK_SHRINK);
+	localthres_grid.attach(*localthres_indent, 0, 0);
+	localthres_grid.attach_next_to(localthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
 	localthres_radiobutton.set_label("Local:");
 
 	SPACING(globalthres_indent, INDENTATION);
-	globalthres_box.pack_start(*globalthres_indent, Gtk::PACK_SHRINK);
-	globalthres_box.pack_start(globalthres_radiobutton, Gtk::PACK_SHRINK);
+	globalthres_grid.attach(*globalthres_indent, 0, 0);
+	globalthres_grid.attach_next_to(globalthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
 	globalthres_radiobutton.set_label("Global:");
 
 	smoothness_group = localthres_radiobutton.get_group();
@@ -740,11 +736,11 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 		0, 0, 2, 1);
 	options_grid.attach(smoothness_label,
 		0, 1, 2, 1);
-	options_grid.attach(localthres_box,
+	options_grid.attach(localthres_grid,
 		0, 2, 1, 1);
 	options_grid.attach(localthres_spin,
 		1, 2, 1, 1);
-	options_grid.attach(globalthres_box,
+	options_grid.attach(globalthres_grid,
 		0, 3, 1, 1);
 	options_grid.attach(globalthres_spin,
 		1, 3, 1, 1);
@@ -753,6 +749,7 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	options_grid.attach(feather_dist,
 		1, 4, 1, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -669,12 +669,12 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
 	SPACING(localthres_indent, INDENTATION);
-	localthres_grid.attach(*localthres_indent, 0, 0);
+	localthres_grid.attach(*localthres_indent, 0, 0, 1, 1);
 	localthres_grid.attach_next_to(localthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
 	localthres_radiobutton.set_label("Local:");
 
 	SPACING(globalthres_indent, INDENTATION);
-	globalthres_grid.attach(*globalthres_indent, 0, 0);
+	globalthres_grid.attach(*globalthres_indent, 0, 0, 1, 1);
 	globalthres_grid.attach_next_to(globalthres_radiobutton, Gtk::POS_RIGHT, 1, 1);
 	globalthres_radiobutton.set_label("Global:");
 

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -109,21 +109,17 @@ class studio::StatePolygon_Context : public sigc::trackable
 	void popup_handle_menu(synfigapp::ValueDesc value_desc);
 	void refresh_ducks();
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
+	Gtk::Grid id_grid;
 
-	// layer types to create:
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_polygon_togglebutton;
 	Gtk::ToggleButton layer_region_togglebutton;
@@ -131,39 +127,28 @@ class studio::StatePolygon_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Grid layer_types_grid;
 
-	// blend method
 	Gtk::Label blend_label;
-	Gtk::HBox blend_box;
 	Widget_Enum blend_enum;
+	Gtk::Grid blend_grid;
 
-	// opacity
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
-	// brush size
 	Gtk::Label bline_width_label;
 	Widget_Distance bline_width_dist;
 
-	// invert
 	Gtk::Label invert_label;
 	Gtk::CheckButton invert_checkbutton;
-	Gtk::HBox invert_box;
+	Gtk::Grid invert_grid;
 
-	// feather size
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
-	// link origins
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::HBox link_origins_box;
-
-	// spline origins at center
-	Gtk::Label origins_at_center_label;
-	Gtk::CheckButton layer_origins_at_center_checkbutton;
-	Gtk::HBox origins_at_center_box;
+	Gtk::Grid link_origins_grid;
 
 public:
 
@@ -482,11 +467,11 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
-
-	id_box.pack_start(id_entry);
+	id_grid.attach(id_label, 0, 0);
+	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
+	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -506,20 +491,21 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
 	SPACING(layer_types_indent, INDENTATION);
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_polygon_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach_next_to(layer_polygon_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
+	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
-	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
+	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -545,10 +531,11 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	invert_label.set_label(_("Invert"));
 	invert_label.set_halign(Gtk::ALIGN_START);
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
+	invert_label.set_hexpand();
 
-	invert_box.pack_start(invert_label);
-	invert_box.pack_end(invert_checkbutton, Gtk::PACK_SHRINK);
-	invert_box.set_sensitive(false);
+	invert_grid.attach(invert_label, 0, 0);
+	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	invert_grid.set_sensitive(false);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -562,23 +549,24 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
+	link_origins_label.set_hexpand();
 
-	link_origins_box.pack_start(link_origins_label);
-	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
-	link_origins_box.set_sensitive(false);
+	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	link_origins_grid.set_sensitive(false);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_box,
+	options_grid.attach(id_grid,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_box,
+	options_grid.attach(layer_types_grid,
 		0, 3, 2, 1);
-	options_grid.attach(blend_box,
+	options_grid.attach(blend_grid,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -590,15 +578,16 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 		0, 6, 1, 1);
 	options_grid.attach(bline_width_dist,
 		1, 6, 1, 1);
-	options_grid.attach(invert_box,
+	options_grid.attach(invert_grid,
 		0, 7, 2, 1);
 	options_grid.attach(feather_label,
 		0, 8, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 8, 1, 1);
-	options_grid.attach(link_origins_box,
+	options_grid.attach(link_origins_grid,
 		0, 9, 2, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
@@ -1363,10 +1352,10 @@ StatePolygon_Context::toggle_layer_creation()
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag())
 	{
-		invert_box.set_sensitive(true);
+		invert_grid.set_sensitive(true);
 	}
 	else
-		invert_box.set_sensitive(false);
+		invert_grid.set_sensitive(false);
 
 	// feather size
 	if (get_layer_polygon_flag() ||
@@ -1391,9 +1380,9 @@ StatePolygon_Context::toggle_layer_creation()
 		get_layer_curve_gradient_flag() +
 		get_layer_polygon_flag() >= 2)
 		{
-			link_origins_box.set_sensitive(true);
+			link_origins_grid.set_sensitive(true);
 		}
-	else link_origins_box.set_sensitive(false);
+	else link_origins_grid.set_sensitive(false);
 
   // update layer flags
   layer_polygon_flag = get_layer_polygon_flag();

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -469,7 +469,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0);
+	id_grid.attach(id_label, 0, 0, 1, 1);
 	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
 	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
@@ -491,7 +491,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
 	SPACING(layer_types_indent, INDENTATION);
-	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
 	layer_types_grid.attach_next_to(layer_polygon_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
@@ -504,7 +504,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach(blend_label, 0, 0, 1, 1);
 	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -533,7 +533,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
 	invert_label.set_hexpand();
 
-	invert_grid.attach(invert_label, 0, 0);
+	invert_grid.attach(invert_label, 0, 0, 1, 1);
 	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	invert_grid.set_sensitive(false);
 
@@ -551,7 +551,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
 	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	link_origins_grid.set_sensitive(false);
 

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -118,7 +118,7 @@ class studio::StatePolygon_Context : public sigc::trackable
 
 	Gtk::Label id_label;
 	Gtk::Entry id_entry;
-	Gtk::Grid id_grid;
+	Gtk::Box id_box;
 
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_polygon_togglebutton;
@@ -127,11 +127,11 @@ class studio::StatePolygon_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::Grid layer_types_grid;
+	Gtk::Box layer_types_box;
 
 	Gtk::Label blend_label;
 	Widget_Enum blend_enum;
-	Gtk::Grid blend_grid;
+	Gtk::Box blend_box;
 
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
@@ -141,14 +141,14 @@ class studio::StatePolygon_Context : public sigc::trackable
 
 	Gtk::Label invert_label;
 	Gtk::CheckButton invert_checkbutton;
-	Gtk::Grid invert_grid;
+	Gtk::Box invert_box;
 
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::Grid link_origins_grid;
+	Gtk::Box link_origins_box;
 
 public:
 
@@ -467,11 +467,10 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0, 1, 1);
-	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
-	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*id_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -491,21 +490,20 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
 	SPACING(layer_types_indent, INDENTATION);
-	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
-	layer_types_grid.attach_next_to(layer_polygon_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_polygon_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_advanced_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_plant_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_curve_gradient_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0, 1, 1);
-	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
+	blend_box.pack_start(blend_label, false, false, 0);
+	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -531,11 +529,10 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	invert_label.set_label(_("Invert"));
 	invert_label.set_halign(Gtk::ALIGN_START);
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
-	invert_label.set_hexpand();
 
-	invert_grid.attach(invert_label, 0, 0, 1, 1);
-	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	invert_grid.set_sensitive(false);
+	invert_box.pack_start(invert_label, true, true, 0);
+	invert_box.pack_start(invert_checkbutton, false, false, 0);
+	invert_box.set_sensitive(false);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -549,24 +546,23 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
-	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
-	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	link_origins_grid.set_sensitive(false);
+	link_origins_box.pack_start(link_origins_label, true, true, 0);
+	link_origins_box.pack_start(layer_link_origins_checkbutton, false, false, 0);
+	link_origins_box.set_sensitive(false);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_grid,
+	options_grid.attach(id_box,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_grid,
+	options_grid.attach(layer_types_box,
 		0, 3, 2, 1);
-	options_grid.attach(blend_grid,
+	options_grid.attach(blend_box,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -578,13 +574,13 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 		0, 6, 1, 1);
 	options_grid.attach(bline_width_dist,
 		1, 6, 1, 1);
-	options_grid.attach(invert_grid,
+	options_grid.attach(invert_box,
 		0, 7, 2, 1);
 	options_grid.attach(feather_label,
 		0, 8, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 8, 1, 1);
-	options_grid.attach(link_origins_grid,
+	options_grid.attach(link_origins_box,
 		0, 9, 2, 1);
 
 	options_grid.set_vexpand(false);
@@ -1352,10 +1348,10 @@ StatePolygon_Context::toggle_layer_creation()
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag())
 	{
-		invert_grid.set_sensitive(true);
+		invert_box.set_sensitive(true);
 	}
 	else
-		invert_grid.set_sensitive(false);
+		invert_box.set_sensitive(false);
 
 	// feather size
 	if (get_layer_polygon_flag() ||
@@ -1380,9 +1376,9 @@ StatePolygon_Context::toggle_layer_creation()
 		get_layer_curve_gradient_flag() +
 		get_layer_polygon_flag() >= 2)
 		{
-			link_origins_grid.set_sensitive(true);
+			link_origins_box.set_sensitive(true);
 		}
-	else link_origins_grid.set_sensitive(false);
+	else link_origins_box.set_sensitive(false);
 
   // update layer flags
   layer_polygon_flag = get_layer_polygon_flag();

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -116,7 +116,7 @@ class studio::StateRectangle_Context : public sigc::trackable
 
 	Gtk::Label id_label;
 	Gtk::Entry id_entry;
-	Gtk::Grid id_grid;
+	Gtk::Box id_box;
 
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_rectangle_togglebutton;
@@ -125,11 +125,11 @@ class studio::StateRectangle_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::Grid layer_types_grid;
+	Gtk::Box layer_types_box;
 
 	Gtk::Label blend_label;
 	Widget_Enum blend_enum;
-	Gtk::Grid blend_grid;
+	Gtk::Box blend_box;
 
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
@@ -139,7 +139,7 @@ class studio::StateRectangle_Context : public sigc::trackable
 
 	Gtk::Label invert_label;
 	Gtk::CheckButton invert_checkbutton;
-	Gtk::Grid invert_grid;
+	Gtk::Box invert_box;
 
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
@@ -149,7 +149,7 @@ class studio::StateRectangle_Context : public sigc::trackable
 
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::Grid link_origins_grid;
+	Gtk::Box link_origins_box;
 
 public:
 
@@ -484,11 +484,10 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0, 1, 1);
-	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
-	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*id_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -509,21 +508,20 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
-	layer_types_grid.attach_next_to(layer_rectangle_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_rectangle_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_advanced_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_plant_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_curve_gradient_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0, 1, 1);
-	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
+	blend_box.pack_start(blend_label, false, false, 0);
+	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -548,11 +546,10 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	invert_label.set_label(_("Invert"));
 	invert_label.set_halign(Gtk::ALIGN_START);
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
-	invert_label.set_hexpand();
 
-	invert_grid.attach(invert_label, 0, 0, 1, 1);
-	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	invert_grid.set_sensitive(false);
+	invert_box.pack_start(invert_label, true, true, 0);
+	invert_box.pack_start(invert_checkbutton, false, false, 0);
+	invert_box.set_sensitive(false);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -575,24 +572,23 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
-	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
-	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	link_origins_grid.set_sensitive(false);
+	link_origins_box.pack_start(link_origins_label, true, true, 0);
+	link_origins_box.pack_start(layer_link_origins_checkbutton, false, false, 0);
+	link_origins_box.set_sensitive(false);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_grid,
+	options_grid.attach(id_box,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_grid,
+	options_grid.attach(layer_types_box,
 		0, 3, 2, 1);
-	options_grid.attach(blend_grid,
+	options_grid.attach(blend_box,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -604,7 +600,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 		0, 6, 1, 1);
 	options_grid.attach(bline_width_dist,
 		1, 6, 1, 1);
-	options_grid.attach(invert_grid,
+	options_grid.attach(invert_box,
 		0, 7, 2, 1);
 	options_grid.attach(feather_label,
 		0, 8, 1, 1);
@@ -614,7 +610,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 		0, 9, 1, 1);
 	options_grid.attach(expand_dist,
 		1, 9, 1, 1);
-	options_grid.attach(link_origins_grid,
+	options_grid.attach(link_origins_box,
 		0, 10, 2, 1);
 
 	options_grid.set_vexpand(false);
@@ -1272,10 +1268,10 @@ StateRectangle_Context::toggle_layer_creation()
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag())
 	{
-		invert_grid.set_sensitive(true);
+		invert_box.set_sensitive(true);
 	}
 	else
-		invert_grid.set_sensitive(false);
+		invert_box.set_sensitive(false);
 
 	// feather size
 	if (get_layer_rectangle_flag() ||
@@ -1313,9 +1309,9 @@ StateRectangle_Context::toggle_layer_creation()
 		get_layer_plant_flag() +
 		get_layer_curve_gradient_flag() >= 2)
 		{
-			link_origins_grid.set_sensitive(true);
+			link_origins_box.set_sensitive(true);
 		}
-	else link_origins_grid.set_sensitive(false);
+	else link_origins_box.set_sensitive(false);
 
   // update layer flags
   layer_rectangle_flag = get_layer_rectangle_flag();

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -107,21 +107,17 @@ class studio::StateRectangle_Context : public sigc::trackable
 
 	bool prev_workarea_layer_status_;
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
+	Gtk::Grid id_grid;
 
-	// layer types to create:
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_rectangle_togglebutton;
 	Gtk::ToggleButton layer_region_togglebutton;
@@ -129,38 +125,31 @@ class studio::StateRectangle_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Grid layer_types_grid;
 
-	// blend method
 	Gtk::Label blend_label;
-	Gtk::HBox blend_box;
 	Widget_Enum blend_enum;
+	Gtk::Grid blend_grid;
 
-	// opacity
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
-	// brush size
 	Gtk::Label bline_width_label;
 	Widget_Distance bline_width_dist;
 
-	// invert
 	Gtk::Label invert_label;
 	Gtk::CheckButton invert_checkbutton;
-	Gtk::HBox invert_box;
+	Gtk::Grid invert_grid;
 
-	// feather size
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
-	// expansion
 	Gtk::Label expand_label;
 	Widget_Distance expand_dist;
 
-	// link origins
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::HBox link_origins_box;
+	Gtk::Grid link_origins_grid;
 
 public:
 
@@ -495,11 +484,11 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
-
-	id_box.pack_start(id_entry);
+	id_grid.attach(id_label, 0, 0);
+	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
+	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -520,20 +509,21 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_rectangle_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach_next_to(layer_rectangle_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
+	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
-	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
+	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -558,10 +548,11 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	invert_label.set_label(_("Invert"));
 	invert_label.set_halign(Gtk::ALIGN_START);
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
+	invert_label.set_hexpand();
 
-	invert_box.pack_start(invert_label);
-	invert_box.pack_end(invert_checkbutton, Gtk::PACK_SHRINK);
-	invert_box.set_sensitive(false);
+	invert_grid.attach(invert_label, 0, 0);
+	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	invert_grid.set_sensitive(false);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -584,23 +575,24 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
+	link_origins_label.set_hexpand();
 
-	link_origins_box.pack_start(link_origins_label);
-	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
-	link_origins_box.set_sensitive(false);
+	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	link_origins_grid.set_sensitive(false);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_box,
+	options_grid.attach(id_grid,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_box,
+	options_grid.attach(layer_types_grid,
 		0, 3, 2, 1);
-	options_grid.attach(blend_box,
+	options_grid.attach(blend_grid,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -612,7 +604,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 		0, 6, 1, 1);
 	options_grid.attach(bline_width_dist,
 		1, 6, 1, 1);
-	options_grid.attach(invert_box,
+	options_grid.attach(invert_grid,
 		0, 7, 2, 1);
 	options_grid.attach(feather_label,
 		0, 8, 1, 1);
@@ -622,9 +614,10 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 		0, 9, 1, 1);
 	options_grid.attach(expand_dist,
 		1, 9, 1, 1);
-	options_grid.attach(link_origins_box,
+	options_grid.attach(link_origins_grid,
 		0, 10, 2, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
@@ -1279,10 +1272,10 @@ StateRectangle_Context::toggle_layer_creation()
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag())
 	{
-		invert_box.set_sensitive(true);
+		invert_grid.set_sensitive(true);
 	}
 	else
-		invert_box.set_sensitive(false);
+		invert_grid.set_sensitive(false);
 
 	// feather size
 	if (get_layer_rectangle_flag() ||
@@ -1320,9 +1313,9 @@ StateRectangle_Context::toggle_layer_creation()
 		get_layer_plant_flag() +
 		get_layer_curve_gradient_flag() >= 2)
 		{
-			link_origins_box.set_sensitive(true);
+			link_origins_grid.set_sensitive(true);
 		}
-	else link_origins_box.set_sensitive(false);
+	else link_origins_grid.set_sensitive(false);
 
   // update layer flags
   layer_rectangle_flag = get_layer_rectangle_flag();

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -486,7 +486,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0);
+	id_grid.attach(id_label, 0, 0, 1, 1);
 	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
 	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
@@ -509,7 +509,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
 	layer_types_grid.attach_next_to(layer_rectangle_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
@@ -522,7 +522,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach(blend_label, 0, 0, 1, 1);
 	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -550,7 +550,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
 	invert_label.set_hexpand();
 
-	invert_grid.attach(invert_label, 0, 0);
+	invert_grid.attach(invert_label, 0, 0, 1, 1);
 	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	invert_grid.set_sensitive(false);
 
@@ -577,7 +577,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
 	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	link_origins_grid.set_sensitive(false);
 

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -112,7 +112,7 @@ class studio::StateRotate_Context : public sigc::trackable
 
 	Gtk::Label scale_label;
 	Gtk::CheckButton scale_checkbutton;
-	Gtk::HBox scale_box;
+	Gtk::Grid scale_grid;
 
 public:
 
@@ -213,18 +213,19 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 	scale_label.set_halign(Gtk::ALIGN_START);
 	scale_label.set_valign(Gtk::ALIGN_CENTER);
 
-	scale_box.pack_start(scale_label);
-	scale_box.pack_end(scale_checkbutton, Gtk::PACK_SHRINK);
+	scale_grid.attach(scale_label, 0, 0);
+	scale_grid.attach_next_to(scale_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(scale_box,
+	options_grid.attach(scale_grid,
 		0, 1, 2, 1);
 
 	scale_checkbutton.signal_toggled().connect(sigc::mem_fun(*this,&StateRotate_Context::refresh_scale_flag));
 
 	options_grid.set_hexpand();
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.show_all();

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -213,7 +213,7 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 	scale_label.set_halign(Gtk::ALIGN_START);
 	scale_label.set_valign(Gtk::ALIGN_CENTER);
 
-	scale_grid.attach(scale_label, 0, 0);
+	scale_grid.attach(scale_label, 0, 0, 1, 1);
 	scale_grid.attach_next_to(scale_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	// Toolbox layout

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -112,7 +112,7 @@ class studio::StateRotate_Context : public sigc::trackable
 
 	Gtk::Label scale_label;
 	Gtk::CheckButton scale_checkbutton;
-	Gtk::Grid scale_grid;
+	Gtk::Box scale_box;
 
 public:
 
@@ -209,17 +209,16 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 	title_label.set_valign(Gtk::ALIGN_CENTER);
 
 	scale_label.set_label(_("Allow Scale"));
-	scale_label.set_hexpand();
 	scale_label.set_halign(Gtk::ALIGN_START);
 	scale_label.set_valign(Gtk::ALIGN_CENTER);
 
-	scale_grid.attach(scale_label, 0, 0, 1, 1);
-	scale_grid.attach_next_to(scale_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	scale_box.pack_start(scale_label, true, true, 0);
+	scale_box.pack_start(scale_checkbutton, false, false, 0);
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(scale_grid,
+	options_grid.attach(scale_box,
 		0, 1, 2, 1);
 
 	scale_checkbutton.signal_toggled().connect(sigc::mem_fun(*this,&StateRotate_Context::refresh_scale_flag));

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -100,7 +100,7 @@ class studio::StateScale_Context : public sigc::trackable
 
 	Gtk::Label aspect_lock_label;
 	Gtk::CheckButton aspect_lock_checkbutton;
-	Gtk::HBox aspect_lock_box;
+	Gtk::Grid aspect_lock_grid;
 
 public:
 
@@ -198,17 +198,18 @@ StateScale_Context::StateScale_Context(CanvasView* canvas_view):
 	aspect_lock_label.set_hexpand();
 	aspect_lock_label.set_halign(Gtk::ALIGN_START);
 	aspect_lock_label.set_valign(Gtk::ALIGN_CENTER);
-	aspect_lock_box.pack_start(aspect_lock_label);
-	aspect_lock_box.pack_end(aspect_lock_checkbutton, Gtk::PACK_SHRINK);
+	aspect_lock_grid.attach(aspect_lock_label, 0, 0);
+	aspect_lock_grid.attach_next_to(aspect_lock_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(aspect_lock_box,
+	options_grid.attach(aspect_lock_grid,
 		0, 1, 2, 1);
 
 	aspect_lock_checkbutton.signal_toggled().connect(sigc::mem_fun(*this,&StateScale_Context::refresh_aspect_lock_flag));
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.show_all();

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -198,7 +198,7 @@ StateScale_Context::StateScale_Context(CanvasView* canvas_view):
 	aspect_lock_label.set_hexpand();
 	aspect_lock_label.set_halign(Gtk::ALIGN_START);
 	aspect_lock_label.set_valign(Gtk::ALIGN_CENTER);
-	aspect_lock_grid.attach(aspect_lock_label, 0, 0);
+	aspect_lock_grid.attach(aspect_lock_label, 0, 0, 1, 1);
 	aspect_lock_grid.attach_next_to(aspect_lock_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	// Toolbox layout

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -100,7 +100,7 @@ class studio::StateScale_Context : public sigc::trackable
 
 	Gtk::Label aspect_lock_label;
 	Gtk::CheckButton aspect_lock_checkbutton;
-	Gtk::Grid aspect_lock_grid;
+	Gtk::Box aspect_lock_box;
 
 public:
 
@@ -198,13 +198,13 @@ StateScale_Context::StateScale_Context(CanvasView* canvas_view):
 	aspect_lock_label.set_hexpand();
 	aspect_lock_label.set_halign(Gtk::ALIGN_START);
 	aspect_lock_label.set_valign(Gtk::ALIGN_CENTER);
-	aspect_lock_grid.attach(aspect_lock_label, 0, 0, 1, 1);
-	aspect_lock_grid.attach_next_to(aspect_lock_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	aspect_lock_box.pack_start(aspect_lock_label, true, true, 0);
+	aspect_lock_box.pack_start(aspect_lock_checkbutton, false, false, 0);
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(aspect_lock_grid,
+	options_grid.attach(aspect_lock_box,
 		0, 1, 2, 1);
 
 	aspect_lock_checkbutton.signal_toggled().connect(sigc::mem_fun(*this,&StateScale_Context::refresh_aspect_lock_flag));

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -85,7 +85,7 @@ class studio::StateSketch_Context : public sigc::trackable
 
 	Gtk::Label show_sketch_label;
 	Gtk::CheckButton show_sketch_checkbutton;
-	Gtk::Grid show_sketch_grid;
+	Gtk::Box show_sketch_box;
 
 	void clear_sketch();
 	void save_sketch();
@@ -249,13 +249,13 @@ StateSketch_Context::StateSketch_Context(CanvasView* canvas_view):
 	show_sketch_label.set_valign(Gtk::ALIGN_CENTER);
 	show_sketch_label.set_hexpand();
 
-	show_sketch_grid.attach(show_sketch_label, 0, 0, 1, 1);
-	show_sketch_grid.attach_next_to(show_sketch_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	show_sketch_box.pack_start(show_sketch_label, true, true, 0);
+	show_sketch_box.pack_start(show_sketch_checkbutton, false, false, 0);
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(show_sketch_grid,
+	options_grid.attach(show_sketch_box,
 		0, 1, 2, 1);
 
 	options_grid.set_vexpand(false);

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -249,7 +249,7 @@ StateSketch_Context::StateSketch_Context(CanvasView* canvas_view):
 	show_sketch_label.set_valign(Gtk::ALIGN_CENTER);
 	show_sketch_label.set_hexpand();
 
-	show_sketch_grid.attach(show_sketch_label, 0, 0);
+	show_sketch_grid.attach(show_sketch_label, 0, 0, 1, 1);
 	show_sketch_grid.attach_next_to(show_sketch_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	// Toolbox layout

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -85,7 +85,7 @@ class studio::StateSketch_Context : public sigc::trackable
 
 	Gtk::Label show_sketch_label;
 	Gtk::CheckButton show_sketch_checkbutton;
-	Gtk::HBox show_sketch_box;
+	Gtk::Grid show_sketch_grid;
 
 	void clear_sketch();
 	void save_sketch();
@@ -247,16 +247,18 @@ StateSketch_Context::StateSketch_Context(CanvasView* canvas_view):
 	show_sketch_label.set_label(_("Show Sketch"));
 	show_sketch_label.set_halign(Gtk::ALIGN_START);
 	show_sketch_label.set_valign(Gtk::ALIGN_CENTER);
+	show_sketch_label.set_hexpand();
 
-	show_sketch_box.pack_start(show_sketch_label);
-	show_sketch_box.pack_end(show_sketch_checkbutton, Gtk::PACK_SHRINK);
+	show_sketch_grid.attach(show_sketch_label, 0, 0);
+	show_sketch_grid.attach_next_to(show_sketch_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(show_sketch_box,
+	options_grid.attach(show_sketch_grid,
 		0, 1, 2, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -107,21 +107,17 @@ class studio::StateStar_Context : public sigc::trackable
 
 	bool prev_workarea_layer_status_;
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
+	Gtk::Grid id_grid;
 
-	// layer types to create:
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_star_togglebutton;
 	Gtk::ToggleButton layer_region_togglebutton;
@@ -129,79 +125,64 @@ class studio::StateStar_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Grid layer_types_grid;
 
-	// blend method
 	Gtk::Label blend_label;
-	Gtk::HBox blend_box;
 	Widget_Enum blend_enum;
+	Gtk::Grid blend_grid;
 
-	// opacity
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
-	// brush size
 	Gtk::Label bline_width_label;
 	Widget_Distance bline_width_dist;
 
-	// star points
 	Gtk::Label number_of_points_label;
 	Glib::RefPtr<Gtk::Adjustment> number_of_points_adj;
 	Gtk::SpinButton	number_of_points_spin;
 
-	// radius ratio
 	Gtk::Label radius_ratio_label;
 	Glib::RefPtr<Gtk::Adjustment> radius_ratio_adj;
 	Gtk::SpinButton	radius_ratio_spin;
 
-	// angle offset
 	Gtk::Label angle_offset_label;
 	Glib::RefPtr<Gtk::Adjustment> angle_offset_adj;
 	Gtk::SpinButton	angle_offset_spin;
 
-	// regular polygon
 	Gtk::Label regular_polygon_label;
 	Gtk::CheckButton regular_polygon_checkbutton;
-	Gtk::HBox regular_polygon_box;
+	Gtk::Grid regular_polygon_grid;
 
-	// inner width
 	Gtk::Label outer_width_label;
 	Glib::RefPtr<Gtk::Adjustment> outer_width_adj;
 	Gtk::SpinButton	outer_width_spin;
 
-	// inner tangent
 	Gtk::Label inner_tangent_label;
 	Glib::RefPtr<Gtk::Adjustment> inner_tangent_adj;
 	Gtk::SpinButton	inner_tangent_spin;
 
-	// outer width
 	Gtk::Label inner_width_label;
 	Glib::RefPtr<Gtk::Adjustment> inner_width_adj;
 	Gtk::SpinButton	inner_width_spin;
 
-	// outer tangent
 	Gtk::Label outer_tangent_label;
 	Glib::RefPtr<Gtk::Adjustment> outer_tangent_adj;
 	Gtk::SpinButton	outer_tangent_spin;
 
-	// invert
 	Gtk::Label invert_label;
 	Gtk::CheckButton invert_checkbutton;
-	Gtk::HBox invert_box;
+	Gtk::Grid invert_grid;
 
-	// feather size
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
-	// link origins
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::HBox link_origins_box;
+	Gtk::Grid link_origins_grid;
 
-	// spline origins at center
 	Gtk::Label origins_at_center_label;
 	Gtk::CheckButton layer_origins_at_center_checkbutton;
-	Gtk::HBox origins_at_center_box;
+	Gtk::Grid origins_at_center_grid;
 
 public:
 
@@ -617,11 +598,11 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
-
-	id_box.pack_start(id_entry);
+	id_grid.attach(id_label, 0, 0);
+	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
+	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -642,20 +623,21 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_star_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_plant_togglebutton, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_curve_gradient_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach_next_to(layer_star_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
+	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
-	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
+	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -693,9 +675,10 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	regular_polygon_label.set_label(_("Regular Polygon"));
 	regular_polygon_label.set_halign(Gtk::ALIGN_START);
 	regular_polygon_label.set_valign(Gtk::ALIGN_CENTER);
+	regular_polygon_label.set_hexpand();
 
-	regular_polygon_box.pack_start(regular_polygon_label);
-	regular_polygon_box.pack_end(regular_polygon_checkbutton, Gtk::PACK_SHRINK);
+	regular_polygon_grid.attach(regular_polygon_label, 0, 0);
+	regular_polygon_grid.attach_next_to(regular_polygon_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	inner_width_label.set_label(_("Inner Width:"));
 	inner_width_label.set_halign(Gtk::ALIGN_START);
@@ -716,10 +699,11 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	invert_label.set_label(_("Invert"));
 	invert_label.set_halign(Gtk::ALIGN_START);
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
+	invert_label.set_hexpand();
 
-	invert_box.pack_start(invert_label);
-	invert_box.pack_end(invert_checkbutton, Gtk::PACK_SHRINK);
-	invert_box.set_sensitive(false);
+	invert_grid.attach(invert_label, 0, 0);
+	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	invert_grid.set_sensitive(false);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -733,31 +717,33 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
+	link_origins_label.set_hexpand();
 
-	link_origins_box.pack_start(link_origins_label);
-	link_origins_box.pack_end(layer_link_origins_checkbutton, Gtk::PACK_SHRINK);
-	link_origins_box.set_sensitive(false);
+	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	link_origins_grid.set_sensitive(false);
 
 	origins_at_center_label.set_label(_("Spline Origins at Center"));
 	origins_at_center_label.set_halign(Gtk::ALIGN_START);
 	origins_at_center_label.set_valign(Gtk::ALIGN_CENTER);
+	origins_at_center_label.set_hexpand();
 
-	origins_at_center_box.pack_start(origins_at_center_label);
-	origins_at_center_box.pack_end(layer_origins_at_center_checkbutton, Gtk::PACK_SHRINK);
-	origins_at_center_box.set_sensitive(false);
+	origins_at_center_grid.attach(origins_at_center_label, 0, 0);
+	origins_at_center_grid.attach_next_to(layer_origins_at_center_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	origins_at_center_grid.set_sensitive(false);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_box,
+	options_grid.attach(id_grid,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_box,
+	options_grid.attach(layer_types_grid,
 		0, 3, 2, 1);
-	options_grid.attach(blend_box,
+	options_grid.attach(blend_grid,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -781,7 +767,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 		0, 9, 1, 1);
 	options_grid.attach(radius_ratio_spin,
 		1, 9, 1, 1);
-	options_grid.attach(regular_polygon_box,
+	options_grid.attach(regular_polygon_grid,
 		0, 10, 2, 1);
 	options_grid.attach(inner_width_label,
 		0, 11, 1, 1);
@@ -799,17 +785,18 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 		0, 14, 1, 1);
 	options_grid.attach(outer_tangent_spin,
 		1, 14, 1, 1);
-	options_grid.attach(invert_box,
+	options_grid.attach(invert_grid,
 		0, 15, 2, 1);
 	options_grid.attach(feather_label,
 		0, 16, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 16, 1, 1);
-	options_grid.attach(link_origins_box,
+	options_grid.attach(link_origins_grid,
 		0, 17, 2, 1);
-	options_grid.attach(origins_at_center_box,
+	options_grid.attach(origins_at_center_grid,
 		0, 18, 2, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);
@@ -1592,10 +1579,10 @@ StateStar_Context::toggle_layer_creation()
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag())
 	{
-		invert_box.set_sensitive(true);
+		invert_grid.set_sensitive(true);
 	}
 	else
-		invert_box.set_sensitive(false);
+		invert_grid.set_sensitive(false);
 
 	// feather size
 	if (get_layer_star_flag() ||
@@ -1619,10 +1606,10 @@ StateStar_Context::toggle_layer_creation()
 		get_layer_plant_flag() ||
 		get_layer_curve_gradient_flag())
 	{
-		origins_at_center_box.set_sensitive(true);
+		origins_at_center_grid.set_sensitive(true);
 	}
 	else
-		origins_at_center_box.set_sensitive(false);
+		origins_at_center_grid.set_sensitive(false);
 
 	// link origins
 	if (get_layer_region_flag() +
@@ -1632,9 +1619,9 @@ StateStar_Context::toggle_layer_creation()
 		get_layer_curve_gradient_flag() +
 		get_layer_star_flag() >= 2)
 	{
-		link_origins_box.set_sensitive(true);
+		link_origins_grid.set_sensitive(true);
 	}
-	else link_origins_box.set_sensitive(false);
+	else link_origins_grid.set_sensitive(false);
 
   // update layer flags
   layer_star_flag = get_layer_star_flag();

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -600,7 +600,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0);
+	id_grid.attach(id_label, 0, 0, 1, 1);
 	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
 	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
@@ -623,7 +623,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
 	layer_types_grid.attach_next_to(layer_star_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
 	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
@@ -636,7 +636,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach(blend_label, 0, 0, 1, 1);
 	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -677,7 +677,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	regular_polygon_label.set_valign(Gtk::ALIGN_CENTER);
 	regular_polygon_label.set_hexpand();
 
-	regular_polygon_grid.attach(regular_polygon_label, 0, 0);
+	regular_polygon_grid.attach(regular_polygon_label, 0, 0, 1, 1);
 	regular_polygon_grid.attach_next_to(regular_polygon_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	inner_width_label.set_label(_("Inner Width:"));
@@ -701,7 +701,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
 	invert_label.set_hexpand();
 
-	invert_grid.attach(invert_label, 0, 0);
+	invert_grid.attach(invert_label, 0, 0, 1, 1);
 	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	invert_grid.set_sensitive(false);
 
@@ -719,7 +719,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
 	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0);
+	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
 	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	link_origins_grid.set_sensitive(false);
 
@@ -728,7 +728,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	origins_at_center_label.set_valign(Gtk::ALIGN_CENTER);
 	origins_at_center_label.set_hexpand();
 
-	origins_at_center_grid.attach(origins_at_center_label, 0, 0);
+	origins_at_center_grid.attach(origins_at_center_label, 0, 0, 1, 1);
 	origins_at_center_grid.attach_next_to(layer_origins_at_center_checkbutton, Gtk::POS_RIGHT, 1, 1);
 	origins_at_center_grid.set_sensitive(false);
 

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -116,7 +116,7 @@ class studio::StateStar_Context : public sigc::trackable
 
 	Gtk::Label id_label;
 	Gtk::Entry id_entry;
-	Gtk::Grid id_grid;
+	Gtk::Box id_box;
 
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_star_togglebutton;
@@ -125,11 +125,11 @@ class studio::StateStar_Context : public sigc::trackable
 	Gtk::ToggleButton layer_advanced_outline_togglebutton;
 	Gtk::ToggleButton layer_curve_gradient_togglebutton;
 	Gtk::ToggleButton layer_plant_togglebutton;
-	Gtk::Grid layer_types_grid;
+	Gtk::Box layer_types_box;
 
 	Gtk::Label blend_label;
 	Widget_Enum blend_enum;
-	Gtk::Grid blend_grid;
+	Gtk::Box blend_box;
 
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
@@ -151,7 +151,7 @@ class studio::StateStar_Context : public sigc::trackable
 
 	Gtk::Label regular_polygon_label;
 	Gtk::CheckButton regular_polygon_checkbutton;
-	Gtk::Grid regular_polygon_grid;
+	Gtk::Box regular_polygon_box;
 
 	Gtk::Label outer_width_label;
 	Glib::RefPtr<Gtk::Adjustment> outer_width_adj;
@@ -171,18 +171,18 @@ class studio::StateStar_Context : public sigc::trackable
 
 	Gtk::Label invert_label;
 	Gtk::CheckButton invert_checkbutton;
-	Gtk::Grid invert_grid;
+	Gtk::Box invert_box;
 
 	Gtk::Label feather_label;
 	Widget_Distance feather_dist;
 
 	Gtk::Label link_origins_label;
 	Gtk::CheckButton layer_link_origins_checkbutton;
-	Gtk::Grid link_origins_grid;
+	Gtk::Box link_origins_box;
 
 	Gtk::Label origins_at_center_label;
 	Gtk::CheckButton layer_origins_at_center_checkbutton;
-	Gtk::Grid origins_at_center_grid;
+	Gtk::Box origins_at_center_box;
 
 public:
 
@@ -598,11 +598,10 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0, 1, 1);
-	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
-	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*id_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -623,21 +622,20 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
-	layer_types_grid.attach_next_to(layer_star_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_region_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_advanced_outline_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_plant_togglebutton, Gtk::POS_RIGHT, 1, 1);
-	layer_types_grid.attach_next_to(layer_curve_gradient_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_star_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_advanced_outline_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_plant_togglebutton, false, false, 0);
+	layer_types_box.pack_start(layer_curve_gradient_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0, 1, 1);
-	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
+	blend_box.pack_start(blend_label, false, false, 0);
+	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -675,10 +673,9 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	regular_polygon_label.set_label(_("Regular Polygon"));
 	regular_polygon_label.set_halign(Gtk::ALIGN_START);
 	regular_polygon_label.set_valign(Gtk::ALIGN_CENTER);
-	regular_polygon_label.set_hexpand();
 
-	regular_polygon_grid.attach(regular_polygon_label, 0, 0, 1, 1);
-	regular_polygon_grid.attach_next_to(regular_polygon_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	regular_polygon_box.pack_start(regular_polygon_label, true, true, 0);
+	regular_polygon_box.pack_start(regular_polygon_checkbutton, false, false, 0);
 
 	inner_width_label.set_label(_("Inner Width:"));
 	inner_width_label.set_halign(Gtk::ALIGN_START);
@@ -699,11 +696,10 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	invert_label.set_label(_("Invert"));
 	invert_label.set_halign(Gtk::ALIGN_START);
 	invert_label.set_valign(Gtk::ALIGN_CENTER);
-	invert_label.set_hexpand();
 
-	invert_grid.attach(invert_label, 0, 0, 1, 1);
-	invert_grid.attach_next_to(invert_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	invert_grid.set_sensitive(false);
+	invert_box.pack_start(invert_label, true, true, 0);
+	invert_box.pack_start(invert_checkbutton, false, false, 0);
+	invert_box.set_sensitive(false);
 
 	feather_label.set_label(_("Feather:"));
 	feather_label.set_halign(Gtk::ALIGN_START);
@@ -717,33 +713,31 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	link_origins_label.set_label(_("Link Origins"));
 	link_origins_label.set_halign(Gtk::ALIGN_START);
 	link_origins_label.set_valign(Gtk::ALIGN_CENTER);
-	link_origins_label.set_hexpand();
 
-	link_origins_grid.attach(link_origins_label, 0, 0, 1, 1);
-	link_origins_grid.attach_next_to(layer_link_origins_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	link_origins_grid.set_sensitive(false);
+	link_origins_box.pack_start(link_origins_label, true, true, 0);
+	link_origins_box.pack_start(layer_link_origins_checkbutton, false, false, 0);
+	link_origins_box.set_sensitive(false);
 
 	origins_at_center_label.set_label(_("Spline Origins at Center"));
 	origins_at_center_label.set_halign(Gtk::ALIGN_START);
 	origins_at_center_label.set_valign(Gtk::ALIGN_CENTER);
-	origins_at_center_label.set_hexpand();
 
-	origins_at_center_grid.attach(origins_at_center_label, 0, 0, 1, 1);
-	origins_at_center_grid.attach_next_to(layer_origins_at_center_checkbutton, Gtk::POS_RIGHT, 1, 1);
-	origins_at_center_grid.set_sensitive(false);
+	origins_at_center_box.pack_start(origins_at_center_label, true, true, 0);
+	origins_at_center_box.pack_start(layer_origins_at_center_checkbutton, false, false, 0);
+	origins_at_center_box.set_sensitive(false);
 
 	load_settings();
 
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_grid,
+	options_grid.attach(id_box,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_grid,
+	options_grid.attach(layer_types_box,
 		0, 3, 2, 1);
-	options_grid.attach(blend_grid,
+	options_grid.attach(blend_box,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -767,7 +761,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 		0, 9, 1, 1);
 	options_grid.attach(radius_ratio_spin,
 		1, 9, 1, 1);
-	options_grid.attach(regular_polygon_grid,
+	options_grid.attach(regular_polygon_box,
 		0, 10, 2, 1);
 	options_grid.attach(inner_width_label,
 		0, 11, 1, 1);
@@ -785,15 +779,15 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 		0, 14, 1, 1);
 	options_grid.attach(outer_tangent_spin,
 		1, 14, 1, 1);
-	options_grid.attach(invert_grid,
+	options_grid.attach(invert_box,
 		0, 15, 2, 1);
 	options_grid.attach(feather_label,
 		0, 16, 1, 1);
 	options_grid.attach(feather_dist,
 		1, 16, 1, 1);
-	options_grid.attach(link_origins_grid,
+	options_grid.attach(link_origins_box,
 		0, 17, 2, 1);
-	options_grid.attach(origins_at_center_grid,
+	options_grid.attach(origins_at_center_box,
 		0, 18, 2, 1);
 
 	options_grid.set_vexpand(false);
@@ -1579,10 +1573,10 @@ StateStar_Context::toggle_layer_creation()
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag())
 	{
-		invert_grid.set_sensitive(true);
+		invert_box.set_sensitive(true);
 	}
 	else
-		invert_grid.set_sensitive(false);
+		invert_box.set_sensitive(false);
 
 	// feather size
 	if (get_layer_star_flag() ||
@@ -1606,10 +1600,10 @@ StateStar_Context::toggle_layer_creation()
 		get_layer_plant_flag() ||
 		get_layer_curve_gradient_flag())
 	{
-		origins_at_center_grid.set_sensitive(true);
+		origins_at_center_box.set_sensitive(true);
 	}
 	else
-		origins_at_center_grid.set_sensitive(false);
+		origins_at_center_box.set_sensitive(false);
 
 	// link origins
 	if (get_layer_region_flag() +
@@ -1619,9 +1613,9 @@ StateStar_Context::toggle_layer_creation()
 		get_layer_curve_gradient_flag() +
 		get_layer_star_flag() >= 2)
 	{
-		link_origins_grid.set_sensitive(true);
+		link_origins_box.set_sensitive(true);
 	}
-	else link_origins_grid.set_sensitive(false);
+	else link_origins_box.set_sensitive(false);
 
   // update layer flags
   layer_star_flag = get_layer_star_flag();

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -111,22 +111,22 @@ class studio::StateText_Context
 
 	Gtk::Label id_label;
 	Gtk::Entry id_entry;
-	Gtk::Grid id_grid;
+	Gtk::Box id_box;
 
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_text_togglebutton;
-	Gtk::Grid layer_types_grid;
+	Gtk::Box layer_types_box;
 
 	Gtk::Label blend_label;
 	Widget_Enum blend_enum;
-	Gtk::Grid blend_grid;
+	Gtk::Box blend_box;
 
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
 	Gtk::Label paragraph_label;
 	Gtk::CheckButton paragraph_checkbutton;
-	Gtk::Grid paragraph_grid;
+	Gtk::Box paragraph_box;
 
 	Gtk::Label size_label;
 	Widget_Vector size_widget;
@@ -392,11 +392,10 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0, 1, 1);
-	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
-	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
+	id_box.pack_start(id_label, false, false, 0);
+	id_box.pack_start(*id_gap, false, false, 0);
+	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -407,16 +406,15 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
-	layer_types_grid.attach_next_to(layer_text_togglebutton, Gtk::POS_RIGHT, 1, 1);
+	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_types_box.pack_start(layer_text_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0, 1, 1);
-	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
+	blend_box.pack_start(blend_label, false, false, 0);
+	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -433,9 +431,8 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	paragraph_label.set_label(_("Multiline Text"));
 	paragraph_label.set_halign(Gtk::ALIGN_START);
 	paragraph_label.set_valign(Gtk::ALIGN_CENTER);
-	paragraph_label.set_hexpand();
-	paragraph_grid.attach(paragraph_label, 0, 0, 1, 1);
-	paragraph_grid.attach_next_to(paragraph_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	paragraph_box.pack_start(paragraph_label, true, true, 0);
+	paragraph_box.pack_start(paragraph_checkbutton, false, false, 0);
 
 	size_label.set_label(_("Size:"));
 	size_label.set_halign(Gtk::ALIGN_START);
@@ -457,13 +454,13 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_grid,
+	options_grid.attach(id_box,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_grid,
+	options_grid.attach(layer_types_box,
 		0, 3, 2, 1);
-	options_grid.attach(blend_grid,
+	options_grid.attach(blend_box,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -471,7 +468,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 		0, 5, 1, 1);
 	options_grid.attach(opacity_hscl,
 		1, 5, 1, 1);
-	options_grid.attach(paragraph_grid,
+	options_grid.attach(paragraph_box,
 		0, 6, 2, 1);
 	options_grid.attach(size_label,
 		0, 7, 1, 1);

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -102,48 +102,38 @@ class studio::StateText_Context
 
 	bool prev_workarea_layer_status_;
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of options
 	Gtk::Grid options_grid;
 
-	// title
 	Gtk::Label title_label;
 
-	// layer name:
 	Gtk::Label id_label;
-	Gtk::HBox id_box;
 	Gtk::Entry id_entry;
+	Gtk::Grid id_grid;
 
-	// layer types to create:
 	Gtk::Label layer_types_label;
 	Gtk::ToggleButton layer_text_togglebutton;
-	Gtk::HBox layer_types_box;
+	Gtk::Grid layer_types_grid;
 
-	// blend method
 	Gtk::Label blend_label;
-	Gtk::HBox blend_box;
 	Widget_Enum blend_enum;
+	Gtk::Grid blend_grid;
 
-	// opacity
 	Gtk::Label opacity_label;
 	Gtk::Scale opacity_hscl;
 
-	// paragraph
 	Gtk::Label paragraph_label;
 	Gtk::CheckButton paragraph_checkbutton;
-	Gtk::HBox paragraph_box;
+	Gtk::Grid paragraph_grid;
 
-	// size
 	Gtk::Label size_label;
 	Widget_Vector size_widget;
 
-	// orientation
 	Gtk::Label orientation_label;
 	Widget_Vector orientation_widget;
 
-	// font family
 	Gtk::Label family_label;
 	Gtk::Entry family_entry;
 
@@ -402,11 +392,11 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
+	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
-
-	id_box.pack_start(id_entry);
+	id_grid.attach(id_label, 0, 0);
+	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
+	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
 	layer_types_label.set_label(_("Layer Type:"));
 	layer_types_label.set_halign(Gtk::ALIGN_START);
@@ -417,15 +407,16 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
-	layer_types_box.pack_start(layer_text_togglebutton, Gtk::PACK_SHRINK);
+	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach_next_to(layer_text_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
+	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_box.pack_start(blend_label, Gtk::PACK_SHRINK);
-	blend_box.pack_start(*blend_gap, Gtk::PACK_SHRINK);
+	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -442,8 +433,9 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	paragraph_label.set_label(_("Multiline Text"));
 	paragraph_label.set_halign(Gtk::ALIGN_START);
 	paragraph_label.set_valign(Gtk::ALIGN_CENTER);
-	paragraph_box.pack_start(paragraph_label, Gtk::PACK_SHRINK);
-	paragraph_box.pack_end(paragraph_checkbutton, Gtk::PACK_SHRINK);
+	paragraph_label.set_hexpand();
+	paragraph_grid.attach(paragraph_label, 0, 0);
+	paragraph_grid.attach_next_to(paragraph_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	size_label.set_label(_("Size:"));
 	size_label.set_halign(Gtk::ALIGN_START);
@@ -465,13 +457,13 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(id_box,
+	options_grid.attach(id_grid,
 		0, 1, 2, 1);
 	options_grid.attach(layer_types_label,
 		0, 2, 2, 1);
-	options_grid.attach(layer_types_box,
+	options_grid.attach(layer_types_grid,
 		0, 3, 2, 1);
-	options_grid.attach(blend_box,
+	options_grid.attach(blend_grid,
 		0, 4, 1, 1);
 	options_grid.attach(blend_enum,
 		1, 4, 1, 1);
@@ -479,7 +471,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 		0, 5, 1, 1);
 	options_grid.attach(opacity_hscl,
 		1, 5, 1, 1);
-	options_grid.attach(paragraph_box,
+	options_grid.attach(paragraph_grid,
 		0, 6, 2, 1);
 	options_grid.attach(size_label,
 		0, 7, 1, 1);
@@ -494,6 +486,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	options_grid.attach(family_entry,
 		1, 9, 1, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.set_margin_bottom(0);

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -394,7 +394,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	id_label.set_valign(Gtk::ALIGN_CENTER);
 	id_entry.set_hexpand();
 	SPACING(id_gap, GAP);
-	id_grid.attach(id_label, 0, 0);
+	id_grid.attach(id_label, 0, 0, 1, 1);
 	id_grid.attach_next_to(*id_gap, Gtk::POS_RIGHT, 1, 1);
 	id_grid.attach_next_to(id_entry, Gtk::POS_RIGHT, 1, 1);
 
@@ -407,7 +407,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 
 	SPACING(layer_types_indent, INDENTATION);
 
-	layer_types_grid.attach(*layer_types_indent, 0, 0);
+	layer_types_grid.attach(*layer_types_indent, 0, 0, 1, 1);
 	layer_types_grid.attach_next_to(layer_text_togglebutton, Gtk::POS_RIGHT, 1, 1);
 
 	blend_label.set_label(_("Blend Method:"));
@@ -415,7 +415,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
 	blend_label.set_vexpand();
 	SPACING(blend_gap, GAP);
-	blend_grid.attach(blend_label, 0, 0);
+	blend_grid.attach(blend_label, 0, 0, 1, 1);
 	blend_grid.attach_next_to(*blend_gap, Gtk::POS_RIGHT, 1, 1);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -434,7 +434,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	paragraph_label.set_halign(Gtk::ALIGN_START);
 	paragraph_label.set_valign(Gtk::ALIGN_CENTER);
 	paragraph_label.set_hexpand();
-	paragraph_grid.attach(paragraph_label, 0, 0);
+	paragraph_grid.attach(paragraph_label, 0, 0, 1, 1);
 	paragraph_grid.attach_next_to(paragraph_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	size_label.set_label(_("Size:"));

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -247,7 +247,7 @@ StateWidth_Context::StateWidth_Context(CanvasView* canvas_view):
 	relative_label.set_valign(Gtk::ALIGN_CENTER);
 	relative_label.set_hexpand();
 	
-	relative_grid.attach(relative_label, 0, 0);
+	relative_grid.attach(relative_label, 0, 0, 1, 1);
 	relative_grid.attach_next_to(relative_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	growth_label.set_label(_("Growth:"));

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -93,10 +93,9 @@ class studio::StateWidth_Context : public sigc::trackable
 
 	WorkArea::PushState push_state;
 
-	//Toolbox settings
+	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	//Toolbox display
 	Gtk::Grid options_grid;
 	Gtk::Label title_label;
 
@@ -107,7 +106,7 @@ class studio::StateWidth_Context : public sigc::trackable
 
 	Gtk::Label relative_label;
 	Gtk::CheckButton relative_checkbutton;
-	Gtk::HBox relative_box;
+	Gtk::Grid relative_grid;
 
 	Gtk::Label growth_label;
 	Gtk::Label radius_label;
@@ -246,9 +245,10 @@ StateWidth_Context::StateWidth_Context(CanvasView* canvas_view):
 	relative_label.set_label(_("Relative Growth"));
 	relative_label.set_halign(Gtk::ALIGN_START);
 	relative_label.set_valign(Gtk::ALIGN_CENTER);
+	relative_label.set_hexpand();
 	
-	relative_box.pack_start(relative_label);
-	relative_box.pack_end(relative_checkbutton, Gtk::PACK_SHRINK);
+	relative_grid.attach(relative_label, 0, 0);
+	relative_grid.attach_next_to(relative_checkbutton, Gtk::POS_RIGHT, 1, 1);
 
 	growth_label.set_label(_("Growth:"));
 	growth_label.set_halign(Gtk::ALIGN_START);
@@ -277,9 +277,10 @@ StateWidth_Context::StateWidth_Context(CanvasView* canvas_view):
 		0, 2, 1, 1);
 	options_grid.attach(*influence_radius,
 		1, 2, 1, 1);
-	options_grid.attach(relative_box,
+	options_grid.attach(relative_grid,
 		0, 3, 2, 1);
 
+	options_grid.set_vexpand(false);
 	options_grid.set_border_width(GAP*2);
 	options_grid.set_row_spacing(GAP);
 	options_grid.show_all();

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -106,7 +106,7 @@ class studio::StateWidth_Context : public sigc::trackable
 
 	Gtk::Label relative_label;
 	Gtk::CheckButton relative_checkbutton;
-	Gtk::Grid relative_grid;
+	Gtk::Box relative_box;
 
 	Gtk::Label growth_label;
 	Gtk::Label radius_label;
@@ -247,8 +247,8 @@ StateWidth_Context::StateWidth_Context(CanvasView* canvas_view):
 	relative_label.set_valign(Gtk::ALIGN_CENTER);
 	relative_label.set_hexpand();
 	
-	relative_grid.attach(relative_label, 0, 0, 1, 1);
-	relative_grid.attach_next_to(relative_checkbutton, Gtk::POS_RIGHT, 1, 1);
+	relative_box.pack_start(relative_label, true, true, 0);
+	relative_box.pack_start(relative_checkbutton, false, false, 0);
 
 	growth_label.set_label(_("Growth:"));
 	growth_label.set_halign(Gtk::ALIGN_START);
@@ -277,7 +277,7 @@ StateWidth_Context::StateWidth_Context(CanvasView* canvas_view):
 		0, 2, 1, 1);
 	options_grid.attach(*influence_radius,
 		1, 2, 1, 1);
-	options_grid.attach(relative_grid,
+	options_grid.attach(relative_box,
 		0, 3, 2, 1);
 
 	options_grid.set_vexpand(false);


### PR DESCRIPTION
Replaced the following deprecated stuff:
- `Gtk::HBox`

and some comments cleaning as well.