### PR TITLE
[CMake] Bump minimum required CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 project(synfig-studio)

--- a/ETL/CMakeLists.txt
+++ b/ETL/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(ETL)
 

--- a/synfig-core/CMakeLists.txt
+++ b/synfig-core/CMakeLists.txt
@@ -1,5 +1,4 @@
-# TODO: find out which version is actually required
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(synfig-core)
 

--- a/synfig-core/src/CMakeLists.txt
+++ b/synfig-core/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# TODO: find out which version is actually required
-cmake_minimum_required(VERSION 3.1)
-
 ##
 ## Find packages
 ##

--- a/synfig-studio/CMakeLists.txt
+++ b/synfig-studio/CMakeLists.txt
@@ -1,5 +1,4 @@
-## TODO: find out which version is actually required
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 include(SynfigIntltool)
 
 project(synfigstudio)

--- a/synfig-studio/src/CMakeLists.txt
+++ b/synfig-studio/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
-
 ##
 ## Find packages
 ##


### PR DESCRIPTION
Actually we need version 3.1 at the moment