### PR TITLE
[Synfig Core] Set Random and Derivative valuenodes enum parameters to static by default

### DIFF
--- a/synfig-core/src/modules/mod_noise/valuenode_random.cpp
+++ b/synfig-core/src/modules/mod_noise/valuenode_random.cpp
@@ -65,10 +65,14 @@ ValueNode_Random::ValueNode_Random(const ValueBase &value):
 	init_children_vocab();
 	random.set_seed(time(nullptr));
 
+	ValueNode_Const::Handle val_smooth;
+	val_smooth = ValueNode_Const::Handle::cast_static(ValueNode_Const::create(int(RandomNoise::SMOOTH_CUBIC)));
+	val_smooth->set_static(true);
+
 	set_link("radius",ValueNode_Const::create(Real(1)));
 	set_link("seed",ValueNode_Const::create(random.get_seed()));
 	set_link("speed",ValueNode_Const::create(Real(1)));
-	set_link("smooth",ValueNode_Const::create(int(RandomNoise::SMOOTH_CUBIC)));
+	set_link("smooth",val_smooth);
 	set_link("loop",ValueNode_Const::create(Real(0)));
 
 	Type &type(get_type());
@@ -269,7 +273,6 @@ ValueNode_Random::get_children_vocab_vfunc()const
 		.add_enum_value(RandomNoise::SMOOTH_SPLINE,"spline",_("Spline"))
 		.add_enum_value(RandomNoise::SMOOTH_CUBIC,"cubic",_("Cubic"))
 	);
-
 
 	ret.push_back(ParamDesc(ValueBase(),"loop")
 		.set_local_name(_("Loop Time"))

--- a/synfig-core/src/synfig/valuenodes/valuenode_derivative.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_derivative.cpp
@@ -149,9 +149,18 @@ ValueNode_Derivative::ValueNode_Derivative(const ValueBase &value):
 	LinkableValueNode(value.get_type())
 {
 	init_children_vocab();
+
+	ValueNode_Const::Handle val_acc;
+	val_acc = ValueNode_Const::Handle::cast_static(ValueNode_Const::create((int)(NORMAL)));
+	val_acc->set_static(true);
+
+	ValueNode_Const::Handle val_order;
+	val_order = ValueNode_Const::Handle::cast_static(ValueNode_Const::create((int)(FIRST)));
+	val_order->set_static(true);
+
 	set_link("interval",      ValueNode_Const::create(Real(0.01))); // Default interval
-	set_link("accuracy",      ValueNode_Const::create((int)(NORMAL)));
-	set_link("order",         ValueNode_Const::create((int)(FIRST)));
+	set_link("accuracy",      val_acc);
+	set_link("order",         val_order);
 
 	Type &type(get_type());
 	if (type == type_real)


### PR DESCRIPTION
Fix #2131