### PR TITLE
[Core] Fixed incorrect background restoration on animated GIFs with transparent background

### DIFF
--- a/synfig-core/src/modules/mod_gif/trgt_gif.cpp
+++ b/synfig-core/src/modules/mod_gif/trgt_gif.cpp
@@ -259,7 +259,7 @@ gif::end_frame()
 	if(build_off_previous)
 		gec_flags|=DISPOSE_NONE;
 	else
-		gec_flags|=DISPOSE_RESTORE_PREVIOUS;
+		gec_flags|=DISPOSE_RESTORE_BGCOLOR;
 	if(has_transparency)
 		gec_flags|=1;
 


### PR DESCRIPTION
![circle-move-simulation](https://user-images.githubusercontent.com/5604544/116773150-e3896b80-aa7d-11eb-9f6d-28c42b291a32.gif)


Test file:
[circle-move.zip](https://github.com/synfig/synfig/files/6408996/circle-move.zip)


Linked issues:
https://forums.synfig.org/t/unwanted-layer-duplicate-appearing-in-rendered-gif/11995
https://forums.synfig.org/t/noob-rendering-original-bitmap-image-remains-behind-animation-solved/11957
