### PR TITLE
[CMake] Fixed ETL tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@ endif(MSVC)
 
 message("-- CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
+if (${ENABLE_TESTS})
+	enable_testing()
+endif()
+
 include(SynfigFindGit)
 
 add_subdirectory(ETL)

--- a/ETL/CMakeLists.txt
+++ b/ETL/CMakeLists.txt
@@ -4,17 +4,6 @@ project(ETL)
 
 option(ENABLE_TESTS "Enable tests" OFF)
 
-find_package(Threads)
-if (CMAKE_USE_PTHREADS_INIT)
-    set(HAVE_LIBPTHREAD ON)
-endif()
-
-## for tests
-include_directories(${CMAKE_SOURCE_DIR})
-
-## for test to find generated etl_profile.h
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 add_subdirectory(ETL)
 
 if (${ENABLE_TESTS})

--- a/ETL/test/CMakeLists.txt
+++ b/ETL/test/CMakeLists.txt
@@ -1,35 +1,42 @@
 # for test to find generated etl_profile.h
 include_directories(${PROJECT_BINARY_DIR})
 
+# for ETL headers
 include_directories(${PROJECT_SOURCE_DIR})
 
 add_executable(angle angle.cpp)
-add_test(test_angle angle)
+add_test(NAME test_angle COMMAND angle)
 
 add_executable(fixed fixed.cpp)
-add_test(test_fixed fixed)
+add_test(NAME test_fixed COMMAND fixed)
 
 add_executable(clock clock.cpp)
-add_test(test_clock clock)
+add_test(NAME test_clock COMMAND clock)
 
 add_executable(handle handle.cpp)
-add_test(test_handle handle)
+add_test(NAME test_handle COMMAND handle)
 
 add_executable(hermite hermite.cpp)
-add_test(test_hermite hermite)
+add_test(NAME test_hermite COMMAND hermite)
 
 add_executable(stringf stringf.cpp)
-add_test(test_stringf stringf)
+add_test(NAME test_stringf COMMAND stringf)
 
 add_executable(pen pen.cpp)
-add_test(test_pen pen)
+add_test(NAME test_pen COMMAND pen)
 
 add_executable(surface surface.cpp)
-add_test(test_surface surface)
+add_test(NAME test_surface COMMAND surface)
 
 add_executable(smart_ptr smart_ptr.cpp)
-add_test(test_smart_ptr smart_ptr)
+add_test(NAME test_smart_ptr COMMAND smart_ptr)
 
 add_executable(benchmark benchmark.cpp)
-add_test(test_benchmark benchmark)
+add_test(NAME test_benchmark COMMAND benchmark)
+
+set_target_properties(
+		angle fixed clock handle hermite stringf pen surface smart_ptr benchmark
+		PROPERTIES
+		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test
+)
 


### PR DESCRIPTION
Now tests can be run with `make test` command.

Tests cannot be built at this time due to the lack of GLib dependency.
This will be fixed later.