### PR TITLE
[CMake] Synfig now builds correctly on any system without MLT library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ endif()
 if(MSVC)
 	add_definitions(-D_USE_MATH_DEFINES) # <cmath> header need this define to add M_PI define
 	add_definitions(-DNOMINMAX) # windows.h defines min/max and brokes std::min/max
-	add_definitions(-DWITHOUT_MLT) # Disable MLT for MSVC build (as there are no such package yet)
 
 	## /MP Enable multi-processor compilation (faster)
 	add_compile_options(/MP /W0 /bigobj)

--- a/synfig-core/src/CMakeLists.txt
+++ b/synfig-core/src/CMakeLists.txt
@@ -170,7 +170,7 @@ else()
 		pkg_check_modules(CAIRO REQUIRED cairo)
 		pkg_check_modules(PANGOCAIRO REQUIRED pangocairo) # lyr_freetype
 		pkg_check_modules(LIBXML REQUIRED libxml++-2.6)
-		pkg_check_modules(MLT REQUIRED mlt++)
+		pkg_check_modules(MLT mlt++)
 		pkg_check_modules(FFTW REQUIRED fftw3)
 		pkg_check_modules(FT REQUIRED freetype2) # for lyr_freetype
 		pkg_check_modules(LIBPNG REQUIRED libpng) # for mod_png
@@ -184,6 +184,10 @@ else()
 		## TODO: move to module where it is actually required
 		pkg_check_modules(PANGO REQUIRED pango)
 	endif()
+endif()
+
+if (NOT MLT_FOUND)
+	add_definitions(-DWITHOUT_MLT) # disable MLT if not found
 endif()
 
 foreach(pkg_config_lib 

--- a/synfig-studio/src/CMakeLists.txt
+++ b/synfig-studio/src/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
 		pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
 		pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
 		pkg_check_modules(LIBXML REQUIRED libxml++-2.6)
-		pkg_check_modules(MLT REQUIRED mlt++) # required for widget_soundwave
+		pkg_check_modules(MLT mlt++) # required for widget_soundwave
 	endif()
 
 	foreach(pkg_config_lib SIGCPP GTKMM LIBXML MLT FFTW)
@@ -45,6 +45,10 @@ endif()
 
 if(FONT_CONFIG_FOUND)
 	add_definitions(-DWITH_FONTCONFIG)
+endif()
+
+if (NOT MLT_FOUND)
+	add_definitions(-DWITHOUT_MLT) # disable MLT if not found
 endif()
 
 ##
@@ -66,7 +70,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 include_directories(
-    SYSTEM
         ${SIGCPP_INCLUDE_DIRS}
         ${GTKMM_INCLUDE_DIRS}
 )


### PR DESCRIPTION
The MLT library has already been made optional for MSVC build.

This commit disables the use of MLT if MLT library not found.
Now Synfig builds correctly on any system without MLT library.