### PR TITLE
[Studio] Set the minimum height of the toolbox

### DIFF
--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -90,10 +90,11 @@ Dock_Toolbox::Dock_Toolbox():
 	scrolled_window->show();
 
 	Widget_Defaults* widget_defaults(manage(new Widget_Defaults()));
+	widget_defaults->set_size_request(-1, 100);
 
 	tool_box_paned = manage(new Gtk::Paned(Gtk::ORIENTATION_VERTICAL));
-	tool_box_paned->pack1(*scrolled_window, Gtk::PACK_EXPAND_WIDGET|Gtk::PACK_SHRINK, 3);
-	tool_box_paned->pack2(*widget_defaults, Gtk::PACK_EXPAND_WIDGET|Gtk::PACK_SHRINK, 3);
+	tool_box_paned->pack1(*scrolled_window, Gtk::PACK_EXPAND_WIDGET|Gtk::PACK_SHRINK, false);
+	tool_box_paned->pack2(*widget_defaults, Gtk::PACK_EXPAND_WIDGET|Gtk::PACK_SHRINK, false);
 	tool_box_paned->set_position(200);
 	tool_box_paned->show_all();
 	add(*tool_box_paned);


### PR DESCRIPTION
So that the color widget cannot be hidden by mistake or after undocking the toolbox.

**Before**
![Toolbox before](https://user-images.githubusercontent.com/5604544/118070626-786e5c00-b3d0-11eb-91d0-428655fb1fe0.png)
![Toolbox before](https://user-images.githubusercontent.com/5604544/118070643-7e643d00-b3d0-11eb-8706-3952a66e596a.png)



**After**
![Toolbox after](https://user-images.githubusercontent.com/5604544/118070594-6a204000-b3d0-11eb-8191-c526bb8e15f3.png)

