### PR TITLE
[MacOS] Removed unnecessary pip installation

### DIFF
--- a/1-setup-osx-brew.sh
+++ b/1-setup-osx-brew.sh
@@ -15,7 +15,7 @@ set -e
 
 if ! ( which brew >/dev/null ); then
     echo "No brew found. Installing..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
 WORKDIR=`dirname "$0"`
@@ -74,20 +74,8 @@ do
     brew info "$pkg" | grep 'Not installed' >/dev/null && brew install "$pkg"
 done
 
-if ! ( which pip >/dev/null ); then
-    echo "No pip found. Installing..."
-    echo "Running python in sudo (you need root privelegies to do that)..."
-    # Dependency for lxml
-    curl https://bootstrap.pypa.io/get-pip.py | sudo python
-fi
 
-# Installing lxml using pip
-export PIPBINARY=pip
-if `which pip3 >/dev/null`; then
-    PIPBINARY=pip3
-fi
-
-# Do not install lxml for GitHub Actions (it fails to build on MacOS 11.0)
+# Do not install lxml for GitHub Actions
 if [[ -z "${CI}" ]]; then
-    STATIC_DEPS=true sudo $PIPBINARY install lxml
+    STATIC_DEPS=true pip3 install lxml
 fi


### PR DESCRIPTION
`pip3` is part of the python formula, so it's already installed with
`brew install python` command
This change was introduced in this commit: 2a886a8. As you can
see there is no python formula here, this is why it was not detected.

Also `Homebrew` uses `pip3` not `pip` binary.