### PR TITLE
[Studio] Fixed issue with incorrect window size setting when undocking/docking a window

### DIFF
--- a/synfig-studio/src/gui/docks/dockable.h
+++ b/synfig-studio/src/gui/docks/dockable.h
@@ -64,6 +64,8 @@ private:
 	Gtk::ScrolledWindow *container;
 	Gtk::EventBox *toolbar_container;
 	bool dnd_success_;
+	// required to restore the size of the Docked item (size is not available after detaching the widget from the parent container)
+	GtkRequisition saved_widget_size_ = {-1, -1};
 
 public:
 	sigc::signal<void>& signal_stock_id_changed() { return signal_stock_id_changed_; }
@@ -90,6 +92,8 @@ public:
 	void reset_container();
 	void reset_toolbar();
 	void clear();
+
+	GtkRequisition get_size() const { return saved_widget_size_; }
 
 	Gtk::ScrolledWindow* get_container() const
 		{ return container; }

--- a/synfig-studio/src/gui/docks/dockmanager.h
+++ b/synfig-studio/src/gui/docks/dockmanager.h
@@ -116,7 +116,7 @@ public:
 	static void remove_widget_by_pointer_recursive(Gtk::Widget *widget) { remove_widget_recursive(*widget); }
 	static void remove_empty_container_recursive(Gtk::Container &container);
 	static void remove_empty_container_by_pointer_recursive(Gtk::Container *container) { remove_empty_container_recursive(*container); }
-	static bool add_widget(Gtk::Widget &dest_widget, Gtk::Widget &src_widget, bool vertical, bool first);
+	static bool add_widget(Gtk::Widget &dest_widget, Gtk::Widget &src_widget, bool vertical, bool first, GtkRequisition src_widget_size);
 	static bool add_dockable(Gtk::Widget &dest_widget, Dockable &dockable, bool vertical, bool first);
 }; // END of class DockManager
 


### PR DESCRIPTION
Also it now correctly sets the window title for a undocked window.


**Title before**
![Title before](https://user-images.githubusercontent.com/5604544/118218065-e6825400-b4a0-11eb-8b9f-beea7319f17c.png)

**Title after**
![Title after](https://user-images.githubusercontent.com/5604544/118218092-f13ce900-b4a0-11eb-8a38-5e87a9da143b.png)


**Before**
https://user-images.githubusercontent.com/5604544/118217832-72e04700-b4a0-11eb-9c77-e1b9508d8121.mp4

**After**

https://user-images.githubusercontent.com/5604544/118217859-82f82680-b4a0-11eb-8a27-090eb1c5c57e.mp4



