### PR TITLE
Fixed 'locale::facet::_S_create_c_locale name not valid' error when compiling with MinGW compiler

### DIFF
--- a/synfig-core/src/synfig/string_helper.cpp
+++ b/synfig-core/src/synfig/string_helper.cpp
@@ -33,17 +33,26 @@
 
 #include <algorithm>
 #include <locale>
+#include "general.h"
 #endif
 
 std::string
 synfig::remove_trailing_zeroes(const std::string& text, bool force_decimal_point)
 {
 	std::string result(text);
+// TODO(ice0): move all the locale related code to the initialization part
+// MinGW C++ std::locale accepts "C" and "POSIX" it does not support other locales.
+	ChangeLocale changeLocale(LC_NUMERIC, "");
+#ifdef __MINGW32__
+	struct lconv *locale_info = localeconv();
+	const char* decimal_point = locale_info->decimal_point;
+#else
 	std::locale l(setlocale(LC_NUMERIC, nullptr));
 	const char decimal_point = std::use_facet< std::numpunct<char> >(l).decimal_point();
+#endif
 	const size_t decimal_point_pos = text.find(decimal_point);
 
-	if (decimal_point_pos == text.npos) {
+	if (decimal_point_pos == std::string::npos) {
 		if (force_decimal_point)
 			result += decimal_point + std::string("0");
 	} else if (decimal_point_pos == text.length()-1) {


### PR DESCRIPTION
This error appears when starting Synfig:

![Screenshot_146](https://user-images.githubusercontent.com/5604544/118447295-ce1d6e00-b71a-11eb-9488-acbc1d53987c.png)

MinGW C++ std::locale accepts "C" and "POSIX" and
it does not support other locales.