### PR TITLE
Fixed incorrect behavior when passing '-DMSYS=1' to CMake [cmake]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,18 @@ endif()
 # MSYS is defined for MSYS Makefiles generator and undefined for Ninja (for example)
 # But if you run CMake from MSYS shell, we can still detect MSYS by environment variables (MINGW_PREFIX)
 # https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/How-To-Write-Platform-Checks
-if(MINGW AND NOT MSYS)
-	if (NOT DEFINED ENV{MINGW_PREFIX})
-		message(FATAL_ERROR "Currently we only support MSYS2 environment for MinGW compiler on Windows."
-				" Please pass '-DMSYS=1' to your CMake command to force using MSYS."
-				" Also you need to set MINGW_PREFIX environment variable if your MSYS2 installation is not in standard path (c:\\msys64\\mingw64)")
-	else()
-		set(MSYS ON)
-		set(MSYS_ROOT "$ENV{MINGW_PREFIX}/..")
+if(MINGW)
+	if(NOT DEFINED ENV{MINGW_PREFIX})
+		if(MSYS)
+			set(ENV{MINGW_PREFIX} "c:\\msys64\\mingw64\\")
+		else()
+			message(FATAL_ERROR "Currently we only support MSYS2 environment for MinGW compiler on Windows."
+					" Please pass '-DMSYS=1' to your CMake command to force using MSYS."
+					" Also you need to set MINGW_PREFIX environment variable if your MSYS2 installation is not in standard path (c:\\msys64\\mingw64)")
+		endif()
 	endif()
+	set(MSYS ON)
+	set(MSYS_ROOT "$ENV{MINGW_PREFIX}/..")
 endif()
 
 #set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")


### PR DESCRIPTION
It should set `MINGW_PREFIX` to the default location `c:\msys64\mingw64\`