### PR TITLE
[Synfig Studio] Make sure sequence separator string is always in sync with Preferences

### DIFF
--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -330,6 +330,7 @@ void
 RenderSettings::on_render_pressed()
 {
 	String filename=entry_filename.get_text();
+	tparam.sequence_separator = App::sequence_separator;
 	
 	if(!check_target_destination())
 	{
@@ -451,7 +452,7 @@ RenderSettings::check_target_destination()
 					n_frame++)
 			{
 				if(Glib::file_test(filename_sans_extension(filename) +
-					tparam.sequence_separator + 
+					App::sequence_separator +
 					etl::strprintf("%04d", n_frame) +
 					extension, Glib::FILE_TEST_EXISTS))
 					n_frames_overwrite++;


### PR DESCRIPTION
Fix #1460.

The culprit of the issue was that the sequence separator string was updated only on the first initialization of `Render Settings` dialog.

This pull requests makes sure the sequence separator string is always in sync with the current value set in `Preferences` when `Render` button is pressed.