### PR TITLE
Fix some shortcuts/accels - for item deletion and animation stop

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1319,7 +1319,6 @@ App::get_default_accel_map()
 		{"<Primary><Shift>z",       "<Actions>/action_group_dock_history/redo"},
 #endif
 		{"Delete",                  "<Actions>/action_group_layer_action_manager/action-LayerRemove"},
-    	{"KP_Delete",               "<Actions>/action_group_layer_action_manager/action-LayerRemove"},
 		{"<Control>parenleft" ,     "<Actions>/canvasview/decrease-low-res-pixel-size"},
 		{"<Control>parenright" ,    "<Actions>/canvasview/increase-low-res-pixel-size"},
 		{"<Control><Mod1>parenleft",  "<Actions>/action_group_layer_action_manager/amount-dec"},

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1290,7 +1290,6 @@ App::get_default_accel_map()
 		{"F8",                      "<Actions>/canvasview/properties"},
 		{"F12",                     "<Actions>/canvasview/options"},
 		{"<control>i",              "<Actions>/canvasview/import"},
-		//{"escape",                  "<Actions>/canvasview/stop")},
 		{"<Control>g",              "<Actions>/canvasview/toggle-grid-show"},
 		{"<Control>l",              "<Actions>/canvasview/toggle-grid-snap"},
 		{"<Control>n",              "<Actions>/mainwindow/new"},
@@ -1341,7 +1340,7 @@ App::get_default_accel_map()
 		{"<Control>minus",          "<Actions>/canvasview/canvas-zoom-out-2"},
 		{"<Control>0",              "<Actions>/canvasview/canvas-zoom-fit-2"},
 		{"space",                   "<Actions>/canvasview/play"},
-		{"space",                   "<Actions>/canvasview/pause"},
+		{"<Shift>space",            "<Actions>/canvasview/pause"},
 		{"<Control>space",          "<Actions>/canvasview/animate"},
 	};
 

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1519,9 +1519,7 @@ CanvasView::init_menus()
 		sigc::mem_fun(*this,&CanvasView::on_unselect_layers)
 	);
 
-	// the stop is not as normal stop but pause. So use "Pause" in UI, including TEXT and
-	// icon. the internal code is still using stop.
-	action_group->add( Gtk::Action::create("stop", Gtk::StockID("synfig-animate_pause")),
+	action_group->add( Gtk::Action::create("pause", Gtk::StockID("synfig-animate_pause")),
 		sigc::mem_fun(*this, &CanvasView::stop_async)
 	);
 

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -74,7 +74,8 @@ bool LayerTree::on_key_press_event(GdkEventKey* event)
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	switch (event->keyval) {
-		case GDK_KEY_Delete: {
+		case GDK_KEY_Delete:
+		case GDK_KEY_KP_Delete: {
 			LayerList layers = get_selected_layers();
 
 			if (layers.size() == 0) return true; // nothing to do

--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -603,6 +603,7 @@ Widget_Curves::on_event(GdkEvent *event)
 			return true;
 		switch (event->key.keyval) {
 		case GDK_KEY_Delete:
+		case GDK_KEY_KP_Delete:
 			delete_selected();
 			return true;
 		default:

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -352,6 +352,7 @@ bool Widget_Timetrack::on_event(GdkEvent* event)
 			return true;
 		switch (event->key.keyval) {
 		case GDK_KEY_Delete:
+		case GDK_KEY_KP_Delete:
 			delete_selected();
 			return true;
 		case GDK_KEY_n:


### PR DESCRIPTION
- Add Numpad Delete key to some widgets as an alternative to regular Delete key
- Remove Numpad Delete key from CanvasView accels, because deprecated Gtk::UIManager only allows one accel per action
- Restore old 'Stop' ('Pause' on GUI) : it was renamed by mistake and missed this action