### PR TITLE
[Studio] Shortcut editor more organized and asks for user confirmation

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1253,11 +1253,11 @@ DEFINE_ACTION("keyframe-properties", _("Properties"))
 	}
 }
 
-const std::multimap<const char*, const char*>&
+const std::map<const char*, const char*>&
 App::get_default_accel_map()
 {
 	// Add default keyboard accelerators
-	static const std::multimap<const char*, const char*> default_accel_map = {
+	static const std::map<const char*, const char*> default_accel_map = {
 		// Toolbox
 		{"s",             "<Actions>/action_group_state_manager/state-normal"},
 		{"m",             "<Actions>/action_group_state_manager/state-smooth_move"},

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -334,7 +334,7 @@ public:
 	static void load_accel_map();
 	static void save_accel_map();
 	/// \param[out] map Maps AccelKey to Action
-	static const std::multimap<const char*, const char*>& get_default_accel_map();
+	static const std::map<const char*, const char*>& get_default_accel_map();
 	static void load_file_window_size();
 	static void load_language_settings();
 	static void set_workspace_default();

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -68,6 +68,8 @@ enum ShortcutsColumns{
 	SHORTCUT_COLUMN_ID_ACTION_NAME = 0,
 	SHORTCUT_COLUMN_ID_ACTION_KEY = 1,
 	SHORTCUT_COLUMN_ID_ACTION_MODS = 2,
+	SHORTCUT_COLUMN_ID_ACTION_SHORT_NAME = 3,
+	SHORTCUT_COLUMN_ID_IS_ACTION = 4,
 };
 
 /* === P R O C E D U R E S ================================================= */
@@ -471,40 +473,73 @@ Dialog_Setup::create_shortcuts_page(Dialog_Template::PageInfo pi)
 	attach_label_section(pi.grid, _("Keyboard Shortcuts"), row++);
 
 	Gtk::TreeModelColumnRecord columns;
-	Gtk::TreeModelColumn<std::string> action_name;
-	Gtk::TreeModelColumn<guint> action_key;
-	Gtk::TreeModelColumn<Gdk::ModifierType> action_mods;
-	columns.add(action_name);  //SHORTCUT_COLUMN_ID_ACTION_NAME
-	columns.add(action_key);   //SHORTCUT_COLUMN_ID_ACTION_KEY
-	columns.add(action_mods);  //SHORTCUT_COLUMN_ID_ACTION_MODS
-	auto model = Gtk::ListStore::create(columns);
+	Gtk::TreeModelColumn<std::string> action_name_col;
+	Gtk::TreeModelColumn<guint> action_key_col;
+	Gtk::TreeModelColumn<Gdk::ModifierType> action_mods_col;
+	Gtk::TreeModelColumn<std::string> action_short_name_col;
+	Gtk::TreeModelColumn<bool> action_is_action_col;
+	columns.add(action_name_col);  //SHORTCUT_COLUMN_ID_ACTION_NAME
+	columns.add(action_key_col);   //SHORTCUT_COLUMN_ID_ACTION_KEY
+	columns.add(action_mods_col);  //SHORTCUT_COLUMN_ID_ACTION_MODS
+	columns.add(action_short_name_col);  //SHORTCUT_COLUMN_ID_ACTION_SHORT_NAME
+	columns.add(action_is_action_col);  //SHORTCUT_COLUMN_ID_IS_ACTION
+	auto model = Gtk::TreeStore::create(columns);
+
 	treeview_accels = manage(new Gtk::TreeView(model));
 	treeview_accels->set_hexpand(true);
 	treeview_accels->set_vexpand(true);
-	treeview_accels->append_column("Action", action_name);
+	treeview_accels->append_column(_("Action"), action_short_name_col);
+	treeview_accels->set_search_column(action_short_name_col);
 
 	renderer_accel.property_editable() = true;
 
 	renderer_accel.signal_accel_edited().connect(sigc::mem_fun(*this, &Dialog_Setup::on_accel_edited));
 	renderer_accel.signal_accel_cleared().connect(sigc::mem_fun(*this, &Dialog_Setup::on_accel_cleared));
 
-	const int shortcut_col_idx = -1 + treeview_accels->append_column("Shortcut", renderer_accel);
-	treeview_accels->get_column(shortcut_col_idx)->add_attribute(renderer_accel, "accel-key", action_key);
-	treeview_accels->get_column(shortcut_col_idx)->add_attribute(renderer_accel, "accel-mods", action_mods);
+	const int shortcut_col_idx = -1 + treeview_accels->append_column(_("Shortcut"), renderer_accel);
+	treeview_accels->get_column(shortcut_col_idx)->add_attribute(renderer_accel, "accel-key", action_key_col);
+	treeview_accels->get_column(shortcut_col_idx)->add_attribute(renderer_accel, "accel-mods", action_mods_col);
+	treeview_accels->get_column(shortcut_col_idx)->add_attribute(renderer_accel, "visible", action_is_action_col);
 
 	auto map = App::get_default_accel_map();
-	for (const auto& pair : map) {
+
+	// sort by action path
+	std::map<std::string,std::string> action_map;
+	for (const auto& pair : map)
+		action_map[pair.second] = pair.first;
+
+	std::string current_section_name = "-";
+	Gtk::TreeRow current_section_row;
+	for (const auto& pair : action_map) {
+		const std::string &action_full_path = pair.first;
+
+		const auto separator_pos = action_full_path.find_last_of('/');
+
+		// New section?
+		if (action_full_path.compare(0, current_section_name.size(), current_section_name) != 0) {
+			current_section_name = action_full_path.substr(0, separator_pos);
+			current_section_row = *model->append();
+
+			current_section_row.set_value(action_short_name_col, current_section_name);
+			current_section_row.set_value(action_key_col, guint(0));
+			current_section_row.set_value(action_mods_col, Gdk::ModifierType(0));
+			current_section_row.set_value(action_is_action_col, false);
+		}
+
+		Gtk::TreeRow row = *model->append(current_section_row.children());
+
 		Gtk::AccelKey accel;
-		Gtk::TreeRow row = *model->append();
+		if (!Gtk::AccelMap::lookup_entry(action_full_path, accel))
+			accel = Gtk::AccelKey(pair.second, action_full_path);
 
-		row.set_value(action_name, std::string(pair.second));
-
-		if (!Gtk::AccelMap::lookup_entry(pair.second, accel))
-			accel = Gtk::AccelKey(pair.first, pair.second);
-
-		row.set_value(action_key, accel.get_key());
-		row.set_value(action_mods, accel.get_mod());
+		row.set_value(action_name_col, action_full_path);
+		row.set_value(action_key_col, accel.get_key());
+		row.set_value(action_mods_col, accel.get_mod());
+		row.set_value(action_short_name_col, action_full_path.substr(separator_pos+1));
+		row.set_value(action_is_action_col, true);
 	}
+
+	treeview_accels->expand_all();
 
 	Gtk::ScrolledWindow *scroll = manage(new Gtk::ScrolledWindow());
 	scroll->add(*treeview_accels);
@@ -779,24 +814,26 @@ Dialog_Setup::on_restore_pressed()
 		// Keyboard accels
 		auto accel_rows = treeview_accels->get_model()->children();
 		auto default_accel_map = App::get_default_accel_map();
-		for (auto& row : accel_rows) {
-			Gtk::AccelKey accel;
+		for (const auto& section_row : accel_rows) {
+			for (auto& row : section_row.children()) {
+				Gtk::AccelKey accel;
 
-			std::string accel_path;
-			row.get_value(SHORTCUT_COLUMN_ID_ACTION_NAME, accel_path);
+				std::string accel_path;
+				row.get_value(SHORTCUT_COLUMN_ID_ACTION_NAME, accel_path);
 
-			bool found = false;
-			for (auto it = default_accel_map.begin(); it != default_accel_map.end(); ++it) {
-				if (it->second == accel_path) {
-					Gtk::AccelKey accel(it->first);
-					Gtk::AccelMap::change_entry(accel_path, accel.get_key(), accel.get_mod(), true);
-					found = true;
-					break;
+				bool found = false;
+				for (auto it = default_accel_map.begin(); it != default_accel_map.end(); ++it) {
+					if (it->second == accel_path) {
+						Gtk::AccelKey accel(it->first);
+						Gtk::AccelMap::change_entry(accel_path, accel.get_key(), accel.get_mod(), true);
+						found = true;
+						break;
+					}
 				}
-			}
 
-			if (!found) {
-				Gtk::AccelMap::change_entry(accel_path, 0, Gdk::ModifierType(0), true);
+				if (!found) {
+					Gtk::AccelMap::change_entry(accel_path, 0, Gdk::ModifierType(0), true);
+				}
 			}
 		}
 	}
@@ -945,17 +982,19 @@ Dialog_Setup::on_apply_pressed()
 
 	// Set keyboard accels for actions
 	auto accel_rows = treeview_accels->get_model()->children();
-	for (auto& row : accel_rows) {
-		Gtk::AccelKey accel;
+	for (const auto& section_row : accel_rows) {
+		for (auto& row : section_row.children()) {
+			Gtk::AccelKey accel;
 
-		std::string accel_path;
-		row.get_value(SHORTCUT_COLUMN_ID_ACTION_NAME, accel_path);
-		guint accel_key;
-		row.get_value(SHORTCUT_COLUMN_ID_ACTION_KEY, accel_key);
-		Gdk::ModifierType accel_mod;
-		row.get_value(SHORTCUT_COLUMN_ID_ACTION_MODS, accel_mod);
+			std::string accel_path;
+			row.get_value(SHORTCUT_COLUMN_ID_ACTION_NAME, accel_path);
+			guint accel_key;
+			row.get_value(SHORTCUT_COLUMN_ID_ACTION_KEY, accel_key);
+			Gdk::ModifierType accel_mod;
+			row.get_value(SHORTCUT_COLUMN_ID_ACTION_MODS, accel_mod);
 
-		Gtk::AccelMap::change_entry(accel_path, accel_key, accel_mod, true);
+			Gtk::AccelMap::change_entry(accel_path, accel_key, accel_mod, true);
+		}
 	}
 
 	App::save_settings();
@@ -1232,15 +1271,22 @@ Dialog_Setup::refresh()
 
 	// Refresh keyboard accels for actions
 	auto accel_rows = treeview_accels->get_model()->children();
-	for (auto& row : accel_rows) {
-		Gtk::AccelKey accel;
+	for (auto& section_row : accel_rows) {
+		for (auto& row : section_row.children()) {
+			Gtk::AccelKey accel;
 
-		std::string accel_path;
-		row.get_value(SHORTCUT_COLUMN_ID_ACTION_NAME, accel_path);
+			bool is_action;
+			row.get_value(SHORTCUT_COLUMN_ID_IS_ACTION, is_action);
+			if (!is_action)
+				continue;
 
-		if (Gtk::AccelMap::lookup_entry(accel_path, accel)) {
-			row.set_value(SHORTCUT_COLUMN_ID_ACTION_KEY, accel.get_key());
-			row.set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, accel.get_mod());
+			std::string accel_path;
+			row.get_value(SHORTCUT_COLUMN_ID_ACTION_NAME, accel_path);
+
+			if (Gtk::AccelMap::lookup_entry(accel_path, accel)) {
+				row.set_value(SHORTCUT_COLUMN_ID_ACTION_KEY, accel.get_key());
+				row.set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, accel.get_mod());
+			}
 		}
 	}
 

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -550,6 +550,35 @@ Dialog_Setup::create_shortcuts_page(Dialog_Template::PageInfo pi)
 void
 Dialog_Setup::on_accel_edited(const Glib::ustring& path_string, guint accel_key, Gdk::ModifierType accel_mods, guint hardware_keycode)
 {
+	Gtk::TreeIter problematic_iter;
+	treeview_accels->get_model()->foreach_iter([accel_key, accel_mods, &problematic_iter] (const Gtk::TreeModel::iterator& iter) -> bool {
+		guint row_accel_key;
+		Gdk::ModifierType row_accel_mods;
+		(*iter).get_value(SHORTCUT_COLUMN_ID_ACTION_KEY, row_accel_key);
+		(*iter).get_value(SHORTCUT_COLUMN_ID_ACTION_MODS, row_accel_mods);
+
+		if (accel_key == row_accel_key && accel_mods == row_accel_mods) {
+			problematic_iter = iter;
+			return true;
+		}
+
+		return false;
+	});
+
+	if (problematic_iter && treeview_accels->get_model()->get_path(problematic_iter).to_string() != path_string) {
+		std::string accel_path;
+		problematic_iter->get_value(SHORTCUT_COLUMN_ID_ACTION_NAME, accel_path);
+
+		std::string message = _("This shortcut is already set for\n\t%s\n\nAre you sure? It will unset for previously bound action.");
+		message = etl::strprintf(message.c_str(), accel_path.c_str());
+		bool accepted = App::dialog_message_2b(_("Shortcut In Use"), message, Gtk::MESSAGE_QUESTION, _("Cancel"), _("OK"));
+		if (!accepted)
+			return;
+
+		problematic_iter->set_value(SHORTCUT_COLUMN_ID_ACTION_KEY, 0);
+		problematic_iter->set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, Gdk::ModifierType(0));
+	}
+
 	auto iter = treeview_accels->get_model()->get_iter(path_string);
 	iter->set_value(SHORTCUT_COLUMN_ID_ACTION_KEY, accel_key);
 	iter->set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, accel_mods);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -545,6 +545,10 @@ Dialog_Setup::create_shortcuts_page(Dialog_Template::PageInfo pi)
 	scroll->add(*treeview_accels);
 
 	pi.grid->attach(*scroll, 0, row++, 1, 1);
+
+	Gtk::Button *restore_default_accels = manage(new Gtk::Button(_("Restore default shortcuts")));
+	restore_default_accels->signal_clicked().connect(sigc::mem_fun(*this, &Dialog_Setup::on_restore_default_accels_pressed));
+	pi.grid->attach(*restore_default_accels, 0, row++, 1, 1);
 }
 
 void
@@ -584,11 +588,42 @@ Dialog_Setup::on_accel_edited(const Glib::ustring& path_string, guint accel_key,
 	iter->set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, accel_mods);
 }
 
-void Dialog_Setup::on_accel_cleared(const Glib::ustring& path_string)
+void
+Dialog_Setup::on_accel_cleared(const Glib::ustring& path_string)
 {
 	auto iter = treeview_accels->get_model()->get_iter(path_string);
 	iter->set_value(SHORTCUT_COLUMN_ID_ACTION_KEY, 0);
 	iter->set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, Gdk::ModifierType(0));
+}
+
+void
+Dialog_Setup::on_restore_default_accels_pressed()
+{
+	std::string message = _("Do you really want to restore the default shortcuts?");
+	bool accepted = App::dialog_message_2b(_("Restore Default Shortcuts"), message, Gtk::MESSAGE_QUESTION, _("Cancel"), _("OK"));
+	if (!accepted)
+		return;
+
+	auto accel_rows = treeview_accels->get_model()->children();
+	auto default_accel_map = App::get_default_accel_map();
+	for (const auto& section_row : accel_rows) {
+		for (auto& row : section_row.children()) {
+			Gtk::AccelKey accel;
+
+			std::string accel_path;
+			row.get_value(SHORTCUT_COLUMN_ID_ACTION_NAME, accel_path);
+
+			for (auto it = default_accel_map.begin(); it != default_accel_map.end(); ++it) {
+				if (it->second == accel_path) {
+					accel = Gtk::AccelKey(it->first);
+					break;
+				}
+			}
+
+			row.set_value(SHORTCUT_COLUMN_ID_ACTION_KEY, accel.get_key());
+			row.set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, accel.get_mod());
+		}
+	}
 }
 
 void
@@ -1315,6 +1350,9 @@ Dialog_Setup::refresh()
 			if (Gtk::AccelMap::lookup_entry(accel_path, accel)) {
 				row.set_value(SHORTCUT_COLUMN_ID_ACTION_KEY, accel.get_key());
 				row.set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, accel.get_mod());
+			} else {
+				row.set_value(SHORTCUT_COLUMN_ID_ACTION_KEY, 0);
+				row.set_value(SHORTCUT_COLUMN_ID_ACTION_MODS, Gdk::ModifierType(0));
 			}
 		}
 	}

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -191,6 +191,7 @@ class Dialog_Setup : public Dialog_Template
 
 	void on_accel_edited(const Glib::ustring& path_string, guint accel_key, Gdk::ModifierType accel_mods, guint hardware_keycode);
 	void on_accel_cleared(const Glib::ustring& path_string);
+	void on_restore_default_accels_pressed();
 public:
 	/*
  -- ** -- S I G N A L S -------------------------------------------------------


### PR DESCRIPTION
- It visually separates actions in sections (TreeView)
- Actions and sections sorted alphabetically
- It warns about user trying to bind an already-in-use shortcut
- It features a button to Restore Default Accels only (instead of resetting all Synfig Studio settings) and asks for user confirmation before restoration

![Captura de tela de 2021-05-31 09-12-35](https://user-images.githubusercontent.com/1323987/120280735-717b9080-c28e-11eb-80de-d3606cdb02c0.png)
