### PR TITLE
[Synfig Studio] Fixed closed docks bug

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1702,7 +1702,6 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 		dock_manager->show_all_dock_dialogs();
 
 		main_window->present();
-		dock_toolbox->present();
 
 		splash_screen.hide();
 

--- a/synfig-studio/src/gui/docks/dock_canvases.cpp
+++ b/synfig-studio/src/gui/docks/dock_canvases.cpp
@@ -211,9 +211,6 @@ Dock_Canvases::new_instance(etl::handle<studio::Instance> instance)
 			loose_instance
 		)
 	);
-
-	present();
-
 }
 
 void


### PR DESCRIPTION
* Removed explicit dock_toolbox->present()

If user explicitly undocks and closes this dock don't hesitate to keep
it hidden and let user load the dock manually from the menu bar instead
of forcing the dock as dialog

* Removed explicit present() in Dock_Canvases new_instance()

Explicitly calling present() was causing a bug where every new canvas
instance would force this dock (Canvases) to be shown as a dialog even 
though it was undocked and closed/hidden by the user.

Fixes #1803 