### PR TITLE
Replaced `Gtk::Alignment` spaces with CSS margins

### DIFF
--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -81,3 +81,11 @@
 	margin-top   : 6px;
 	margin-bottom: 0px;
 }
+
+#gap {
+	margin-end : 3px;
+}
+
+#indentation{
+	margin-start : 6px;
+}

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -82,10 +82,10 @@
 	margin-bottom: 0px;
 }
 
-#gap {
+.gap {
 	margin-right : 3px;
 }
 
-#indentation{
+.indentation{
 	margin-left : 6px;
 }

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -83,9 +83,9 @@
 }
 
 #gap {
-	margin-end : 3px;
+	margin-right : 3px;
 }
 
 #indentation{
-	margin-start : 6px;
+	margin-left : 6px;
 }

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -84,7 +84,6 @@ using namespace studio;
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -504,7 +503,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -523,7 +522,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	layer_region_togglebutton.set_name("indentation");
+	layer_region_togglebutton.get_style_context()->add_class("indentation");
 
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
@@ -534,7 +533,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_name("gap");
+	blend_label.get_style_context()->add_class("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -504,7 +504,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_margin_end(GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -523,7 +523,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	layer_region_togglebutton.set_margin_start(INDENTATION);
+	layer_region_togglebutton.set_name("indentation");
 
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
@@ -534,7 +534,7 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_margin_end(GAP);
+	blend_label.set_name("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -33,7 +33,6 @@
 
 #include <gui/states/state_bline.h>
 
-#include <gtkmm/alignment.h>
 #include <gtkmm/imagemenuitem.h>
 #include <gtkmm/separatormenuitem.h>
 
@@ -82,13 +81,6 @@ using namespace studio;
 	button.set_tooltip_text(tooltip) ;\
 	button.signal_toggled().connect(sigc::mem_fun(*this, \
 		&studio::StateBLine_Context::toggle_layer_creation))
-#endif
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
 #endif
 
 const int GAP = 3;
@@ -512,9 +504,8 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(id_gap, GAP);
+	id_label.set_margin_end(GAP);
 	id_box.pack_start(id_label, false, false, 0);
-	id_box.pack_start(*id_gap, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
@@ -532,9 +523,8 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	SPACING(layer_types_indent, INDENTATION);
+	layer_region_togglebutton.set_margin_start(INDENTATION);
 
-	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_advanced_outline_togglebutton, false, false, 0);
@@ -544,9 +534,8 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(blend_gap, GAP);
+	blend_label.set_margin_end(GAP);
 	blend_box.pack_start(blend_label, false, false, 0);
-	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -31,7 +31,6 @@
 
 #include <gui/states/state_bone.h>
 
-#include <gtkmm/alignment.h>
 #include <gtkmm/radiobutton.h>
 #include <gtkmm/separatormenuitem.h>
 
@@ -65,13 +64,6 @@ using namespace synfig;
 using namespace synfigapp;
 
 /* === M A C R O S ========================================================= */
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
-#endif
 
 #define GAP	(3)
 #define DEFAULT_WIDTH (0.1)

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -83,7 +83,6 @@ enum CircleFalloff
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -525,7 +524,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -546,7 +545,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	layer_circle_togglebutton.set_name("indentation");
+	layer_circle_togglebutton.get_style_context()->add_class("indentation");
 
 	layer_types_box.pack_start(layer_circle_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
@@ -558,7 +557,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_name("gap");
+	blend_label.get_style_context()->add_class("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -594,7 +593,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	bline_point_angle_offset_label.set_sensitive(false);
 	bline_point_angle_offset_spin.set_sensitive(false);
 
-	bline_point_angle_offset_label.set_name("indentation");
+	bline_point_angle_offset_label.get_style_context()->add_class("indentation");
 	bline_point_angle_offset_box.pack_start(bline_point_angle_offset_label, false, false, 0);
 
 	invert_label.set_label(_("Invert"));
@@ -618,7 +617,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	falloff_label.set_halign(Gtk::ALIGN_START);
 	falloff_label.set_valign(Gtk::ALIGN_CENTER);
 	falloff_label.set_sensitive(false);
-	falloff_label.set_name("indentation");
+	falloff_label.get_style_context()->add_class("indentation");
 	falloff_box.pack_start(falloff_label, false, false, 0);
 
 	falloff_enum.set_param_desc(ParamDesc("falloff")

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -82,13 +82,6 @@ enum CircleFalloff
 		&studio::StateCircle_Context::toggle_layer_creation))
 #endif
 
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
-#endif
-
 const int GAP = 3;
 const int INDENTATION = 6;
 
@@ -532,9 +525,8 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(id_gap, GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, false, false, 0);
-	id_box.pack_start(*id_gap, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
@@ -554,9 +546,8 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	SPACING(layer_types_indent, INDENTATION);
+	layer_circle_togglebutton.set_name("indentation");
 
-	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
 	layer_types_box.pack_start(layer_circle_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
@@ -567,9 +558,8 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(blend_gap, GAP);
+	blend_label.set_name("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
-	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -604,8 +594,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	bline_point_angle_offset_label.set_sensitive(false);
 	bline_point_angle_offset_spin.set_sensitive(false);
 
-	SPACING(bline_point_angle_offset_indent, INDENTATION);
-	bline_point_angle_offset_box.pack_start(*bline_point_angle_offset_indent, false, false, 0);
+	bline_point_angle_offset_label.set_name("indentation");
 	bline_point_angle_offset_box.pack_start(bline_point_angle_offset_label, false, false, 0);
 
 	invert_label.set_label(_("Invert"));
@@ -629,8 +618,7 @@ StateCircle_Context::StateCircle_Context(CanvasView* canvas_view):
 	falloff_label.set_halign(Gtk::ALIGN_START);
 	falloff_label.set_valign(Gtk::ALIGN_CENTER);
 	falloff_label.set_sensitive(false);
-	SPACING(falloff_indent, INDENTATION);
-	falloff_box.pack_start(*falloff_indent, false, false, 0);
+	falloff_label.set_name("indentation");
 	falloff_box.pack_start(falloff_label, false, false, 0);
 
 	falloff_enum.set_param_desc(ParamDesc("falloff")

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -82,7 +82,6 @@ using namespace studio;
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -609,7 +608,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -624,7 +623,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_advanced_outline_togglebutton,
 		("synfig-layer_geometry_advanced_outline"), _("Create an advanced outline layer"));
 
-	layer_region_togglebutton.set_name("indentation");
+	layer_region_togglebutton.get_style_context()->add_class("indentation");
 
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
@@ -633,7 +632,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_name("gap");
+	blend_label.get_style_context()->add_class("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
@@ -662,8 +661,8 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	pressure_width_box.pack_start(pressure_width_label, true, true, 0);
 	pressure_width_box.pack_start(pressure_width_checkbutton, false, false, 0);
 
-	min_pressure_label.set_name("indentation");
-	min_pressure_spin.set_name("gap");
+	min_pressure_label.get_style_context()->add_class("indentation");
+	min_pressure_spin.get_style_context()->add_class("gap");
 
 	min_pressure_label.set_label(_("Min Width:"));
 	min_pressure_label.set_halign(Gtk::ALIGN_START);
@@ -677,11 +676,11 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	smoothness_label.set_halign(Gtk::ALIGN_START);
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
-	localthres_radiobutton.set_name("indentation");
+	localthres_radiobutton.get_style_context()->add_class("indentation");
 	localthres_box.pack_start(localthres_radiobutton, false, false, 0);
 	localthres_radiobutton.set_label(_("Local:"));
 
-	globalthres_radiobutton.set_name("indentation");
+	globalthres_radiobutton.get_style_context()->add_class("indentation");
 	globalthres_box.pack_start(globalthres_radiobutton, false, false, 0);
 	globalthres_radiobutton.set_label(_("Global:"));
 
@@ -689,7 +688,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	globalthres_radiobutton.set_group(smoothness_group);
 
 	width_max_error_label.set_label(_("Width Max Error:"));
-	width_max_error_label.set_name("gap");
+	width_max_error_label.get_style_context()->add_class("gap");
 	width_max_error_label.set_halign(Gtk::ALIGN_START);
 	width_max_error_label.set_valign(Gtk::ALIGN_CENTER);
 	width_max_error_box.pack_start(width_max_error_label, false, false, 0);

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -34,7 +34,6 @@
 
 #include <gui/states/state_draw.h>
 
-#include <gtkmm/alignment.h>
 #include <gtkmm/radiobutton.h>
 
 #include <gui/app.h>
@@ -80,13 +79,6 @@ using namespace studio;
 	button.set_tooltip_text(tooltip); \
 	button.signal_toggled().connect(sigc::mem_fun(*this, \
 		&studio::StateDraw_Context::toggle_layer_creation))
-#endif
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
 #endif
 
 const int GAP = 3;
@@ -617,9 +609,8 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(id_gap, GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, false, false, 0);
-	id_box.pack_start(*id_gap, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
@@ -633,9 +624,8 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_advanced_outline_togglebutton,
 		("synfig-layer_geometry_advanced_outline"), _("Create an advanced outline layer"));
 
-	SPACING(layer_types_indent, INDENTATION);
+	layer_region_togglebutton.set_name("indentation");
 
-	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_advanced_outline_togglebutton, false, false, 0);
@@ -643,9 +633,8 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(blend_gap, GAP);
+	blend_label.set_name("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
-	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))
@@ -673,29 +662,26 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	pressure_width_box.pack_start(pressure_width_label, true, true, 0);
 	pressure_width_box.pack_start(pressure_width_checkbutton, false, false, 0);
 
-	SPACING(min_pressure_indent, INDENTATION);
-	SPACING(min_pressure_gap, GAP);
+	min_pressure_label.set_name("indentation");
+	min_pressure_spin.set_name("gap");
+
 	min_pressure_label.set_label(_("Min Width:"));
 	min_pressure_label.set_halign(Gtk::ALIGN_START);
 	min_pressure_label.set_valign(Gtk::ALIGN_CENTER);
-	min_pressure_label_box.pack_start(*min_pressure_indent, false, false, 0);
 	min_pressure_label_box.pack_start(min_pressure_label, false, false, 0);
 
 	min_pressure_box.pack_start(min_pressure_spin, true, true, 0);
-	min_pressure_box.pack_start(*min_pressure_gap, false, false, 0);
 	min_pressure_box.pack_start(min_pressure_checkbutton, false, false, 0);
 
 	smoothness_label.set_label(_("Smoothness"));
 	smoothness_label.set_halign(Gtk::ALIGN_START);
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
-	SPACING(localthres_indent, INDENTATION);
-	localthres_box.pack_start(*localthres_indent, false, false, 0);
+	localthres_radiobutton.set_name("indentation");
 	localthres_box.pack_start(localthres_radiobutton, false, false, 0);
 	localthres_radiobutton.set_label(_("Local:"));
 
-	SPACING(globalthres_indent, INDENTATION);
-	globalthres_box.pack_start(*globalthres_indent, false, false, 0);
+	globalthres_radiobutton.set_name("indentation");
 	globalthres_box.pack_start(globalthres_radiobutton, false, false, 0);
 	globalthres_radiobutton.set_label(_("Global:"));
 
@@ -703,11 +689,10 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	globalthres_radiobutton.set_group(smoothness_group);
 
 	width_max_error_label.set_label(_("Width Max Error:"));
-	SPACING(width_max_error_gap, GAP);
+	width_max_error_label.set_name("gap");
 	width_max_error_label.set_halign(Gtk::ALIGN_START);
 	width_max_error_label.set_valign(Gtk::ALIGN_CENTER);
 	width_max_error_box.pack_start(width_max_error_label, false, false, 0);
-	width_max_error_box.pack_start(*width_max_error_gap, false, false, 0);
 
 	round_ends_label.set_label(_("Round Ends"));
 	round_ends_label.set_halign(Gtk::ALIGN_START);

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -33,8 +33,6 @@
 
 #include <gui/states/state_gradient.h>
 
-#include <gtkmm/alignment.h>
-
 #include <gui/app.h>
 #include <gui/canvasview.h>
 #include <gui/docks/dialog_tooloptions.h>
@@ -70,13 +68,6 @@ using namespace studio;
 	button.set_tooltip_text(tooltip); \
 	button.signal_toggled().connect(sigc::mem_fun(*this, \
 		&studio::StateGradient_Context::fun))
-#endif
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
 #endif
 
 const int GAP = 3;
@@ -395,9 +386,8 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(name_gap, GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, false, false, 0);
-	id_box.pack_start(*name_gap, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
@@ -413,8 +403,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_spiral_gradient_togglebutton, toggle_layer_spiral_gradient,
 		("synfig-layer_gradient_spiral"), _("Create a spiral gradient"));
 
-	SPACING(layer_types_indent, INDENTATION);
-	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_linear_gradient_togglebutton.set_name("indentation");
 	layer_types_box.pack_start(layer_linear_gradient_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_radial_gradient_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_conical_gradient_togglebutton, false, false, 0);
@@ -423,10 +412,9 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(blend_gap, GAP);
+	blend_label.set_name("gap");
 
 	blend_box.pack_start(blend_label, false, false, 0);
-	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -71,7 +71,6 @@ using namespace studio;
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -386,7 +385,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -403,7 +402,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_spiral_gradient_togglebutton, toggle_layer_spiral_gradient,
 		("synfig-layer_gradient_spiral"), _("Create a spiral gradient"));
 
-	layer_linear_gradient_togglebutton.set_name("indentation");
+	layer_linear_gradient_togglebutton.get_style_context()->add_class("indentation");
 	layer_types_box.pack_start(layer_linear_gradient_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_radial_gradient_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_conical_gradient_togglebutton, false, false, 0);
@@ -412,7 +411,7 @@ StateGradient_Context::StateGradient_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_name("gap");
+	blend_label.get_style_context()->add_class("gap");
 
 	blend_box.pack_start(blend_label, false, false, 0);
 

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -81,7 +81,6 @@ using namespace studio;
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -603,7 +602,7 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 
 	id_label.set_label(_("Name:"));
 	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
@@ -614,7 +613,7 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_region_togglebutton,
 		("synfig-layer_geometry_region"), _("Create a region layer"));
 
-	layer_region_togglebutton.set_name("indentation");
+	layer_region_togglebutton.get_style_context()->add_class("indentation");
 	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
 	//layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
 	//layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
@@ -638,8 +637,8 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	pressure_width_box.pack_start(pressure_width_label, Gtk::PACK_SHRINK);
 	pressure_width_box.pack_end(pressure_width_checkbutton, Gtk::PACK_SHRINK);
 
-	min_pressure_label.set_name("indentation");
-	min_pressure_checkbutton.set_name("gap");
+	min_pressure_label.get_style_context()->add_class("indentation");
+	min_pressure_checkbutton.get_style_context()->add_class("gap");
 	min_pressure_label.set_label(_("Min Width:"));
 	min_pressure_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 	min_pressure_label_box.pack_start(min_pressure_label, Gtk::PACK_SHRINK);
@@ -651,11 +650,11 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	smoothness_label.set_halign(Gtk::ALIGN_START);
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
-	localthres_radiobutton.set_name("indentation");
+	localthres_radiobutton.get_style_context()->add_class("indentation");
 	localthres_box.pack_start(localthres_radiobutton, false, false, 0);
 	localthres_radiobutton.set_label("Local:");
 
-	globalthres_radiobutton.set_name("indentation");
+	globalthres_radiobutton.get_style_context()->add_class("indentation");
 	globalthres_box.pack_start(globalthres_radiobutton, false, false, 0);
 	globalthres_radiobutton.set_label("Global:");
 
@@ -663,7 +662,7 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	globalthres_radiobutton.set_group(smoothness_group);
 
 	width_max_error_label.set_label(_("Width Max Error:"));
-	width_max_error_label.set_name("gap");
+	width_max_error_label.get_style_context()->add_class("gap");
 	width_max_error_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 	width_max_error_box.pack_start(width_max_error_label, Gtk::PACK_SHRINK);
 

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -34,8 +34,6 @@
 
 #include <gui/states/state_lasso.h>
 
-#include <gtkmm/alignment.h>
-
 #include <gtkmm/radiobutton.h>
 
 #include <synfig/general.h>
@@ -80,13 +78,6 @@ using namespace studio;
 	button.set_tooltip_text(tooltip); \
 	button.signal_toggled().connect(sigc::mem_fun(*this, \
 		&studio::StateLasso_Context::toggle_layer_creation))
-#endif
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
 #endif
 
 const int GAP = 3;
@@ -612,9 +603,8 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 
 	id_label.set_label(_("Name:"));
 	id_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-	SPACING(id_gap, GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, Gtk::PACK_SHRINK);
-	id_box.pack_start(*id_gap, Gtk::PACK_SHRINK);
 
 	id_box.pack_start(id_entry);
 
@@ -624,15 +614,10 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_region_togglebutton,
 		("synfig-layer_geometry_region"), _("Create a region layer"));
 
-	
-	SPACING(layer_types_indent, INDENTATION);
-
-	layer_types_box.pack_start(*layer_types_indent, Gtk::PACK_SHRINK);
+	layer_region_togglebutton.set_name("indentation");
 	layer_types_box.pack_start(layer_region_togglebutton, Gtk::PACK_SHRINK);
 	//layer_types_box.pack_start(layer_outline_togglebutton, Gtk::PACK_SHRINK);
 	//layer_types_box.pack_start(layer_advanced_outline_togglebutton, Gtk::PACK_SHRINK);
-
-	SPACING(blend_gap, GAP);
 	
 	opacity_label.set_label(_("Opacity:"));
 	opacity_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
@@ -653,28 +638,24 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	pressure_width_box.pack_start(pressure_width_label, Gtk::PACK_SHRINK);
 	pressure_width_box.pack_end(pressure_width_checkbutton, Gtk::PACK_SHRINK);
 
-	SPACING(min_pressure_indent, INDENTATION);
-	SPACING(min_pressure_gap, GAP);
+	min_pressure_label.set_name("indentation");
+	min_pressure_checkbutton.set_name("gap");
 	min_pressure_label.set_label(_("Min Width:"));
 	min_pressure_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
-	min_pressure_label_box.pack_start(*min_pressure_indent, Gtk::PACK_SHRINK);
 	min_pressure_label_box.pack_start(min_pressure_label, Gtk::PACK_SHRINK);
 
 	min_pressure_box.pack_end(min_pressure_checkbutton, Gtk::PACK_SHRINK);
-	min_pressure_box.pack_end(*min_pressure_gap, Gtk::PACK_SHRINK);
 	min_pressure_box.pack_end(min_pressure_spin);
 
 	smoothness_label.set_label(_("Smoothness"));
 	smoothness_label.set_halign(Gtk::ALIGN_START);
 	smoothness_label.set_valign(Gtk::ALIGN_CENTER);
 
-	SPACING(localthres_indent, INDENTATION);
-	localthres_box.pack_start(*localthres_indent, false, false, 0);
+	localthres_radiobutton.set_name("indentation");
 	localthres_box.pack_start(localthres_radiobutton, false, false, 0);
 	localthres_radiobutton.set_label("Local:");
 
-	SPACING(globalthres_indent, INDENTATION);
-	globalthres_box.pack_start(*globalthres_indent, false, false, 0);
+	globalthres_radiobutton.set_name("indentation");
 	globalthres_box.pack_start(globalthres_radiobutton, false, false, 0);
 	globalthres_radiobutton.set_label("Global:");
 
@@ -682,10 +663,9 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	globalthres_radiobutton.set_group(smoothness_group);
 
 	width_max_error_label.set_label(_("Width Max Error:"));
-	SPACING(width_max_error_gap, GAP);
+	width_max_error_label.set_name("gap");
 	width_max_error_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 	width_max_error_box.pack_start(width_max_error_label, Gtk::PACK_SHRINK);
-	width_max_error_box.pack_start(*width_max_error_gap, Gtk::PACK_SHRINK);
 
 	round_ends_label.set_label(_("Round Ends"));
 	round_ends_label.set_alignment(Gtk::ALIGN_START, Gtk::ALIGN_CENTER);

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -458,7 +458,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_margin_end(GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -479,7 +479,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	layer_polygon_togglebutton.set_margin_start(INDENTATION);
+	layer_polygon_togglebutton.set_name("indentation");
 
 	layer_types_box.pack_start(layer_polygon_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
@@ -491,7 +491,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_margin_end(GAP);
+	blend_label.set_name("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -33,8 +33,6 @@
 
 #include <gui/states/state_polygon.h>
 
-#include <gtkmm/alignment.h>
-
 #include <gui/app.h>
 #include <gui/canvasview.h>
 #include <gui/docks/dialog_tooloptions.h>
@@ -75,13 +73,6 @@ using namespace studio;
 	button.set_tooltip_text(tooltip) ;\
 	button.signal_toggled().connect(sigc::mem_fun(*this, \
 		&studio::StatePolygon_Context::toggle_layer_creation))
-#endif
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
 #endif
 
 const int GAP = 3;
@@ -467,9 +458,8 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(id_gap, GAP);
+	id_label.set_margin_end(GAP);
 	id_box.pack_start(id_label, false, false, 0);
-	id_box.pack_start(*id_gap, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
@@ -489,8 +479,8 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	SPACING(layer_types_indent, INDENTATION);
-	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_polygon_togglebutton.set_margin_start(INDENTATION);
+
 	layer_types_box.pack_start(layer_polygon_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
@@ -501,9 +491,8 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(blend_gap, GAP);
+	blend_label.set_margin_end(GAP);
 	blend_box.pack_start(blend_label, false, false, 0);
-	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -76,7 +76,6 @@ using namespace studio;
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -458,7 +457,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -479,7 +478,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	layer_polygon_togglebutton.set_name("indentation");
+	layer_polygon_togglebutton.get_style_context()->add_class("indentation");
 
 	layer_types_box.pack_start(layer_polygon_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
@@ -491,7 +490,7 @@ StatePolygon_Context::StatePolygon_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_name("gap");
+	blend_label.get_style_context()->add_class("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -33,7 +33,6 @@
 
 #include <gui/states/state_rectangle.h>
 
-#include <gtkmm/alignment.h>
 
 #include <gui/app.h>
 #include <gui/canvasview.h>
@@ -74,13 +73,6 @@ using namespace studio;
 	button.set_tooltip_text(tooltip); \
 	button.signal_toggled().connect(sigc::mem_fun(*this, \
 		&studio::StateRectangle_Context::toggle_layer_creation))
-#endif
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
 #endif
 
 const int GAP = 3;
@@ -484,9 +476,8 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(id_gap, GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, false, false, 0);
-	id_box.pack_start(*id_gap, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
@@ -506,9 +497,8 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	SPACING(layer_types_indent, INDENTATION);
+	layer_rectangle_togglebutton.set_name("indentation");
 
-	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
 	layer_types_box.pack_start(layer_rectangle_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
@@ -519,9 +509,8 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(blend_gap, GAP);
+	blend_label.set_name("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
-	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -76,7 +76,6 @@ using namespace studio;
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -476,7 +475,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -497,7 +496,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	layer_rectangle_togglebutton.set_name("indentation");
+	layer_rectangle_togglebutton.get_style_context()->add_class("indentation");
 
 	layer_types_box.pack_start(layer_rectangle_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
@@ -509,7 +508,7 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_name("gap");
+	blend_label.get_style_context()->add_class("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -75,7 +75,6 @@ using namespace studio;
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -589,7 +588,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -610,7 +609,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	layer_star_togglebutton.set_name("indentation");
+	layer_star_togglebutton.get_style_context()->add_class("indentation");
 	layer_types_box.pack_start(layer_star_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
@@ -621,7 +620,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_name("gap");
+	blend_label.get_style_context()->add_class("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -33,8 +33,6 @@
 
 #include <gui/states/state_star.h>
 
-#include <gtkmm/alignment.h>
-
 #include <gui/app.h>
 #include <gui/canvasview.h>
 #include <gui/docks/dialog_tooloptions.h>
@@ -74,13 +72,6 @@ using namespace studio;
 	button.set_tooltip_text(tooltip) ;\
 	button.signal_toggled().connect(sigc::mem_fun(*this, \
 		&studio::StateStar_Context::toggle_layer_creation))
-#endif
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
 #endif
 
 const int GAP = 3;
@@ -598,9 +589,8 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(id_gap, GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, false, false, 0);
-	id_box.pack_start(*id_gap, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
@@ -620,9 +610,7 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	LAYER_CREATION(layer_curve_gradient_togglebutton,
 		("synfig-layer_gradient_curve"), _("Create a gradient layer"));
 
-	SPACING(layer_types_indent, INDENTATION);
-
-	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_star_togglebutton.set_name("indentation");
 	layer_types_box.pack_start(layer_star_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_region_togglebutton, false, false, 0);
 	layer_types_box.pack_start(layer_outline_togglebutton, false, false, 0);
@@ -633,9 +621,8 @@ StateStar_Context::StateStar_Context(CanvasView* canvas_view):
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(blend_gap, GAP);
+	blend_label.set_name("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
-	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -33,8 +33,6 @@
 
 #include "state_text.h"
 
-#include <gtkmm/alignment.h>
-
 #include <gui/app.h>
 #include <gui/canvasview.h>
 #include <gui/docks/dock_toolbox.h>
@@ -72,13 +70,6 @@ using namespace studio;
 	button.set_tooltip_text(tooltip); \
 	button.signal_toggled().connect(sigc::mem_fun(*this, \
 		&studio::StateText_Context::toggle_layer_creation))
-#endif
-
-// indentation for options layout
-#ifndef SPACING
-#define SPACING(name, px) \
-	Gtk::Alignment *name = Gtk::manage(new Gtk::Alignment()); \
-	name->set_size_request(px)
 #endif
 
 const int GAP = 3;
@@ -391,9 +382,8 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(id_gap, GAP);
+	id_label.set_name("gap");
 	id_box.pack_start(id_label, false, false, 0);
-	id_box.pack_start(*id_gap, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
 	layer_types_label.set_label(_("Layer Type:"));
@@ -403,17 +393,14 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	LAYER_CREATION(layer_text_togglebutton,
 		("synfig-layer_other_text"), _("Create a text layer"));
 
-	SPACING(layer_types_indent, INDENTATION);
-
-	layer_types_box.pack_start(*layer_types_indent, false, false, 0);
+	layer_text_togglebutton.set_name("indentation");
 	layer_types_box.pack_start(layer_text_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	SPACING(blend_gap, GAP);
+	blend_label.set_name("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
-	blend_box.pack_start(*blend_gap, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")
 		.set_local_name(_("Blend Method"))

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -73,7 +73,6 @@ using namespace studio;
 #endif
 
 const int GAP = 3;
-const int INDENTATION = 6;
 
 /* === G L O B A L S ======================================================= */
 
@@ -382,7 +381,7 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	id_label.set_label(_("Name:"));
 	id_label.set_halign(Gtk::ALIGN_START);
 	id_label.set_valign(Gtk::ALIGN_CENTER);
-	id_label.set_name("gap");
+	id_label.get_style_context()->add_class("gap");
 	id_box.pack_start(id_label, false, false, 0);
 	id_box.pack_start(id_entry, true, true, 0);
 
@@ -393,13 +392,13 @@ StateText_Context::StateText_Context(CanvasView *canvasView):
 	LAYER_CREATION(layer_text_togglebutton,
 		("synfig-layer_other_text"), _("Create a text layer"));
 
-	layer_text_togglebutton.set_name("indentation");
+	layer_text_togglebutton.get_style_context()->add_class("indentation");
 	layer_types_box.pack_start(layer_text_togglebutton, false, false, 0);
 
 	blend_label.set_label(_("Blend Method:"));
 	blend_label.set_halign(Gtk::ALIGN_START);
 	blend_label.set_valign(Gtk::ALIGN_CENTER);
-	blend_label.set_name("gap");
+	blend_label.get_style_context()->add_class("gap");
 	blend_box.pack_start(blend_label, false, false, 0);
 
 	blend_enum.set_param_desc(ParamDesc(Color::BLEND_COMPOSITE,"blend_method")


### PR DESCRIPTION
@ice0 @Keyikedalube @rodolforg 

This PR is meant for removal of SPACES that are added with the help of  ``` alignment.h ``` .