### PR TITLE
Clean synfigapp::ValueDesc a bit

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
@@ -347,13 +347,9 @@ Action::ValueDescLink::prepare()
 					link_is_scaled=true;
 		}
 
-	std::list<ValueDesc>::iterator iter;
-
 	//Now let's loop through all the value desc
-	for(iter=value_desc_list.begin();iter!=value_desc_list.end();++iter)
+	for(const ValueDesc& value_desc : value_desc_list)
 	{
-		ValueDesc& value_desc(*iter);
-
 		// only one of the selected items can be exported - that's the one we're linking to
 		// don't link it to itself
 		if (value_desc.is_exported())
@@ -373,7 +369,7 @@ Action::ValueDescLink::prepare()
 			if(!link_is_scaled)
 			{
 				//Let's create a Scale Value Node
-				synfig::ValueNode::Handle scale_value_node=synfig::ValueNodeRegistry::create("scale",iter->get_value(time));
+				synfig::ValueNode::Handle scale_value_node=synfig::ValueNodeRegistry::create("scale",value_desc.get_value(time));
 				if(!scale_value_node)
 					throw Error(Error::TYPE_BUG);
 				scale_value_node->set_parent_canvas(get_canvas());

--- a/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
@@ -78,7 +78,7 @@ ACTION_SET_VERSION(Action::ValueDescLinkOpposite,"0.0");
 /* === M E T H O D S ======================================================= */
 
 Action::ValueDescLink::ValueDescLink():
-poison(false), status_level(0), link_scalar(0.0), link_opposite(false)
+poison(false), status_level(0), link_opposite(false)
 {
 }
 
@@ -168,7 +168,6 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 			}
 
 			link_value_node=value_desc.get_value_node();
-			link_scalar=1.0;
 			status_message = _("Used exported ValueNode ('") + link_value_node->get_id() + _("').");
 		}
 		else if(value_desc.is_value_node())
@@ -178,7 +177,6 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 				status_level = 1;
 				status_message = _("Using the only available ValueNode.");
 				link_value_node=value_desc.get_value_node();
-				link_scalar=1.0;
 			}
 			else if(link_value_node->is_exported())
 			{
@@ -192,7 +190,6 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 					status_level = 2;
 					status_message = _("Using the most referenced ValueNode.");
 					link_value_node=value_desc.get_value_node();
-					link_scalar=1.0;
 				}
 				else if (status_level <= 2)
 				{
@@ -207,7 +204,6 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 				status_level = 3;
 				status_message = _("There's a tie for most referenced; using the animated ValueNode.");
 				link_value_node=value_desc.get_value_node();
-				link_scalar=1.0;
 			}
 			else if(ValueNode_Const::Handle::cast_dynamic(value_desc.get_value_node()) && !ValueNode_Const::Handle::cast_dynamic(link_value_node))
 			{
@@ -229,7 +225,6 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 					status_level = 4;
 					status_message = _("There's a tie for most referenced, and both are animated; using the one with the most waypoints.");
 					link_value_node=value_desc.get_value_node();
-					link_scalar=1.0;
 				}
 				else if (status_level <= 4)
 				{
@@ -249,7 +244,6 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 					status_level = 4;
 					status_message = _("There's a tie for most referenced, and both are linkable value node animated; using the one with the most waypoints.");
 					link_value_node=value_desc.get_value_node();
-					link_scalar=1.0;
 				}
 				else if (status_level <= 4)
 				{
@@ -265,7 +259,6 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 					status_level = 5;
 					status_message = _("Everything is tied; using the least recently modified value.");
 					link_value_node=value_desc.get_value_node();
-					link_scalar=1.0;
 				}
 				else if (status_level <= 5)
 				{
@@ -415,7 +408,7 @@ Action::ValueDescLink::prepare()
 			// value node to convert to scale -1.0 before connect.
 			// Check also if the link value node is NOT also a scale -1
 			// And check also if we are linking opposite
-			if( (value_desc.get_scalar()*link_scalar<0 || link_opposite) && (link_is_scaled==false))
+			if(link_opposite && !link_is_scaled)
 			{
 				//Let's create a Scale Value Node
 				synfig::ValueNode::Handle scale_value_node=synfig::ValueNodeRegistry::create("scale",iter->get_value(time));
@@ -464,7 +457,7 @@ Action::ValueDescLink::prepare()
 					throw Error(Error::TYPE_NOTREADY);
 				add_action_front(action3);
 			}
-			else if((iter->get_scalar()*link_scalar<0 || link_opposite) && (link_is_scaled==true))
+			else if(link_opposite && link_is_scaled)
 			{
 				//Let's connect the link value node -> link to the value node
 				// There is not needed conversion to scale of the value node

--- a/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
@@ -348,8 +348,7 @@ Action::ValueDescLink::prepare()
 		}
 
 	std::list<ValueDesc>::iterator iter;
-	bool found_inverse(false);
-	// found_inverse =  true only if all they are tangents and some are inversed tangents
+
 	//Now let's loop through all the value desc
 	for(iter=value_desc_list.begin();iter!=value_desc_list.end();++iter)
 	{
@@ -362,18 +361,16 @@ Action::ValueDescLink::prepare()
 		// Don't link the selected to itself (maybe it is redundant with the previous check)
 		if(value_desc.get_value_node() == link_value_node)
 			continue;
-		// found_inverse xor link_opposite
-		// If     found_inverse and not link_opposite then scale by -1 first (smart link)
-		// If     found inverse and     link_opposite then do a direct link instead
-		// If not found_inverse and not link_opposite then do a direct link instead
-		// If not found_inverse and     link_opposite then scale by -1 first (smart link)
-		if((found_inverse && !link_opposite) || (!found_inverse && link_opposite))
+
+		// If not link_opposite then do a direct link instead
+		// If link_opposite then scale by -1 first (smart link)
+		if(link_opposite)
 		{
 			//Check if the current value node has opposite scalar than the link
 			// value node to convert to scale -1.0 before connect.
 			// Check also if the link value node is NOT also a scale -1
 			// And check also if we are linking opposite
-			if(link_opposite && !link_is_scaled)
+			if(!link_is_scaled)
 			{
 				//Let's create a Scale Value Node
 				synfig::ValueNode::Handle scale_value_node=synfig::ValueNodeRegistry::create("scale",iter->get_value(time));
@@ -422,7 +419,7 @@ Action::ValueDescLink::prepare()
 					throw Error(Error::TYPE_NOTREADY);
 				add_action_front(action3);
 			}
-			else if(link_opposite && link_is_scaled)
+			else
 			{
 				//Let's connect the link value node -> link to the value node
 				// There is not needed conversion to scale of the value node
@@ -438,22 +435,6 @@ Action::ValueDescLink::prepare()
 				if(!action4->is_ready())
 					throw Error(Error::TYPE_NOTREADY);
 				add_action_front(action4);
-			}
-			else
-			{
-				//Let's connect the link value node to the value node
-				Action::Handle action(Action::create("ValueDescConnect"));
-
-				action->set_param("canvas",get_canvas());
-				action->set_param("canvas_interface",get_canvas_interface());
-				action->set_param("src",link_value_node);
-				action->set_param("dest",value_desc);
-
-				assert(action->is_ready());
-				if(!action->is_ready())
-					throw Error(Error::TYPE_NOTREADY);
-
-				add_action_front(action);
 			}
 		} // found inverse
 		else // Not found inverse so do a regular link

--- a/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
@@ -348,42 +348,7 @@ Action::ValueDescLink::prepare()
 		}
 
 	std::list<ValueDesc>::iterator iter;
-	// Gets the scalar value of the current value node
-	Real current_scalar(0);
-	if(value_desc_list.begin()->parent_is_linkable_value_node())
-		current_scalar=value_desc_list.begin()->get_scalar();
 	bool found_inverse(false);
-	// Check if we are dealing the case of linking different types of tangents
-	for(iter=value_desc_list.begin();iter!=value_desc_list.end();++iter)
-	{
-		ValueDesc& v_desc(*iter);
-		// If parent is linkable value node
-		if(v_desc.parent_is_linkable_value_node())
-		{
-			// if the link describe to any tangent (index 4 or 5), continue
-			if(v_desc.get_index() == 4 || v_desc.get_index() == 5)
-			{
-				synfig::Real iter_scalar=v_desc.get_scalar();
-				// Let's compare the sign  of scalar of the value node with the current one
-				// and remember if a change of sign is seen.
-				if(iter_scalar*current_scalar < 0) // if they have different signs
-				{
-					found_inverse=true;
-					current_scalar=iter_scalar;
-				}
-			}
-			else // link doesn't describe a tangent
-			{
-				found_inverse=false;
-				break;
-			}
-		}
-		else // parent is not a linkable value node
-		{
-			found_inverse=false;
-			break;
-		}
-	}
 	// found_inverse =  true only if all they are tangents and some are inversed tangents
 	//Now let's loop through all the value desc
 	for(iter=value_desc_list.begin();iter!=value_desc_list.end();++iter)

--- a/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
@@ -168,7 +168,7 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 			}
 
 			link_value_node=value_desc.get_value_node();
-			link_scalar=value_desc.parent_is_linkable_value_node()?value_desc.get_scalar():1.0;
+			link_scalar=1.0;
 			status_message = _("Used exported ValueNode ('") + link_value_node->get_id() + _("').");
 		}
 		else if(value_desc.is_value_node())
@@ -178,7 +178,7 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 				status_level = 1;
 				status_message = _("Using the only available ValueNode.");
 				link_value_node=value_desc.get_value_node();
-				link_scalar=value_desc.parent_is_linkable_value_node()?value_desc.get_scalar():1.0;
+				link_scalar=1.0;
 			}
 			else if(link_value_node->is_exported())
 			{
@@ -192,7 +192,7 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 					status_level = 2;
 					status_message = _("Using the most referenced ValueNode.");
 					link_value_node=value_desc.get_value_node();
-					link_scalar=value_desc.parent_is_linkable_value_node()?value_desc.get_scalar():1.0;
+					link_scalar=1.0;
 				}
 				else if (status_level <= 2)
 				{
@@ -207,7 +207,7 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 				status_level = 3;
 				status_message = _("There's a tie for most referenced; using the animated ValueNode.");
 				link_value_node=value_desc.get_value_node();
-				link_scalar=value_desc.parent_is_linkable_value_node()?value_desc.get_scalar():1.0;
+				link_scalar=1.0;
 			}
 			else if(ValueNode_Const::Handle::cast_dynamic(value_desc.get_value_node()) && !ValueNode_Const::Handle::cast_dynamic(link_value_node))
 			{
@@ -229,7 +229,7 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 					status_level = 4;
 					status_message = _("There's a tie for most referenced, and both are animated; using the one with the most waypoints.");
 					link_value_node=value_desc.get_value_node();
-					link_scalar=value_desc.parent_is_linkable_value_node()?value_desc.get_scalar():1.0;
+					link_scalar=1.0;
 				}
 				else if (status_level <= 4)
 				{
@@ -249,7 +249,7 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 					status_level = 4;
 					status_message = _("There's a tie for most referenced, and both are linkable value node animated; using the one with the most waypoints.");
 					link_value_node=value_desc.get_value_node();
-					link_scalar=value_desc.parent_is_linkable_value_node()?value_desc.get_scalar():1.0;
+					link_scalar=1.0;
 				}
 				else if (status_level <= 4)
 				{
@@ -265,7 +265,7 @@ Action::ValueDescLink::set_param(const synfig::String& name, const Action::Param
 					status_level = 5;
 					status_message = _("Everything is tied; using the least recently modified value.");
 					link_value_node=value_desc.get_value_node();
-					link_scalar=value_desc.parent_is_linkable_value_node()?value_desc.get_scalar():1.0;
+					link_scalar=1.0;
 				}
 				else if (status_level <= 5)
 				{

--- a/synfig-studio/src/synfigapp/actions/valuedesclink.h
+++ b/synfig-studio/src/synfigapp/actions/valuedesclink.h
@@ -62,10 +62,6 @@ private:
 	synfig::String status_message;
 	//! Time where the value nodes are evaluated
 	synfig::Time time;
-	//! Scalar value of the link value node. It is used for linking tangents.
-	//! In the synfig::ParamDesc list there is a value used to draw the tangents on the
-	//! canvas that is called scalar
-	synfig::Real link_scalar;
 	//! If true then link opposite is being called.
 	bool link_opposite;
 public:

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -320,7 +320,7 @@ public:
 	synfig::Real
 	get_scalar()const
 	{ assert(parent_is_linkable_value_node()); return 1.0; }
-	
+
 	synfig::String
 	get_name()const
 		{ assert(parent_is_linkable_value_node()); return (synfig::LinkableValueNode::Handle::cast_reinterpret(parent_value_node))->link_name(index); }

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -55,6 +55,8 @@ class ValueDesc
 
 	// Info for ValueNode parent
 	synfig::ValueNode::Handle parent_value_node;
+	static const int IS_WAYPOINT = -2;
+	static const int IS_CONST = -1;
 	int index;					// -2 if it's a waypoint, -1 if it's const, >=0 if it's LinkableValueNode
 	synfig::Time waypoint_time;
 
@@ -140,7 +142,7 @@ public:
 	ValueDesc(synfig::Layer::Handle layer,const synfig::String& param_name,const ValueDesc &parent = blank):
 		layer(layer),
 		name(param_name),
-		index(-1),
+		index(IS_CONST),
 		scalar(0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
@@ -149,7 +151,7 @@ public:
 	ValueDesc(synfig::Layer::LooseHandle layer,const synfig::String& param_name,const ValueDesc &parent = blank):
 		layer(layer),
 		name(param_name),
-		index(-1),
+		index(IS_CONST),
 		scalar(0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
@@ -180,7 +182,7 @@ public:
 
 	ValueDesc(synfig::ValueNode_Animated::Handle parent_value_node,synfig::Time waypoint_time,const ValueDesc &parent = blank):
 		parent_value_node(parent_value_node),
-		index(-2),
+		index(IS_WAYPOINT),
 		waypoint_time(waypoint_time),
 		scalar(0),
 		parent_desc(init_parent(parent)),
@@ -189,7 +191,7 @@ public:
 
 	ValueDesc(synfig::Canvas::Handle canvas,const synfig::String& name,const ValueDesc &parent = blank):
 		name(name),
-		index(-1),
+		index(IS_CONST),
 		canvas(canvas),
 		scalar(0),
 		parent_desc(init_parent(parent)),
@@ -200,7 +202,7 @@ public:
 
 	ValueDesc(synfig::ValueNode_Const::Handle parent_value_node,const ValueDesc &parent = blank):
 		parent_value_node(parent_value_node),
-		index(-1),
+		index(IS_CONST),
 		scalar(0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
@@ -242,7 +244,7 @@ public:
 	}
 
 	ValueDesc():
-		index(-1), scalar(0), parent_desc(nullptr), links_count(0) { }
+		index(IS_CONST), scalar(0), parent_desc(nullptr), links_count(0) { }
 
 	~ValueDesc()
 	{
@@ -271,10 +273,10 @@ public:
 		{ return parent_is_value_node() && index>=0; }
 	bool
 	parent_is_value_node_const()const
-		{ return parent_is_value_node() && index==-1; }
+		{ return parent_is_value_node() && index==IS_CONST; }
 	bool
 	parent_is_waypoint()const
-		{ return parent_is_value_node() && index==-2; }
+		{ return parent_is_value_node() && index==IS_WAYPOINT; }
 	bool
 	parent_is_canvas()const
 		{ return (bool)canvas; }

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -165,21 +165,6 @@ public:
 		links_count(0)
 	{ }
 
-	ValueDesc(synfig::LinkableValueNode::Handle parent_value_node,int index, synfig::Real s,const ValueDesc &parent = blank):
-		parent_value_node(parent_value_node),
-		index(index),
-		scalar(s),
-		parent_desc(init_parent(parent)),
-		links_count(0)
-	{ }
-
-//	ValueDesc(synfig::LinkableValueNode::Handle parent_value_node,const synfig::String& param_name,const ValueDesc &parent = blank):
-//		parent_value_node(parent_value_node),
-//		index(parent_value_node->get_link_index_from_name(param_name)),
-//		parent_desc(init_parent(parent)),
-//		links_count(0)
-//	{ }
-
 	ValueDesc(synfig::ValueNode_Animated::Handle parent_value_node,synfig::Time waypoint_time,const ValueDesc &parent = blank):
 		parent_value_node(parent_value_node),
 		index(IS_WAYPOINT),

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -316,10 +316,6 @@ public:
 	int
 	get_index()const
 		{ assert(parent_is_linkable_value_node()); return index; }
-	
-	synfig::Real
-	get_scalar()const
-	{ assert(parent_is_linkable_value_node()); return 1.0; }
 
 	synfig::String
 	get_name()const

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -67,9 +67,6 @@ class ValueDesc
 	//! When value node id (name) changes, update internal reference
 	void on_id_changed();
 
-	// Info for visual editon
-	synfig::Real scalar;
-
 	// Info for sub-value of parent ValueDesc
 	std::vector<synfig::String> sub_names;
 
@@ -99,8 +96,6 @@ public:
 			return false;
 		if((parent_value_node||rhs.parent_value_node) && (parent_value_node!=rhs.parent_value_node))
 			return false;
-		if(scalar!=rhs.scalar)
-			return false;
 		if(index!=rhs.index)
 			return false;
 		if(sub_names!=rhs.sub_names)
@@ -124,7 +119,6 @@ public:
 		index = other.index;
 		waypoint_time = other.waypoint_time;
 		canvas = other.canvas;
-		scalar = other.scalar;
 		sub_names = other.sub_names;
 		if (parent_desc && 0 >= --parent_desc->links_count)
 			delete parent_desc;
@@ -143,7 +137,6 @@ public:
 		layer(layer),
 		name(param_name),
 		index(IS_CONST),
-		scalar(0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
 	{ }
@@ -152,7 +145,6 @@ public:
 		layer(layer),
 		name(param_name),
 		index(IS_CONST),
-		scalar(0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
 	{ }
@@ -160,7 +152,6 @@ public:
 	ValueDesc(synfig::LinkableValueNode::Handle parent_value_node,int index,const ValueDesc &parent = blank):
 		parent_value_node(parent_value_node),
 		index(index),
-		scalar(1.0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
 	{ }
@@ -169,7 +160,6 @@ public:
 		parent_value_node(parent_value_node),
 		index(IS_WAYPOINT),
 		waypoint_time(waypoint_time),
-		scalar(0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
 	{ }
@@ -178,7 +168,6 @@ public:
 		name(name),
 		index(IS_CONST),
 		canvas(canvas),
-		scalar(0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
 	{
@@ -188,7 +177,6 @@ public:
 	ValueDesc(synfig::ValueNode_Const::Handle parent_value_node,const ValueDesc &parent = blank):
 		parent_value_node(parent_value_node),
 		index(IS_CONST),
-		scalar(0),
 		parent_desc(init_parent(parent)),
 		links_count(0)
 	{ }
@@ -200,7 +188,6 @@ public:
 		index(parent.index),
 		waypoint_time(parent.waypoint_time),
 		canvas(parent.canvas),
-		scalar(parent.scalar),
 		parent_desc(init_parent(parent)),
 		links_count(0)
 	{
@@ -218,7 +205,6 @@ public:
 		index(other.index),
 		waypoint_time(other.waypoint_time),
 		canvas(other.canvas),
-		scalar(other.scalar),
 		sub_names(other.sub_names),
 		parent_desc(other.parent_desc),
 		links_count(0)
@@ -229,7 +215,7 @@ public:
 	}
 
 	ValueDesc():
-		index(IS_CONST), scalar(0), parent_desc(nullptr), links_count(0) { }
+		index(IS_CONST), parent_desc(nullptr), links_count(0) { }
 
 	~ValueDesc()
 	{
@@ -333,7 +319,7 @@ public:
 	
 	synfig::Real
 	get_scalar()const
-	{ assert(parent_is_linkable_value_node()); return scalar; }
+	{ assert(parent_is_linkable_value_node()); return 1.0; }
 	
 	synfig::String
 	get_name()const

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -78,7 +78,7 @@ class ValueDesc
 
 	static ValueDesc* init_parent(const ValueDesc& parent)
 	{
-		if (!parent.is_valid()) return NULL;
+		if (!parent.is_valid()) return nullptr;
 		ValueDesc *p = new ValueDesc(parent);
 		p->links_count++;
 		return p;
@@ -124,10 +124,10 @@ public:
 		canvas = other.canvas;
 		scalar = other.scalar;
 		sub_names = other.sub_names;
-		if (parent_desc != NULL && 0 >= --parent_desc->links_count)
+		if (parent_desc && 0 >= --parent_desc->links_count)
 			delete parent_desc;
 		parent_desc = other.parent_desc;
-		if (parent_desc != NULL) parent_desc->links_count++;
+		if (parent_desc) parent_desc->links_count++;
 
 		if (id_changed_connection.connected())
 			id_changed_connection.disconnect();
@@ -238,18 +238,18 @@ public:
 	{
 		if (other.id_changed_connection.connected())
 			id_changed_connection = get_value_node()->signal_id_changed().connect(sigc::mem_fun(*this, &ValueDesc::on_id_changed));
-		if (parent_desc != NULL) parent_desc->links_count++;
+		if (parent_desc) parent_desc->links_count++;
 	}
 
 	ValueDesc():
-		index(-1), scalar(0), parent_desc(NULL), links_count(0) { }
+		index(-1), scalar(0), parent_desc(nullptr), links_count(0) { }
 
 	~ValueDesc()
 	{
 		assert(links_count == 0);
 		if (id_changed_connection.connected())
 			id_changed_connection.disconnect();
-		if (parent_desc != NULL && 0 >= --parent_desc->links_count)
+		if (parent_desc && 0 >= --parent_desc->links_count)
 			delete parent_desc;
 	}
 
@@ -306,11 +306,11 @@ public:
 
 	bool
 	is_parent_desc_declared()const
-		{ return parent_desc != NULL; }
+		{ return parent_desc; }
 	
 	// Get members
 	const ValueDesc& get_sub_parent_desc()const
-		{ return parent_desc == NULL ? blank : *parent_desc; }
+		{ return parent_desc ? *parent_desc : blank; }
 	const ValueDesc& get_origin_desc()const
 		{ return parent_is_value_desc() ? get_sub_parent_desc().get_origin_desc() : *this ; }
 	const ValueDesc& get_parent_desc()const
@@ -377,7 +377,7 @@ public:
 			return layer->get_canvas();
 		if(parent_value_node)
 			return parent_value_node->get_root_canvas();
-		return 0;
+		return nullptr;
 	}
 
 	synfig::ValueNode::Handle
@@ -394,7 +394,7 @@ public:
 			return parent_value_node;
 		if(parent_is_waypoint())
 			return (synfig::ValueNode_Animated::Handle::cast_reinterpret(parent_value_node))->find(waypoint_time)->get_value_node();
-		return 0;
+		return nullptr;
 	}
 
 	synfig::ValueBase

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -255,7 +255,7 @@ public:
 			delete parent_desc;
 	}
 
-	// Instrocpection members
+	// Introspection members
 	bool
 	is_valid()const
 		{ return layer || parent_value_node || (canvas && !name.empty()); }
@@ -264,10 +264,10 @@ public:
 
 	bool
 	parent_is_layer()const
-		{ return (bool)layer; }
+		{ return layer; }
 	bool
 	parent_is_value_node()const
-		{ return (bool)parent_value_node; }
+		{ return parent_value_node; }
 	bool
 	parent_is_linkable_value_node()const
 		{ return parent_is_value_node() && index>=0; }
@@ -279,7 +279,7 @@ public:
 		{ return parent_is_value_node() && index==IS_WAYPOINT; }
 	bool
 	parent_is_canvas()const
-		{ return (bool)canvas; }
+		{ return canvas; }
 	bool
 	parent_is_value_desc()const
 		{ return !sub_names.empty(); }
@@ -288,7 +288,7 @@ public:
 	is_value_node()const
 		{ return parent_is_value_node()
 		      || parent_is_canvas()
-			  || (parent_is_layer() && (bool)layer->dynamic_param_list().count(name));
+			  || (parent_is_layer() && layer->dynamic_param_list().count(name) > 0);
 		}
 	bool
 	is_const()const


### PR DESCRIPTION
Remove useless variable member `ValueDesc::scalar`, some NULL/0 usages and old casts.

Basic explanation:
- `scalar`could have only two values: 0.0 (if invalid/useless) and 1.0 (if ValueDesc was a LinkableValueNode, the only situation when scalar had a meaning);
-  This variable was only used in action ValueDescLink, where it would be multiplied by `scalar` of another ValueDesc and checked if it would yell a negative value;
- In any case, the product of two ValueDesc::scalar could only give 0.0 or 1.0, so it would never be negative. The comparison is always false then;
- In a cascade effect, everything that depended on this comparison would never be affected and could be safely deleted.