### PR TITLE
[Studio] Fixed crash in rare cases caused by race condition when rebuilding LayerTreeStore

### DIFF
--- a/synfig-studio/src/gui/trees/layertreestore.cpp
+++ b/synfig-studio/src/gui/trees/layertreestore.cpp
@@ -720,7 +720,7 @@ void
 LayerTreeStore::queue_rebuild()
 {
 	if (queued) return;
-	queued = false;
+	queued = true;
 	queue_connection.disconnect();
 	queue_connection=Glib::signal_timeout().connect(
 		sigc::bind_return(
@@ -733,7 +733,9 @@ LayerTreeStore::queue_rebuild()
 void
 LayerTreeStore::rebuild()
 {
-	if (queued) queued = false;
+	std::lock_guard<std::mutex> lock(rebuild_queue_mtx);
+
+	queued = false;
 
 	// disconnect any subcanvas_changed connections
 	std::map<synfig::Layer::Handle, sigc::connection>::iterator iter;

--- a/synfig-studio/src/gui/trees/layertreestore.h
+++ b/synfig-studio/src/gui/trees/layertreestore.h
@@ -125,7 +125,8 @@ public:
 
 private:
 
-	bool queued;
+	std::atomic<bool> queued;
+	std::mutex rebuild_queue_mtx;
 
 	sigc::connection queue_connection;
 


### PR DESCRIPTION
There was a mistake in 'queued' assignment in queue_rebuild().

Besides, internal class methods directly call rebuild() and it
could crash due to race condition.