### PR TITLE
[Synfig Studio] Middle click on a tab now closes the root canvas only when all child canvases are closed

### DIFF
--- a/synfig-studio/src/gui/docks/dockbook.cpp
+++ b/synfig-studio/src/gui/docks/dockbook.cpp
@@ -263,7 +263,7 @@ DockBook::tab_button_pressed(GdkEventButton* event, Dockable* dockable)
 
 	// Handle middle mouse click event first before showing the canvas
 	if (event->button == 2 && canvas_view) {
-		canvas_view->close_instance();
+		canvas_view->close_view();
 		return true;
 	}
 


### PR DESCRIPTION
If a sub-canvas tab was middle clicked, hide that tab instead of force
closing the root canvas which has an unintended side effect of closing
all other exported sub-canvases.

Fixes #2203