### PR TITLE
SVG importer: fix outlined rectangle and implement missing shapes

### DIFF
--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -275,7 +275,7 @@ Svg_parser::parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style
 		const Glib::ustring nodename = node->get_name();
 
 		// Is element known ?
-		const std::vector<const char*> valid_elements = {"g", "path", "polygon", "rect", "circle", "line", "polyline"};
+		const std::vector<const char*> valid_elements = {"g", "path", "polygon", "rect", "circle", "ellipse", "line", "polyline"};
 		if (valid_elements.end() == std::find(valid_elements.begin(), valid_elements.end(), nodename))
 			return;
 
@@ -382,6 +382,8 @@ Svg_parser::parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style
 			k = parser_path_rect(nodeElement, style, mtx);
 		else if(nodename.compare("circle")==0)
 			k = parser_path_circle(nodeElement, style, mtx);
+		else if(nodename.compare("ellipse")==0)
+			k = parser_path_ellipse(nodeElement, style, mtx);
 		else if(nodename.compare("line")==0)
 			k = parser_line(nodeElement, style, mtx);
 		else if(nodename.compare("polyline")==0)
@@ -1230,6 +1232,32 @@ Svg_parser::parser_path_circle(const xmlpp::Element* nodeElement, const Style& s
 							  circle_radius, circle_radius, circle_x - circle_radius, circle_y,
 							  circle_radius, circle_radius, circle_x, circle_y - circle_radius,
 							  circle_radius, circle_radius, circle_x + circle_radius, circle_y
+							  );
+	k = parser_path_d(path,mtx);
+
+	return k;
+}
+
+std::list<BLine>
+Svg_parser::parser_path_ellipse(const xmlpp::Element *nodeElement, const Style &style, const SVGMatrix &mtx)
+{
+	std::list<BLine> k;
+	if (!nodeElement)
+		return k;
+	float ellipse_x = style.compute("cx", "0", style.compute("width", "0"));
+	float ellipse_y = style.compute("cy", "0", style.compute("height", "0"));;
+	double ellipse_rx = -1, ellipse_ry = -1;
+	parser_rxry_property(style, style.compute("width", "0"), style.compute("height", "0"), ellipse_rx, ellipse_ry);
+
+	if (approximate_zero(ellipse_rx) || approximate_zero(ellipse_ry))
+		return k;
+	std::string path = etl::strprintf("M %lf %lf A %lf %lf 0 0,1 %lf %lf A %lf %lf 0 0,1 %lf %lf "
+												"A %lf %lf 0 0,1 %lf %lf A %lf %lf 0 0,1 %lf %lf z",
+							  ellipse_x + ellipse_rx, ellipse_y,
+							  ellipse_rx, ellipse_ry, ellipse_x, ellipse_y + ellipse_ry,
+							  ellipse_rx, ellipse_ry, ellipse_x - ellipse_rx, ellipse_y,
+							  ellipse_rx, ellipse_ry, ellipse_x, ellipse_y - ellipse_ry,
+							  ellipse_rx, ellipse_ry, ellipse_x + ellipse_rx, ellipse_y
 							  );
 	k = parser_path_d(path,mtx);
 

--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -275,7 +275,7 @@ Svg_parser::parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style
 		const Glib::ustring nodename = node->get_name();
 
 		// Is element known ?
-		const std::vector<const char*> valid_elements = {"g", "path", "polygon", "rect", "circle"};
+		const std::vector<const char*> valid_elements = {"g", "path", "polygon", "rect", "circle", "line"};
 		if (valid_elements.end() == std::find(valid_elements.begin(), valid_elements.end(), nodename))
 			return;
 
@@ -311,6 +311,9 @@ Svg_parser::parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style
 
 		//Fill
 		FillType typeFill = FILL_TYPE_NONE;
+
+		if (nodename.compare("line") == 0)
+			fill = "none";
 
 		if(fill.compare("none")!=0){
 			typeFill = FILL_TYPE_SIMPLE;
@@ -379,6 +382,8 @@ Svg_parser::parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style
 			k = parser_path_rect(nodeElement, style, mtx);
 		else if(nodename.compare("circle")==0)
 			k = parser_path_circle(nodeElement, style, mtx);
+		else if(nodename.compare("line")==0)
+			k = parser_line(nodeElement, style, mtx);
 
 		if (k.empty())
 			return;
@@ -1224,6 +1229,34 @@ Svg_parser::parser_path_circle(const xmlpp::Element* nodeElement, const Style& s
 							  circle_radius, circle_radius, circle_x, circle_y - circle_radius,
 							  circle_radius, circle_radius, circle_x + circle_radius, circle_y
 							  );
+	k = parser_path_d(path,mtx);
+
+	return k;
+}
+
+std::list<BLine>
+Svg_parser::parser_line(const xmlpp::Element *nodeElement, const Style &style, const SVGMatrix &mtx)
+{
+	std::list<BLine> k;
+	if (!nodeElement)
+		return k;
+
+	double x1 = 0;
+	double x2 = 0;
+	double y1 = 0;
+	double y2 = 0;
+
+	try {
+		x1 = std::stod(nodeElement->get_attribute_value("x1"));
+		x2 = std::stod(nodeElement->get_attribute_value("x2"));
+		y1 = std::stod(nodeElement->get_attribute_value("y1"));
+		y2 = std::stod(nodeElement->get_attribute_value("y2"));
+	} catch (...) {
+		synfig::error("SVG Parser: Invalid <line> attribute: x1,y1,x2,y2 should be real values or percentages!");
+		return k;
+	}
+
+	std::string path = etl::strprintf("M %lf %lf L %lf %lf", x1, y1, x2, y2);
 	k = parser_path_d(path,mtx);
 
 	return k;

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -191,12 +191,15 @@ private:
 		void parser_canvas(const xmlpp::Node* node);
 		void parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style style, const SVGMatrix& mtx_parent);
 
+		void parser_rxry_property(const Style &style, double width_reference, double height_reference, double &rx, double &ry);
+
 		/* === LAYER PARSERS ============================== */
 		void parser_layer(const xmlpp::Node* node, xmlpp::Element* root, Style style, const SVGMatrix& mtx);
 		void parser_rect(const xmlpp::Element* nodeElement, xmlpp::Element* root, const Style& style);
 		/* === CONVERT TO PATH PARSERS ==================== */
 		std::list<BLine> parser_path_polygon(const Glib::ustring& polygon_points, const SVGMatrix& mtx);
 		std::list<BLine> parser_path_d(const String& path_d, const SVGMatrix& mtx);
+		std::list<BLine> parser_path_rect(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 
 		/* === EFFECTS PARSERS ============================ */
 		void parser_effects(const xmlpp::Element* nodeElement, xmlpp::Element* root, const Style& parent_style, const SVGMatrix& mtx);

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -191,7 +191,7 @@ private:
 		void parser_canvas(const xmlpp::Node* node);
 		void parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style style, const SVGMatrix& mtx_parent);
 
-		void parser_rxry_property(const Style &style, double width_reference, double height_reference, double &rx, double &ry);
+		bool parser_rxry_property(const Style &style, double width_reference, double height_reference, double &rx, double &ry);
 
 		/* === LAYER PARSERS ============================== */
 		void parser_layer(const xmlpp::Node* node, xmlpp::Element* root, Style style, const SVGMatrix& mtx);

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -202,6 +202,7 @@ private:
 		std::list<BLine> parser_path_d(const String& path_d, const SVGMatrix& mtx);
 		std::list<BLine> parser_path_rect(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 		std::list<BLine> parser_path_circle(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
+		std::list<BLine> parser_path_ellipse(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 		std::list<BLine> parser_line(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 		std::list<BLine> parser_polyline(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -196,10 +196,12 @@ private:
 		/* === LAYER PARSERS ============================== */
 		void parser_layer(const xmlpp::Node* node, xmlpp::Element* root, Style style, const SVGMatrix& mtx);
 		void parser_rect(const xmlpp::Element* nodeElement, xmlpp::Element* root, const Style& style);
+		void parser_circle(const xmlpp::Element* nodeElement, xmlpp::Element* root, const Style& style);
 		/* === CONVERT TO PATH PARSERS ==================== */
 		std::list<BLine> parser_path_polygon(const Glib::ustring& polygon_points, const SVGMatrix& mtx);
 		std::list<BLine> parser_path_d(const String& path_d, const SVGMatrix& mtx);
 		std::list<BLine> parser_path_rect(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
+		std::list<BLine> parser_path_circle(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 
 		/* === EFFECTS PARSERS ============================ */
 		void parser_effects(const xmlpp::Element* nodeElement, xmlpp::Element* root, const Style& parent_style, const SVGMatrix& mtx);

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -202,6 +202,7 @@ private:
 		std::list<BLine> parser_path_d(const String& path_d, const SVGMatrix& mtx);
 		std::list<BLine> parser_path_rect(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 		std::list<BLine> parser_path_circle(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
+		std::list<BLine> parser_line(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 
 		/* === EFFECTS PARSERS ============================ */
 		void parser_effects(const xmlpp::Element* nodeElement, xmlpp::Element* root, const Style& parent_style, const SVGMatrix& mtx);

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -203,6 +203,7 @@ private:
 		std::list<BLine> parser_path_rect(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 		std::list<BLine> parser_path_circle(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 		std::list<BLine> parser_line(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
+		std::list<BLine> parser_polyline(const xmlpp::Element* nodeElement, const Style& style, const SVGMatrix& mtx);
 
 		/* === EFFECTS PARSERS ============================ */
 		void parser_effects(const xmlpp::Element* nodeElement, xmlpp::Element* root, const Style& parent_style, const SVGMatrix& mtx);


### PR DESCRIPTION
Now few essential elements are missing: <text>, <image>, <filter> and <use>.