### PR TITLE
Added `seekpos` method for FileSystemNative::ReadStream

### DIFF
--- a/synfig-core/src/synfig/filesystemnative.cpp
+++ b/synfig-core/src/synfig/filesystemnative.cpp
@@ -68,6 +68,10 @@ FileSystemNative::ReadStream::~ReadStream()
 size_t FileSystemNative::ReadStream::internal_read(void *buffer, size_t size)
 	{ return fread(buffer, 1, size, file_); }
 
+std::istream::pos_type FileSystemNative::ReadStream::seekpos(std::istream::pos_type pos, std::ios_base::openmode which) {
+	fseek(file_, pos, SEEK_SET);
+	return ftell(file_);
+}
 
 // WriteStream
 

--- a/synfig-core/src/synfig/filesystemnative.h
+++ b/synfig-core/src/synfig/filesystemnative.h
@@ -52,6 +52,7 @@ namespace synfig
 			FILE *file_;
 			ReadStream(FileSystem::Handle file_system, FILE *file);
 			virtual size_t internal_read(void *buffer, size_t size);
+			std::istream::pos_type seekpos(std::istream::pos_type pos, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
 		public:
 			virtual ~ReadStream();
 		};


### PR DESCRIPTION
This fixes non-working `seekg` method.

Related issue: #2219