### PR TITLE
[Studio] Fixed crash in debug builds when right-clicking on some waypoints

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_waypoint.cpp
+++ b/synfig-studio/src/gui/widgets/widget_waypoint.cpp
@@ -254,8 +254,9 @@ void Widget_Waypoint::set_valuedesc(synfigapp::ValueDesc& value_desc)
 
 	value_widget->set_value_desc(value_desc);
 	synfig::ParamDesc param_desc;
-	if (value_desc.find_param_desc(param_desc))
-		value_widget->set_param_desc(param_desc);
+	if (value_desc.parent_is_layer())
+		value_desc.find_param_desc(param_desc);
+	value_widget->set_param_desc(param_desc);
 }
 
 const synfig::Waypoint &


### PR DESCRIPTION
It only makes sense in this case.
Debug builds crash otherwise due to an assert in find_param_desc().

Reported by GregorysonofCarl here:
https://forums.synfig.org/t/crash-when-right-clicking-waypoints/12391/6
