### PR TITLE
[Release] Starting preparations for releasing v1.4.3

### DIFF
--- a/ETL/configure.ac
+++ b/ETL/configure.ac
@@ -2,7 +2,7 @@
 
 # -- I N I T --------------------------------------------------
 AC_PREREQ(2.60)
-AC_INIT([Extended Template Library],[1.4.2],[https://github.com/synfig/synfig/issues],[ETL])
+AC_INIT([Extended Template Library],[1.4.3],[https://github.com/synfig/synfig/issues],[ETL])
 AC_REVISION
 
 AC_CONFIG_AUX_DIR(config)

--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -3,7 +3,7 @@
 # -- I N I T --------------------------------------------------
 
 AC_PREREQ([2.60])
-AC_INIT([Synfig Core],[1.4.2],[https://github.com/synfig/synfig/issues],[synfig])
+AC_INIT([Synfig Core],[1.4.3],[https://github.com/synfig/synfig/issues],[synfig])
 AC_REVISION()
 
 AC_CONFIG_AUX_DIR(config)
@@ -293,8 +293,8 @@ AM_GNU_GETTEXT([external])
 # This is here so autoreconf will run autopoint
 AM_GNU_GETTEXT_VERSION([0.15])
 
-PKG_CHECK_MODULES(ETL, [ETL >= 1.4.2],,[
-	AC_MSG_ERROR([ ** You need to install the ETL (version 1.4.2 or greater).])
+PKG_CHECK_MODULES(ETL, [ETL >= 1.4.3],,[
+	AC_MSG_ERROR([ ** You need to install the ETL (version 1.4.3 or greater).])
 ])
 CONFIG_DEPS="$CONFIG_DEPS ETL"
 

--- a/synfig-studio/configure.ac
+++ b/synfig-studio/configure.ac
@@ -3,7 +3,7 @@
 # -- I N I T --------------------------------------------------
 
 AC_PREREQ([2.60])
-AC_INIT([Synfig Studio],[1.4.2],[https://github.com/synfig/synfig/issues],[synfigstudio])
+AC_INIT([Synfig Studio],[1.4.3],[https://github.com/synfig/synfig/issues],[synfigstudio])
 AC_REVISION()
 
 AM_CONDITIONAL(DEVELOPMENT_SNAPSHOT, false)
@@ -102,8 +102,8 @@ PKG_CHECK_MODULES(GTKMM, gtkmm-3.0,,[
 AC_SUBST(GTKMM_CFLAGS)
 AC_SUBST(GTKMM_LIBS)
 
-PKG_CHECK_MODULES(SYNFIG, [synfig >= 1.4.2] [ETL >= 1.4.2] sigc++-2.0,,[
-    AC_MSG_ERROR([ ** Unable to set up dependent libraries (synfig >= 1.4.2, ETL >= 1.4.2, sigc++-2.0) ])
+PKG_CHECK_MODULES(SYNFIG, [synfig >= 1.4.3] [ETL >= 1.4.3] sigc++-2.0,,[
+    AC_MSG_ERROR([ ** Unable to set up dependent libraries (synfig >= 1.4.3, ETL >= 1.4.3, sigc++-2.0) ])
 ])
 AC_SUBST(SYNFIG_CFLAGS)
 AC_SUBST(SYNFIG_LIBS)

--- a/synfig-studio/org.synfig.SynfigStudio.appdata.xml.in
+++ b/synfig-studio/org.synfig.SynfigStudio.appdata.xml.in
@@ -55,6 +55,6 @@
   <url type="translate">https://www.transifex.com/morevnaproject/synfig/</url>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.4.2" date="2021-07-28"></release>
+    <release version="1.4.3" date="2021-07-29"></release>
   </releases>
 </component>

--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -2,7 +2,7 @@
 ## Configure
 ##
 
-set(STUDIO_VERSION "1.4.2")
+set(STUDIO_VERSION "1.4.3")
 set(SHOW_EXTRA_INFO OFF) # this needs some fixes to work
 set(DATA_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Path, where the share directory with the pixmaps, sounds, plugins and translations is located. Default: Prefix, where Synfig Studio is going to be installed")
 set(IMG_EXT "png" CACHE STRING "File extension of the pixmaps (without the \".\"). Default: png")


### PR DESCRIPTION
I am starting preparations for 1.4.3 release!

* **Bump version to 1.4.3** - This is the first commit I have made, it is automatically created when I executed script `./version-bump.sh 1.4.3` from Synfig's source dir (according to instructions here - https://synfig-docs-dev.readthedocs.io/en/latest/common/release.html#update-version-number).