### PR TITLE
Bump version number for 1.6.0

### DIFF
--- a/ETL/configure.ac
+++ b/ETL/configure.ac
@@ -2,7 +2,7 @@
 
 # -- I N I T --------------------------------------------------
 AC_PREREQ(2.60)
-AC_INIT([Extended Template Library],[1.5.0],[https://github.com/synfig/synfig/issues],[ETL])
+AC_INIT([Extended Template Library],[1.6.0],[https://github.com/synfig/synfig/issues],[ETL])
 AC_REVISION
 
 AM_SILENT_RULES([yes])

--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -3,7 +3,7 @@
 # -- I N I T --------------------------------------------------
 
 AC_PREREQ([2.60])
-AC_INIT([Synfig Core],[1.5.0],[https://github.com/synfig/synfig/issues],[synfig])
+AC_INIT([Synfig Core],[1.6.0],[https://github.com/synfig/synfig/issues],[synfig])
 AC_REVISION()
 
 AM_SILENT_RULES([yes])
@@ -295,8 +295,8 @@ AM_GNU_GETTEXT([external])
 # This is here so autoreconf will run autopoint
 AM_GNU_GETTEXT_VERSION([0.15])
 
-PKG_CHECK_MODULES(ETL, [ETL >= 1.5.0],,[
-	AC_MSG_ERROR([ ** You need to install the ETL (version 1.5.0 or greater).])
+PKG_CHECK_MODULES(ETL, [ETL >= 1.6.0],,[
+	AC_MSG_ERROR([ ** You need to install the ETL (version 1.6.0 or greater).])
 ])
 CONFIG_DEPS="$CONFIG_DEPS ETL"
 

--- a/synfig-studio/configure.ac
+++ b/synfig-studio/configure.ac
@@ -3,7 +3,7 @@
 # -- I N I T --------------------------------------------------
 
 AC_PREREQ([2.60])
-AC_INIT([Synfig Studio],[1.5.0],[https://github.com/synfig/synfig/issues],[synfigstudio])
+AC_INIT([Synfig Studio],[1.6.0],[https://github.com/synfig/synfig/issues],[synfigstudio])
 AC_REVISION()
 
 AM_SILENT_RULES([yes])
@@ -101,8 +101,8 @@ PKG_CHECK_MODULES(GTKMM, gtkmm-3.0,,[
 AC_SUBST(GTKMM_CFLAGS)
 AC_SUBST(GTKMM_LIBS)
 
-PKG_CHECK_MODULES(SYNFIG, [synfig >= 1.5.0] [ETL >= 1.5.0] sigc++-2.0,,[
-    AC_MSG_ERROR([ ** Unable to set up dependent libraries (synfig >= 1.5.0, ETL >= 1.5.0, sigc++-2.0) ])
+PKG_CHECK_MODULES(SYNFIG, [synfig >= 1.6.0] [ETL >= 1.6.0] sigc++-2.0,,[
+    AC_MSG_ERROR([ ** Unable to set up dependent libraries (synfig >= 1.6.0, ETL >= 1.6.0, sigc++-2.0) ])
 ])
 AC_SUBST(SYNFIG_CFLAGS)
 AC_SUBST(SYNFIG_LIBS)

--- a/synfig-studio/org.synfig.SynfigStudio.appdata.xml.in
+++ b/synfig-studio/org.synfig.SynfigStudio.appdata.xml.in
@@ -55,6 +55,6 @@
   <url type="translate">https://www.transifex.com/morevnaproject/synfig/</url>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.5.0" date="2021-08-13"></release>
+    <release version="1.6.0" date="2021-08-23"></release>
   </releases>
 </component>


### PR DESCRIPTION
I did that commit by executing the following command from source root dir  - `./version-bump.sh 1.6.0` (see https://synfig-docs-dev.readthedocs.io/en/latest/common/release.html#update-version-number)