### PR TITLE
Studio: avoid lambda functions for signal callbacks

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2197,13 +2197,13 @@ void App::save_custom_workspace()
 	Gtk::Entry * name_entry = Gtk::manage(new Gtk::Entry());
 	name_entry->set_margin_start(16);
 	name_entry->set_margin_end(16);
-	name_entry->signal_changed().connect([&](){
+	name_entry->signal_changed().connect(sigc::track_obj([&](){
 		std::string name = synfig::trim(name_entry->get_text());
 		bool has_equal_sign = name.find("=") != std::string::npos;
 		ok_button->set_sensitive(!name.empty() && !has_equal_sign);
 		if (ok_button->is_sensitive())
 			ok_button->grab_default();
-	});
+	}, dialog));
 	name_entry->signal_activate().connect(sigc::mem_fun(*ok_button, &Gtk::Button::clicked));
 
 	dialog.get_content_area()->set_spacing(12);

--- a/synfig-studio/src/gui/dialogs/dialog_workspaces.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_workspaces.cpp
@@ -182,14 +182,14 @@ void Dialog_Workspaces::on_rename_clicked()
 	Gtk::Entry * name_entry = Gtk::manage(new Gtk::Entry());
 	name_entry->set_margin_start(16);
 	name_entry->set_margin_end(16);
-	name_entry->signal_changed().connect([&](){
+	name_entry->signal_changed().connect(sigc::track_obj([&](){
 		std::string name = name_entry->get_text();
 		synfig::trim(name);
 		bool has_equal_sign = name.find("=") != std::string::npos;
 		ok_button->set_sensitive(!name.empty() && !has_equal_sign);
 		if (ok_button->is_sensitive())
 			ok_button->grab_default();
-	});
+	}, *this));
 	name_entry->signal_activate().connect(sigc::mem_fun(*ok_button, &Gtk::Button::clicked));
 	name_entry->set_text(old_name);
 

--- a/synfig-studio/src/gui/docks/dock_curves.cpp
+++ b/synfig-studio/src/gui/docks/dock_curves.cpp
@@ -132,19 +132,9 @@ Dock_Curves::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
 	tree_layer->signal_param_tree_header_height_changed().connect(
 		sigc::mem_fun(*this, &studio::Dock_Curves::on_update_header_height) );
 
-	curves->signal_waypoint_clicked().connect([=](synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button) {
-		if (button != 3)
-			return;
-		button = 2;
-		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
-	});
+	curves->signal_waypoint_clicked().connect(sigc::mem_fun(*this, &Dock_Curves::on_curves_waypoint_clicked));
 
-	curves->signal_waypoint_double_clicked().connect([=](synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button) {
-		if (button != 1)
-			return;
-		button = -1;
-		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
-	});
+	curves->signal_waypoint_double_clicked().connect(sigc::mem_fun(*this, &Dock_Curves::on_curves_waypoint_double_clicked));
 
 	canvas_view->set_ext_widget(get_name(),curves);
 }
@@ -224,4 +214,26 @@ Dock_Curves::on_update_header_height(int height)
 	widget_timeslider_.get_size_request(w, h);
 	if (h != ts_height)
 		widget_timeslider_.set_size_request(-1, ts_height);
+}
+
+void
+Dock_Curves::on_curves_waypoint_clicked(synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoint_set, int button)
+{
+	if (button != 3)
+		return;
+	button = 2;
+	CanvasView::LooseHandle canvas_view = get_canvas_view();
+	if (canvas_view)
+		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
+}
+
+void
+Dock_Curves::on_curves_waypoint_double_clicked(synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoint_set, int button)
+{
+	if (button != 1)
+		return;
+	button = -1;
+	CanvasView::LooseHandle canvas_view = get_canvas_view();
+	if (canvas_view)
+		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
 }

--- a/synfig-studio/src/gui/docks/dock_curves.h
+++ b/synfig-studio/src/gui/docks/dock_curves.h
@@ -74,6 +74,9 @@ private:
 	//! Signal handler for studio::LayerTree::signal_param_tree_header_height_changed
 	/* \see studio::LayerTree::signal_param_tree_header_height_changed */
 	void on_update_header_height(int height);
+
+	void on_curves_waypoint_clicked(synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button);
+	void on_curves_waypoint_double_clicked(synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button);
 }; // END of Dock_Curves
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -94,23 +94,11 @@ void Dock_Timetrack2::init_canvas_view_vfunc(etl::loose_handle<CanvasView> canva
 		sigc::mem_fun(*this, &studio::Dock_Timetrack2::on_update_header_height)
 	);
 
-	widget_timetrack->signal_waypoint_clicked().connect([=](synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button) {
-		if (button != 3)
-			return;
-		button = 2;
-		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
-	});
+	widget_timetrack->signal_waypoint_clicked().connect(sigc::mem_fun(*this, &Dock_Timetrack2::on_widget_timetrack_waypoint_clicked));
 
-	widget_timetrack->signal_waypoint_double_clicked().connect([=](synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button) {
-		if (button != 1)
-			return;
-		button = -1;
-		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
-	});
+	widget_timetrack->signal_waypoint_double_clicked().connect(sigc::mem_fun(*this, &Dock_Timetrack2::on_widget_timetrack_waypoint_double_clicked));
 
-	widget_timetrack->signal_action_state_changed().connect([=](){
-		update_tool_palette_action();
-	});
+	widget_timetrack->signal_action_state_changed().connect(sigc::mem_fun(*this, &Dock_Timetrack2::update_tool_palette_action));
 }
 
 void Dock_Timetrack2::changed_canvas_view_vfunc(etl::loose_handle<CanvasView> canvas_view)
@@ -170,6 +158,26 @@ void Dock_Timetrack2::on_update_header_height(int height)
 		widget_timeslider.set_size_request(-1, ts_height);
 }
 
+void Dock_Timetrack2::on_widget_timetrack_waypoint_clicked(synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoint_set, int button)
+{
+	if (button != 3)
+		return;
+	button = 2;
+	CanvasView::LooseHandle canvas_view = get_canvas_view();
+	if (canvas_view)
+		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
+}
+
+void Dock_Timetrack2::on_widget_timetrack_waypoint_double_clicked(synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoint_set, int button)
+{
+	if (button != 1)
+		return;
+	button = -1;
+	CanvasView::LooseHandle canvas_view = get_canvas_view();
+	if (canvas_view)
+		canvas_view->on_waypoint_clicked_canvasview(value_desc, waypoint_set, button);
+}
+
 void Dock_Timetrack2::setup_tool_palette()
 {
 	Gtk::ToolItemGroup *tool_item_group = Gtk::manage(new Gtk::ToolItemGroup());
@@ -218,10 +226,10 @@ void Dock_Timetrack2::setup_tool_palette()
 		}
 		tool_button->set_tooltip_text(tooltip);
 		tool_button->set_group(button_group);
-		tool_button->signal_toggled().connect([this, tool_button, action_state](){
+		tool_button->signal_toggled().connect(sigc::track_obj([this, tool_button, action_state](){
 			if (tool_button->get_active())
 				current_widget_timetrack->set_action_state(action_state);
-		});
+		}, *this));
 		action_button_map[tool_button->get_name()] = tool_button;
 		tool_item_group->add(*tool_button);
 	}

--- a/synfig-studio/src/gui/docks/dock_timetrack2.h
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.h
@@ -60,6 +60,9 @@ private:
 
 	void on_update_header_height(int height);
 
+	void on_widget_timetrack_waypoint_clicked(synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button);
+	void on_widget_timetrack_waypoint_double_clicked(synfigapp::ValueDesc value_desc, std::set<synfig::Waypoint,std::less<synfig::UniqueID>> waypoint_set, int button);
+
 	void setup_tool_palette();
 	void update_tool_palette_action();
 	std::map<std::string, Gtk::RadioToolButton*> action_button_map;

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -118,6 +118,7 @@ class studio::StateBLine_Context : public sigc::trackable
 	bool on_vertex_change(const studio::Duck &duck, synfig::ValueNode_Const::Handle value_node);
 	bool on_tangent1_change(const studio::Duck &duck, handle<WorkArea::Duck> other_duck, synfig::ValueNode_Const::Handle value_node);
 	bool on_tangent2_change(const studio::Duck &duck, handle<WorkArea::Duck> other_duck, synfig::ValueNode_Const::Handle value_node);
+	void on_first_duck_clicked();
 
 	void popup_handle_menu(synfig::ValueNode_Const::Handle value_node);
 	void popup_vertex_menu(synfig::ValueNode_Const::Handle value_node);
@@ -1338,10 +1339,7 @@ StateBLine_Context::refresh_ducks(bool button_down)
 #endif
 		// Loop it and finish if user clicked on the first vertex
 		if (iter == bline_point_list.begin()) {
-			duck->signal_user_click(0).connect([&](){
-				loop_=true;
-				run();
-			});
+			duck->signal_user_click(0).connect(sigc::mem_fun(*this, &StateBLine_Context::on_first_duck_clicked));
 		}
 
 		duck->set_name(strprintf("%p-vertex",value_node.get()));
@@ -1577,6 +1575,13 @@ StateBLine_Context::on_tangent2_change(const studio::Duck &duck, handle<WorkArea
 		get_work_area()->queue_draw();
 	}
 	return true;
+}
+
+void
+StateBLine_Context::on_first_duck_clicked()
+{
+	loop_=true;
+	run();
 }
 
 void

--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -503,18 +503,11 @@ Widget_Curves::Widget_Curves()
 	channel_point_sd.set_zoom_enabled(true);
 	channel_point_sd.set_scroll_enabled(true);
 	channel_point_sd.set_canvas_interface(canvas_interface);
-	channel_point_sd.signal_drag_canceled().connect([&]() {
-		overlapped_waypoints.clear();
-	});
-	channel_point_sd.signal_drag_finished().connect([&](bool /*started_by_keys*/) {
-//		overlapped_waypoints.clear();
-	});
+	channel_point_sd.signal_drag_canceled().connect(sigc::mem_fun(*this, &Widget_Curves::on_channel_point_drag_canceled));
+	channel_point_sd.signal_drag_finished().connect(sigc::mem_fun(*this, &Widget_Curves::on_channel_point_drag_finished));
 	channel_point_sd.signal_redraw_needed().connect(sigc::mem_fun(*this, &Gtk::Widget::queue_draw));
 	channel_point_sd.signal_focus_requested().connect(sigc::mem_fun(*this, &Gtk::Widget::grab_focus));
-	channel_point_sd.signal_selection_changed().connect([=](){
-		overlapped_waypoints.clear();
-		queue_draw();
-	});
+	channel_point_sd.signal_selection_changed().connect(sigc::mem_fun(*this, &Widget_Curves::on_channel_point_selection_changed));
 	channel_point_sd.signal_zoom_in_requested().connect(sigc::mem_fun(*this, &Widget_Curves::zoom_in));
 	channel_point_sd.signal_zoom_out_requested().connect(sigc::mem_fun(*this, &Widget_Curves::zoom_out));
 	channel_point_sd.signal_zoom_horizontal_in_requested().connect(sigc::mem_fun(*this, &Widget_Curves::zoom_horizontal_in));
@@ -876,6 +869,24 @@ Widget_Curves::on_draw(const Cairo::RefPtr<Cairo::Context> &cr)
 	cr->restore();
 
 	return true;
+}
+
+void
+Widget_Curves::on_channel_point_drag_canceled()
+{
+	overlapped_waypoints.clear();
+}
+
+void
+Widget_Curves::on_channel_point_drag_finished(bool /*started_by_keys*/)
+{
+}
+
+void
+Widget_Curves::on_channel_point_selection_changed()
+{
+	overlapped_waypoints.clear();
+	queue_draw();
 }
 
 void

--- a/synfig-studio/src/gui/widgets/widget_curves.h
+++ b/synfig-studio/src/gui/widgets/widget_curves.h
@@ -124,6 +124,10 @@ protected:
 	bool on_event(GdkEvent *event);
 	bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr);
 
+	void on_channel_point_drag_canceled();
+	void on_channel_point_drag_finished(bool /*started_by_keys*/);
+	void on_channel_point_selection_changed();
+
 	void delete_selected();
 	bool add_waypoint_to(int point_x, int point_y);
 }; // END of class Widget_Curves

--- a/synfig-studio/src/gui/widgets/widget_fontfamily.cpp
+++ b/synfig-studio/src/gui/widgets/widget_fontfamily.cpp
@@ -153,11 +153,7 @@ Widget_FontFamily::Widget_FontFamily()
 	set_wrap_width(1); // https://github.com/synfig/synfig/issues/650
 
 	if (get_has_entry())
-		static_cast<Gtk::Entry*>(get_child())->signal_activate().connect([=](){ signal_activate().emit(); });
-	signal_changed().connect([=]() {
-		if (!get_has_entry() || get_active_row_number() != -1)
-			signal_activate().emit();
-	});
+		static_cast<Gtk::Entry*>(get_child())->signal_activate().connect(sigc::mem_fun(signal_activate(), &sigc::signal<void>::emit));
 }
 
 Widget_FontFamily::~Widget_FontFamily()
@@ -192,4 +188,7 @@ Widget_FontFamily::on_changed()
 		Gtk::TreeModel::Row row = *iter;
 		value = row.get_value(enum_model.value);
 	}
+
+	if (!get_has_entry() || get_active_row_number() != -1)
+		signal_activate().emit();
 }

--- a/synfig-studio/src/gui/widgets/widget_fontfamily.h
+++ b/synfig-studio/src/gui/widgets/widget_fontfamily.h
@@ -70,7 +70,7 @@ public:
 
 	sigc::signal<void>& signal_activate() { return signal_activate_; }
 private:
-	virtual void on_changed();
+	virtual void on_changed() override;
 
 	sigc::signal<void> signal_activate_;
 }; // END of class Widget_FontFamily

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -220,6 +220,15 @@ private:
 	bool fetch_waypoints(const WaypointItem &wi, std::set<synfig::Waypoint, std::less<synfig::UniqueID> > &waypoint_set) const;
 	void on_waypoint_clicked(const WaypointItem &wi, unsigned int button, Gdk::Point /*point*/);
 	void on_waypoint_double_clicked(const WaypointItem &wi, unsigned int button, Gdk::Point /*point*/);
+	void on_waypoint_action_changed();
+
+	void on_params_store_row_inserted(const Gtk::TreeModel::Path&, const Gtk::TreeModel::iterator&);
+	void on_params_store_row_deleted(const Gtk::TreeModel::Path&);
+	void on_params_store_rows_reordered(const Gtk::TreeModel::Path&, const Gtk::TreeModel::iterator&, int*);
+	void on_params_store_row_changed(const Gtk::TreeModel::Path& path, const Gtk::TreeModel::iterator&);
+
+	void on_range_adjustment_value_changed();
+	void on_range_adjustment_changed();
 
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int> signal_waypoint_clicked_;
 	sigc::signal<void, synfigapp::ValueDesc, std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int> signal_waypoint_double_clicked_;

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -2161,7 +2161,7 @@ studio::WorkArea::queue_render(bool refresh)
 		{ dirty_trap_queued++; return; }
 	dirty_trap_queued = 0;
 	// avoiding dead-lock : github#1071
-	Glib::signal_idle().connect_once([=] () {
+	Glib::signal_idle().connect_once(sigc::track_obj([=] () {
 		if (refresh) {
 			renderer_canvas->clear_render();
 			Glib::signal_idle().connect_once(
@@ -2170,7 +2170,7 @@ studio::WorkArea::queue_render(bool refresh)
 		} else {
 			renderer_canvas->enqueue_render();
 		}
-	});
+	}, *this));
 }
 
 void


### PR DESCRIPTION
Specially important for WorkArea queuing rendering.

Reasoning by Kjell Ahlstedt (gtkmm maintainer) follows below:

From the documentation of sigc::mem_fun():

```
 * @note If the object type inherits from sigc::trackable, and the
 * functor returned from mem_fun() is assigned to a sigc::slot, the functor
 * will be automatically cleared when the object goes out of scope. Invoking
 * that slot will then have no effect and will not try to use the destroyed
 * instance.
```

In most examples in the gtkmm tutorial the signal handlers are members of widgets.
All widgets inherit from sigc::trackable. The automatic disconnection when a
widget is destroyed would be lost if a sigc::mem_fun() is replaced by a C++ lambda
expression. Unless it's combined with sigc::track_obj():

```c++
m_button.signal_clicked().connect(sigc::track_obj([this]{ on_button_clicked(); }, *this));
```
but that's no better than sigc::mem_fun(), is it?

This kind of automatic disconnection is not always necessary. Some instances of
mem_fun() could be replaced by lambda expressions, to show that it's possible.
Preferably together with a description of the pros and cons of mem_fun() and
lambda expressions. But I don't recommend replacing the majority of the mem_fun()s.

https://gitlab.gnome.org/GNOME/gtkmm-documentation/-/issues/10