### PR TITLE
[Core] fix access modifiers for valuenode classes

### DIFF
--- a/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
@@ -43,6 +43,7 @@
 #include <synfig/value.h>
 #include <synfig/valuenode.h>
 #include <synfig/curve.h>
+#include <synfig/dashitem.h>
 
 #include <synfig/valuenodes/valuenode_bline.h>
 #include <synfig/valuenodes/valuenode_wplist.h>

--- a/synfig-core/src/modules/mod_noise/valuenode_random.cpp
+++ b/synfig-core/src/modules/mod_noise/valuenode_random.cpp
@@ -106,7 +106,7 @@ ValueNode_Random::create_new()const
 }
 
 ValueNode_Random*
-ValueNode_Random::create(const ValueBase &x)
+ValueNode_Random::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Random(x);
 }

--- a/synfig-core/src/modules/mod_noise/valuenode_random.h
+++ b/synfig-core/src/modules/mod_noise/valuenode_random.h
@@ -52,36 +52,33 @@ class ValueNode_Random : public LinkableValueNode
 
 	mutable RandomNoise random;
 	//RandomNoise::SmoothType smooth;
+
 	ValueNode_Random(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_Random> Handle;
 	typedef etl::handle<const ValueNode_Random> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Random* create(const ValueBase &x);
+	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
 	virtual ~ValueNode_Random();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
-
-	void randomize_seed();
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Random* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
+
+private:
+	void randomize_seed();
 }; // END of class ValueNode_Random
 
 }; // END of namespace synfig

--- a/synfig-core/src/modules/mod_noise/valuenode_random.h
+++ b/synfig-core/src/modules/mod_noise/valuenode_random.h
@@ -59,7 +59,7 @@ public:
 	typedef etl::handle<ValueNode_Random> Handle;
 	typedef etl::handle<const ValueNode_Random> ConstHandle;
 
-	static ValueNode_Random* create(const ValueBase &x);
+	static ValueNode_Random* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
 	virtual ~ValueNode_Random();
 

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -1939,7 +1939,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 				if (load_old_weighted_bonelink)
 				{
 					ValueNode_StaticList::Handle list = ValueNode_StaticList::Handle::cast_dynamic(c[index]);
-					ValueNode_BoneWeightPair::Handle wp = ValueNode_BoneWeightPair::Handle::cast_dynamic(list->get_link_vfunc(0));
+					ValueNode_BoneWeightPair::Handle wp = ValueNode_BoneWeightPair::Handle::cast_dynamic(list->get_link(0));
 					ValueNode::Handle bone = wp->get_link(0);
 					
 					c[index] = bone;
@@ -2035,7 +2035,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 				if (load_old_weighted_bonelink)
 				{
 					ValueNode_StaticList::Handle list = ValueNode_StaticList::Handle::cast_dynamic(c[index]);
-					ValueNode_BoneWeightPair::Handle wp = ValueNode_BoneWeightPair::Handle::cast_dynamic(list->get_link_vfunc(0));
+					ValueNode_BoneWeightPair::Handle wp = ValueNode_BoneWeightPair::Handle::cast_dynamic(list->get_link(0));
 					ValueNode::Handle bone = wp->get_link(0);
 					
 					c[index] = bone;

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -1939,7 +1939,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 				{
 					ValueNode_StaticList::Handle list = ValueNode_StaticList::Handle::cast_dynamic(c[index]);
 					ValueNode_BoneWeightPair::Handle wp = ValueNode_BoneWeightPair::Handle::cast_dynamic(list->get_link_vfunc(0));
-					ValueNode::Handle bone = wp->get_link_vfunc(0);
+					ValueNode::Handle bone = wp->get_link(0);
 					
 					c[index] = bone;
 				}
@@ -2035,7 +2035,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 				{
 					ValueNode_StaticList::Handle list = ValueNode_StaticList::Handle::cast_dynamic(c[index]);
 					ValueNode_BoneWeightPair::Handle wp = ValueNode_BoneWeightPair::Handle::cast_dynamic(list->get_link_vfunc(0));
-					ValueNode::Handle bone = wp->get_link_vfunc(0);
+					ValueNode::Handle bone = wp->get_link(0);
 					
 					c[index] = bone;
 				}

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -56,6 +56,7 @@
 
 #include "blur.h"
 #include "boneweightpair.h"
+#include "dashitem.h"
 #include "exception.h"
 #include "importer.h"
 #include "gradient.h"

--- a/synfig-core/src/synfig/valuenodes/valuenode_add.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_add.cpp
@@ -131,7 +131,7 @@ ValueNode_Add::create_new()const
 }
 
 ValueNode_Add*
-ValueNode_Add::create(const ValueBase& value)
+ValueNode_Add::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Add(value);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_add.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_add.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_Add> Handle;
 	typedef etl::handle<const ValueNode_Add> ConstHandle;
 
-	static ValueNode_Add* create(const ValueBase &value=ValueBase());
+	static ValueNode_Add* create(const ValueBase& value=ValueBase(), etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Add();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_add.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_add.h
@@ -42,36 +42,38 @@ namespace synfig {
 
 class ValueNode_Add : public LinkableValueNode
 {
-public:
-	typedef etl::handle<ValueNode_Add> Handle;
-	typedef etl::handle<const ValueNode_Add> ConstHandle;
-
-protected:
-	ValueNode_Add(const ValueBase &value);
-
-private:
 	ValueNode::RHandle ref_a;
 	ValueNode::RHandle ref_b;
 	ValueNode::RHandle scalar;
 
+	ValueNode_Add(const ValueBase &value);
+
 public:
-	LinkableValueNode* create_new()const;
+	typedef etl::handle<ValueNode_Add> Handle;
+	typedef etl::handle<const ValueNode_Add> ConstHandle;
+
 	static ValueNode_Add* create(const ValueBase &value=ValueBase());
 	virtual ~ValueNode_Add();
-	virtual ValueBase operator()(Time t)const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
 	static bool check_type(Type &type);
-	virtual Vocab get_children_vocab_vfunc()const;
+
+	virtual ValueBase operator()(Time t) const override;
 
 	//! Checks if it is possible to call get_inverse() for target_value at time t.
 	//! If so, return the link_index related to the return value provided by get_inverse()
-	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
 	//! Returns the modified Link to match the target value at time t
-	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
-	
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const override;
+
+protected:
+	virtual LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Add
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_and.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_and.cpp
@@ -72,7 +72,7 @@ ValueNode_And::ValueNode_And(const ValueBase &x):
 }
 
 ValueNode_And*
-ValueNode_And::create(const ValueBase &x)
+ValueNode_And::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_And(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_and.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_and.h
@@ -45,27 +45,28 @@ class ValueNode_And : public LinkableValueNode
 	ValueNode::RHandle link1_;
 	ValueNode::RHandle link2_;
 
+	ValueNode_And(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_And> Handle;
 	typedef etl::handle<const ValueNode_And> ConstHandle;
 
-	ValueNode_And(const ValueBase &x);
-	virtual ValueBase operator()(Time t)const;
+	static ValueNode_And* create(const ValueBase &x);
 	virtual ~ValueNode_And();
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+
+	virtual ValueBase operator()(Time t) const override;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_And* create(const ValueBase &x);
-	virtual LinkableValueNode::Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual LinkableValueNode::Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_And
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_and.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_and.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_And> Handle;
 	typedef etl::handle<const ValueNode_And> ConstHandle;
 
-	static ValueNode_And* create(const ValueBase &x);
+	static ValueNode_And* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_And();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_anglestring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_anglestring.cpp
@@ -83,7 +83,7 @@ ValueNode_AngleString::create_new()const
 }
 
 ValueNode_AngleString*
-ValueNode_AngleString::create(const ValueBase &x)
+ValueNode_AngleString::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_AngleString(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_anglestring.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_anglestring.h
@@ -47,29 +47,28 @@ class ValueNode_AngleString : public LinkableValueNode
 	ValueNode::RHandle precision_;
 	ValueNode::RHandle zero_pad_;
 
-	ValueNode_AngleString(const ValueBase &value);
+	ValueNode_AngleString(const ValueBase &x);
 
 public:
-
 	typedef etl::handle<ValueNode_AngleString> Handle;
 	typedef etl::handle<const ValueNode_AngleString> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
+	static ValueNode_AngleString* create(const ValueBase &x);
 	virtual ~ValueNode_AngleString();
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+
+	virtual ValueBase operator()(Time t) const override;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_AngleString* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual LinkableValueNode::Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_AngleString
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_anglestring.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_anglestring.h
@@ -53,7 +53,7 @@ public:
 	typedef etl::handle<ValueNode_AngleString> Handle;
 	typedef etl::handle<const ValueNode_AngleString> ConstHandle;
 
-	static ValueNode_AngleString* create(const ValueBase &x);
+	static ValueNode_AngleString* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_AngleString();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_animated.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animated.h
@@ -66,8 +66,6 @@ public:
 	static Handle create(ValueNode::Handle value_node, const Time& time);
 
 	virtual ValueBase operator()(Time t) const;
-	virtual void get_values_vfunc(std::map<Time, ValueBase> &x) const;
-
 	virtual Interpolation get_interpolation()const
 		{ return ValueNode_AnimatedInterfaceConst::get_interpolation(); }
 	virtual void set_interpolation(Interpolation i)
@@ -78,6 +76,7 @@ protected:
 
 	virtual void on_changed();
 	virtual void get_times_vfunc(Node::time_set &set) const;
+	virtual void get_values_vfunc(std::map<Time, ValueBase> &x) const;
 };
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.cpp
@@ -355,7 +355,7 @@ ValueNode_AnimatedFile::create_new() const
 	{ return new ValueNode_AnimatedFile(get_type()); }
 
 ValueNode_AnimatedFile*
-ValueNode_AnimatedFile::create(const ValueBase &x)
+ValueNode_AnimatedFile::create(const ValueBase& x, etl::loose_handle<Canvas>)
 	{ return new ValueNode_AnimatedFile(x.get_type()); }
 
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.h
@@ -61,7 +61,7 @@ public:
 	typedef etl::handle<ValueNode_AnimatedFile> Handle;
 	typedef etl::handle<const ValueNode_AnimatedFile> ConstHandle;
 
-	static ValueNode_AnimatedFile* create(const ValueBase &x);
+	static ValueNode_AnimatedFile* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_AnimatedFile();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.h
@@ -43,10 +43,6 @@ namespace synfig {
 /** \class ValueNode_AnimatedFile */
 class ValueNode_AnimatedFile : public LinkableValueNode, public ValueNode_AnimatedInterfaceConst
 {
-public:
-	typedef etl::handle<ValueNode_AnimatedFile> Handle;
-	typedef etl::handle<const ValueNode_AnimatedFile> ConstHandle;
-
 private:
 	class Internal;
 
@@ -62,29 +58,31 @@ private:
 	void file_changed();
 
 public:
-	~ValueNode_AnimatedFile();
+	typedef etl::handle<ValueNode_AnimatedFile> Handle;
+	typedef etl::handle<const ValueNode_AnimatedFile> ConstHandle;
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	virtual ValueNode::LooseHandle get_link_vfunc(int i) const;
-
-	static bool check_type(Type &type);
 	static ValueNode_AnimatedFile* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc() const;
+	virtual ~ValueNode_AnimatedFile();
 
-	virtual ValueBase operator()(Time t) const;
-	virtual void get_values_vfunc(std::map<Time, ValueBase> &x) const;
+	virtual ValueBase operator()(Time t) const override;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 	String get_file_field(Time t, const String &field_name) const;
 
 protected:
-	LinkableValueNode* create_new() const;
+	LinkableValueNode* create_new() const override;
 
-	virtual void on_changed();
-	virtual bool set_link_vfunc(int i, ValueNode::Handle x);
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual LinkableValueNode::Vocab get_children_vocab_vfunc() const override;
+
+	virtual void get_values_vfunc(std::map<Time, ValueBase> &x) const override;
+
+	virtual void on_changed() override;
 };
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
@@ -80,7 +80,7 @@ ValueNode_Atan2::create_new()const
 }
 
 ValueNode_Atan2*
-ValueNode_Atan2::create(const ValueBase &x)
+ValueNode_Atan2::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Atan2(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_atan2.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_atan2.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Atan2> Handle;
 	typedef etl::handle<const ValueNode_Atan2> ConstHandle;
 
-	static ValueNode_Atan2* create(const ValueBase &value=ValueBase());
+	static ValueNode_Atan2* create(const ValueBase& value=ValueBase(), etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Atan2();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_atan2.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_atan2.h
@@ -48,31 +48,25 @@ class ValueNode_Atan2 : public LinkableValueNode
 	ValueNode_Atan2(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_Atan2> Handle;
 	typedef etl::handle<const ValueNode_Atan2> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Atan2* create(const ValueBase &value=ValueBase());
 	virtual ~ValueNode_Atan2();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	virtual LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Atan2* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Atan2
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_average.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_average.cpp
@@ -86,7 +86,7 @@ ValueNode_Average::ValueNode_Average(Type &type, Canvas::LooseHandle canvas):
 ValueNode_Average::~ValueNode_Average() { }
 
 ValueNode_Average*
-ValueNode_Average::create(const ValueBase &value, Canvas::LooseHandle canvas)
+ValueNode_Average::create(const ValueBase& value, Canvas::LooseHandle canvas)
 	{ return new ValueNode_Average(value, canvas); }
 
 ValueBase

--- a/synfig-core/src/synfig/valuenodes/valuenode_average.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_average.h
@@ -47,7 +47,7 @@ public:
 	typedef etl::handle<const ValueNode_Average> ConstHandle;
 
 	ValueNode_Average(Type &type, etl::loose_handle<Canvas> canvas);
-	static ValueNode_Average* create(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
+	static ValueNode_Average* create(const ValueBase& value, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Average();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_average.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_average.h
@@ -40,27 +40,24 @@ namespace synfig {
 
 class ValueNode_Average : public ValueNode_DynamicList
 {
-public:
+	ValueNode_Average(const ValueBase &value, etl::loose_handle<Canvas> canvas);
 
+public:
 	typedef etl::handle<ValueNode_Average> Handle;
 	typedef etl::handle<const ValueNode_Average> ConstHandle;
 
-
-	ValueNode_Average(const ValueBase &value, etl::loose_handle<Canvas> canvas);
 	ValueNode_Average(Type &type, etl::loose_handle<Canvas> canvas);
+	static ValueNode_Average* create(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
 	virtual ~ValueNode_Average();
 
- 	virtual ValueBase operator()(Time t)const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-
-public:
-	static bool check_type(Type &type);
-	static ValueNode_Average* create(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
+	LinkableValueNode* create_new() const override;
 }; // END of class ValueNode_Average
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -42,10 +42,6 @@
 #include <synfig/localization.h>
 #include <synfig/valuenode_registry.h>
 #include <synfig/exception.h>
-#include <synfig/blinepoint.h>
-#include <vector>
-#include <list>
-#include <algorithm>
 #include <ETL/hermite>
 #include <ETL/calculus>
 #include <synfig/segment.h>

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -393,7 +393,7 @@ ValueNode_BLine::~ValueNode_BLine()
 }
 
 ValueNode_BLine*
-ValueNode_BLine::create(const ValueBase &value, Canvas::LooseHandle canvas)
+ValueNode_BLine::create(const ValueBase& value, Canvas::LooseHandle canvas)
 {
 	if(value.get_type()!=type_list)
 		return 0;

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.h
@@ -33,13 +33,9 @@
 /* === H E A D E R S ======================================================= */
 
 #include <vector>
-#include <list>
 
-#include <synfig/valuenode.h>
-#include <synfig/time.h>
-#include <synfig/uniqueid.h>
 #include <synfig/blinepoint.h>
-#include "valuenode_dynamiclist.h"
+#include <synfig/valuenodes/valuenode_dynamiclist.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -72,43 +68,37 @@ Real bline_length(const ValueBase &bline, bool bline_loop, std::vector<Real> *le
 */
 class ValueNode_BLine : public ValueNode_DynamicList
 {
-public:
-
-	typedef etl::handle<ValueNode_BLine> Handle;
-	typedef etl::handle<const ValueNode_BLine> ConstHandle;
-
-
 	ValueNode_BLine(etl::loose_handle<Canvas> canvas = 0);
-
-public:
-
- 	virtual ValueBase operator()(Time t)const;
-
-	virtual ~ValueNode_BLine();
-
-	virtual String link_local_name(int i)const;
-
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-
-	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5);
-
-protected:
-
-	LinkableValueNode* create_new()const;
-
-public:
-	//using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_BLine* create(const ValueBase &x=type_list, etl::loose_handle<Canvas> canvas = 0);
 
 	//! Returns the BlinePoint at time t, with the tangents modified if
 	//! the vertex is boned influenced, otherwise returns the Blinepoint at time t.
-	BLinePoint get_blinepoint(std::vector<ListEntry>::const_iterator current, Time t)const;
-	virtual Vocab get_children_vocab_vfunc()const;
+	BLinePoint get_blinepoint(std::vector<ListEntry>::const_iterator current, Time t) const;
+
+public:
+	typedef etl::handle<ValueNode_BLine> Handle;
+	typedef etl::handle<const ValueNode_BLine> ConstHandle;
+
+	static ValueNode_BLine* create(const ValueBase &x=type_list, etl::loose_handle<Canvas> canvas = 0);
+	virtual ~ValueNode_BLine();
+
+	virtual ValueBase operator()(Time t) const override;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	virtual String link_local_name(int i) const override;
+	static bool check_type(Type &type);
+
+	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5) override;
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
+
+public:
 #ifdef _DEBUG
-	virtual void ref()const;
-	virtual bool unref()const;
+	virtual void ref() const override;
+	virtual bool unref() const override;
 #endif
 }; // END of class ValueNode_BLine
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.h
@@ -78,7 +78,7 @@ public:
 	typedef etl::handle<ValueNode_BLine> Handle;
 	typedef etl::handle<const ValueNode_BLine> ConstHandle;
 
-	static ValueNode_BLine* create(const ValueBase &x=type_list, etl::loose_handle<Canvas> canvas = 0);
+	static ValueNode_BLine* create(const ValueBase& x=type_list, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_BLine();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
@@ -70,7 +70,7 @@ ValueNode_BLineCalcTangent::ValueNode_BLineCalcTangent(Type &x):
 	if(x!=type_angle && x!=type_real && x!=type_vector)
 		throw Exception::BadType(x.description.local_name);
 
-	ValueNode_BLine* value_node(new ValueNode_BLine());
+	ValueNode_BLine* value_node(ValueNode_BLine::create());
 	set_link("bline",value_node);
 	set_link("loop",ValueNode_Const::create(bool(false)));
 	set_link("amount",ValueNode_Const::create(Real(0.5)));

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
@@ -87,7 +87,7 @@ ValueNode_BLineCalcTangent::create_new()const
 }
 
 ValueNode_BLineCalcTangent*
-ValueNode_BLineCalcTangent::create(const ValueBase &x)
+ValueNode_BLineCalcTangent::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_BLineCalcTangent(x.get_type());
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.h
@@ -56,7 +56,7 @@ public:
 	typedef etl::handle<ValueNode_BLineCalcTangent> Handle;
 	typedef etl::handle<const ValueNode_BLineCalcTangent> ConstHandle;
 
-	static ValueNode_BLineCalcTangent* create(const ValueBase &x=type_vector);
+	static ValueNode_BLineCalcTangent* create(const ValueBase& x=type_vector, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_BLineCalcTangent();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.h
@@ -53,30 +53,26 @@ class ValueNode_BLineCalcTangent : public LinkableValueNode
 	ValueNode_BLineCalcTangent(Type &x=type_vector);
 
 public:
-
 	typedef etl::handle<ValueNode_BLineCalcTangent> Handle;
 	typedef etl::handle<const ValueNode_BLineCalcTangent> ConstHandle;
 
-	virtual ValueBase operator()(Time t, Real amount)const;
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_BLineCalcTangent* create(const ValueBase &x=type_vector);
 	virtual ~ValueNode_BLineCalcTangent();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
+	virtual ValueBase operator()(Time t, Real amount) const;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	LinkableValueNode* create_new()const;
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_BLineCalcTangent* create(const ValueBase &x=type_vector);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_BLineCalcTangent
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
@@ -70,7 +70,7 @@ ValueNode_BLineCalcVertex::ValueNode_BLineCalcVertex(Type &x):
 	if(x!=type_vector)
 		throw Exception::BadType(x.description.local_name);
 
-	ValueNode_BLine* value_node(new ValueNode_BLine());
+	ValueNode_BLine* value_node(ValueNode_BLine::create());
 	set_link("bline",value_node);
 	set_link("loop",ValueNode_Const::create(bool(false)));
 	set_link("amount",ValueNode_Const::create(Real(0.5)));

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
@@ -84,7 +84,7 @@ ValueNode_BLineCalcVertex::create_new()const
 }
 
 ValueNode_BLineCalcVertex*
-ValueNode_BLineCalcVertex::create(const ValueBase &x)
+ValueNode_BLineCalcVertex::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_BLineCalcVertex(x.get_type());
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.h
@@ -49,29 +49,25 @@ class ValueNode_BLineCalcVertex : public LinkableValueNode
 	ValueNode_BLineCalcVertex(Type &x=type_vector);
 
 public:
-
 	typedef etl::handle<ValueNode_BLineCalcVertex> Handle;
 	typedef etl::handle<const ValueNode_BLineCalcVertex> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_BLineCalcVertex* create(const ValueBase &x=type_vector);
 	virtual ~ValueNode_BLineCalcVertex();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_BLineCalcVertex* create(const ValueBase &x=type_vector);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_BLineCalcVertex
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_BLineCalcVertex> Handle;
 	typedef etl::handle<const ValueNode_BLineCalcVertex> ConstHandle;
 
-	static ValueNode_BLineCalcVertex* create(const ValueBase &x=type_vector);
+	static ValueNode_BLineCalcVertex* create(const ValueBase& x=type_vector, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_BLineCalcVertex();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
@@ -85,7 +85,7 @@ ValueNode_BLineCalcWidth::create_new()const
 }
 
 ValueNode_BLineCalcWidth*
-ValueNode_BLineCalcWidth::create(const ValueBase &x)
+ValueNode_BLineCalcWidth::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_BLineCalcWidth(x.get_type());
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
@@ -70,7 +70,7 @@ ValueNode_BLineCalcWidth::ValueNode_BLineCalcWidth(Type &x):
 	if(x!=type_real)
 		throw Exception::BadType(x.description.local_name);
 
-	ValueNode_BLine* value_node(new ValueNode_BLine());
+	ValueNode_BLine* value_node(ValueNode_BLine::create());
 	set_link("bline",value_node);
 	set_link("loop",ValueNode_Const::create(bool(false)));
 	set_link("amount",ValueNode_Const::create(Real(0.5)));

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.h
@@ -51,30 +51,26 @@ class ValueNode_BLineCalcWidth : public LinkableValueNode
 	ValueNode_BLineCalcWidth(Type &x=type_real);
 
 public:
-
 	typedef etl::handle<ValueNode_BLineCalcWidth> Handle;
 	typedef etl::handle<const ValueNode_BLineCalcWidth> ConstHandle;
 
-	virtual ValueBase operator()(Time t, Real amount)const;
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_BLineCalcWidth* create(const ValueBase &x=type_real);
 	virtual ~ValueNode_BLineCalcWidth();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
+	virtual ValueBase operator()(Time t, Real amount) const;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_BLineCalcWidth* create(const ValueBase &x=type_real);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_BLineCalcWidth
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.h
@@ -54,7 +54,7 @@ public:
 	typedef etl::handle<ValueNode_BLineCalcWidth> Handle;
 	typedef etl::handle<const ValueNode_BLineCalcWidth> ConstHandle;
 
-	static ValueNode_BLineCalcWidth* create(const ValueBase &x=type_real);
+	static ValueNode_BLineCalcWidth* create(const ValueBase& x=type_real, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_BLineCalcWidth();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.cpp
@@ -80,7 +80,7 @@ ValueNode_BLineRevTangent::ValueNode_BLineRevTangent(const ValueNode::Handle &x)
 }
 
 ValueNode_BLineRevTangent*
-ValueNode_BLineRevTangent::create(const ValueBase &x)
+ValueNode_BLineRevTangent::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_BLineRevTangent(ValueNode_Const::create(x));
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_BLineRevTangent> Handle;
 	typedef etl::handle<const ValueNode_BLineRevTangent> ConstHandle;
 
-	static ValueNode_BLineRevTangent* create(const ValueBase &x=type_vector);
+	static ValueNode_BLineRevTangent* create(const ValueBase& x=type_vector, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_BLineRevTangent();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.h
@@ -49,29 +49,25 @@ class ValueNode_BLineRevTangent : public LinkableValueNode
 	ValueNode_BLineRevTangent(const ValueNode::Handle &x);
 
 public:
-
 	typedef etl::handle<ValueNode_BLineRevTangent> Handle;
 	typedef etl::handle<const ValueNode_BLineRevTangent> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_BLineRevTangent* create(const ValueBase &x=type_vector);
 	virtual ~ValueNode_BLineRevTangent();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	LinkableValueNode* create_new()const;
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_BLineRevTangent* create(const ValueBase &x=type_vector);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_BLineRevTangent
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
@@ -307,7 +307,7 @@ ValueNode_Bone::create_new()const
 }
 
 ValueNode_Bone*
-ValueNode_Bone::create(const ValueBase &x, Canvas::LooseHandle canvas)
+ValueNode_Bone::create(const ValueBase& x, Canvas::LooseHandle canvas)
 {
 	return new ValueNode_Bone(x, canvas);
 }
@@ -1032,7 +1032,7 @@ ValueNode_Bone_Root::set_root_canvas(etl::loose_handle<Canvas> canvas)
 }
 
 ValueNode_Bone*
-ValueNode_Bone_Root::create(const ValueBase &x)
+ValueNode_Bone_Root::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return get_root_bone().get();
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
@@ -426,7 +426,7 @@ ValueNode_Bone::get_parent(Time t)const
 		return parent;
 	}
 	assert(0);
-	return ValueNode_Bone::ConstHandle::cast_dynamic(new ValueNode_Bone_Root);
+	return new ValueNode_Bone_Root();
 }
 
 ValueBase

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.h
@@ -66,7 +66,7 @@ public:
 	typedef std::set<LooseHandle> BoneSet;
 	typedef std::list<LooseHandle> BoneList;
 
-	static ValueNode_Bone* create(const ValueBase &x, etl::loose_handle<Canvas> canvas = nullptr);
+	static ValueNode_Bone* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Bone();
 
 	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
@@ -138,7 +138,7 @@ private:
 class ValueNode_Bone_Root : public ValueNode_Bone
 {
 public:
-	static ValueNode_Bone* create(const ValueBase &x);
+	static ValueNode_Bone* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	ValueNode_Bone_Root();
 	virtual ~ValueNode_Bone_Root();
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.h
@@ -58,7 +58,6 @@ protected:
 	ValueNode_Bone(const ValueBase &value, etl::loose_handle<Canvas> canvas = nullptr);
 
 public:
-
 	typedef etl::handle<ValueNode_Bone> Handle;
 	typedef etl::handle<const ValueNode_Bone> ConstHandle;
 	typedef etl::loose_handle<ValueNode_Bone> LooseHandle;
@@ -67,42 +66,42 @@ public:
 	typedef std::set<LooseHandle> BoneSet;
 	typedef std::list<LooseHandle> BoneList;
 
-	virtual ValueBase operator()(Time t)const;
-
-	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
-
+	static ValueNode_Bone* create(const ValueBase &x, etl::loose_handle<Canvas> canvas = nullptr);
 	virtual ~ValueNode_Bone();
-	virtual void set_guid(const GUID& new_guid);
-	virtual void set_root_canvas(etl::loose_handle<Canvas> canvas);
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-	virtual String get_bone_name(Time t)const;
+	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-	
-	// checks if point belongs to the range of influence of current bone
-	bool have_influence_on(Time t, const Vector &x)const
-		{ return (*this)(t).get(Bone()).have_influence_on(x); }
+	virtual ValueBase operator()(Time t) const override;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual void set_guid(const GUID& new_guid) override;
+	virtual void set_root_canvas(etl::loose_handle<Canvas> canvas) override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-	virtual void on_changed();
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
+
+	virtual void on_changed() override;
 
 public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual String get_bone_name(Time t)const;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Bone* create(const ValueBase &x, etl::loose_handle<Canvas> canvas = nullptr);
-	virtual Vocab get_children_vocab_vfunc()const;
 	ValueNode_Bone::LooseHandle find(String name)const;
 	String unique_name(String name)const;
 	static void show_bone_map(etl::loose_handle<Canvas> canvas, const char *file, int line, String text, Time t=0);
 	static BoneMap get_bone_map(etl::handle<const Canvas> canvas);
 	static BoneList get_ordered_bones(etl::handle<const Canvas> canvas);
+
+	// checks if point belongs to the range of influence of current bone
+	bool have_influence_on(Time t, const Vector &x)const
+		{ return (*this)(t).get(Bone()).have_influence_on(x); }
 
 	ValueNode_Bone::ConstHandle is_ancestor_of(ValueNode_Bone::ConstHandle bone, Time t)const;
 	virtual bool is_root()const { return false; }
@@ -123,10 +122,10 @@ public:
 	static ValueNode_Bone::Handle get_root_bone();
 
 #ifdef _DEBUG
-	virtual void ref()const;
-	virtual bool unref()const;
-	virtual void rref()const;
-	virtual void runref()const;
+	virtual void ref() const override;
+	virtual bool unref() const override;
+	virtual void rref() const override;
+	virtual void runref() const override;
 #endif
 
 private:
@@ -139,39 +138,38 @@ private:
 class ValueNode_Bone_Root : public ValueNode_Bone
 {
 public:
-
+	static ValueNode_Bone* create(const ValueBase &x);
 	ValueNode_Bone_Root();
 	virtual ~ValueNode_Bone_Root();
 
-	virtual ValueBase operator()(Time t)const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-	virtual String get_bone_name(Time t)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual void set_guid(const GUID& new_guid);
-	virtual void set_root_canvas(etl::loose_handle<Canvas> canvas);
+	virtual void set_guid(const GUID& new_guid) override;
+	virtual void set_root_canvas(etl::loose_handle<Canvas> canvas) override;
 
-	virtual int link_count()const;
-	virtual bool is_root()const { return true; }
-
-private:
-	Matrix get_animated_matrix(Time t, Point child_origin)const;
+	virtual int link_count() const override;
 
 protected:
-	LinkableValueNode* create_new()const;
+	LinkableValueNode* create_new() const override;
 
 public:
-	static bool check_type(Type &type);
-	static ValueNode_Bone* create(const ValueBase &x);
+	virtual String get_bone_name(Time t) const override;
+
+	virtual bool is_root() const override { return true; }
 
 #ifdef _DEBUG
-	virtual void ref()const;
-	virtual bool unref()const;
-	virtual void rref()const;
-	virtual void runref()const;
+	virtual void ref() const override;
+	virtual bool unref() const override;
+	virtual void rref() const override;
+	virtual void runref() const override;
 #endif
 
+private:
+	Matrix get_animated_matrix(Time t, Point child_origin) const override;
 }; // END of class ValueNode_Bone_Root
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.cpp
@@ -95,7 +95,7 @@ ValueNode_BoneInfluence::ValueNode_BoneInfluence(const ValueNode::Handle &x, Can
 }
 
 ValueNode_BoneInfluence*
-ValueNode_BoneInfluence::create(const ValueBase &x, Canvas::LooseHandle canvas)
+ValueNode_BoneInfluence::create(const ValueBase& x, Canvas::LooseHandle canvas, etl::loose_handle<Canvas>)
 {
 	if (x.get_type() == type_bline_point)
 		return new ValueNode_BoneInfluence(ValueNode_Composite::create(x, canvas), canvas);

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.h
@@ -54,7 +54,7 @@ public:
 	typedef etl::handle<ValueNode_BoneInfluence> Handle;
 	typedef etl::handle<const ValueNode_BoneInfluence> ConstHandle;
 
-	static ValueNode_BoneInfluence* create(const ValueBase &x, etl::loose_handle<Canvas>);
+	static ValueNode_BoneInfluence* create(const ValueBase& x, etl::loose_handle<Canvas>, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_BoneInfluence();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.h
@@ -47,45 +47,36 @@ class ValueNode_BoneInfluence : public LinkableValueNode
 	mutable Matrix transform_, inverse_transform_;
 	mutable bool checked_inverse_, has_inverse_;
 
+	ValueNode_BoneInfluence(Type &x);
+	ValueNode_BoneInfluence(const ValueNode::Handle &x, etl::loose_handle<Canvas> canvas);
+
 public:
 	typedef etl::handle<ValueNode_BoneInfluence> Handle;
 	typedef etl::handle<const ValueNode_BoneInfluence> ConstHandle;
 
-	ValueNode_BoneInfluence(Type &x);
-
-	ValueNode_BoneInfluence(const ValueNode::Handle &x, etl::loose_handle<Canvas> canvas);
-
-//	static Handle create(Type &x);
-//	static Handle create(const ValueNode::Handle &x);
-
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_BoneInfluence* create(const ValueBase &x, etl::loose_handle<Canvas>);
 	virtual ~ValueNode_BoneInfluence();
 
-	virtual String get_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-	LinkableValueNode* create_new()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 
 public:
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	virtual Vocab get_children_vocab_vfunc()const;
-	static ValueNode_BoneInfluence* create(const ValueBase &x, etl::loose_handle<Canvas>);
-
 	Matrix calculate_transform(Time t)const;
 	Matrix& get_transform(bool rebuild=false, Time t=0)const;
 	void set_transform(Matrix transform)const { transform_ = transform; checked_inverse_ = false; }
 	bool has_inverse_transform()const;
 	Matrix& get_inverse_transform()const;
-
 }; // END of class ValueNode_BoneInfluence
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_bonelink.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bonelink.cpp
@@ -73,7 +73,7 @@ ValueNode_BoneLink::ValueNode_BoneLink(const ValueBase &x):
 }
 
 ValueNode_BoneLink*
-ValueNode_BoneLink::create(const ValueBase &x)
+ValueNode_BoneLink::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_BoneLink(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_bonelink.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bonelink.h
@@ -48,34 +48,33 @@ class ValueNode_BoneLink : public LinkableValueNode
 	ValueNode::RHandle scale_x_;
 	ValueNode::RHandle scale_y_;
 
+	ValueNode_BoneLink(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_BoneLink> Handle;
 	typedef etl::handle<const ValueNode_BoneLink> ConstHandle;
 
-	ValueNode_BoneLink(const ValueBase &x);
-
-	Transformation get_bone_transformation(Time t)const;
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_BoneLink* create(const ValueBase &x);
 	virtual ~ValueNode_BoneLink();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual void set_root_canvas(etl::loose_handle<Canvas> canvas) override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 
 public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_BoneLink* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
-	virtual void set_root_canvas(etl::loose_handle<Canvas> canvas);
+	Transformation get_bone_transformation(Time t) const;
 }; // END of class ValueNode_Pow
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_bonelink.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bonelink.h
@@ -54,7 +54,7 @@ public:
 	typedef etl::handle<ValueNode_BoneLink> Handle;
 	typedef etl::handle<const ValueNode_BoneLink> ConstHandle;
 
-	static ValueNode_BoneLink* create(const ValueBase &x);
+	static ValueNode_BoneLink* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_BoneLink();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.cpp
@@ -91,7 +91,7 @@ ValueNode_BoneWeightPair::create_new()const
 }
 
 ValueNode_BoneWeightPair*
-ValueNode_BoneWeightPair::create(const ValueBase &x, Canvas::LooseHandle canvas)
+ValueNode_BoneWeightPair::create(const ValueBase& x, Canvas::LooseHandle canvas, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_BoneWeightPair(x, canvas);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_BoneWeightPair> Handle;
 	typedef etl::handle<const ValueNode_BoneWeightPair> ConstHandle;
 
-	static ValueNode_BoneWeightPair* create(const ValueBase &x, etl::loose_handle<Canvas>);
+	static ValueNode_BoneWeightPair* create(const ValueBase& x, etl::loose_handle<Canvas>, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_BoneWeightPair();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.h
@@ -48,31 +48,25 @@ class ValueNode_BoneWeightPair : public LinkableValueNode
 	ValueNode_BoneWeightPair(const ValueBase &value, etl::loose_handle<Canvas> = 0);
 
 public:
-
 	typedef etl::handle<ValueNode_BoneWeightPair> Handle;
 	typedef etl::handle<const ValueNode_BoneWeightPair> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_BoneWeightPair* create(const ValueBase &x, etl::loose_handle<Canvas>);
 	virtual ~ValueNode_BoneWeightPair();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_BoneWeightPair* create(const ValueBase &x, etl::loose_handle<Canvas>);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_BoneWeightPair
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_compare.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_compare.cpp
@@ -76,7 +76,7 @@ ValueNode_Compare::ValueNode_Compare(const ValueBase &x):
 }
 
 ValueNode_Compare*
-ValueNode_Compare::create(const ValueBase &x)
+ValueNode_Compare::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Compare(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_compare.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_compare.h
@@ -49,33 +49,28 @@ class ValueNode_Compare : public LinkableValueNode
 	ValueNode::RHandle equal_;
 	ValueNode::RHandle less_;
 
+	ValueNode_Compare(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Compare> Handle;
 	typedef etl::handle<const ValueNode_Compare> ConstHandle;
 
-	ValueNode_Compare(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Compare* create(const ValueBase &x);
 	virtual ~ValueNode_Compare();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Compare* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Compare
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_compare.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_compare.h
@@ -55,7 +55,7 @@ public:
 	typedef etl::handle<ValueNode_Compare> Handle;
 	typedef etl::handle<const ValueNode_Compare> ConstHandle;
 
-	static ValueNode_Compare* create(const ValueBase &x);
+	static ValueNode_Compare* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Compare();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
@@ -205,7 +205,7 @@ ValueNode_Composite::~ValueNode_Composite()
 }
 
 ValueNode_Composite*
-ValueNode_Composite::create(const ValueBase &value, Canvas::LooseHandle canvas)
+ValueNode_Composite::create(const ValueBase& value, Canvas::LooseHandle canvas)
 {
 	return new ValueNode_Composite(value, canvas);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.h
@@ -44,33 +44,33 @@ namespace synfig {
 class ValueNode_Composite : public LinkableValueNode
 {
 	ValueNode::RHandle components[MAX_LINKS];
+
 	ValueNode_Composite(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
 
 public:
 	typedef etl::handle<ValueNode_Composite> Handle;
 	typedef etl::handle<const ValueNode_Composite> ConstHandle;
 
+	static ValueNode_Composite* create(const ValueBase &x, etl::loose_handle<Canvas> canvas = nullptr);
+	virtual ~ValueNode_Composite();
 
-	~ValueNode_Composite();
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-	virtual String link_name(int i)const;
-	virtual ValueBase operator()(Time t)const;
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-	virtual int get_link_index_from_name(const String &name)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	String link_name(int i) const override;
+	int get_link_index_from_name(const String &name) const override;
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-	LinkableValueNode* create_new()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-public:
-	using synfig::LinkableValueNode::set_link_vfunc;
-	using synfig::LinkableValueNode::get_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Composite* create(const ValueBase &x, etl::loose_handle<Canvas> canvas = 0);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
+
 }; // END of class ValueNode_Composite
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Composite> Handle;
 	typedef etl::handle<const ValueNode_Composite> ConstHandle;
 
-	static ValueNode_Composite* create(const ValueBase &x, etl::loose_handle<Canvas> canvas = nullptr);
+	static ValueNode_Composite* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Composite();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_const.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_const.cpp
@@ -75,7 +75,7 @@ ValueNode_Const::ValueNode_Const(const ValueBase &x, Canvas::LooseHandle canvas)
 
 
 ValueNode*
-ValueNode_Const::create(const ValueBase &x, Canvas::LooseHandle canvas)
+ValueNode_Const::create(const ValueBase& x, Canvas::LooseHandle canvas)
 {
 	// this is nasty - shouldn't it be done somewhere else?
 	if (x.get_type() == type_bone_object)

--- a/synfig-core/src/synfig/valuenodes/valuenode_const.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_const.h
@@ -40,44 +40,44 @@ namespace synfig {
 
 class ValueNode_Const : public ValueNode
 {
-public:
-	typedef etl::handle<ValueNode_Const> Handle;
-	typedef etl::handle<const ValueNode_Const> ConstHandle;
-
-private:
 	ValueBase value;
 
 	ValueNode_Const();
 	ValueNode_Const(const ValueBase &x, etl::loose_handle<Canvas> canvas = 0);
 
 public:
+	typedef etl::handle<ValueNode_Const> Handle;
+	typedef etl::handle<const ValueNode_Const> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
+	/// create a new ValueNode_Const object with the given value.
+	/// Unless the given value is a Bone, in which case make a ValueNode_Bone.
+	static ValueNode* create(const ValueBase &x=ValueBase(), etl::loose_handle<Canvas> canvas = 0);
 	virtual ~ValueNode_Const();
 
-	const ValueBase &get_value()const;
-	ValueBase &get_value();
-	void set_value(const ValueBase &data);
+	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
 
-	bool get_static()const {return get_value().get_static();}
-	void set_static(bool x) { get_value().set_static(x); }
-	virtual Interpolation get_interpolation()const {return get_value().get_interpolation();}
-	virtual void set_interpolation(Interpolation x) { get_value().set_interpolation(x); }
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+
+	virtual Interpolation get_interpolation() const override {return get_value().get_interpolation();}
+	virtual void set_interpolation(Interpolation x) override { get_value().set_interpolation(x); }
 #ifdef _DEBUG
-	String get_string()const;
-#endif	// _DEBUG
-public:
-	// create a new ValueNode_Const object with the given value.
-	// Unless the given value is a Bone, in which case make a ValueNode_Bone.
-	static ValueNode* create(const ValueBase &x=ValueBase(), etl::loose_handle<Canvas> canvas = 0);
+	String get_string() const override;
+#endif // _DEBUG
 
 protected:
-	virtual void get_times_vfunc(Node::time_set &set) const;
-	virtual void get_values_vfunc(std::map<Time, ValueBase> &x) const;
+	virtual void get_times_vfunc(Node::time_set &set) const override;
+	virtual void get_values_vfunc(std::map<Time, ValueBase> &x) const override;
+
+public:
+	const ValueBase& get_value() const;
+	ValueBase& get_value();
+	void set_value(const ValueBase &data);
+
+	bool get_static() const {return get_value().get_static();}
+	void set_static(bool x) { get_value().set_static(x); }
 };
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_cos.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_cos.cpp
@@ -80,7 +80,7 @@ ValueNode_Cos::create_new()const
 }
 
 ValueNode_Cos*
-ValueNode_Cos::create(const ValueBase &x)
+ValueNode_Cos::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Cos(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_cos.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_cos.h
@@ -52,27 +52,23 @@ public:
 	typedef etl::handle<ValueNode_Cos> Handle;
 	typedef etl::handle<const ValueNode_Cos> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Cos* create(const ValueBase &x);
 	virtual ~ValueNode_Cos();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Cos* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
+
 }; // END of class ValueNode_Cos
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_cos.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_cos.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_Cos> Handle;
 	typedef etl::handle<const ValueNode_Cos> ConstHandle;
 
-	static ValueNode_Cos* create(const ValueBase &x);
+	static ValueNode_Cos* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Cos();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_derivative.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_derivative.cpp
@@ -180,7 +180,7 @@ ValueNode_Derivative::create_new()const
 }
 
 ValueNode_Derivative*
-ValueNode_Derivative::create(const ValueBase &x)
+ValueNode_Derivative::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Derivative(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_derivative.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_derivative.h
@@ -39,7 +39,7 @@
 namespace synfig {
 
 // Class ValueNode_Derivative
-// Implementation of a derivateive based on finite diferences
+// Implementation of a derivative based on finite diferences
 // See: http://en.wikipedia.org/wiki/Finite_difference
 // and http://en.wikipedia.org/wiki/Finite_difference_coefficients
 
@@ -70,26 +70,22 @@ public:
 	typedef etl::handle<ValueNode_Derivative> Handle;
 	typedef etl::handle<const ValueNode_Derivative> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Derivative* create(const ValueBase &x);
 	virtual ~ValueNode_Derivative();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Derivative* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Derivative
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_derivative.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_derivative.h
@@ -70,7 +70,7 @@ public:
 	typedef etl::handle<ValueNode_Derivative> Handle;
 	typedef etl::handle<const ValueNode_Derivative> ConstHandle;
 
-	static ValueNode_Derivative* create(const ValueBase &x);
+	static ValueNode_Derivative* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Derivative();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_dilist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dilist.cpp
@@ -76,7 +76,7 @@ ValueNode_DIList::~ValueNode_DIList()
 }
 
 ValueNode_DIList*
-ValueNode_DIList::create(const ValueBase &value)
+ValueNode_DIList::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	// if the parameter is not a list type, return null
 	if(value.get_type()!=type_list)

--- a/synfig-core/src/synfig/valuenodes/valuenode_dilist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dilist.h
@@ -32,13 +32,6 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <vector>
-#include <list>
-
-#include <synfig/valuenode.h>
-#include <synfig/time.h>
-#include <synfig/uniqueid.h>
-#include <synfig/dashitem.h>
 #include "valuenode_dynamiclist.h"
 
 /* === M A C R O S ========================================================= */
@@ -54,43 +47,41 @@ namespace synfig {
 */
 class ValueNode_DIList : public ValueNode_DynamicList
 {
-private:
 	ValueNode::RHandle bline_;
-public:
 
-	typedef etl::handle<ValueNode_DIList> Handle;
-	typedef etl::handle<const ValueNode_DIList> ConstHandle;
-	typedef etl::handle<const ValueNode_DIList> LooseHandle;
 	ValueNode_DIList();
 
 public:
+	typedef etl::handle<ValueNode_DIList> Handle;
+	typedef etl::handle<const ValueNode_DIList> ConstHandle;
+	typedef etl::handle<const ValueNode_DIList> LooseHandle;
 
- 	virtual ValueBase operator()(Time t)const;
+	// Creates a Value Node Width Point List from another compatible list
+	static ValueNode_DIList* create(const ValueBase &x=type_list);
 	virtual ~ValueNode_DIList();
-	virtual String link_local_name(int i)const;
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+	virtual String link_local_name(int i) const override;
+
+	virtual ValueBase operator()(Time t) const override;
+
 	//! Inserts a new entry between the previous found
 	//! dashitem and the one where the action was called
 	//! \param index the index of the entry where the action is done
 	//! \param time the time when inserted in animation mode
 	//! \param origin unused. Always is in the middle.
 	//! \return the new List Entry
-	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5);
+	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5) override;
+
 	//! Gets the bline RHandle
-	ValueNode::LooseHandle get_bline()const;
+	ValueNode::LooseHandle get_bline() const;
 	//! Sets the bline RHandle
 	void set_bline(ValueNode::Handle b);
 
 protected:
-
-	LinkableValueNode* create_new()const;
-
-public:
-
-	static bool check_type(Type &type);
-	// Creates a Value Node Width Point List from another compatible list
-	static ValueNode_DIList* create(const ValueBase &x=type_list);
+	LinkableValueNode* create_new() const override;
 }; // END of class ValueNode_DIList
 
 typedef ValueNode_DIList::ListEntry::ActivepointList ActivepointList;

--- a/synfig-core/src/synfig/valuenodes/valuenode_dilist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dilist.h
@@ -57,7 +57,7 @@ public:
 	typedef etl::handle<const ValueNode_DIList> LooseHandle;
 
 	// Creates a Value Node Width Point List from another compatible list
-	static ValueNode_DIList* create(const ValueBase &x=type_list);
+	static ValueNode_DIList* create(const ValueBase& x=type_list, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_DIList();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.cpp
@@ -86,7 +86,7 @@ ValueNode_DotProduct::create_new()const
 }
 
 ValueNode_DotProduct*
-ValueNode_DotProduct::create(const ValueBase &x)
+ValueNode_DotProduct::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_DotProduct(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_DotProduct> Handle;
 	typedef etl::handle<const ValueNode_DotProduct> ConstHandle;
 
-	static ValueNode_DotProduct* create(const ValueBase &x);
+	static ValueNode_DotProduct* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_DotProduct();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.h
@@ -48,31 +48,25 @@ class ValueNode_DotProduct : public LinkableValueNode
 	ValueNode_DotProduct(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_DotProduct> Handle;
 	typedef etl::handle<const ValueNode_DotProduct> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_DotProduct* create(const ValueBase &x);
 	virtual ~ValueNode_DotProduct();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_DotProduct* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_DotProduct
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_duplicate.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_duplicate.cpp
@@ -75,7 +75,7 @@ ValueNode_Duplicate::ValueNode_Duplicate(const ValueBase &x):
 }
 
 ValueNode_Duplicate*
-ValueNode_Duplicate::create(const ValueBase &x)
+ValueNode_Duplicate::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Duplicate(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_duplicate.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_duplicate.h
@@ -47,36 +47,33 @@ class ValueNode_Duplicate : public LinkableValueNode
 	ValueNode::RHandle step_;
 	mutable Real index;
 
+	ValueNode_Duplicate(Type &x);
+	ValueNode_Duplicate(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Duplicate> Handle;
 	typedef etl::handle<const ValueNode_Duplicate> ConstHandle;
 
-	ValueNode_Duplicate(Type &x);
-	ValueNode_Duplicate(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-	void reset_index(Time t)const;
-	bool step(Time t)const;
-	int count_steps(Time t)const;
-
+	static ValueNode_Duplicate* create(const ValueBase &x);
 	virtual ~ValueNode_Duplicate();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
+
+	void reset_index(Time t) const;
+	bool step(Time t) const;
+	int count_steps(Time t) const;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Duplicate* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Duplicate
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_duplicate.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_duplicate.h
@@ -54,7 +54,7 @@ public:
 	typedef etl::handle<ValueNode_Duplicate> Handle;
 	typedef etl::handle<const ValueNode_Duplicate> ConstHandle;
 
-	static ValueNode_Duplicate* create(const ValueBase &x);
+	static ValueNode_Duplicate* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Duplicate();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamic.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamic.cpp
@@ -111,7 +111,7 @@ ValueNode_Dynamic::create_new()const
 }
 
 ValueNode_Dynamic*
-ValueNode_Dynamic::create(const ValueBase &x)
+ValueNode_Dynamic::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Dynamic(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamic.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamic.h
@@ -32,11 +32,11 @@
 
 #include <synfig/valuenode.h>
 #include "valuenode_derivative.h"
-#include "valuenode_const.h"
 #include <synfig/vector.h>
 
 /* === M A C R O S ========================================================= */
 #define MASS_INERTIA_MINIMUM 0.0000001
+
 /* === C L A S S E S & S T R U C T S ======================================= */
 
 namespace synfig {
@@ -86,37 +86,34 @@ private:
 		*/
 	mutable std::vector<double> state;
 	void reset_state(Time t)const;
-public:
 
+public:
 	typedef etl::handle<ValueNode_Dynamic> Handle;
 	typedef etl::handle<const ValueNode_Dynamic> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Dynamic* create(const ValueBase &x);
 	virtual ~ValueNode_Dynamic();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Dynamic* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Dynamic
 
 
 class Oscillator
 {
 	etl::handle<const ValueNode_Dynamic> d;
+
 public:
     Oscillator(const ValueNode_Dynamic* x) : d(x) { }
     void operator() ( const std::vector<double> &x , std::vector<double> &dxdt , const double t )

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamic.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamic.h
@@ -91,7 +91,7 @@ public:
 	typedef etl::handle<ValueNode_Dynamic> Handle;
 	typedef etl::handle<const ValueNode_Dynamic> ConstHandle;
 
-	static ValueNode_Dynamic* create(const ValueBase &x);
+	static ValueNode_Dynamic* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Dynamic();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
@@ -623,7 +623,7 @@ ValueNode_DynamicList::~ValueNode_DynamicList()
 }
 
 ValueNode_DynamicList*
-ValueNode_DynamicList::create(const ValueBase &value)
+ValueNode_DynamicList::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	//vector<ValueBase> value_list(value.operator vector<ValueBase>());
 	std::vector<ValueBase> value_list(value.get_list());

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.h
@@ -34,10 +34,9 @@
 #include <vector>
 #include <list>
 
-#include <synfig/valuenode.h>
-#include <synfig/time.h>
-#include <synfig/uniqueid.h>
 #include <synfig/activepoint.h>
+#include <synfig/uniqueid.h>
+#include <synfig/valuenode.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -78,7 +77,16 @@ class Canvas;
 */
 class ValueNode_DynamicList : public LinkableValueNode
 {
+	Type *container_type;
+	bool loop_;
+
+protected:
+	ValueNode_DynamicList(Type &container_type=type_nil, etl::loose_handle<Canvas> canvas = 0);
+	ValueNode_DynamicList(Type &container_type, Type &type, etl::loose_handle<Canvas> canvas = 0);
+
 public:
+	typedef etl::handle<ValueNode_DynamicList> Handle;
+	typedef etl::handle<const ValueNode_DynamicList> ConstHandle;
 
 	/*! \class ListEntry
 	**	\brief Contains a potential list item, and associated timing information
@@ -161,54 +169,56 @@ public:
 		ListEntry(const ValueNode::Handle &value_node,Time begin, Time end);
 	}; // END of struct ValueNode_DynamicList::ListEntry
 
-	typedef etl::handle<ValueNode_DynamicList> Handle;
-	typedef etl::handle<const ValueNode_DynamicList> ConstHandle;
-
-protected:
-	ValueNode_DynamicList(Type &container_type=type_nil, etl::loose_handle<Canvas> canvas = 0);
-	ValueNode_DynamicList(Type &container_type, Type &type, etl::loose_handle<Canvas> canvas = 0);
-
-	Type *container_type;
-
-	bool loop_;
-
-
-public:
 	std::vector<ListEntry> list;
 
+	static ValueNode_DynamicList* create(const ValueBase &x=type_gradient);
+	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
+	virtual ~ValueNode_DynamicList();
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual int link_count() const override;
+	virtual String link_local_name(int i) const override;
+	virtual String link_name(int i) const override;
+	virtual int get_link_index_from_name(const String &name) const override;
+
+	virtual ValueBase operator()(Time t) const override;
+
+	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5);
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual void get_times_vfunc(Node::time_set &set) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
+
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
 public:
+	/*! \note The construction parameter (\a type) is the type that the list
+	**	contains, rather than the type that it will yield
+	**	(which is ValueBase::TYPE_LIST)
+	*/
+	static Handle create_on_canvas(Type &type=type_nil, etl::loose_handle<Canvas> canvas = 0);
 
 	void add(const ValueNode::Handle &value_node, int index=-1) { add(ListEntry(value_node), index); }
 	void add(const ListEntry &value_node, int index=-1);
 	void erase(const ValueNode::Handle &value_node);
 	void reindex();
 
-	int find_next_valid_entry(int x, Time t)const;
-	int find_prev_valid_entry(int x, Time t)const;
+	int find_next_valid_entry(int x, Time t) const;
+	int find_prev_valid_entry(int x, Time t) const;
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual int link_count()const;
-
-	virtual String link_name(int i)const;
-
- 	virtual ValueBase operator()(Time t)const;
-
-	virtual ~ValueNode_DynamicList();
-
-	virtual String link_local_name(int i)const;
-	virtual int get_link_index_from_name(const String &name)const;
-
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-
-	bool get_loop()const { return loop_; }
+	bool get_loop() const { return loop_; }
 	void set_loop(bool x) { loop_=x; }
 
 	void set_member_canvas(etl::loose_handle<Canvas>);
 
-	Type& get_contained_type()const;
-
+	Type& get_contained_type() const;
 
 	// TODO: better type-checking
 	template <typename iterator> static Handle
@@ -221,30 +231,6 @@ public:
 	}
 
 	void insert_time(const Time& location, const Time& delta);
-	//void manipulate_time(const Time& old_begin,const Time& old_end,const Time& new_begin,const Time& new_end);
-
-	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
-
-	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5);
-
-protected:
-
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	LinkableValueNode* create_new()const;
-
-	virtual void get_times_vfunc(Node::time_set &set) const;
-
-public:
-	/*! \note The construction parameter (\a id) is the type that the list
-	**	contains, rather than the type that it will yield
-	**	(which is ValueBase::TYPE_LIST)
-	*/
-	static Handle create_on_canvas(Type &type=type_nil, etl::loose_handle<Canvas> canvas = 0);
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_DynamicList* create(const ValueBase &x=type_gradient);
-	virtual Vocab get_children_vocab_vfunc()const;
 }; // END of class ValueNode_DynamicList
 
 typedef ValueNode_DynamicList::ListEntry::Activepoint Activepoint;

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.h
@@ -171,7 +171,7 @@ public:
 
 	std::vector<ListEntry> list;
 
-	static ValueNode_DynamicList* create(const ValueBase &x=type_gradient);
+	static ValueNode_DynamicList* create(const ValueBase& x=type_gradient, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
 	virtual ~ValueNode_DynamicList();
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_exp.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_exp.cpp
@@ -80,7 +80,7 @@ ValueNode_Exp::create_new()const
 }
 
 ValueNode_Exp*
-ValueNode_Exp::create(const ValueBase &x)
+ValueNode_Exp::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Exp(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_exp.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_exp.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_Exp> Handle;
 	typedef etl::handle<const ValueNode_Exp> ConstHandle;
 
-	static ValueNode_Exp* create(const ValueBase &x);
+	static ValueNode_Exp* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Exp();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_exp.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_exp.h
@@ -47,31 +47,25 @@ class ValueNode_Exp : public LinkableValueNode
 	ValueNode_Exp(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_Exp> Handle;
 	typedef etl::handle<const ValueNode_Exp> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Exp* create(const ValueBase &x);
 	virtual ~ValueNode_Exp();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Exp* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Exp
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.cpp
@@ -82,7 +82,7 @@ ValueNode_GradientColor::create_new()const
 }
 
 ValueNode_GradientColor*
-ValueNode_GradientColor::create(const ValueBase &x)
+ValueNode_GradientColor::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_GradientColor(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.h
@@ -49,31 +49,25 @@ class ValueNode_GradientColor : public LinkableValueNode
 	ValueNode_GradientColor(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_GradientColor> Handle;
 	typedef etl::handle<const ValueNode_GradientColor> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_GradientColor* create(const ValueBase &x);
 	virtual ~ValueNode_GradientColor();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_GradientColor* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_GradientColor
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_GradientColor> Handle;
 	typedef etl::handle<const ValueNode_GradientColor> ConstHandle;
 
-	static ValueNode_GradientColor* create(const ValueBase &x);
+	static ValueNode_GradientColor* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_GradientColor();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.cpp
@@ -75,7 +75,7 @@ ValueNode_GradientRotate::create_new()const
 }
 
 ValueNode_GradientRotate*
-ValueNode_GradientRotate::create(const ValueBase& x)
+ValueNode_GradientRotate::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	Type &type(x.get_type());
 	if(type!=type_gradient)

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.h
@@ -42,43 +42,31 @@ namespace synfig {
 
 class ValueNode_GradientRotate : public LinkableValueNode
 {
+	ValueNode::RHandle ref_gradient;
+	ValueNode::RHandle ref_offset;
+
+	ValueNode_GradientRotate(const Gradient& x);
+
 public:
 	typedef etl::handle<ValueNode_GradientRotate> Handle;
 	typedef etl::handle<const ValueNode_GradientRotate> ConstHandle;
 
-protected:
-
-	ValueNode_GradientRotate(const Gradient& x);
-
-private:
-
-	ValueNode::RHandle ref_gradient;
-	ValueNode::RHandle ref_offset;
-
-public:
-
+	static ValueNode_GradientRotate* create(const ValueBase &x=type_gradient);
 	virtual ~ValueNode_GradientRotate();
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual ValueBase operator()(Time t)const;
-
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-
-//	static bool check_type(Type &type);
-protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-
-	LinkableValueNode* create_new()const;
-
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-
-	using synfig::LinkableValueNode::set_link_vfunc;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
 	static bool check_type(Type &type);
-	static ValueNode_GradientRotate* create(const ValueBase &x=type_gradient);
-	virtual Vocab get_children_vocab_vfunc()const;
+
+	virtual ValueBase operator()(Time t) const override;
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_GradientRotate
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_GradientRotate> Handle;
 	typedef etl::handle<const ValueNode_GradientRotate> ConstHandle;
 
-	static ValueNode_GradientRotate* create(const ValueBase &x=type_gradient);
+	static ValueNode_GradientRotate* create(const ValueBase& x=type_gradient, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_GradientRotate();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_greyed.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_greyed.cpp
@@ -70,7 +70,7 @@ ValueNode_Greyed::ValueNode_Greyed(const ValueNode::Handle &x):
 }
 
 ValueNode_Greyed*
-ValueNode_Greyed::create(const ValueBase &x)
+ValueNode_Greyed::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Greyed(ValueNode_Const::create(x));
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_greyed.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_greyed.h
@@ -41,20 +41,21 @@ namespace synfig {
 
 class ValueNode_Greyed : public ValueNode_Reference
 {
-public:
-	typedef etl::handle<ValueNode_Greyed> Handle;
 	ValueNode_Greyed(Type &x);
 	ValueNode_Greyed(const ValueNode::Handle &x);
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+public:
+	typedef etl::handle<ValueNode_Greyed> Handle;
+
+	static ValueNode_Greyed* create(const ValueBase &x);
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
 
 protected:
-	LinkableValueNode* create_new()const;
+	LinkableValueNode* create_new() const override;
 
-public:
-	static ValueNode_Greyed* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Greyed
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_greyed.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_greyed.h
@@ -47,7 +47,7 @@ class ValueNode_Greyed : public ValueNode_Reference
 public:
 	typedef etl::handle<ValueNode_Greyed> Handle;
 
-	static ValueNode_Greyed* create(const ValueBase &x);
+	static ValueNode_Greyed* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 
 	virtual String get_name() const override;
 	virtual String get_local_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_integer.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_integer.cpp
@@ -90,7 +90,7 @@ ValueNode_Integer::ValueNode_Integer(const ValueBase &x):
 }
 
 ValueNode_Integer*
-ValueNode_Integer::create(const ValueBase &x)
+ValueNode_Integer::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Integer(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_integer.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_integer.h
@@ -44,39 +44,35 @@ class ValueNode_Integer : public LinkableValueNode
 {
 	ValueNode::RHandle integer_;
 
+	ValueNode_Integer(Type &x);
+	ValueNode_Integer(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Integer> Handle;
 	typedef etl::handle<const ValueNode_Integer> ConstHandle;
 
-	ValueNode_Integer(Type &x);
-	ValueNode_Integer(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Integer* create(const ValueBase &x);
 	virtual ~ValueNode_Integer();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual ValueBase operator()(Time t) const override;
 
 	//! Checks if it is possible to call get_inverse() for target_value at time t.
 	//! If so, return the link_index related to the return value provided by get_inverse()
-	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
 	//! Returns the modified Link to match the target value at time t
-	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Integer* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Integer
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_integer.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_integer.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Integer> Handle;
 	typedef etl::handle<const ValueNode_Integer> ConstHandle;
 
-	static ValueNode_Integer* create(const ValueBase &x);
+	static ValueNode_Integer* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Integer();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_intstring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_intstring.cpp
@@ -82,7 +82,7 @@ ValueNode_IntString::create_new()const
 }
 
 ValueNode_IntString*
-ValueNode_IntString::create(const ValueBase &x)
+ValueNode_IntString::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_IntString(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_intstring.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_intstring.h
@@ -49,30 +49,24 @@ class ValueNode_IntString : public LinkableValueNode
 	ValueNode_IntString(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_IntString> Handle;
 	typedef etl::handle<const ValueNode_IntString> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_IntString* create(const ValueBase &x);
 	virtual ~ValueNode_IntString();
 
 	virtual String get_name()const;
 	virtual String get_local_name()const;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t)const;
 
 protected:
 	LinkableValueNode* create_new()const;
+
 	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_IntString* create(const ValueBase &x);
 	virtual Vocab get_children_vocab_vfunc()const;
 }; // END of class ValueNode_IntString
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_intstring.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_intstring.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_IntString> Handle;
 	typedef etl::handle<const ValueNode_IntString> ConstHandle;
 
-	static ValueNode_IntString* create(const ValueBase &x);
+	static ValueNode_IntString* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_IntString();
 
 	virtual String get_name()const;

--- a/synfig-core/src/synfig/valuenodes/valuenode_join.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_join.cpp
@@ -90,7 +90,7 @@ ValueNode_Join::create_new()const
 }
 
 ValueNode_Join*
-ValueNode_Join::create(const ValueBase &x)
+ValueNode_Join::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Join(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_join.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_join.h
@@ -53,7 +53,7 @@ public:
 	typedef etl::handle<ValueNode_Join> Handle;
 	typedef etl::handle<const ValueNode_Join> ConstHandle;
 
-	static ValueNode_Join* create(const ValueBase &x);
+	static ValueNode_Join* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Join();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_join.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_join.h
@@ -50,31 +50,25 @@ class ValueNode_Join : public LinkableValueNode
 	ValueNode_Join(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_Join> Handle;
 	typedef etl::handle<const ValueNode_Join> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Join* create(const ValueBase &x);
 	virtual ~ValueNode_Join();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Join* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Join
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_linear.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_linear.cpp
@@ -116,7 +116,7 @@ ValueNode_Linear::create_new()const
 }
 
 ValueNode_Linear*
-ValueNode_Linear::create(const ValueBase &x)
+ValueNode_Linear::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Linear(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_linear.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_linear.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Linear> Handle;
 	typedef etl::handle<const ValueNode_Linear> ConstHandle;
 
-	static ValueNode_Linear* create(const ValueBase &x);
+	static ValueNode_Linear* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Linear();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_linear.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_linear.h
@@ -48,31 +48,25 @@ class ValueNode_Linear : public LinkableValueNode
 	ValueNode_Linear(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_Linear> Handle;
 	typedef etl::handle<const ValueNode_Linear> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Linear* create(const ValueBase &x);
 	virtual ~ValueNode_Linear();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Linear* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Linear
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_log.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_log.cpp
@@ -74,7 +74,7 @@ ValueNode_Logarithm::ValueNode_Logarithm(const ValueBase &x):
 }
 
 ValueNode_Logarithm*
-ValueNode_Logarithm::create(const ValueBase &x)
+ValueNode_Logarithm::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Logarithm(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_log.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_log.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_Logarithm> Handle;
 	typedef etl::handle<const ValueNode_Logarithm> ConstHandle;
 
-	static ValueNode_Logarithm* create(const ValueBase &x);
+	static ValueNode_Logarithm* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Logarithm();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_log.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_log.h
@@ -46,32 +46,28 @@ class ValueNode_Logarithm : public LinkableValueNode
 	ValueNode::RHandle epsilon_;
 	ValueNode::RHandle infinite_;
 
+	ValueNode_Logarithm(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Logarithm> Handle;
 	typedef etl::handle<const ValueNode_Logarithm> ConstHandle;
 
-	ValueNode_Logarithm(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Logarithm* create(const ValueBase &x);
 	virtual ~ValueNode_Logarithm();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Logarithm* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Logarithm
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_not.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_not.cpp
@@ -69,7 +69,7 @@ ValueNode_Not::ValueNode_Not(const ValueBase &x):
 }
 
 ValueNode_Not*
-ValueNode_Not::create(const ValueBase &x)
+ValueNode_Not::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Not(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_not.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_not.h
@@ -44,32 +44,28 @@ class ValueNode_Not : public LinkableValueNode
 {
 	ValueNode::RHandle link_;
 
+	ValueNode_Not(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Not> Handle;
 	typedef etl::handle<const ValueNode_Not> ConstHandle;
 
-	ValueNode_Not(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Not* create(const ValueBase &x);
 	virtual ~ValueNode_Not();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Not* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Not
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_not.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_not.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_Not> Handle;
 	typedef etl::handle<const ValueNode_Not> ConstHandle;
 
-	static ValueNode_Not* create(const ValueBase &x);
+	static ValueNode_Not* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Not();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_or.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_or.cpp
@@ -72,7 +72,7 @@ ValueNode_Or::ValueNode_Or(const ValueBase &x):
 }
 
 ValueNode_Or*
-ValueNode_Or::create(const ValueBase &x)
+ValueNode_Or::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Or(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_or.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_or.h
@@ -45,32 +45,28 @@ class ValueNode_Or : public LinkableValueNode
 	ValueNode::RHandle link1_;
 	ValueNode::RHandle link2_;
 
+	ValueNode_Or(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Or> Handle;
 	typedef etl::handle<const ValueNode_Or> ConstHandle;
 
-	ValueNode_Or(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Or* create(const ValueBase &x);
 	virtual ~ValueNode_Or();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Or* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Or
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_or.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_or.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Or> Handle;
 	typedef etl::handle<const ValueNode_Or> ConstHandle;
 
-	static ValueNode_Or* create(const ValueBase &x);
+	static ValueNode_Or* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Or();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_pow.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_pow.cpp
@@ -74,7 +74,7 @@ ValueNode_Pow::ValueNode_Pow(const ValueBase &x):
 }
 
 ValueNode_Pow*
-ValueNode_Pow::create(const ValueBase &x)
+ValueNode_Pow::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Pow(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_pow.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_pow.h
@@ -48,32 +48,28 @@ class ValueNode_Pow : public LinkableValueNode
 	ValueNode::RHandle epsilon_;
 	ValueNode::RHandle infinite_;
 
+	ValueNode_Pow(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Pow> Handle;
 	typedef etl::handle<const ValueNode_Pow> ConstHandle;
 
-	ValueNode_Pow(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Pow* create(const ValueBase &x);
 	virtual ~ValueNode_Pow();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Pow* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Pow
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_pow.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_pow.h
@@ -54,7 +54,7 @@ public:
 	typedef etl::handle<ValueNode_Pow> Handle;
 	typedef etl::handle<const ValueNode_Pow> ConstHandle;
 
-	static ValueNode_Pow* create(const ValueBase &x);
+	static ValueNode_Pow* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Pow();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
@@ -92,7 +92,7 @@ ValueNode_RadialComposite::~ValueNode_RadialComposite()
 }
 
 ValueNode_RadialComposite*
-ValueNode_RadialComposite::create(const ValueBase &value)
+ValueNode_RadialComposite::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_RadialComposite(value);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.h
@@ -49,7 +49,7 @@ public:
 	typedef etl::handle<ValueNode_RadialComposite> Handle;
 	typedef etl::handle<const ValueNode_RadialComposite> ConstHandle;
 
-	static ValueNode_RadialComposite* create(const ValueBase &x);
+	static ValueNode_RadialComposite* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_RadialComposite();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.h
@@ -42,32 +42,32 @@ namespace synfig {
 class ValueNode_RadialComposite : public LinkableValueNode
 {
 	ValueNode::RHandle components[6];
+
 	ValueNode_RadialComposite(const ValueBase &value);
 
 public:
 	typedef etl::handle<ValueNode_RadialComposite> Handle;
 	typedef etl::handle<const ValueNode_RadialComposite> ConstHandle;
 
+	static ValueNode_RadialComposite* create(const ValueBase &x);
 	virtual ~ValueNode_RadialComposite();
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-	virtual String link_name(int i)const;
-	virtual ValueBase operator()(Time t)const;
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-	virtual int get_link_index_from_name(const String &name)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual String link_name(int i) const override;
+	virtual int get_link_index_from_name(const String &name) const override;
+
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-	LinkableValueNode* create_new()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-public:
-	using synfig::LinkableValueNode::set_link_vfunc;
-	using synfig::LinkableValueNode::get_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_RadialComposite* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_RadialComposite
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
@@ -117,7 +117,7 @@ ValueNode_Range::create_new()const
 }
 
 ValueNode_Range*
-ValueNode_Range::create(const ValueBase& value)
+ValueNode_Range::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Range(value);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_range.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_range.h
@@ -47,39 +47,36 @@ class ValueNode_Range : public LinkableValueNode
 
 	ValueNode_Range(const ValueBase &value);
 
-	ValueBase get_inverse(const Time& t, const synfig::Vector &target_value) const;
-	ValueBase get_inverse(const Time& t, const synfig::Angle &target_value) const;
-
 public:
-
 	typedef etl::handle<ValueNode_Range> Handle;
 	typedef etl::handle<const ValueNode_Range> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Range* create(const ValueBase &value=ValueBase());
 	virtual ~ValueNode_Range();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual ValueBase operator()(Time t) const override;
 
 	//! Checks if it is possible to call get_inverse() for target_value at time t.
 	//! If so, return the link_index related to the return value provided by get_inverse()
-	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
 	//! Returns the modified Link to match the target value at time t
-	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const override;
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	LinkableValueNode* create_new()const;
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Range* create(const ValueBase &value=ValueBase());
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
+
+private:
+	ValueBase get_inverse(const Time& t, const synfig::Vector &target_value) const;
+	ValueBase get_inverse(const Time& t, const synfig::Angle &target_value) const;
 }; // END of class ValueNode_Range
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_range.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_range.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Range> Handle;
 	typedef etl::handle<const ValueNode_Range> ConstHandle;
 
-	static ValueNode_Range* create(const ValueBase &value=ValueBase());
+	static ValueNode_Range* create(const ValueBase& value=ValueBase(), etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Range();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
@@ -90,7 +90,7 @@ ValueNode_Real::ValueNode_Real(const ValueBase &x):
 }
 
 ValueNode_Real*
-ValueNode_Real::create(const ValueBase &x)
+ValueNode_Real::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Real(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_real.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_Real> Handle;
 	typedef etl::handle<const ValueNode_Real> ConstHandle;
 
-	static ValueNode_Real* create(const ValueBase &x);
+	static ValueNode_Real* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Real();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_real.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.h
@@ -45,39 +45,35 @@ class ValueNode_Real : public LinkableValueNode
 {
 	ValueNode::RHandle real_;
 
+	ValueNode_Real(Type &x);
+	ValueNode_Real(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Real> Handle;
 	typedef etl::handle<const ValueNode_Real> ConstHandle;
 
-	ValueNode_Real(Type &x);
-	ValueNode_Real(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Real* create(const ValueBase &x);
 	virtual ~ValueNode_Real();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual ValueBase operator()(Time t) const override;
 
 	//! Checks if it is possible to call get_inverse() for target_value at time t.
 	//! If so, return the link_index related to the return value provided by get_inverse()
-	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
 	//! Returns the modified Link to match the target value at time t
-	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Real* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Real
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_realstring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_realstring.cpp
@@ -83,7 +83,7 @@ ValueNode_RealString::create_new()const
 }
 
 ValueNode_RealString*
-ValueNode_RealString::create(const ValueBase &x)
+ValueNode_RealString::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_RealString(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_realstring.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_realstring.h
@@ -50,31 +50,25 @@ class ValueNode_RealString : public LinkableValueNode
 	ValueNode_RealString(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_RealString> Handle;
 	typedef etl::handle<const ValueNode_RealString> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_RealString* create(const ValueBase &x);
 	virtual ~ValueNode_RealString();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_RealString* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_RealString
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_realstring.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_realstring.h
@@ -53,7 +53,7 @@ public:
 	typedef etl::handle<ValueNode_RealString> Handle;
 	typedef etl::handle<const ValueNode_RealString> ConstHandle;
 
-	static ValueNode_RealString* create(const ValueBase &x);
+	static ValueNode_RealString* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_RealString();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.cpp
@@ -77,7 +77,7 @@ ValueNode_Reciprocal::ValueNode_Reciprocal(const ValueBase &x):
 }
 
 ValueNode_Reciprocal*
-ValueNode_Reciprocal::create(const ValueBase &x)
+ValueNode_Reciprocal::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Reciprocal(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.h
@@ -46,32 +46,28 @@ class ValueNode_Reciprocal : public LinkableValueNode
 	ValueNode::RHandle epsilon_;
 	ValueNode::RHandle infinite_;
 
+	ValueNode_Reciprocal(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Reciprocal> Handle;
 	typedef etl::handle<const ValueNode_Reciprocal> ConstHandle;
 
-	ValueNode_Reciprocal(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Reciprocal* create(const ValueBase &x);
 	virtual ~ValueNode_Reciprocal();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Reciprocal* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Reciprocal
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_Reciprocal> Handle;
 	typedef etl::handle<const ValueNode_Reciprocal> ConstHandle;
 
-	static ValueNode_Reciprocal* create(const ValueBase &x);
+	static ValueNode_Reciprocal* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Reciprocal();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_reference.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reference.cpp
@@ -71,7 +71,7 @@ ValueNode_Reference::ValueNode_Reference(const ValueNode::Handle &x):
 }
 
 ValueNode_Reference*
-ValueNode_Reference::create(const ValueBase &x)
+ValueNode_Reference::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Reference(ValueNode_Const::create(x));
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_reference.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reference.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Reference> Handle;
 	typedef etl::handle<const ValueNode_Reference> ConstHandle;
 
-	static ValueNode_Reference* create(const ValueBase &x);
+	static ValueNode_Reference* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Reference();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_reference.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reference.h
@@ -42,38 +42,31 @@ namespace synfig {
 class ValueNode_Reference : public LinkableValueNode
 {
 	ValueNode::RHandle link_;
+
+protected:
+	ValueNode_Reference(Type &x);
+	ValueNode_Reference(const ValueNode::Handle &x);
+
 public:
 	typedef etl::handle<ValueNode_Reference> Handle;
 	typedef etl::handle<const ValueNode_Reference> ConstHandle;
 
-	ValueNode_Reference(Type &x);
-
-	ValueNode_Reference(const ValueNode::Handle &x);
-
-//	static Handle create(Type &x);
-//	static Handle create(const ValueNode::Handle &x);
-
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Reference* create(const ValueBase &x);
 	virtual ~ValueNode_Reference();
 
-	virtual String get_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-	LinkableValueNode* create_new()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-public:
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Reference* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Reference
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.cpp
@@ -80,7 +80,7 @@ ValueNode_Repeat_Gradient::create_new()const
 }
 
 ValueNode_Repeat_Gradient*
-ValueNode_Repeat_Gradient::create(const ValueBase& x)
+ValueNode_Repeat_Gradient::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	Type &type(x.get_type());
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.h
@@ -42,16 +42,6 @@ namespace synfig {
 
 class ValueNode_Repeat_Gradient : public LinkableValueNode
 {
-public:
-	typedef etl::handle<ValueNode_Repeat_Gradient> Handle;
-	typedef etl::handle<const ValueNode_Repeat_Gradient> ConstHandle;
-
-protected:
-
-	ValueNode_Repeat_Gradient(const Gradient& x);
-
-private:
-
 	ValueNode::RHandle gradient_;
 	ValueNode::RHandle count_;
 	ValueNode::RHandle width_;
@@ -60,29 +50,28 @@ private:
 	ValueNode::RHandle start_color_;
 	ValueNode::RHandle end_color_;
 
-public:
+	ValueNode_Repeat_Gradient(const Gradient& x);
 
+public:
+	typedef etl::handle<ValueNode_Repeat_Gradient> Handle;
+	typedef etl::handle<const ValueNode_Repeat_Gradient> ConstHandle;
+
+	static ValueNode_Repeat_Gradient* create(const ValueBase &x=type_gradient);
 	virtual ~ValueNode_Repeat_Gradient();
 
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual ValueBase operator()(Time t)const;
-
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-
-//	static bool check_type(Type &type);
-
-	LinkableValueNode* create_new()const;
-
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
 	static bool check_type(Type &type);
-	static ValueNode_Repeat_Gradient* create(const ValueBase &x=type_gradient);
-	virtual Vocab get_children_vocab_vfunc()const;
+
+	virtual ValueBase operator()(Time t) const override;
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Repeat_Gradient
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.h
@@ -56,7 +56,7 @@ public:
 	typedef etl::handle<ValueNode_Repeat_Gradient> Handle;
 	typedef etl::handle<const ValueNode_Repeat_Gradient> ConstHandle;
 
-	static ValueNode_Repeat_Gradient* create(const ValueBase &x=type_gradient);
+	static ValueNode_Repeat_Gradient* create(const ValueBase& x=type_gradient, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Repeat_Gradient();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
@@ -40,6 +40,7 @@
 #include <synfig/segment.h>
 #include <synfig/gradient.h>
 #include <synfig/blinepoint.h>
+#include <synfig/dashitem.h>
 
 #include "valuenode_bline.h"
 #include "valuenode_dilist.h"

--- a/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
@@ -111,7 +111,7 @@ ValueNode_Reverse::ValueNode_Reverse(const ValueBase &x):
 }
 
 ValueNode_Reverse*
-ValueNode_Reverse::create(const ValueBase &x)
+ValueNode_Reverse::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Reverse(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_reverse.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reverse.h
@@ -53,7 +53,7 @@ public:
 	typedef etl::handle<ValueNode_Reverse> Handle;
 	typedef etl::handle<const ValueNode_Reverse> ConstHandle;
 
-	static ValueNode_Reverse* create(const ValueBase &x);
+	static ValueNode_Reverse* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Reverse();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_reverse.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reverse.h
@@ -46,33 +46,29 @@ class ValueNode_Reverse : public LinkableValueNode
 {
 	ValueNode::RHandle link_;
 
+	ValueNode_Reverse(Type &x);
+	ValueNode_Reverse(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Reverse> Handle;
 	typedef etl::handle<const ValueNode_Reverse> ConstHandle;
 
-	ValueNode_Reverse(Type &x);
-	ValueNode_Reverse(const ValueBase &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Reverse* create(const ValueBase &x);
 	virtual ~ValueNode_Reverse();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Reverse* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Reverse
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_scale.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_scale.cpp
@@ -107,7 +107,7 @@ ValueNode_Scale::create_new()const
 }
 
 ValueNode_Scale*
-ValueNode_Scale::create(const ValueBase& value)
+ValueNode_Scale::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Scale(value);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_scale.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_scale.h
@@ -42,49 +42,37 @@ namespace synfig {
 
 class ValueNode_Scale : public LinkableValueNode
 {
-public:
-	typedef etl::handle<ValueNode_Scale> Handle;
-	typedef etl::handle<const ValueNode_Scale> ConstHandle;
-
-private:
 	ValueNode::RHandle value_node;
 	ValueNode::RHandle scalar;
 
 	ValueNode_Scale(const ValueBase &value);
 
 public:
+	typedef etl::handle<ValueNode_Scale> Handle;
+	typedef etl::handle<const ValueNode_Scale> ConstHandle;
 
-	//static Handle create(Type &type=type_nil);
-
-	//static Handle create(ValueNode::Handle value_node, Real scalar);
-
+	static ValueNode_Scale* create(const ValueBase &x);
 	virtual ~ValueNode_Scale();
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual ValueBase operator()(Time t)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 	//! Checks if it is possible to call get_inverse() for target_value at time t.
 	//! If so, return the link_index related to the return value provided by get_inverse()
-	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
 	//! Returns the modified Link to match the target value at time t
-	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const override;
 
-	virtual String get_name()const;
-
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	virtual LinkableValueNode* create_new() const override;
 
-	virtual LinkableValueNode* create_new()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Scale* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Scale
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_scale.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_scale.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Scale> Handle;
 	typedef etl::handle<const ValueNode_Scale> ConstHandle;
 
-	static ValueNode_Scale* create(const ValueBase &x);
+	static ValueNode_Scale* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Scale();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.cpp
@@ -75,7 +75,7 @@ ValueNode_SegCalcTangent::ValueNode_SegCalcTangent(Type &x):
 }
 
 ValueNode_SegCalcTangent*
-ValueNode_SegCalcTangent::create(const ValueBase &x)
+ValueNode_SegCalcTangent::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_SegCalcTangent(x.get_type());
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_SegCalcTangent> Handle;
 	typedef etl::handle<const ValueNode_SegCalcTangent> ConstHandle;
 
-	static ValueNode_SegCalcTangent* create(const ValueBase &x=type_vector);
+	static ValueNode_SegCalcTangent* create(const ValueBase& x=type_vector, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_SegCalcTangent();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.h
@@ -47,32 +47,25 @@ class ValueNode_SegCalcTangent : public LinkableValueNode
 	ValueNode_SegCalcTangent(Type &x=type_vector);
 
 public:
-
 	typedef etl::handle<ValueNode_SegCalcTangent> Handle;
 	typedef etl::handle<const ValueNode_SegCalcTangent> ConstHandle;
 
-	//static Handle create(Type &x=type_vector);
-
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_SegCalcTangent* create(const ValueBase &x=type_vector);
 	virtual ~ValueNode_SegCalcTangent();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	LinkableValueNode* create_new()const;
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_SegCalcTangent* create(const ValueBase &x=type_vector);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_SegCalcTangent
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.cpp
@@ -74,7 +74,7 @@ ValueNode_SegCalcVertex::ValueNode_SegCalcVertex(Type &x):
 }
 
 ValueNode_SegCalcVertex*
-ValueNode_SegCalcVertex::create(const ValueBase &x)
+ValueNode_SegCalcVertex::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_SegCalcVertex(x.get_type());
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_SegCalcVertex> Handle;
 	typedef etl::handle<const ValueNode_SegCalcVertex> ConstHandle;
 
-	static ValueNode_SegCalcVertex* create(const ValueBase &x=type_vector);
+	static ValueNode_SegCalcVertex* create(const ValueBase& x=type_vector, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_SegCalcVertex();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.h
@@ -47,29 +47,25 @@ class ValueNode_SegCalcVertex : public LinkableValueNode
 	ValueNode_SegCalcVertex(Type &x=type_vector);
 
 public:
-
 	typedef etl::handle<ValueNode_SegCalcVertex> Handle;
 	typedef etl::handle<const ValueNode_SegCalcVertex> ConstHandle;
 
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_SegCalcVertex* create(const ValueBase &x=type_vector);
 	virtual ~ValueNode_SegCalcVertex();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_SegCalcVertex* create(const ValueBase &x=type_vector);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_SegCalcVertex
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_sine.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_sine.cpp
@@ -79,7 +79,7 @@ ValueNode_Sine::create_new()const
 }
 
 ValueNode_Sine*
-ValueNode_Sine::create(const ValueBase &x)
+ValueNode_Sine::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Sine(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_sine.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_sine.h
@@ -48,31 +48,25 @@ class ValueNode_Sine : public LinkableValueNode
 	ValueNode_Sine(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_Sine> Handle;
 	typedef etl::handle<const ValueNode_Sine> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Sine* create(const ValueBase &x);
 	virtual ~ValueNode_Sine();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Sine* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Sine
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_sine.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_sine.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_Sine> Handle;
 	typedef etl::handle<const ValueNode_Sine> ConstHandle;
 
-	static ValueNode_Sine* create(const ValueBase &x);
+	static ValueNode_Sine* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Sine();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_staticlist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_staticlist.cpp
@@ -305,7 +305,7 @@ ValueNode_StaticList::create_on_canvas(Type &type, Canvas::LooseHandle canvas)
 }
 
 ValueNode_StaticList*
-ValueNode_StaticList::create(const ValueBase &value)
+ValueNode_StaticList::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	std::vector<ValueBase> value_list(value.get_list());
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_staticlist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_staticlist.h
@@ -31,18 +31,15 @@
 /* === H E A D E R S ======================================================= */
 
 #include <vector>
-#include <list>
 
-#include <synfig/valuenode.h>
-#include <synfig/time.h>
 #include <synfig/uniqueid.h>
+#include <synfig/valuenode.h>
 
 /* === M A C R O S ========================================================= */
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
 namespace synfig {
-class ValueNode_BLine;
 class Canvas;
 
 /*! \class ValueNode_StaticList
@@ -52,51 +49,62 @@ class Canvas;
 */
 class ValueNode_StaticList : public LinkableValueNode
 {
+	Type *container_type;
+	bool loop_;
+
+protected:
+	ValueNode_StaticList(Type &container_type=type_nil, etl::loose_handle<Canvas> canvas = 0);
+
 public:
 	typedef etl::handle<ValueNode_StaticList> Handle;
 	typedef etl::handle<const ValueNode_StaticList> ConstHandle;
 	typedef ValueNode::Handle ListEntry;
 	typedef ValueNode::RHandle ReplaceableListEntry;
 
-protected:
-	ValueNode_StaticList(Type &container_type=type_nil, etl::loose_handle<Canvas> canvas = 0);
-
-	virtual ~ValueNode_StaticList();
-
-	Type *container_type;
-
-	bool loop_;
-
-public:
 	std::vector<ReplaceableListEntry> list;
 
+	static ValueNode_StaticList* create(const ValueBase &x=type_gradient);
+	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
+	virtual ~ValueNode_StaticList();
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual int link_count() const override;
+	virtual String link_local_name(int i) const override;
+	virtual String link_name(int i) const override;
+	virtual int get_link_index_from_name(const String &name) const override;
+
+	virtual ValueBase operator()(Time t) const override;
+
+	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5);
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
+
 public:
+	/*! \note The construction parameter (\a type) is the type that the list
+	**	contains, rather than the type that it will yield
+	**	(which is type_list)
+	*/
+	static Handle create_on_canvas(Type &type=type_nil, etl::loose_handle<Canvas> canvas = 0);
 
 	void add(const ValueNode::Handle &value_node, int index=-1);
 	void erase(const ListEntry &value_node);
 //	void reindex();
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual int link_count()const;
-
-	virtual String link_name(int i)const;
-
-	virtual ValueBase operator()(Time t)const;
-
-	virtual String link_local_name(int i)const;
-	virtual int get_link_index_from_name(const String &name)const;
-
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-
-	bool get_loop()const { return loop_; }
+	bool get_loop() const { return loop_; }
 	void set_loop(bool x) { loop_=x; }
 
 	void set_member_canvas(etl::loose_handle<Canvas>);
 
-	Type& get_contained_type()const;
-
+	Type& get_contained_type() const;
 
 	// TODO: better type-checking
 	template <typename iterator> static Handle
@@ -109,34 +117,10 @@ public:
 	}
 
 //	void insert_time(const Time& location, const Time& delta);
-	//void manipulate_time(const Time& old_begin,const Time& old_end,const Time& new_begin,const Time& new_end);
-
-	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
-
-	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5);
-
-protected:
-
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	LinkableValueNode* create_new()const;
-
-//	virtual void get_times_vfunc(Node::time_set &set) const;
-
-public:
-	/*! \note The construction parameter (\a id) is the type that the list
-	**	contains, rather than the type that it will yield
-	**	(which is type_list)
-	*/
-	static Handle create_on_canvas(Type &type=type_nil, etl::loose_handle<Canvas> canvas = 0);
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_StaticList* create(const ValueBase &x=type_gradient);
-	virtual Vocab get_children_vocab_vfunc()const;
 
 #ifdef _DEBUG
-	virtual void ref()const;
-	virtual bool unref()const;
+	virtual void ref() const override;
+	virtual bool unref() const override;
 #endif
 
 }; // END of class ValueNode_StaticList

--- a/synfig-core/src/synfig/valuenodes/valuenode_staticlist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_staticlist.h
@@ -63,7 +63,7 @@ public:
 
 	std::vector<ReplaceableListEntry> list;
 
-	static ValueNode_StaticList* create(const ValueBase &x=type_gradient);
+	static ValueNode_StaticList* create(const ValueBase& x=type_gradient, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
 	virtual ~ValueNode_StaticList();
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_step.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_step.cpp
@@ -95,7 +95,7 @@ ValueNode_Step::create_new()const
 }
 
 ValueNode_Step*
-ValueNode_Step::create(const ValueBase &x)
+ValueNode_Step::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Step(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_step.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_step.h
@@ -49,31 +49,25 @@ class ValueNode_Step : public LinkableValueNode
 	ValueNode_Step(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_Step> Handle;
 	typedef etl::handle<const ValueNode_Step> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Step* create(const ValueBase &x);
 	virtual ~ValueNode_Step();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Step* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Step
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_step.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_step.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_Step> Handle;
 	typedef etl::handle<const ValueNode_Step> ConstHandle;
 
-	static ValueNode_Step* create(const ValueBase &x);
+	static ValueNode_Step* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Step();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_stripes.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_stripes.cpp
@@ -77,7 +77,7 @@ ValueNode_Stripes::create_new()const
 }
 
 ValueNode_Stripes*
-ValueNode_Stripes::create(const ValueBase& x)
+ValueNode_Stripes::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	Type &type(x.get_type());
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_stripes.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_stripes.h
@@ -42,44 +42,33 @@ namespace synfig {
 
 class ValueNode_Stripes : public LinkableValueNode
 {
-public:
-	typedef etl::handle<ValueNode_Stripes> Handle;
-	typedef etl::handle<const ValueNode_Stripes> ConstHandle;
-
-protected:
-
-	ValueNode_Stripes();
-
-private:
-
 	ValueNode::RHandle color1_;
 	ValueNode::RHandle color2_;
 	ValueNode::RHandle stripes_;
 	ValueNode::RHandle width_;
 
-public:
+	ValueNode_Stripes();
 
+public:
+	typedef etl::handle<ValueNode_Stripes> Handle;
+	typedef etl::handle<const ValueNode_Stripes> ConstHandle;
+
+	static ValueNode_Stripes* create(const ValueBase &x=type_gradient);
 	virtual ~ValueNode_Stripes();
 
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual ValueBase operator()(Time t)const;
-
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-
-//	static bool check_type(Type &type);
-
-	LinkableValueNode* create_new()const;
-
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
 	static bool check_type(Type &type);
-	static ValueNode_Stripes* create(const ValueBase &x=type_gradient);
-	virtual Vocab get_children_vocab_vfunc()const;
+
+	virtual ValueBase operator()(Time t) const override;
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Stripes
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_stripes.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_stripes.h
@@ -53,7 +53,7 @@ public:
 	typedef etl::handle<ValueNode_Stripes> Handle;
 	typedef etl::handle<const ValueNode_Stripes> ConstHandle;
 
-	static ValueNode_Stripes* create(const ValueBase &x=type_gradient);
+	static ValueNode_Stripes* create(const ValueBase& x=type_gradient, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Stripes();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
@@ -132,7 +132,7 @@ ValueNode_Subtract::create_new()const
 }
 
 ValueNode_Subtract*
-ValueNode_Subtract::create(const ValueBase& value)
+ValueNode_Subtract::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Subtract(value);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.h
@@ -42,39 +42,42 @@ namespace synfig {
 
 class ValueNode_Subtract : public LinkableValueNode
 {
-public:
-	typedef etl::handle<ValueNode_Subtract> Handle;
-	typedef etl::handle<const ValueNode_Subtract> ConstHandle;
-
-protected:
-	ValueNode_Subtract(const ValueBase &value);
-
-private:
 	ValueNode::RHandle ref_a;
 	ValueNode::RHandle ref_b;
 	ValueNode::RHandle scalar;
 
+	ValueNode_Subtract(const ValueBase &value);
+
 public:
-	LinkableValueNode* create_new()const;
+	typedef etl::handle<ValueNode_Subtract> Handle;
+	typedef etl::handle<const ValueNode_Subtract> ConstHandle;
+
 	static ValueNode_Subtract* create(const ValueBase &value=ValueBase());
 	virtual ~ValueNode_Subtract();
-	virtual ValueBase operator()(Time t)const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
 	static bool check_type(Type &type);
 
+	virtual ValueBase operator()(Time t) const override;
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
+
+public:
 	//! Gets the left-hand-side value_node
-	ValueNode::Handle get_lhs()const { return ref_a; }
+	ValueNode::Handle get_lhs() const { return ref_a; }
 
 	//! Gets the right-hand-side value_node
-	ValueNode::Handle get_rhs()const { return ref_b; }
+	ValueNode::Handle get_rhs() const { return ref_b; }
 
 	//! Gets the scalar value_node
-	ValueNode::Handle get_scalar()const { return scalar; }
-
-	virtual Vocab get_children_vocab_vfunc()const;
+	ValueNode::Handle get_scalar() const { return scalar; }
 }; // END of class ValueNode_Subtract
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.h
@@ -52,7 +52,7 @@ public:
 	typedef etl::handle<ValueNode_Subtract> Handle;
 	typedef etl::handle<const ValueNode_Subtract> ConstHandle;
 
-	static ValueNode_Subtract* create(const ValueBase &value=ValueBase());
+	static ValueNode_Subtract* create(const ValueBase& value=ValueBase(), etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Subtract();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
@@ -73,7 +73,7 @@ ValueNode_Switch::ValueNode_Switch(const ValueBase &x):
 }
 
 ValueNode_Switch*
-ValueNode_Switch::create(const ValueBase &x)
+ValueNode_Switch::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_Switch(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.h
@@ -53,7 +53,7 @@ public:
 	typedef etl::handle<ValueNode_Switch> Handle;
 	typedef etl::handle<const ValueNode_Switch> ConstHandle;
 
-	static ValueNode_Switch* create(const ValueBase &x);
+	static ValueNode_Switch* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_Switch();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.h
@@ -45,38 +45,30 @@ class ValueNode_Switch : public LinkableValueNode
 	ValueNode::RHandle link_off_;
 	ValueNode::RHandle link_on_;
 	ValueNode::RHandle switch_;
+
+	ValueNode_Switch(Type &x);
+	ValueNode_Switch(const ValueBase &x);
+
 public:
 	typedef etl::handle<ValueNode_Switch> Handle;
 	typedef etl::handle<const ValueNode_Switch> ConstHandle;
 
-	ValueNode_Switch(Type &x);
-
-	ValueNode_Switch(const ValueBase &x);
-
-//	static Handle create(Type &x);
-//	static Handle create(const ValueNode::Handle &x);
-
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_Switch* create(const ValueBase &x);
 	virtual ~ValueNode_Switch();
 
-	virtual String get_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-	LinkableValueNode* create_new()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-public:
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_Switch* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_Switch
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_timedswap.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timedswap.cpp
@@ -113,7 +113,7 @@ ValueNode_TimedSwap::ValueNode_TimedSwap(const ValueBase &value):
 }
 
 ValueNode_TimedSwap*
-ValueNode_TimedSwap::create(const ValueBase& x)
+ValueNode_TimedSwap::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_TimedSwap(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_timedswap.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timedswap.h
@@ -42,12 +42,6 @@ namespace synfig {
 
 class ValueNode_TimedSwap : public LinkableValueNode
 {
-public:
-	typedef etl::handle<ValueNode_TimedSwap> Handle;
-	typedef etl::handle<const ValueNode_TimedSwap> ConstHandle;
-
-private:
-
 	ValueNode::RHandle before;
 	ValueNode::RHandle after;
 	ValueNode::RHandle swap_time;
@@ -56,30 +50,25 @@ private:
 	ValueNode_TimedSwap(const ValueBase &value);
 
 public:
+	typedef etl::handle<ValueNode_TimedSwap> Handle;
+	typedef etl::handle<const ValueNode_TimedSwap> ConstHandle;
 
-//	static Handle create(Type &type);
-
+	static ValueNode_TimedSwap* create(const ValueBase &x);
 	virtual ~ValueNode_TimedSwap();
 
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueBase operator()(Time t)const;
-
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-//	static bool check_type(Type &type);
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
+	virtual LinkableValueNode* create_new() const override;
 
-	virtual LinkableValueNode* create_new()const;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_TimedSwap* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_TimedSwap
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_timedswap.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timedswap.h
@@ -53,7 +53,7 @@ public:
 	typedef etl::handle<ValueNode_TimedSwap> Handle;
 	typedef etl::handle<const ValueNode_TimedSwap> ConstHandle;
 
-	static ValueNode_TimedSwap* create(const ValueBase &x);
+	static ValueNode_TimedSwap* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_TimedSwap();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_timeloop.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timeloop.cpp
@@ -73,7 +73,7 @@ ValueNode_TimeLoop::ValueNode_TimeLoop(const ValueNode::Handle &x):
 }
 
 ValueNode_TimeLoop*
-ValueNode_TimeLoop::create(const ValueBase &x)
+ValueNode_TimeLoop::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_TimeLoop(ValueNode_Const::create(x));
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_timeloop.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timeloop.h
@@ -54,7 +54,7 @@ public:
 	typedef etl::handle<ValueNode_TimeLoop> Handle;
 	typedef etl::handle<const ValueNode_TimeLoop> ConstHandle;
 
-	static ValueNode_TimeLoop* create(const ValueBase &x);
+	static ValueNode_TimeLoop* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_TimeLoop();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_timeloop.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timeloop.h
@@ -47,39 +47,35 @@ class ValueNode_TimeLoop : public LinkableValueNode
 	ValueNode::RHandle local_time_;
 	ValueNode::RHandle duration_;
 
+	ValueNode_TimeLoop(Type &x);
+	ValueNode_TimeLoop(const ValueNode::Handle &x);
+
 public:
 	typedef etl::handle<ValueNode_TimeLoop> Handle;
 	typedef etl::handle<const ValueNode_TimeLoop> ConstHandle;
 
-	ValueNode_TimeLoop(Type &x);
-	ValueNode_TimeLoop(const ValueNode::Handle &x);
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_TimeLoop* create(const ValueBase &x);
 	virtual ~ValueNode_TimeLoop();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
-
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
-
-protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
-
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
-
-	using synfig::LinkableValueNode::set_link_vfunc;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
 	static bool check_type(Type &type);
-	static ValueNode_TimeLoop* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+
+	virtual ValueBase operator()(Time t) const override;
 
 	//! Checks if it is possible to call get_inverse() for target_value at time t.
 	//! If so, return the link_index related to the return value provided by get_inverse()
-	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const;
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
 	//! Returns the modified Link to match the target value at time t
-	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const;
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const override;
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_TimeLoop
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_timestring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timestring.cpp
@@ -75,7 +75,7 @@ ValueNode_TimeString::create_new()const
 }
 
 ValueNode_TimeString*
-ValueNode_TimeString::create(const ValueBase &x)
+ValueNode_TimeString::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_TimeString(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_timestring.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timestring.h
@@ -47,31 +47,25 @@ class ValueNode_TimeString : public LinkableValueNode
 	ValueNode_TimeString(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_TimeString> Handle;
 	typedef etl::handle<const ValueNode_TimeString> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_TimeString* create(const ValueBase &x);
 	virtual ~ValueNode_TimeString();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_TimeString* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_TimeString
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_timestring.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timestring.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_TimeString> Handle;
 	typedef etl::handle<const ValueNode_TimeString> ConstHandle;
 
-	static ValueNode_TimeString* create(const ValueBase &x);
+	static ValueNode_TimeString* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_TimeString();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_twotone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_twotone.cpp
@@ -82,7 +82,7 @@ ValueNode_TwoTone::create_new()const
 }
 
 ValueNode_TwoTone*
-ValueNode_TwoTone::create(const ValueBase& x)
+ValueNode_TwoTone::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_TwoTone(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_twotone.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_twotone.h
@@ -51,7 +51,7 @@ public:
 	typedef etl::handle<ValueNode_TwoTone> Handle;
 	typedef etl::handle<const ValueNode_TwoTone> ConstHandle;
 
-	static ValueNode_TwoTone* create(const ValueBase &x);
+	static ValueNode_TwoTone* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_TwoTone();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_twotone.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_twotone.h
@@ -48,30 +48,25 @@ class ValueNode_TwoTone : public LinkableValueNode
 	ValueNode_TwoTone(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_TwoTone> Handle;
 	typedef etl::handle<const ValueNode_TwoTone> ConstHandle;
 
+	static ValueNode_TwoTone* create(const ValueBase &x);
 	virtual ~ValueNode_TwoTone();
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueBase operator()(Time t)const;
-
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_TwoTone* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_TwoTone
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.cpp
@@ -76,7 +76,7 @@ ValueNode_VectorAngle::create_new()const
 }
 
 ValueNode_VectorAngle*
-ValueNode_VectorAngle::create(const ValueBase &x)
+ValueNode_VectorAngle::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_VectorAngle(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.h
@@ -47,31 +47,25 @@ class ValueNode_VectorAngle : public LinkableValueNode
 	ValueNode_VectorAngle(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_VectorAngle> Handle;
 	typedef etl::handle<const ValueNode_VectorAngle> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_VectorAngle* create(const ValueBase &x);
 	virtual ~ValueNode_VectorAngle();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_VectorAngle* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_VectorAngle
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_VectorAngle> Handle;
 	typedef etl::handle<const ValueNode_VectorAngle> ConstHandle;
 
-	static ValueNode_VectorAngle* create(const ValueBase &x);
+	static ValueNode_VectorAngle* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_VectorAngle();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.cpp
@@ -76,7 +76,7 @@ ValueNode_VectorLength::create_new()const
 }
 
 ValueNode_VectorLength*
-ValueNode_VectorLength::create(const ValueBase &x)
+ValueNode_VectorLength::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_VectorLength(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_VectorLength> Handle;
 	typedef etl::handle<const ValueNode_VectorLength> ConstHandle;
 
-	static ValueNode_VectorLength* create(const ValueBase &x);
+	static ValueNode_VectorLength* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_VectorLength();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.h
@@ -47,31 +47,25 @@ class ValueNode_VectorLength : public LinkableValueNode
 	ValueNode_VectorLength(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_VectorLength> Handle;
 	typedef etl::handle<const ValueNode_VectorLength> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_VectorLength* create(const ValueBase &x);
 	virtual ~ValueNode_VectorLength();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_VectorLength* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_VectorLength
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorx.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorx.cpp
@@ -76,7 +76,7 @@ ValueNode_VectorX::create_new()const
 }
 
 ValueNode_VectorX*
-ValueNode_VectorX::create(const ValueBase &x)
+ValueNode_VectorX::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_VectorX(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorx.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorx.h
@@ -47,31 +47,25 @@ class ValueNode_VectorX : public LinkableValueNode
 	ValueNode_VectorX(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_VectorX> Handle;
 	typedef etl::handle<const ValueNode_VectorX> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_VectorX* create(const ValueBase &x);
 	virtual ~ValueNode_VectorX();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_VectorX* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_VectorX
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorx.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorx.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_VectorX> Handle;
 	typedef etl::handle<const ValueNode_VectorX> ConstHandle;
 
-	static ValueNode_VectorX* create(const ValueBase &x);
+	static ValueNode_VectorX* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_VectorX();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectory.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectory.cpp
@@ -75,7 +75,7 @@ ValueNode_VectorY::create_new()const
 }
 
 ValueNode_VectorY*
-ValueNode_VectorY::create(const ValueBase &x)
+ValueNode_VectorY::create(const ValueBase& x, etl::loose_handle<Canvas>)
 {
 	return new ValueNode_VectorY(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectory.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectory.h
@@ -50,7 +50,7 @@ public:
 	typedef etl::handle<ValueNode_VectorY> Handle;
 	typedef etl::handle<const ValueNode_VectorY> ConstHandle;
 
-	static ValueNode_VectorY* create(const ValueBase &x);
+	static ValueNode_VectorY* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_VectorY();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectory.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectory.h
@@ -47,31 +47,25 @@ class ValueNode_VectorY : public LinkableValueNode
 	ValueNode_VectorY(const ValueBase &value);
 
 public:
-
 	typedef etl::handle<ValueNode_VectorY> Handle;
 	typedef etl::handle<const ValueNode_VectorY> ConstHandle;
 
-
-	virtual ValueBase operator()(Time t)const;
-
+	static ValueNode_VectorY* create(const ValueBase &x);
 	virtual ~ValueNode_VectorY();
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
-	virtual ValueNode::LooseHandle get_link_vfunc(int i)const;
+	virtual ValueBase operator()(Time t) const override;
 
 protected:
-	LinkableValueNode* create_new()const;
-	virtual bool set_link_vfunc(int i,ValueNode::Handle x);
+	LinkableValueNode* create_new() const override;
 
-public:
-	using synfig::LinkableValueNode::get_link_vfunc;
+	virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+	virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
 
-	using synfig::LinkableValueNode::set_link_vfunc;
-	static bool check_type(Type &type);
-	static ValueNode_VectorY* create(const ValueBase &x);
-	virtual Vocab get_children_vocab_vfunc()const;
+	virtual Vocab get_children_vocab_vfunc() const override;
 }; // END of class ValueNode_VectorY
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.cpp
@@ -82,7 +82,7 @@ ValueNode_WeightedAverage::ValueNode_WeightedAverage(Type &type, Canvas::LooseHa
 ValueNode_WeightedAverage::~ValueNode_WeightedAverage() { }
 
 ValueNode_WeightedAverage*
-ValueNode_WeightedAverage::create(const ValueBase &value, Canvas::LooseHandle canvas)
+ValueNode_WeightedAverage::create(const ValueBase& value, Canvas::LooseHandle canvas)
 { 
 	ValueNode_WeightedAverage* value_node(new ValueNode_WeightedAverage(value, canvas));
 	

--- a/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.h
@@ -48,7 +48,7 @@ public:
 	typedef etl::handle<const ValueNode_WeightedAverage> ConstHandle;
 
 	ValueNode_WeightedAverage(Type &type, etl::loose_handle<Canvas> canvas = 0);
-	static ValueNode_WeightedAverage* create(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
+	static ValueNode_WeightedAverage* create(const ValueBase& value, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_WeightedAverage();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.h
@@ -42,25 +42,23 @@ namespace types_namespace { class TypeWeightedValueBase; }
 
 class ValueNode_WeightedAverage : public ValueNode_DynamicList
 {
+	ValueNode_WeightedAverage(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
 public:
 	typedef etl::handle<ValueNode_WeightedAverage> Handle;
 	typedef etl::handle<const ValueNode_WeightedAverage> ConstHandle;
 
-	ValueNode_WeightedAverage(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
 	ValueNode_WeightedAverage(Type &type, etl::loose_handle<Canvas> canvas = 0);
+	static ValueNode_WeightedAverage* create(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
 	virtual ~ValueNode_WeightedAverage();
 
- 	virtual ValueBase operator()(Time t)const;
+	virtual ValueBase operator()(Time t) const override;
 
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
 
 protected:
-	LinkableValueNode* create_new()const;
-
-public:
-	static bool check_type(Type &type);
-	static ValueNode_WeightedAverage* create(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);
+	LinkableValueNode* create_new() const override;
 }; // END of class ValueNode_WeightedAverage
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_wplist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_wplist.cpp
@@ -221,7 +221,7 @@ ValueNode_WPList::~ValueNode_WPList()
 }
 
 ValueNode_WPList*
-ValueNode_WPList::create(const ValueBase &value)
+ValueNode_WPList::create(const ValueBase& value, etl::loose_handle<Canvas>)
 {
 	// if the parameter is not a list type, return null
 	if(value.get_type()!=type_list)

--- a/synfig-core/src/synfig/valuenodes/valuenode_wplist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_wplist.h
@@ -69,7 +69,7 @@ public:
 	typedef etl::handle<const ValueNode_WPList> LooseHandle;
 
 	// Creates a Value Node Width Point List from another compatible list
-	static ValueNode_WPList* create(const ValueBase &x=type_list);
+	static ValueNode_WPList* create(const ValueBase& x=type_list, etl::loose_handle<Canvas> canvas=nullptr);
 	virtual ~ValueNode_WPList();
 
 	virtual String get_name() const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_wplist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_wplist.h
@@ -32,12 +32,6 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <vector>
-#include <list>
-
-#include <synfig/valuenode.h>
-#include <synfig/time.h>
-#include <synfig/uniqueid.h>
 #include <synfig/widthpoint.h>
 #include "valuenode_dynamiclist.h"
 
@@ -65,23 +59,31 @@ synfig::Real widthpoint_interpolate(const WidthPoint& prev, const WidthPoint& ne
 */
 class ValueNode_WPList : public ValueNode_DynamicList
 {
-private:
 	ValueNode::RHandle bline_;
 
-public:
-
-	typedef etl::handle<ValueNode_WPList> Handle;
-	typedef etl::handle<const ValueNode_WPList> ConstHandle;
-	typedef etl::handle<const ValueNode_WPList> LooseHandle;
 	ValueNode_WPList();
 
 public:
+	typedef etl::handle<ValueNode_WPList> Handle;
+	typedef etl::handle<const ValueNode_WPList> ConstHandle;
+	typedef etl::handle<const ValueNode_WPList> LooseHandle;
 
- 	virtual ValueBase operator()(Time t)const;
+	// Creates a Value Node Width Point List from another compatible list
+	static ValueNode_WPList* create(const ValueBase &x=type_list);
 	virtual ~ValueNode_WPList();
-	virtual String link_local_name(int i)const;
-	virtual String get_name()const;
-	virtual String get_local_name()const;
+
+	virtual String get_name() const override;
+	virtual String get_local_name() const override;
+	static bool check_type(Type &type);
+
+	virtual String link_local_name(int i) const override;
+
+	virtual ValueBase operator()(Time t) const override;
+
+protected:
+	LinkableValueNode* create_new() const override;
+
+public:
 	//! Inserts a new entry between the previous found
 	//! widthpoint and the one where the action was called
 	//! with an average width and a middle position.
@@ -89,36 +91,26 @@ public:
 	//! \param time the time when inserted in animation mode
 	//! \param origin unused. Always is in the middle.
 	//! \return the new List Entry
-	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5);
+	virtual ListEntry create_list_entry(int index, Time time=0, Real origin=0.5) override;
 	//! Finds a fully on width point at given time and after the given position
 	//! \param position the position where to start to seek from
 	//! \param time the time when things are evaluated
 	//! \return a width point reference with the proper values
-	WidthPoint find_next_valid_entry_by_position(Real position, Time time=0)const;
+	WidthPoint find_next_valid_entry_by_position(Real position, Time time=0) const;
 	//! Finds a fully on width point at given time and before the given position
 	//! \param position the position where to start to seek from
 	//! \param time the time when things are evaluated
 	//! \return a width point reference with the proper values
-	WidthPoint find_prev_valid_entry_by_position(Real position, Time time=0)const;
+	WidthPoint find_prev_valid_entry_by_position(Real position, Time time=0) const;
 	//! Interpolated width at a a given time based on surrounding full 'on' width points
 	//! \param position the position where to evaluate the width
 	//! \param time the time when evaluates
 	//! \return the interpolated width
-	Real interpolated_width(Real position, Time time)const;
+	Real interpolated_width(Real position, Time time) const;
 	//! Gets the bline RHandle
-	ValueNode::LooseHandle get_bline()const;
+	ValueNode::LooseHandle get_bline() const;
 	//! Sets the bline RHandle
 	void set_bline(ValueNode::Handle b);
-
-protected:
-
-	LinkableValueNode* create_new()const;
-
-public:
-
-	static bool check_type(Type &type);
-	// Creates a Value Node Width Point List from another compatible list
-	static ValueNode_WPList* create(const ValueBase &x=type_list);
 }; // END of class ValueNode_WPList
 
 typedef ValueNode_WPList::ListEntry::ActivepointList ActivepointList;


### PR DESCRIPTION
For unknown reason, some *_vfunc() methods were made public
instead of protected, and something like that.

This PR does some cleanup too, as it uniforms class member order in headers:
- first, private variables
- public typedefs for Handle and ConstHandle
- public creators and destructors
- public (and essential) operator()
- public metadada methods (get_name, get_local_name, check_type)
- protected methods: create_new, *_vefunc, etc.