### PR TITLE
[Studio] Fix dialog responses when user pressing Esc key

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -359,7 +359,10 @@ public:
 		dialog.set_default_response(dflt);
 
 		dialog.show_all();
-		return (Response) dialog.run();
+		int response = dialog.run();
+		if (response != Gtk::RESPONSE_OK)
+			return RESPONSE_CANCEL;
+		return RESPONSE_OK;
 	}
 
 
@@ -387,7 +390,10 @@ public:
 
 		dialog.set_default_response(dflt);
 		dialog.show();
-		return (Response)dialog.run();
+		int response = dialog.run();
+		if (response != Gtk::RESPONSE_YES && response != Gtk::RESPONSE_NO)
+			return RESPONSE_CANCEL;
+		return Response(response);
 	}
 
 
@@ -2206,7 +2212,7 @@ void App::save_custom_workspace()
 	dialog.show_all();
 
 	int response = dialog.run();
-	if (response == Gtk::RESPONSE_CANCEL)
+	if (response != Gtk::RESPONSE_OK)
 		return;
 
 	std::string name = synfig::trim(name_entry->get_text());
@@ -2216,7 +2222,7 @@ void App::save_custom_workspace()
 		workspaces->add_workspace(name, tpl);
 	else {
 		Gtk::MessageDialog confirm_dlg(dialog, _("Do you want to overwrite this workspace?"), false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_OK_CANCEL);
-		if (confirm_dlg.run() == Gtk::RESPONSE_CANCEL)
+		if (confirm_dlg.run() != Gtk::RESPONSE_OK)
 			return;
 		workspaces->set_workspace(name, tpl);
 	}
@@ -3450,12 +3456,11 @@ App::dialog_select_list_item(const std::string &title, const std::string &messag
 	dialog.set_default_size(300, 450);
 	dialog.show_all();
 
-	if (dialog.run() == Gtk::RESPONSE_ACCEPT) {
-		item_index = tree->get_selection()->get_selected()->get_value(model_columns.column_index);
-		return true;
-	}
+	if (dialog.run() != Gtk::RESPONSE_ACCEPT)
+		return false;
 
-	return false;
+	item_index = tree->get_selection()->get_selected()->get_value(model_columns.column_index);
+	return true;
 }
 
 

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -178,7 +178,10 @@ public:
 		dialog.set_default_response(dflt);
 
 		dialog.show_all();
-		return (Response) dialog.run();
+		int response = dialog.run();
+		if (response != Gtk::RESPONSE_OK)
+			return RESPONSE_CANCEL;
+		return RESPONSE_OK;
 	}
 
 	virtual Response yes_no_cancel(
@@ -207,7 +210,10 @@ public:
 
 		dialog.set_default_response(dflt);
 		dialog.show();
-		return (Response)dialog.run();
+		int response = dialog.run();
+		if (response != Gtk::RESPONSE_YES && response != Gtk::RESPONSE_NO)
+			return RESPONSE_CANCEL;
+		return Response(response);
 	}
 
 	virtual bool

--- a/synfig-studio/src/gui/dialogs/dialog_workspaces.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_workspaces.cpp
@@ -130,7 +130,7 @@ void Dialog_Workspaces::on_delete_clicked()
 	char msg[256];
 	snprintf(msg, 255, _("Are you sure you want to delete %d workspaces?"), current_selection->count_selected_rows());
 	Gtk::MessageDialog confirm_dlg(*this, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO, true);
-	if (confirm_dlg.run() == Gtk::RESPONSE_NO)
+	if (confirm_dlg.run() != Gtk::RESPONSE_YES)
 		return;
 
 	// get_selected_rows() return TreePath not TreeIter
@@ -179,7 +179,7 @@ void Dialog_Workspaces::on_rename_clicked()
 	dialog.show_all();
 
 	int response = dialog.run();
-	if (response == Gtk::RESPONSE_CANCEL)
+	if (response != Gtk::RESPONSE_OK)
 		return;
 
 	std::string name = name_entry->get_text();

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1368,11 +1368,11 @@ edit_several_waypoints(etl::handle<CanvasView> canvas_view, std::list<synfigapp:
 
 	dialog.get_content_area()->pack_start(widget_waypoint_model);
 
-	dialog.add_button(_("Cancel"), 0);
-	dialog.add_button(_("Apply"), 1);
+	dialog.add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	dialog.add_button(_("Apply"), Gtk::RESPONSE_APPLY);
 	dialog.show();
 
-	if(dialog.run()==0 || widget_waypoint_model.get_waypoint_model().is_trivial())
+	if(dialog.run()!=Gtk::RESPONSE_APPLY || widget_waypoint_model.get_waypoint_model().is_trivial())
 		return;
 	synfigapp::Action::PassiveGrouper group(canvas_interface->get_instance().get(),_("Set Waypoints"));
 


### PR DESCRIPTION
When user presses Esc key or closes the dialog by clicking on
the X (close) button in window decoration, the dialog does not
return "RESPONSE_CANCEL", but "RESPONSE_DELETE_EVENT".

When programmatically closed, the dialog returns with
"RESPONSE_NONE".

In such cases, the dialog is supposed to be canceled, but
that was not correctly interpreted everywhere.