### PR TITLE
[core] Improve hints for Dash item parameters

### DIFF
--- a/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
@@ -788,19 +788,16 @@ Advanced_Outline::get_param_vocab()const
 	);
 	ret.push_back(ParamDesc("dash_enabled")
 		.set_local_name(_("Dashed Outline"))
-		.set_hint("dash")
 		.set_description(_("When checked, outline is dashed"))
 	);
 	ret.push_back(ParamDesc("dilist")
 		.set_local_name(_("Dash Item List"))
-		.set_hint("dash")
 		.set_origin("origin")
 		.set_description(_("List of dash items that defines the dashed outline"))
 	);
 	ret.push_back(ParamDesc("dash_offset")
 		.set_local_name(_("Dash Items Offset"))
 		.set_is_distance()
-		.set_hint("dash")
 		.set_description(_("Distance to Offset the Dash Items"))
 	);
 	return ret;

--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
@@ -737,7 +737,7 @@ ValueNode_Composite::get_children_vocab_vfunc()const
 		);
 		ret.push_back(ParamDesc(ValueBase(),"width")
 			.set_local_name(_("Width"))
-			.set_description(_("The width of the Width Point"))
+			.set_description(_("The relative width of the Width Point"))
 		);
 		ret.push_back(ParamDesc(ValueBase(),"side_before")
 			.set_local_name(_("Side Type Before"))
@@ -781,10 +781,12 @@ ValueNode_Composite::get_children_vocab_vfunc()const
 		ret.push_back(ParamDesc(ValueBase(),"offset")
 			.set_local_name(_("Offset"))
 			.set_description(_("The offset length of the Dash Item over the Spline"))
+			.set_is_distance()
 		);
 		ret.push_back(ParamDesc(ValueBase(),"length")
 			.set_local_name(_("Length"))
 			.set_description(_("The length of the Dash Item"))
+			.set_is_distance()
 		);
 		ret.push_back(ParamDesc(ValueBase(),"side_before")
 			.set_local_name(_("Side Type Before"))


### PR DESCRIPTION
Dash Item length and offset are measured as distances,
differently of Width Point position, that is relative to
Spline length.

The parameter hint "dash" was not used/parsed anywhere, so
I removed it.

![Captura de tela de 2021-09-16 04-07-35](https://user-images.githubusercontent.com/1323987/133566130-b11e7c83-b821-4c82-a247-a2a0a792187b.png)
