### PR TITLE
Switched Ubuntu version on Github Workflows to 18.04

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -34,8 +34,8 @@ jobs:
           name: MacOS 10.15 Catalina (CMake+Ninja)
           toolchain: cmake-ninja
           allow_failures: true
-        - os: ubuntu-16.04
-          name: Ubuntu 16.04 Xenial (Autotools)
+        - os: ubuntu-18.04
+          name: Ubuntu 18.04 Bionic (Autotools)
           allow_failures: false
           toolchain: autotools
         - os: ubuntu-20.04
@@ -47,11 +47,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-    
+
       - name: Prepare ccache timestamp
         id: ccache_timestamp
         run: echo "::set-output name=timestamp::`date "+%Y%m%d-%H%M%S"`"
-        
+
       - name: Download ccache archive
         id: ccache-archive
         uses: actions/cache@v2.1.3

--- a/.github/workflows/synfig-stable.yml
+++ b/.github/workflows/synfig-stable.yml
@@ -26,8 +26,8 @@ jobs:
           name: MacOS 10.15 Catalina (Autotools)
           toolchain: autotools-release
           allow_failures: false
-        - os: ubuntu-16.04
-          name: Ubuntu 16.04 Xenial (Autotools)
+        - os: ubuntu-18.04
+          name: Ubuntu 18.04 Bionic (Autotools)
           allow_failures: false
           toolchain: autotools-release
 


### PR DESCRIPTION
Version 16.04 is no longer available.
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners