### PR TITLE
Fix magick++ target missing in AppImage

### DIFF
--- a/synfig-core/src/modules/mod_magickpp/Makefile.am
+++ b/synfig-core/src/modules/mod_magickpp/Makefile.am
@@ -35,6 +35,7 @@ libmod_magickpp_la_CXXFLAGS = \
 
 libmod_magickpp_la_LIBADD = \
 	../../synfig/libsynfig.la \
+	@MAGICKPP_LIBS@ \
 	@SYNFIG_LIBS@
 
 endif


### PR DESCRIPTION
Fixes #2320.

This complements the change made in a583e73d4c47914284b15f4a8d7719eafddfe1b4