### PR TITLE
Autotools: Remove @MAGICKPP_LIBS@ variable from LDFLAGS

### DIFF
--- a/synfig-core/src/modules/mod_magickpp/Makefile.am
+++ b/synfig-core/src/modules/mod_magickpp/Makefile.am
@@ -25,7 +25,6 @@ libmod_magickpp_la_SOURCES = \
 
 libmod_magickpp_la_LDFLAGS = \
 	-module \
-	@MAGICKPP_LIBS@ \
 	-no-undefined \
 	-avoid-version
 


### PR DESCRIPTION
...because in 391f8a1540b4c9339bb1141f the @MAGICKPP_LIBS@ variable is placed in correct location now - at 'libmod_magickpp_la_LIBADD' list.

See here - 
https://github.com/synfig/synfig/blob/391f8a1540b4c9339bb1141f4067221f6cc87b8b/synfig-core/src/modules/mod_magickpp/Makefile.am#L36-L39