### PR TITLE
Fix regression: importing image making it upside-down

### DIFF
--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -724,10 +724,6 @@ static void update_layer_size(const RendDesc& rend_desc, Layer::Handle& layer, b
 		} else {
 			x[0] = w*rend_desc.get_pw();
 			x[1] = h*rend_desc.get_ph();
-			if ((size[0] < 0))
-				x[0] = -x[0];
-			if ((size[1] < 0))
-				x[1] = -x[1];
 		}
 
 		if(!layer->set_param("tl",ValueBase(-x/2)))


### PR DESCRIPTION
When "Fit to Canvas" wasn't set in Import Image dialog.

fix #2328