### PR TITLE
minor cleanup on SynfigCommandLineParser

### DIFF
--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -36,16 +36,12 @@
 #include <synfig/localization.h>
 #include <synfig/canvas.h>
 #include <synfig/canvasfilenaming.h>
-#include <synfig/context.h>
 #include <synfig/target.h>
 #include <synfig/layer.h>
 #include <synfig/module.h>
 #include <synfig/importer.h>
 #include <synfig/loadcanvas.h>
 #include <synfig/valuenode_registry.h>
-#include <synfig/filesystemgroup.h>
-#include <synfig/filesystemnative.h>
-#include <synfig/filecontainerzip.h>
 
 #include "definitions.h"
 #include "job.h"
@@ -420,7 +416,6 @@ void SynfigCommandLineParser::process_trivial_info_options()
 
 }
 
-//void OptionsProcessor::process_info_options()
 void SynfigCommandLineParser::process_info_options()
 {
 	if (show_layers_list) {
@@ -494,7 +489,6 @@ void SynfigCommandLineParser::process_info_options()
 	}
 }
 
-//RendDesc OptionsProcessor::extract_renddesc(const RendDesc& renddesc)
 RendDesc SynfigCommandLineParser::extract_renddesc(const RendDesc& renddesc)
 {
 	RendDesc desc = renddesc;
@@ -581,7 +575,6 @@ RendDesc SynfigCommandLineParser::extract_renddesc(const RendDesc& renddesc)
 	return desc;
 }
 
-//TargetParam OptionsProcessor::extract_targetparam()
 TargetParam SynfigCommandLineParser::extract_targetparam()
 {
 	TargetParam params;
@@ -639,7 +632,6 @@ TargetParam SynfigCommandLineParser::extract_targetparam()
 	return params;
 }
 
-//Job OptionsProcessor::extract_job()
 Job SynfigCommandLineParser::extract_job()
 {
 	Job job;
@@ -799,7 +791,6 @@ Job SynfigCommandLineParser::extract_job()
 	return job;
 }
 
-//void OptionsProcessor::print_target_video_codecs_help() const
 void SynfigCommandLineParser::print_target_video_codecs_help() const
 {
 	for (std::vector<VideoCodec>::const_iterator itr = _allowed_video_codecs.begin();
@@ -841,8 +832,7 @@ void signal_test()
 }
 
 // DEBUG options ----------------------------------------------
-//void OptionsProcessor::process_debug_options() throw (SynfigToolException&)
-void SynfigCommandLineParser::process_debug_options() throw (SynfigToolException&)
+void SynfigCommandLineParser::process_debug_options()
 {
 	if (debug_signal)
 	{
@@ -858,4 +848,3 @@ void SynfigCommandLineParser::process_debug_options() throw (SynfigToolException
 }
 
 #endif
-

--- a/synfig-core/src/tool/optionsprocessor.h
+++ b/synfig-core/src/tool/optionsprocessor.h
@@ -27,68 +27,12 @@
 
 #include <string>
 #include <vector>
-#include <synfig/canvas.h>
+#include <synfig/renddesc.h>
 
 #include <glibmm/optioncontext.h>
 #include <glibmm/optiongroup.h>
-//#include <boost/program_options.hpp>
 
-// TODO rename to CommandLineHandler and move the options creation inside.
 /// Class to process all the command line options
-/*class OptionsProcessor
-{
-public:
-	OptionsProcessor(boost::program_options::variables_map& vm,
-					 const boost::program_options::options_description& po_visible);
-
-#ifdef _DEBUG
-	void process_debug_options() throw (SynfigToolException&);
-#endif
-
-	/// Settings options
-	/// verbose, quiet, threads, benchmarks
-	void process_settings_options();
-
-	/// Information options
-	/// Options that will only display information
-	void process_info_options();
-
-	/// Extract the necessary options to create a job
-	/// After this, it is necessary to overwrite the necessary RendDesc options
-	/// and set the target parameters, if provided. Then can be processed
-	Job extract_job();
-
-	/// Overwrite the input RendDesc object with the options given in the command line
-	synfig::RendDesc extract_renddesc(const synfig::RendDesc& renddesc);
-
-	/// Extract the target parameters from the options given in the command line
-	/// video-codec, bitrate, sequence-separator
-	synfig::TargetParam extract_targetparam();
-
-	void print_target_video_codecs_help() const;
-
-private:
-	/// Determine which parameters to show in the canvas info
-	/// canvas-info
-	void extract_canvas_info(Job& job);
-
-	boost::program_options::variables_map _vm;
-	boost::program_options::options_description _po_visible;
-
-	struct VideoCodec
-	{
-		VideoCodec(const std::string& name_, const std::string& description_)
-			: name(name_), description(description_)
-		{ }
-
-		std::string name, description;
-	};
-	//! \warning These codecs are linked to the filename extensions for
-	//!  mod_ffmpeg. If you change this you must change the others accordingly.
-	//!
-	std::vector<VideoCodec> _allowed_video_codecs;
-};*/
-
 class SynfigCommandLineParser
 {
 public:
@@ -127,7 +71,7 @@ public:
 	void print_target_video_codecs_help() const;
 
 #ifdef _DEBUG
-	void process_debug_options() throw (SynfigToolException&);
+	void process_debug_options();
 #endif
 
 private:
@@ -156,7 +100,6 @@ private:
 	int				set_span;
 	int				set_antialias;
 	int				set_quality;
-//			(",Q", quality_arg_desc->default_value(DEFAULT_QUALITY), )
 	int				set_num_threads;
 	Glib::ustring	set_input_file;
 	Glib::ustring	set_output_file;


### PR DESCRIPTION
- remove old commented-out code
- remove unneeded #include
- remove deprecated `throw` in method signature