### PR TITLE
fix regression on Link To Spline: Vertex should be linkable

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuedescblinelink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescblinelink.cpp
@@ -116,11 +116,11 @@ Action::ValueDescBLineLink::is_candidate(const ParamList &x)
 	if (!ValueNode_DynamicList::Handle::cast_dynamic(value_desc_valuenode))
 		return false;
 
-	//! if any of the selected valuedesc belongs to the spline, can't link.
+	// if any of the selected valuedesc belongs to the spline, can't link.
 	const auto range = x.equal_range("selected_value_desc");
 	for (auto it = range.first; it != range.second; ++it) {
 		const auto& selected_value_desc = it->second.get_value_desc();
-		if (selected_value_desc.parent_is_value_node() && value_desc == selected_value_desc.get_parent_value_node())
+		if (selected_value_desc.parent_is_value_node() && value_desc_valuenode == selected_value_desc.get_parent_value_node())
 			return false;
 	}
 


### PR DESCRIPTION
https://forums.synfig.org/t/does-not-show-link-to-spline-when-trying-to-connect-vertex-to-spline/12607

Reported-by: bubutec
Confirmed-by: svarov