### PR TITLE
Bevel parameter of Rectangle layer is a relative value, not distance

### DIFF
--- a/synfig-core/src/modules/mod_geometry/rectangle.cpp
+++ b/synfig-core/src/modules/mod_geometry/rectangle.cpp
@@ -204,7 +204,6 @@ Rectangle::get_param_vocab()const
 	ret.push_back(ParamDesc("bevel")
 		.set_local_name(_("Bevel"))
 		.set_description(_("Use Bevel for the corners"))
-		.set_is_distance()
 	);
 	ret.push_back(ParamDesc("bevCircle")
 		.set_local_name(_("Keep Bevel Circular"))


### PR DESCRIPTION
Range: 0% - 100%, being 100% half of rectangle width/height