### PR TITLE
Text Layer ported to Cobra render engine

### DIFF
--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
@@ -751,32 +751,15 @@ Layer_Freetype::set_shape_param(const String & param, const ValueBase &value)
 			on_param_text_changed();
 		}
 		);
-//	IMPORT_VALUE_PLUS(param_origin,/*needs_sync=true*/);
-//	IMPORT_VALUE_PLUS(param_color,
-//		{
-//			Color color=param_color.get(Color());
-//			if (approximate_zero(color.get_a()))
-//			{
-//				if (converted_blend_)
-//				{
-//					set_blend_method(Color::BLEND_ALPHA_OVER);
-//					color.set_a(1);
-//					param_color.set(color);
-//				} else transparent_color_ = true;
-//			}
-//		}
-//		);
-//	IMPORT_VALUE(param_invert);
 	IMPORT_VALUE_PLUS(param_orient,need_sync |= SYNC_ORIENTATION;);
 	IMPORT_VALUE_PLUS(param_compress,need_sync |= SYNC_COMPRESS);
 	IMPORT_VALUE_PLUS(param_vcompress,need_sync |= SYNC_COMPRESS);
 	IMPORT_VALUE_PLUS(param_use_kerning,need_sync |= SYNC_KERNING);
 	IMPORT_VALUE_PLUS(param_grid_fit,need_sync |= SYNC_GRID_FIT);
 
-//	if(param=="pos")
-//		return set_param("origin", value);
+	if(param=="pos")
+		return set_param("origin", value);
 
-//	return Layer_Shape::set_param(param,value);
 	return false;
 }
 
@@ -799,14 +782,11 @@ Layer_Freetype::get_param(const String& param)const
 	EXPORT_VALUE(param_direction);
 	EXPORT_VALUE(param_size);
 	EXPORT_VALUE(param_text);
-//	EXPORT_VALUE(param_color);
-//	EXPORT_VALUE(param_origin);
 	EXPORT_VALUE(param_orient);
 	EXPORT_VALUE(param_compress);
 	EXPORT_VALUE(param_vcompress);
 	EXPORT_VALUE(param_use_kerning);
 	EXPORT_VALUE(param_grid_fit);
-//	EXPORT_VALUE(param_invert);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
@@ -817,7 +797,8 @@ Layer_Freetype::get_param(const String& param)const
 Layer::Vocab
 Layer_Freetype::get_param_vocab(void)const
 {
-	Layer::Vocab ret(Layer_Shape::get_param_vocab());
+	Layer::Vocab ret(Layer_Composite::get_param_vocab());
+	// Ignore the Layer_Shape params
 
 	ret.push_back(ParamDesc("text")
 		.set_local_name(_("Text"))
@@ -825,10 +806,10 @@ Layer_Freetype::get_param_vocab(void)const
 		.set_hint("paragraph")
 	);
 
-//	ret.push_back(ParamDesc("color")
-//		.set_local_name(_("Color"))
-//		.set_description(_("Color of the text"))
-//	);
+	ret.push_back(ParamDesc("color")
+		.set_local_name(_("Color"))
+		.set_description(_("Color of the text"))
+	);
 
 	ret.push_back(ParamDesc("family")
 		.set_local_name(_("Font Family"))
@@ -894,11 +875,11 @@ Layer_Freetype::get_param_vocab(void)const
 		.set_invisible_duck()
 	);
 
-//	ret.push_back(ParamDesc("origin")
-//		.set_local_name(_("Origin"))
-//		.set_description(_("Text Position"))
-//		.set_is_distance()
-//	);
+	ret.push_back(ParamDesc("origin")
+		.set_local_name(_("Origin"))
+		.set_description(_("Text Position"))
+		.set_is_distance()
+	);
 
 	ret.push_back(ParamDesc("font")
 		.set_local_name(_("Font"))
@@ -917,9 +898,10 @@ Layer_Freetype::get_param_vocab(void)const
 		.set_local_name(_("Sharpen Edges"))
 		.set_description(_("Turn this off if you are animating the text"))
 	);
-//	ret.push_back(ParamDesc("invert")
-//		.set_local_name(_("Invert"))
-//	);
+
+	ret.push_back(ParamDesc("invert")
+		.set_local_name(_("Invert"))
+	);
 	return ret;
 }
 

--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.h
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.h
@@ -53,8 +53,6 @@ class Layer_Freetype : public synfig::Layer_Shape
 private:
 	//!Parameter: (synfig::String) text of the layer;
 	synfig::ValueBase param_text;
-//	//!Parameter: (synfig::Color) color of the text;
-//	synfig::ValueBase param_color;
 	//!Parameter: (synfig::String) font family used in the text
 	synfig::ValueBase param_family;
 	//!Parameter: (int) style used in the font
@@ -71,16 +69,12 @@ private:
 	synfig::ValueBase param_size;
 	//!Parameter: (synfig::Vector) text orientation
 	synfig::ValueBase param_orient;
-//	//!Parameter: (synfig::Point) text position
-//	synfig::ValueBase param_origin;
 	//!Parameter: (synfig::String) font used in the text
 	synfig::ValueBase param_font;
 	//!Parameter: (bool)
 	synfig::ValueBase param_use_kerning;
 	//!Parameter: (bool)
 	synfig::ValueBase param_grid_fit;
-//	//!Parameter: (bool) inverts the rendered text
-//	synfig::ValueBase param_invert;
 
 	FT_Face face;
 #if HAVE_HARFBUZZ


### PR DESCRIPTION
It's magic, I know!

- [x] Text Layer now uses Cobra with Contour Task
- [x] Based on Layer_Shape (as are layers Polygon, Rectangle, Bline, Circle, etc.)
- [x] If selected, it shows a boundary box now
- [x] It is CLICKABLE
- [x] No more blurring when zooming canvas/workarea in
- [x] Doesn't blur layers below it
- [x] Waaay faster (and more optimizations may be done)
- [x] Cobra: `Invert` for multiline is wrong between consecutive text lines (Cobra engine issue... on large zooms it works o.O 
I guess the issue is here `software::Contour::render_polyspan()` or `software::Contour::build_polyspan()`) 
Fix proposed in #2367
- [x] Cobra: hit check for conic curves is wrong, making it difficult to select layers at right of Text layer (fixed via #2358)
- [x] Cobra: hide some Layer Shape parameters (example: `winding number`)

fix #389
fix #631
fix #831
fix #1566
fix #2065 