### PR TITLE
Fix inverted contour rendering for consecutive blank pixel rows between shapes

### DIFF
--- a/synfig-core/src/synfig/rendering/software/function/contour.cpp
+++ b/synfig-core/src/synfig/rendering/software/function/contour.cpp
@@ -185,6 +185,21 @@ software::Contour::render_polyspan(
 					p.put_hline(window.maxx - x);
 				}
 
+				// fill any empty line until next mark
+				if (++y != cur_mark->y)
+				{
+					if (simple_fill)
+					{
+						sp.move_to(window.minx, y);
+						sp.put_block(cur_mark->y - y, window.maxx - window.minx);
+					}
+					else
+					{
+						p.move_to(window.minx, y);
+						p.put_block(cur_mark->y - y, window.maxx - window.minx);
+					}
+				}
+
 				// fill area at the beginning of the next line
 				if (simple_fill)
 				{


### PR DESCRIPTION
Before:
![screenshot_014](https://user-images.githubusercontent.com/332868/137757582-8e9aa587-8f67-422c-a062-56d89a46eda3.png)

After:
![screenshot_018](https://user-images.githubusercontent.com/332868/137757598-7bbe8736-1e6e-4f23-923a-9b3a6cd8e5c8.png)

Though not used by current GUI tools, a Contour may be composed
of more than one polygon or bline-shape.

Let's assume we are rendering a shape like the character 'i':
it is a dot above a straight line segment (or a bit more elaborated
shape), right?
There is at least a pixel row separating them.

If we set 'invert' parameter of the contour that contains both
polygons (dot + straight line segment),
the row(s) between those shapes are not filled, but kept as if
'invert' was not set.