### PR TITLE
[Synfig Studio] Refresh Widget_RendDesc on width/height link toggling

### DIFF
--- a/synfig-studio/src/gui/renddesc.cpp
+++ b/synfig-studio/src/gui/renddesc.cpp
@@ -519,6 +519,7 @@ Widget_RendDesc::on_ratio_wh_toggled()
 		rend_desc_.set_flags(rend_desc_.get_flags()&~RendDesc::LINK_IM_ASPECT);
 		rend_desc_.set_flags(rend_desc_.get_flags()|RendDesc::PX_ASPECT);
 	}
+	refresh();
 }
 
 void


### PR DESCRIPTION
This fix is necessary to avoid out of sync checkbuttons when toggling width/height link from their actual status.
See `Other > Pixel Aspect` status checkbutton for example.

![Screenshot_84](https://user-images.githubusercontent.com/5604544/137669136-f2440ef6-440c-4668-be7b-5a1ff8a8a1d8.png)

![Screenshot_92](https://user-images.githubusercontent.com/5604544/137669184-b89aa8dd-0eba-4241-8751-ac7afbc55462.png)


