### PR TITLE
Fix Orientation parameter display on Text Tool Options Panel

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -449,7 +449,7 @@ class SetsModel : public Gtk::TreeModel::ColumnRecord
 class Preferences : public synfigapp::Settings
 {
 public:
-	virtual bool get_value(const synfig::String& key, synfig::String& value)const
+	virtual bool get_raw_value(const synfig::String& key, synfig::String& value)const override
 	{
 		try
 		{
@@ -623,10 +623,10 @@ public:
 		{
 			synfig::warning("Preferences: Caught exception when attempting to get value.");
 		}
-		return synfigapp::Settings::get_value(key,value);
+		return synfigapp::Settings::get_raw_value(key,value);
 	}
 
-	virtual bool set_value(const synfig::String& key,const synfig::String& value)
+	virtual bool set_value(const synfig::String& key,const synfig::String& value) override
 	{
 		try
 		{
@@ -811,7 +811,7 @@ public:
 		return synfigapp::Settings::set_value(key,value);
 	}
 
-	virtual KeyList get_key_list()const
+	virtual KeyList get_key_list()const override
 	{
 		KeyList ret(synfigapp::Settings::get_key_list());
 		ret.push_back("time_format");
@@ -2387,8 +2387,7 @@ App::dialog_open_file(const std::string &title, std::string &filename, std::stri
 #else   // not USE_WIN32_FILE_DIALOGS
 	synfig::String prev_path;
 
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
+	prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
@@ -2525,10 +2524,7 @@ App::dialog_open_file(const std::string &title, std::string &filename, std::stri
 bool
 App::dialog_open_file_spal(const std::string &title, std::string &filename, std::string preference)
 {
-	synfig::String prev_path;
-
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
@@ -2578,10 +2574,7 @@ App::dialog_open_file_spal(const std::string &title, std::string &filename, std:
 bool
 App::dialog_open_file_sketch(const std::string &title, std::string &filename, std::string preference)
 {
-	synfig::String prev_path;
-
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
@@ -2620,11 +2613,7 @@ App::dialog_open_file_sketch(const std::string &title, std::string &filename, st
 bool
 App::dialog_open_file_image(const std::string &title, std::string &filename, std::string preference)
 {
-	synfig::String prev_path;
-
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
-
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
@@ -2681,11 +2670,7 @@ App::dialog_open_file_image(const std::string &title, std::string &filename, std
 bool
 App::dialog_open_file_audio(const std::string &title, std::string &filename, std::string preference)
 {
-	synfig::String prev_path;
-
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
-
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
@@ -2734,11 +2719,7 @@ App::dialog_open_file_audio(const std::string &title, std::string &filename, std
 bool
 App::dialog_open_file_image_sequence(const std::string &title, std::set<synfig::String> &filenames, std::string preference)
 {
-	synfig::String prev_path;
-
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
-
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
@@ -2861,12 +2842,7 @@ App::dialog_select_importer(const std::string& filename, std::string& plugin)
 bool
 App::dialog_open_file_with_history_button(const std::string &title, std::string &filename, bool &show_history, std::string preference, std::string& plugin_importer)
 {
-
-	synfig::String prev_path;
-
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
-
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
@@ -2969,9 +2945,7 @@ App::dialog_open_folder(const std::string &title, std::string &foldername, std::
 {
 	synfig::String prev_path;
 	synfigapp::Settings settings;
-	if(settings.get_value(preference, prev_path))
-		prev_path = ".";
-
+	prev_path = settings.get_value(preference, ".");
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window,
@@ -3041,11 +3015,7 @@ App::dialog_save_file(const std::string &title, std::string &filename, std::stri
 	}
 	return false;
 #else
-	synfig::String prev_path;
-
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
-
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window, title, Gtk::FILE_CHOOSER_ACTION_SAVE);
@@ -3180,11 +3150,7 @@ App::dialog_save_file(const std::string &title, std::string &filename, std::stri
 std::string
 App::dialog_export_file(const std::string &title, std::string &filename, std::string preference)
 {
-	synfig::String prev_path;
-
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path = Glib::get_home_dir();
-
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window, title, Gtk::FILE_CHOOSER_ACTION_SAVE);
@@ -3239,9 +3205,7 @@ App::dialog_export_file(const std::string &title, std::string &filename, std::st
 bool
 App::dialog_save_file_spal(const std::string &title, std::string &filename, std::string preference)
 {
-	synfig::String prev_path;
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path=Glib::get_home_dir();
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window, title, Gtk::FILE_CHOOSER_ACTION_SAVE);
@@ -3301,9 +3265,7 @@ App::dialog_save_file_spal(const std::string &title, std::string &filename, std:
 bool
 App::dialog_save_file_sketch(const std::string &title, std::string &filename, std::string preference)
 {
-	synfig::String prev_path;
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path=Glib::get_home_dir();
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window, title, Gtk::FILE_CHOOSER_ACTION_SAVE);
@@ -3364,9 +3326,7 @@ App::dialog_save_file_sketch(const std::string &title, std::string &filename, st
 bool
 App::dialog_save_file_render(const std::string &title, std::string &filename, std::string preference)
 {
-	synfig::String prev_path;
-	if(!_preferences.get_value(preference, prev_path))
-		prev_path=Glib::get_home_dir();
+	synfig::String prev_path = _preferences.get_value(preference, Glib::get_home_dir());
 	prev_path = absolute_path(prev_path);
 
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window, title, Gtk::FILE_CHOOSER_ACTION_SAVE);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -959,7 +959,7 @@ Dialog_Setup::on_apply_pressed()
 			input_settings.set_value(strprintf("brush.path_%d", path_count++), path);
 			App::brushes_path.insert(path);
 		}
-		input_settings.set_value("brush.path_count", strprintf("%d", path_count));
+		input_settings.set_value("brush.path_count", path_count);
 	}
 
 	// Set the preferred file name prefix

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -1256,19 +1256,19 @@ Dialog_Setup::refresh()
 	//! Now brush path(s) are hold by input preferences : brush.path_count & brush.path_%d
 	String value;
 	Gtk::TreeIter ui_iter;
-	bool bvalue(input_settings.get_value("brush.path_count",value));
-	int i(atoi(value.c_str()));
+	int brush_path_count = input_settings.get_value("brush.path_count", 0);
 	App::brushes_path.clear();
 	liststore->clear();
-	if(!bvalue || (bvalue && i<=0))
+	if(brush_path_count == 0)
 	{
 		App::brushes_path.insert(ResourceHelper::get_brush_path());
 	}
 	else
 	{
-		for(int j = 0; j<i;j++)
+		for(int j = 0; j<brush_path_count;j++)
 		{
-			if(input_settings.get_value(strprintf("brush.path_%d", j),value))
+			std::string path = input_settings.get_value(strprintf("brush.path_%d", j), "");
+			if(!path.empty())
 			{
 				App::brushes_path.insert(value);
 			}

--- a/synfig-studio/src/gui/dialogsettings.cpp
+++ b/synfig-studio/src/gui/dialogsettings.cpp
@@ -67,7 +67,7 @@ DialogSettings::~DialogSettings()
 }
 
 bool
-DialogSettings::get_value(const synfig::String& key, synfig::String& value)const
+DialogSettings::get_raw_value(const synfig::String& key, synfig::String& value) const
 {
 	if(key=="pos")
 	{
@@ -113,7 +113,7 @@ DialogSettings::get_value(const synfig::String& key, synfig::String& value)const
 		return true;
 	}
 
-	return synfigapp::Settings::get_value(key,value);
+	return synfigapp::Settings::get_raw_value(key,value);
 }
 
 bool
@@ -196,7 +196,7 @@ DialogSettings::set_value(const synfig::String& key,const synfig::String& value)
 }
 
 synfigapp::Settings::KeyList
-DialogSettings::get_key_list()const
+DialogSettings::get_key_list() const
 {
 	synfigapp::Settings::KeyList ret(synfigapp::Settings::get_key_list());
 

--- a/synfig-studio/src/gui/dialogsettings.h
+++ b/synfig-studio/src/gui/dialogsettings.h
@@ -49,9 +49,9 @@ public:
 	DialogSettings(Gtk::Window* window,const synfig::String& name);
 	virtual ~DialogSettings();
 
-	virtual bool get_value(const synfig::String& key, synfig::String& value)const;
-	virtual bool set_value(const synfig::String& key,const synfig::String& value);
-	virtual KeyList get_key_list()const;
+	virtual bool get_raw_value(const synfig::String& key, synfig::String& value) const override;
+	virtual bool set_value(const synfig::String& key,const synfig::String& value) override;
+	virtual KeyList get_key_list() const override;
 };
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/docks/dockdialog.cpp
+++ b/synfig-studio/src/gui/docks/dockdialog.cpp
@@ -59,16 +59,6 @@ using namespace studio;
 
 /* === M A C R O S ========================================================= */
 
-#define GRAB_HINT_DATA(y,default)	{ \
-		String x; \
-		if(synfigapp::Main::settings().get_value(String("pref.")+y+"_hints",x)) \
-		{ \
-			set_type_hint((Gdk::WindowTypeHint)atoi(x.c_str()));	\
-		} else {\
-			set_type_hint(default); \
-		} \
-	}
-
 /* === G L O B A L S ======================================================= */
 
 /* === P R O C E D U R E S ================================================= */
@@ -84,11 +74,14 @@ DockDialog::DockDialog():
 	set_id(synfig::UniqueID().get_uid()^reinterpret_cast<intptr_t>(this));
 
 	set_role(strprintf("dock_dialog_%d",get_id()));
+	{
 #ifdef __APPLE__
-	GRAB_HINT_DATA("dock_dialog", Gdk::WINDOW_TYPE_HINT_NORMAL);
+		const int default_hint = Gdk::WINDOW_TYPE_HINT_NORMAL;
 #else
-	GRAB_HINT_DATA("dock_dialog", Gdk::WINDOW_TYPE_HINT_UTILITY);
+		const int default_hint = Gdk::WINDOW_TYPE_HINT_UTILITY;
 #endif
+		set_type_hint(Gdk::WindowTypeHint(synfigapp::Main::settings().get_value("pref.dock_dialog_hints", default_hint)));
+	}
 	set_keep_above(false);
 
 	//! \todo can we set dialog windows transient for all normal windows, not just the toolbox?

--- a/synfig-studio/src/gui/docks/dockmanager.cpp
+++ b/synfig-studio/src/gui/docks/dockmanager.cpp
@@ -138,7 +138,7 @@ public:
 		synfigapp::Main::settings().remove_domain("workspace");
 	}
 
-	virtual bool get_value(const synfig::String& key_, synfig::String& value)const
+	virtual bool get_raw_value(const synfig::String& key_, synfig::String& value)const override
 	{
 		try
 		{
@@ -148,10 +148,10 @@ public:
 				return true;
 			}
 		}catch (...) { return false; }
-		return synfigapp::Settings::get_value(key_,value);
+		return synfigapp::Settings::get_raw_value(key_,value);
 	}
 
-	virtual bool set_value(const synfig::String& key_,const synfig::String& value)
+	virtual bool set_value(const synfig::String& key_,const synfig::String& value) override
 	{
 		try
 		{
@@ -164,7 +164,7 @@ public:
 		return synfigapp::Settings::set_value(key_,value);
 	}
 
-	virtual KeyList get_key_list()const
+	virtual KeyList get_key_list()const override
 	{
 		synfigapp::Settings::KeyList ret(synfigapp::Settings::get_key_list());
 		ret.push_back("layout");

--- a/synfig-studio/src/gui/mainwindow.cpp
+++ b/synfig-studio/src/gui/mainwindow.cpp
@@ -61,14 +61,6 @@ using namespace studio;
 
 /* === M A C R O S ========================================================= */
 
-#define GRAB_HINT_DATA(y)	{ \
-		String x; \
-		if(synfigapp::Main::settings().get_value(String("pref.")+y+"_hints",x)) \
-		{ \
-			set_type_hint((Gdk::WindowTypeHint)atoi(x.c_str()));	\
-		} \
-	}
-
 /* === G L O B A L S ======================================================= */
 
 /* === P R O C E D U R E S ================================================= */
@@ -140,7 +132,7 @@ MainWindow::MainWindow() :
 	App::dock_manager->signal_dockable_unregistered().connect(
 		sigc::mem_fun(*this,&MainWindow::on_dockable_unregistered) );
 
-	GRAB_HINT_DATA("mainwindow");
+	set_type_hint(Gdk::WindowTypeHint(synfigapp::Main::settings().get_value("pref.mainwindow_hints", Gdk::WindowTypeHint())));
 }
 
 MainWindow::~MainWindow() = default;

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -80,7 +80,7 @@ public:
 		dialog_palette->dialog_settings.remove_domain(name);
 	}
 
-	virtual bool get_value(const synfig::String& key, synfig::String& value)const
+	virtual bool get_value(const synfig::String& key, synfig::String& value)const override
 	{
 		int i(atoi(key.c_str()));
 		if(i<0 || i>=dialog_palette->size())
@@ -90,7 +90,7 @@ public:
 		return true;
 	}
 
-	virtual bool set_value(const synfig::String& key,const synfig::String& value)
+	virtual bool set_value(const synfig::String& key,const synfig::String& value) override
 	{
 		int i(atoi(key.c_str()));
 		if(i<0)
@@ -104,7 +104,7 @@ public:
 		return true;
 	}
 
-	virtual KeyList get_key_list()const
+	virtual KeyList get_key_list()const override
 	{
 		synfigapp::Settings::KeyList ret(synfigapp::Settings::get_key_list());
 

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -371,20 +371,19 @@ StateBLine_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		sanity_check();
 		settings.set_value("bline.id",get_id());
-		settings.set_value("bline.layer_outline",get_layer_outline_flag()?"1":"0");
-		settings.set_value("bline.layer_advanced_outline",get_layer_advanced_outline_flag()?"1":"0");
-		settings.set_value("bline.layer_region",get_layer_region_flag()?"1":"0");
-		settings.set_value("bline.layer_curve_gradient",get_layer_curve_gradient_flag()?"1":"0");
-		settings.set_value("bline.layer_plant",get_layer_plant_flag()?"1":"0");
-		settings.set_value("bline.layer_link_origins",get_layer_link_origins_flag()?"1":"0");
-		settings.set_value("bline.blend",strprintf("%d",get_blend()));
-		settings.set_value("bline.opacity",strprintf("%f",(float)get_opacity()));
+		settings.set_value("bline.layer_outline",get_layer_outline_flag());
+		settings.set_value("bline.layer_advanced_outline",get_layer_advanced_outline_flag());
+		settings.set_value("bline.layer_region",get_layer_region_flag());
+		settings.set_value("bline.layer_curve_gradient",get_layer_curve_gradient_flag());
+		settings.set_value("bline.layer_plant",get_layer_plant_flag());
+		settings.set_value("bline.layer_link_origins",get_layer_link_origins_flag());
+		settings.set_value("bline.blend",get_blend());
+		settings.set_value("bline.opacity",get_opacity());
 		settings.set_value("bline.bline_width", bline_width_dist.get_value().get_string());
 		settings.set_value("bline.feather", feather_dist.get_value().get_string());
-		settings.set_value("bline.auto_export",get_auto_export_flag()?"1":"0");
+		settings.set_value("bline.auto_export",get_auto_export_flag());
 
 	}
 	catch(...)

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -321,8 +321,6 @@ StateBLine_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		set_id(settings.get_value("bline.id", _("NewSpline")));
 
 		set_blend(settings.get_value("bline.blend", int(Color::BLEND_COMPOSITE)));

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -375,7 +375,7 @@ StateBLine_Context::save_settings()
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		sanity_check();
-		settings.set_value("bline.id",get_id().c_str());
+		settings.set_value("bline.id",get_id());
 		settings.set_value("bline.layer_outline",get_layer_outline_flag()?"1":"0");
 		settings.set_value("bline.layer_advanced_outline",get_layer_advanced_outline_flag()?"1":"0");
 		settings.set_value("bline.layer_region",get_layer_region_flag()?"1":"0");

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -322,74 +322,43 @@ StateBLine_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
-		if(settings.get_value("bline.id",value))
-			set_id(value);
-		else
-			set_id(_("NewSpline"));
+		set_id(settings.get_value("bline.id", _("NewSpline")));
 
-		if(settings.get_value("bline.blend",value) && value != "")
-			set_blend(atoi(value.c_str()));
-		else
-			set_blend(0);//(int)Color::BLEND_COMPOSITE); //0 should be blend composites value
+		set_blend(settings.get_value("bline.blend", int(Color::BLEND_COMPOSITE)));
 
-		if(settings.get_value("bline.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_opacity(settings.get_value("bline.opacity", 1.0));
 
-		if(settings.get_value("bline.bline_width",value) && value != "")
-			set_bline_width(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_bline_width(Distance(1, App::distance_system)); // default width
+		set_bline_width(Distance(
+							settings.get_value("bline.bline_width", 1.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("bline.layer_region",value) && value=="0")
-			set_layer_region_flag(false);
-		else
-			set_layer_region_flag(true);
+		set_layer_region_flag(settings.get_value("bline.layer_region", true));
 
-		if(settings.get_value("bline.layer_outline",value) && value=="1")
-			set_layer_outline_flag(true);
-		else
-			set_layer_outline_flag(false);
+		set_layer_outline_flag(settings.get_value("bline.layer_outline", false));
 
-		if(settings.get_value("bline.layer_advanced_outline",value) && value=="0")
-			set_layer_advanced_outline_flag(false);
-		else
-			set_layer_advanced_outline_flag(true);
+		set_layer_advanced_outline_flag(settings.get_value("bline.layer_advanced_outline", true));
 
-		if(settings.get_value("bline.layer_curve_gradient",value) && value=="1")
-			set_layer_curve_gradient_flag(true);
-		else
-			set_layer_curve_gradient_flag(false);
+		set_layer_curve_gradient_flag(settings.get_value("bline.layer_curve_gradient", false));
 
-		if(settings.get_value("bline.layer_plant",value) && value=="1")
-			set_layer_plant_flag(true);
-		else
-			set_layer_plant_flag(false);
+		set_layer_plant_flag(settings.get_value("bline.layer_plant", false));
 
-		if(settings.get_value("bline.layer_link_origins",value) && value=="0")
-			set_layer_link_origins_flag(false);
-		else
-			set_layer_link_origins_flag(true);
+		set_layer_link_origins_flag(settings.get_value("bline.layer_link_origins", true));
 
-		if(settings.get_value("bline.auto_export",value) && value=="1")
-			set_auto_export_flag(true);
-		else
-			set_auto_export_flag(false);
+		set_auto_export_flag(settings.get_value("bline.auto_export", false));
 
-		if(settings.get_value("bline.feather",value))
-			set_feather_size(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_feather_size(Distance(0, App::distance_system));
+		set_feather_size(Distance(
+							settings.get_value("bline.feather", 0.0),
+							App::distance_system)
+						);
 
-	  // determine layer flags
-	  layer_region_flag = get_layer_region_flag();
-	  layer_outline_flag = get_layer_outline_flag();
-	  layer_advanced_outline_flag = get_layer_outline_flag();
-	  layer_curve_gradient_flag = get_layer_curve_gradient_flag();
-	  layer_plant_flag = get_layer_plant_flag();
+		// determine layer flags
+		layer_region_flag = get_layer_region_flag();
+		layer_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
+		layer_plant_flag = get_layer_plant_flag();
 
 		sanity_check();
 	}

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -262,9 +262,9 @@ StateBone_Context::save_settings()
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC,"C");
 		if(c_layer==SKELETON_TYPE)
-			settings.set_value("bone.skel_id",get_id().c_str());
+			settings.set_value("bone.skel_id",get_id());
 		else
-			settings.set_value("bone.skel_deform_id",get_id().c_str());
+			settings.set_value("bone.skel_deform_id",get_id());
 
 		settings.set_value("bone.skel_bone_width",skel_bone_width_dist.get_value().get_string());
 		settings.set_value("bone.skel_deform_bone_width",skel_deform_bone_width_dist.get_value().get_string());

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -233,28 +233,21 @@ StateBone_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC,"C");
-		std::string value;
 		if(c_layer==SKELETON_TYPE){
-			if(settings.get_value("bone.skel_id",value))
-				set_id(value);
-			else
-				set_id(_("NewSkeleton"));
+			set_id(settings.get_value("bone.skel_id", _("NewSkeleton")));
 		}else{
-			if(settings.get_value("bone.skel_deform_id",value))
-				set_id(value);
-			else
-				set_id(_("NewSkeletonDeformation"));
+			set_id(settings.get_value("bone.skel_deform_id", _("NewSkeletonDeformation")));
 		}
 
-		if(settings.get_value("bone.skel_bone_width",value) && !value.empty())
-			set_skel_bone_width(Distance(value));
-		else
-			set_skel_bone_width(Distance(DEFAULT_WIDTH,Distance::SYSTEM_UNITS)); // default width
+		set_skel_bone_width(Distance(
+							settings.get_value("bone.skel_bone_width", DEFAULT_WIDTH),
+							Distance::SYSTEM_UNITS)
+						);
 
-		if(settings.get_value("bone.skel_deform_bone_width",value) && !value.empty())
-			set_skel_deform_bone_width(Distance(value));
-		else
-			set_skel_deform_bone_width(Distance(DEFAULT_WIDTH,Distance::SYSTEM_UNITS)); // default width
+		set_skel_deform_bone_width(Distance(
+							settings.get_value("bone.skel_deform_bone_width", DEFAULT_WIDTH),
+							Distance::SYSTEM_UNITS)
+						);
 	}
 	catch(...)
 	{
@@ -855,7 +848,6 @@ StateBone_Context::event_layer_selection_changed_handler(const Smach::event& /*x
 	Layer::Handle layer = get_canvas_interface()->get_selection_manager()->get_selected_layer();
 	Layer_Skeleton::Handle skel_layer = Layer_Skeleton::Handle::cast_dynamic(layer);
 	Layer_SkeletonDeformation::Handle deform_layer = Layer_SkeletonDeformation::Handle::cast_dynamic(layer);
-	std::string value;
 
 	if(cnt<=1){
 		if((skel_layer || deform_layer) || cnt==0)
@@ -864,17 +856,11 @@ StateBone_Context::event_layer_selection_changed_handler(const Smach::event& /*x
 
 
 	if(skel_layer){
-		if(settings.get_value("bone.skel_id",value))
-			set_id(value);
-		else
-			set_id(_("NewSkeleton"));
+		set_id(settings.get_value("bone.skel_id", _("NewSkeleton")));
 		update_tool_options(SKELETON_TYPE);
 		get_work_area()->set_type_mask(get_work_area()->get_type_mask()-Duck::TYPE_TANGENT-Duck::TYPE_WIDTH);
 	}else if(deform_layer){
-		if(settings.get_value("bone.skel_deform_id",value))
-			set_id(value);
-		else
-			set_id(_("NewSkeletonDeformation"));
+		set_id(settings.get_value("bone.skel_deform_id", _("NewSkeletonDeformation")));
 		update_tool_options(SKELETON_DEFORMATION_TYPE);
 		get_work_area()->set_type_mask(get_work_area()->get_type_mask() - (Duck::TYPE_TANGENT | Duck::TYPE_WIDTH));
 		layer->disable();

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -259,7 +259,6 @@ StateBone_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC,"C");
 		if(c_layer==SKELETON_TYPE)
 			settings.set_value("bone.skel_id",get_id());
 		else

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -232,7 +232,6 @@ StateBone_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC,"C");
 		if(c_layer==SKELETON_TYPE){
 			set_id(settings.get_value("bone.skel_id", _("NewSkeleton")));
 		}else{

--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -476,15 +476,13 @@ StateBrush_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
-		settings.set_value("brush.path_count", strprintf("%d", (int)App::brushes_path.size()));
+		settings.set_value("brush.path_count", (int)App::brushes_path.size());
 		int j = 0;
 		for(std::set<String>::const_iterator i = App::brushes_path.begin(); i != App::brushes_path.end(); ++i)
 			settings.set_value(strprintf("brush.path_%d", j++), *i);
 
 		settings.set_value("brush.selected_brush_filename", selected_brush_config.filename);
-		settings.set_value("brush.eraser", eraser_checkbox.get_active() ? "true" : "false");
+		settings.set_value("brush.eraser", eraser_checkbox.get_active());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -443,15 +443,14 @@ StateBrush_Context::load_settings()
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 
-		String value;
-		bool bvalue(settings.get_value("brush.path_count",value));
-		int count = atoi(value.c_str());
-		if(bvalue && count>0)
+		int brush_path_count = settings.get_value("brush.path_count", 0);
+		if (brush_path_count > 0)
 		{
+			String value;
 			App::brushes_path.clear();
 			int count = atoi(value.c_str());
-			for(int i = 0; i < count; ++i)
-				if(settings.get_value(strprintf("brush.path_%d", i),value))
+			for(int i = 0; i < brush_path_count; ++i)
+				if(settings.get_raw_value(strprintf("brush.path_%d", i),value))
 					App::brushes_path.insert(value);
 		}
 		else
@@ -461,12 +460,12 @@ StateBrush_Context::load_settings()
 		}
 		refresh_tool_options();
 
-		if (settings.get_value("brush.selected_brush_filename",value))
+		std::string value;
+		if (settings.get_raw_value("brush.selected_brush_filename", value))
 			if (brush_buttons.count(value))
 				brush_buttons[value]->set_active(true);
 
-		if (settings.get_value("brush.eraser",value))
-			eraser_checkbox.set_active(value == "true");
+		eraser_checkbox.set_active(settings.get_value("brush.eraser", false));
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -441,8 +441,6 @@ StateBrush_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		int brush_path_count = settings.get_value("brush.path_count", 0);
 		if (brush_path_count > 0)
 		{

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -308,8 +308,6 @@ StateCircle_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		//parse the arguments yargh!
 		set_id(settings.get_value("circle.id", "Circle"));
 

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -309,96 +309,54 @@ StateCircle_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
 		//parse the arguments yargh!
-		if(settings.get_value("circle.id",value))
-			set_id(value);
-		else
-			set_id("Circle");
+		set_id(settings.get_value("circle.id", "Circle"));
 
-		if(settings.get_value("circle.blend",value) && value != "")
-			set_blend(atoi(value.c_str()));
-		else
-			set_blend(0);//(int)Color::BLEND_COMPOSITE); //0 should be blend composites value
+		set_blend(settings.get_value("circle.blend", int(Color::BLEND_COMPOSITE)));
 
-		if(settings.get_value("circle.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_opacity(settings.get_value("circle.opacity", 1.0));
 
-		if(settings.get_value("circle.bline_width",value) && value != "")
-			set_bline_width(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_bline_width(Distance(1, App::distance_system)); // default width
+		set_bline_width(Distance(
+							settings.get_value("circle.bline_width", 1.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("circle.feather",value))
-			set_feather_size(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_feather_size(Distance(0, App::distance_system)); // default feather
+		set_feather_size(Distance(
+							settings.get_value("circle.feather", 0.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("circle.number_of_bline_points",value))
-			set_number_of_bline_points(atof(value.c_str()));
-		else
-			set_number_of_bline_points(4);
 
-		if(settings.get_value("circle.bline_point_angle_offset",value))
-			set_bline_point_angle_offset(atof(value.c_str()));
-		else
-			set_bline_point_angle_offset(0);
+		set_number_of_bline_points(settings.get_value("circle.number_of_bline_points", 4));
 
-		if(settings.get_value("circle.invert",value) && value != "0")
-			set_invert(true);
-		else
-			set_invert(false);
+		set_bline_point_angle_offset(settings.get_value("circle.bline_point_angle_offset", 0.0));
 
-		if(settings.get_value("circle.layer_circle",value) && value=="0")
-			set_layer_circle_flag(false);
-		else
-			set_layer_circle_flag(true);
+		set_invert(settings.get_value("circle.invert", false));
 
-		if(settings.get_value("circle.layer_region",value) && value=="1")
-			set_layer_region_flag(true);
-		else
-			set_layer_region_flag(false);
+		set_layer_circle_flag(settings.get_value("circle.layer_circle", true));
 
-		if(settings.get_value("circle.layer_outline",value) && value=="1")
-			set_layer_outline_flag(true);
-		else
-			set_layer_outline_flag(false);
+		set_layer_region_flag(settings.get_value("circle.layer_region", false));
 
-		if(settings.get_value("circle.layer_advanced_outline",value) && value=="1")
-			set_layer_advanced_outline_flag(true);
-		else
-			set_layer_advanced_outline_flag(false);
+		set_layer_outline_flag(settings.get_value("circle.layer_outline", false));
 
-		if(settings.get_value("circle.layer_curve_gradient",value) && value=="1")
-			set_layer_curve_gradient_flag(true);
-		else
-			set_layer_curve_gradient_flag(false);
+		set_layer_advanced_outline_flag(settings.get_value("circle.layer_advanced_outline", false));
 
-		if(settings.get_value("circle.layer_plant",value) && value=="1")
-			set_layer_plant_flag(true);
-		else
-			set_layer_plant_flag(false);
+		set_layer_curve_gradient_flag(settings.get_value("circle.layer_curve_gradient", false));
 
-		if(settings.get_value("circle.layer_link_origins",value) && value=="0")
-			set_layer_link_origins_flag(false);
-		else
-			set_layer_link_origins_flag(true);
+		set_layer_plant_flag(settings.get_value("circle.layer_plant", false));
 
-		if(settings.get_value("circle.layer_origins_at_center",value) && value=="0")
-			set_layer_origins_at_center_flag(false);
-		else
-			set_layer_origins_at_center_flag(true);
+		set_layer_link_origins_flag(settings.get_value("circle.layer_link_origins", true));
 
-  // determine layer flags
-	layer_circle_flag = get_layer_circle_flag();
-  layer_region_flag = get_layer_region_flag();
-  layer_outline_flag = get_layer_outline_flag();
-  layer_advanced_outline_flag = get_layer_outline_flag();
-  layer_curve_gradient_flag = get_layer_curve_gradient_flag();
-  layer_plant_flag = get_layer_plant_flag();
+		set_layer_origins_at_center_flag(settings.get_value("circle.layer_origins_at_center", true));
+
+		// determine layer flags
+		layer_circle_flag = get_layer_circle_flag();
+		layer_region_flag = get_layer_region_flag();
+		layer_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
+		layer_plant_flag = get_layer_plant_flag();
 
 	}
 	catch(...)

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -368,23 +368,22 @@ StateCircle_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		settings.set_value("circle.id",get_id());
-		settings.set_value("circle.blend",strprintf("%d",get_blend()));
-		settings.set_value("circle.opacity",strprintf("%f",(float)get_opacity()));
+		settings.set_value("circle.blend",get_blend());
+		settings.set_value("circle.opacity",get_opacity());
 		settings.set_value("circle.bline_width", bline_width_dist.get_value().get_string());
 		settings.set_value("circle.feather", feather_dist.get_value().get_string());
-		settings.set_value("circle.number_of_bline_points",strprintf("%d",(int)(get_number_of_bline_points() + 0.5)));
-		settings.set_value("circle.bline_point_angle_offset",strprintf("%f",(float)get_bline_point_angle_offset()));
-		settings.set_value("circle.invert",get_invert()?"1":"0");
-		settings.set_value("circle.layer_circle",get_layer_circle_flag()?"1":"0");
-		settings.set_value("circle.layer_outline",get_layer_outline_flag()?"1":"0");
-		settings.set_value("circle.layer_advanced_outline",get_layer_advanced_outline_flag()?"1":"0");
-		settings.set_value("circle.layer_region",get_layer_region_flag()?"1":"0");
-		settings.set_value("circle.layer_curve_gradient",get_layer_curve_gradient_flag()?"1":"0");
-		settings.set_value("circle.layer_plant",get_layer_plant_flag()?"1":"0");
-		settings.set_value("circle.layer_link_origins",get_layer_link_origins_flag()?"1":"0");
-		settings.set_value("circle.layer_origins_at_center",get_layer_origins_at_center_flag()?"1":"0");
+		settings.set_value("circle.number_of_bline_points",(int)(get_number_of_bline_points() + 0.5));
+		settings.set_value("circle.bline_point_angle_offset",get_bline_point_angle_offset());
+		settings.set_value("circle.invert",get_invert());
+		settings.set_value("circle.layer_circle",get_layer_circle_flag());
+		settings.set_value("circle.layer_outline",get_layer_outline_flag());
+		settings.set_value("circle.layer_advanced_outline",get_layer_advanced_outline_flag());
+		settings.set_value("circle.layer_region",get_layer_region_flag());
+		settings.set_value("circle.layer_curve_gradient",get_layer_curve_gradient_flag());
+		settings.set_value("circle.layer_plant",get_layer_plant_flag());
+		settings.set_value("circle.layer_link_origins",get_layer_link_origins_flag());
+		settings.set_value("circle.layer_origins_at_center",get_layer_origins_at_center_flag());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -440,7 +440,7 @@ StateDraw_Context::save_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("draw.id",get_id().c_str());
+		settings.set_value("draw.id",get_id());
 		settings.set_value("draw.blend",strprintf("%d",get_blend()));
 		settings.set_value("draw.opacity",strprintf("%f",(float)get_opacity()));
 		settings.set_value("draw.bline_width", bline_width_dist.get_value().get_string());

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -373,8 +373,6 @@ StateDraw_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		set_id(settings.get_value("draw.id","NewDrawing"));
 
 		set_blend(settings.get_value("draw.blend", int(Color::BLEND_COMPOSITE)));

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -437,28 +437,27 @@ StateDraw_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		settings.set_value("draw.id",get_id());
-		settings.set_value("draw.blend",strprintf("%d",get_blend()));
-		settings.set_value("draw.opacity",strprintf("%f",(float)get_opacity()));
+		settings.set_value("draw.blend",get_blend());
+		settings.set_value("draw.opacity",get_opacity());
 		settings.set_value("draw.bline_width", bline_width_dist.get_value().get_string());
-		settings.set_value("draw.pressure_width",get_pressure_width_flag()?"1":"0");
-		settings.set_value("draw.auto_loop",get_auto_loop_flag()?"1":"0");
-		settings.set_value("draw.auto_extend",get_auto_extend_flag()?"1":"0");
-		settings.set_value("draw.auto_link",get_auto_link_flag()?"1":"0");
-		settings.set_value("draw.region",get_layer_region_flag()?"1":"0");
-		settings.set_value("draw.outline",get_layer_outline_flag()?"1":"0");
-		settings.set_value("draw.advanced_outline",get_layer_advanced_outline_flag()?"1":"0");
-		settings.set_value("draw.layer_link_origins",get_layer_link_origins_flag()?"1":"0");
-		settings.set_value("draw.auto_export",get_auto_export_flag()?"1":"0");
-		settings.set_value("draw.min_pressure",strprintf("%f",get_min_pressure()));
+		settings.set_value("draw.pressure_width",get_pressure_width_flag());
+		settings.set_value("draw.auto_loop",get_auto_loop_flag());
+		settings.set_value("draw.auto_extend",get_auto_extend_flag());
+		settings.set_value("draw.auto_link",get_auto_link_flag());
+		settings.set_value("draw.region",get_layer_region_flag());
+		settings.set_value("draw.outline",get_layer_outline_flag());
+		settings.set_value("draw.advanced_outline",get_layer_advanced_outline_flag());
+		settings.set_value("draw.layer_link_origins",get_layer_link_origins_flag());
+		settings.set_value("draw.auto_export",get_auto_export_flag());
+		settings.set_value("draw.min_pressure",get_min_pressure());
 		settings.set_value("draw.feather",feather_dist.get_value().get_string());
-		settings.set_value("draw.min_pressure_on",get_min_pressure_flag()?"1":"0");
-		settings.set_value("draw.gthreshold",strprintf("%f",get_gthres()));
-		settings.set_value("draw.widthmaxerror",strprintf("%f",get_width_max_error()));
-		settings.set_value("draw.lthreshold",strprintf("%f",get_lthres()));
-		settings.set_value("draw.localize",get_local_threshold_flag()?"1":"0");
-		settings.set_value("draw.round_ends", get_round_ends_flag()?"1":"0");
+		settings.set_value("draw.min_pressure_on",get_min_pressure_flag());
+		settings.set_value("draw.gthreshold",get_gthres());
+		settings.set_value("draw.widthmaxerror",get_width_max_error());
+		settings.set_value("draw.lthreshold",get_lthres());
+		settings.set_value("draw.localize",get_local_threshold_flag());
+		settings.set_value("draw.round_ends", get_round_ends_flag());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -374,125 +374,59 @@ StateDraw_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
-		if(settings.get_value("draw.id",value))
-			set_id(value);
-		else
-			set_id("NewDrawing");
+		set_id(settings.get_value("draw.id","NewDrawing"));
 
-		if(settings.get_value("draw.blend",value) && value != "")
-			set_blend(atoi(value.c_str()));
-		else
-			set_blend(0);//(int)Color::BLEND_COMPOSITE); //0 should be blend composites value
+		set_blend(settings.get_value("draw.blend", int(Color::BLEND_COMPOSITE)));
 
-		if(settings.get_value("draw.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_opacity(settings.get_value("draw.opacity", 1.0));
 
-		if(settings.get_value("draw.bline_width",value) && value != "")
-			set_bline_width(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_bline_width(Distance(1, App::distance_system)); // default width
+		set_bline_width(Distance(
+							settings.get_value("draw.bline_width", 1.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("draw.pressure_width",value) && value=="0")
-			set_pressure_width_flag(false);
-		else
-			set_pressure_width_flag(true);
+		set_pressure_width_flag(settings.get_value("draw.pressure_width", true));
 
-		if(settings.get_value("draw.auto_loop",value) && value=="0")
-			set_auto_loop_flag(false);
-		else
-			set_auto_loop_flag(true);
+		set_auto_loop_flag(settings.get_value("draw.auto_loop", true));
 
-		if(settings.get_value("draw.auto_extend",value) && value=="0")
-			set_auto_extend_flag(false);
-		else
-			set_auto_extend_flag(true);
+		set_auto_extend_flag(settings.get_value("draw.auto_extend", true));
 
-		if(settings.get_value("draw.auto_link",value) && value=="0")
-			set_auto_link_flag(false);
-		else
-			set_auto_link_flag(true);
+		set_auto_link_flag(settings.get_value("draw.auto_link", true));
 
-		if(settings.get_value("draw.region",value) && value=="0")
-			set_layer_region_flag(false);
-		else
-			set_layer_region_flag(true);
+		set_layer_region_flag(settings.get_value("draw.region", true));
 
-		if(settings.get_value("draw.outline",value) && value=="0")
-			set_layer_outline_flag(false);
-		else
-			set_layer_outline_flag(true);
+		set_layer_outline_flag(settings.get_value("draw.outline", true));
 
-		if(settings.get_value("draw.advanced_outline",value) && value=="0")
-			set_layer_advanced_outline_flag(false);
-		else
-			set_layer_advanced_outline_flag(true);
+		set_layer_advanced_outline_flag(settings.get_value("draw.advanced_outline", true));
 
-		if(settings.get_value("draw.layer_link_origins",value) && value=="0")
-			set_layer_link_origins_flag(false);
-		else
-			set_layer_link_origins_flag(true);
+		set_layer_link_origins_flag(settings.get_value("draw.layer_link_origins", true));
 
-		if(settings.get_value("draw.auto_export",value) && value=="1")
-			set_auto_export_flag(true);
-		else
-			set_auto_export_flag(false);
+		set_auto_export_flag(settings.get_value("draw.auto_export", false));
 
-		if(settings.get_value("draw.min_pressure_on",value) && value=="0")
-			set_min_pressure_flag(false);
-		else
-			set_min_pressure_flag(true);
+		set_min_pressure_flag(settings.get_value("draw.min_pressure_on", true));
 
-		if(settings.get_value("draw.min_pressure",value))
-		{
-			Real n = atof(value.c_str());
-			set_min_pressure(n);
-		}else
-			set_min_pressure(0);
+		set_min_pressure(settings.get_value("draw.min_pressure", 0.0));
 
-		if(settings.get_value("draw.feather",value))
-			set_feather_size(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_feather_size(Distance(0, App::distance_system));
+		set_feather_size(Distance(
+							settings.get_value("draw.feather", 0.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("draw.gthreshold",value))
-		{
-			Real n = atof(value.c_str());
-			set_gthres(n);
-		}
+		set_gthres(settings.get_value("draw.gthreshold", 0.7));
 
-		if(settings.get_value("draw.widthmaxerror",value))
-		{
-			Real n = atof(value.c_str());
-			set_width_max_error(n);
-		}
+		set_width_max_error(settings.get_value("draw.widthmaxerror", 1.0));
 
-		if(settings.get_value("draw.lthreshold",value))
-		{
-			Real n = atof(value.c_str());
-			set_lthres(n);
-		}
+		set_lthres(settings.get_value("draw.lthreshold", 20.0));
 
-		if(settings.get_value("draw.localize",value) && value == "1")
-			//set_local_error_flag(true);
-			set_local_threshold_flag(true);
-		else
-			//set_local_error_flag(false);
-			//set_local_threshold_flag(false);
-			set_global_threshold_flag(true);
+		set_local_threshold_flag(settings.get_value("draw.localize", false));
 
-		if(settings.get_value("draw.round_ends", value) && value == "1")
-			set_round_ends_flag(true);
-		else
-			set_round_ends_flag(false);
+		set_round_ends_flag(settings.get_value("draw.round_ends", false));
 
-	  // determine layer flags
-	  layer_region_flag = get_layer_region_flag();
-	  layer_outline_flag = get_layer_outline_flag();
-	  layer_advanced_outline_flag = get_layer_advanced_outline_flag();
+		// determine layer flags
+		layer_region_flag = get_layer_region_flag();
+		layer_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_advanced_outline_flag();
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -245,48 +245,26 @@ StateGradient_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
-		if(settings.get_value("gradient.id",value))
-			set_id(value);
-		else
-			set_id("Gradient");
+		set_id(settings.get_value("gradient.id", "Gradient"));
 
-		if(settings.get_value("gradient.layer_linear_gradient",value) && value=="0")
-			set_layer_linear_gradient_flag(false);
-		else
-			set_layer_linear_gradient_flag(true);
+		set_layer_linear_gradient_flag(settings.get_value("gradient.layer_linear_gradient", true));
 
-		if(settings.get_value("gradient.layer_radial_gradient",value) && value=="0")
-			set_layer_radial_gradient_flag(false);
-		else
-			set_layer_radial_gradient_flag(true);
+		set_layer_radial_gradient_flag(settings.get_value("gradient.layer_radial_gradient", true));
 
-		if(settings.get_value("gradient.layer_conical_gradient",value) && value=="0")
-			set_layer_conical_gradient_flag(false);
-		else
-			set_layer_conical_gradient_flag(true);
+		set_layer_conical_gradient_flag(settings.get_value("gradient.layer_conical_gradient", true));
 
-		if(settings.get_value("gradient.layer_spiral_gradient",value) && value=="0")
-			set_layer_spiral_gradient_flag(false);
-		else
-			set_layer_spiral_gradient_flag(true);
+		set_layer_spiral_gradient_flag(settings.get_value("gradient.layer_spiral_gradient", true));
 
-		if(settings.get_value("gradient.blend",value))
-			set_blend(atoi(value.c_str()));
-		else
-			set_blend(Color::BLEND_COMPOSITE);
+		set_blend(settings.get_value("gradient.blend", int(Color::BLEND_COMPOSITE)));
 
-		if(settings.get_value("gradient.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_opacity(settings.get_value("gradient.opacity", 1.0));
 
-	  // determine layer flags
+		// determine layer flags
 		layer_linear_gradient_flag = get_layer_linear_gradient_flag();
-	  layer_radial_gradient_flag = get_layer_radial_gradient_flag();
-	  layer_conical_gradient_flag = get_layer_conical_gradient_flag();
-	  layer_spiral_gradient_flag = get_layer_spiral_gradient_flag();
+		layer_radial_gradient_flag = get_layer_radial_gradient_flag();
+		layer_conical_gradient_flag = get_layer_conical_gradient_flag();
+		layer_spiral_gradient_flag = get_layer_spiral_gradient_flag();
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -244,8 +244,6 @@ StateGradient_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		set_id(settings.get_value("gradient.id", "Gradient"));
 
 		set_layer_linear_gradient_flag(settings.get_value("gradient.layer_linear_gradient", true));

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -278,7 +278,7 @@ StateGradient_Context::save_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("gradient.id",get_id().c_str());
+		settings.set_value("gradient.id",get_id());
 		settings.set_value("gradient.layer_linear_gradient",get_layer_linear_gradient_flag()?"1":"0");
 		settings.set_value("gradient.layer_radial_gradient",get_layer_radial_gradient_flag()?"1":"0");
 		settings.set_value("gradient.layer_conical_gradient",get_layer_conical_gradient_flag()?"1":"0");

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -275,14 +275,13 @@ StateGradient_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		settings.set_value("gradient.id",get_id());
-		settings.set_value("gradient.layer_linear_gradient",get_layer_linear_gradient_flag()?"1":"0");
-		settings.set_value("gradient.layer_radial_gradient",get_layer_radial_gradient_flag()?"1":"0");
-		settings.set_value("gradient.layer_conical_gradient",get_layer_conical_gradient_flag()?"1":"0");
-		settings.set_value("gradient.layer_spiral_gradient",get_layer_spiral_gradient_flag()?"1":"0");
-		settings.set_value("gradient.blend",strprintf("%d",get_blend()));
-		settings.set_value("gradient.opacity",strprintf("%f",(float)get_opacity()));
+		settings.set_value("gradient.layer_linear_gradient",get_layer_linear_gradient_flag());
+		settings.set_value("gradient.layer_radial_gradient",get_layer_radial_gradient_flag());
+		settings.set_value("gradient.layer_conical_gradient",get_layer_conical_gradient_flag());
+		settings.set_value("gradient.layer_spiral_gradient",get_layer_spiral_gradient_flag());
+		settings.set_value("gradient.blend",get_blend());
+		settings.set_value("gradient.opacity",get_opacity());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -440,27 +440,26 @@ StateLasso_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		settings.set_value("lasso.id",get_id());
-		settings.set_value("lasso.blend",strprintf("%d",19));
-		settings.set_value("lasso.opacity",strprintf("%f",(float)get_opacity()));
+		settings.set_value("lasso.blend",int(Color::BLEND_ALPHA_OVER));
+		settings.set_value("lasso.opacity",get_opacity());
 		settings.set_value("lasso.bline_width", bline_width_dist.get_value().get_string());
-		settings.set_value("lasso.pressure_width",get_pressure_width_flag()?"1":"0");
-		settings.set_value("lasso.auto_loop",get_auto_loop_flag()?"1":"0");
-		settings.set_value("lasso.auto_extend",get_auto_extend_flag()?"1":"0");
-		settings.set_value("lasso.auto_link",get_auto_link_flag()?"1":"0");
-		settings.set_value("lasso.region",get_layer_region_flag()?"1":"0");
-		settings.set_value("lasso.outline",get_layer_outline_flag()?"1":"0");
-		settings.set_value("lasso.advanced_outline",get_layer_advanced_outline_flag()?"1":"0");
-		settings.set_value("lasso.auto_export",get_auto_export_flag()?"1":"0");
-		settings.set_value("lasso.min_pressure",strprintf("%f",get_min_pressure()));
+		settings.set_value("lasso.pressure_width",get_pressure_width_flag());
+		settings.set_value("lasso.auto_loop",get_auto_loop_flag());
+		settings.set_value("lasso.auto_extend",get_auto_extend_flag());
+		settings.set_value("lasso.auto_link",get_auto_link_flag());
+		settings.set_value("lasso.region",get_layer_region_flag());
+		settings.set_value("lasso.outline",get_layer_outline_flag());
+		settings.set_value("lasso.advanced_outline",get_layer_advanced_outline_flag());
+		settings.set_value("lasso.auto_export",get_auto_export_flag());
+		settings.set_value("lasso.min_pressure",get_min_pressure());
 		settings.set_value("lasso.feather",feather_dist.get_value().get_string());
-		settings.set_value("lasso.min_pressure_on",get_min_pressure_flag()?"1":"0");
-		settings.set_value("lasso.gthreshold",strprintf("%f",get_gthres()));
-		settings.set_value("lasso.widthmaxerror",strprintf("%f",get_width_max_error()));
-		settings.set_value("lasso.lthreshold",strprintf("%f",get_lthres()));
-		settings.set_value("lasso.localize",get_local_threshold_flag()?"1":"0");
-		settings.set_value("lasso.round_ends", get_round_ends_flag()?"1":"0");
+		settings.set_value("lasso.min_pressure_on",get_min_pressure_flag());
+		settings.set_value("lasso.gthreshold",get_gthres());
+		settings.set_value("lasso.widthmaxerror",get_width_max_error());
+		settings.set_value("lasso.lthreshold",get_lthres());
+		settings.set_value("lasso.localize",get_local_threshold_flag());
+		settings.set_value("lasso.round_ends", get_round_ends_flag());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -378,8 +378,6 @@ StateLasso_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		set_id(settings.get_value("lasso.id", "NewDrawing"));
 
 		set_opacity(settings.get_value("lasso.opacity", 1.0));

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -379,100 +379,44 @@ StateLasso_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
-		if(settings.get_value("lasso.id",value))
-			set_id(value);
-		else
-			set_id("NewDrawing");
+		set_id(settings.get_value("lasso.id", "NewDrawing"));
 
+		set_opacity(settings.get_value("lasso.opacity", 1.0));
 
-		if(settings.get_value("lasso.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_bline_width(Distance(
+							settings.get_value("lasso.bline_width", 1.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("lasso.bline_width",value) && value != "")
-			set_bline_width(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_bline_width(Distance(1, App::distance_system)); // default width
+		set_pressure_width_flag(settings.get_value("lasso.pressure_width", true));
 
-		if(settings.get_value("lasso.pressure_width",value) && value=="0")
-			set_pressure_width_flag(false);
-		else
-			set_pressure_width_flag(true);
+		set_auto_loop_flag(settings.get_value("lasso.auto_loop", true));
 
-		if(settings.get_value("lasso.auto_loop",value) && value=="0")
-			set_auto_loop_flag(false);
-		else
-			set_auto_loop_flag(true);
+		set_auto_extend_flag(settings.get_value("lasso.auto_extend", true));
 
-		if(settings.get_value("lasso.auto_extend",value) && value=="0")
-			set_auto_extend_flag(false);
-		else
-			set_auto_extend_flag(true);
+		set_auto_link_flag(settings.get_value("lasso.auto_link", true));
 
-		if(settings.get_value("lasso.auto_link",value) && value=="0")
-			set_auto_link_flag(false);
-		else
-			set_auto_link_flag(true);
+		set_layer_region_flag(settings.get_value("lasso.region", true));
 
-		if(settings.get_value("lasso.region",value) && value=="0")
-			set_layer_region_flag(false);
-		else
-			set_layer_region_flag(true);
+		set_auto_export_flag(settings.get_value("lasso.auto_export", false));
 
-		//if(settings.get_value("lasso.outline",value) && value=="0")
-		//	set_layer_outline_flag(false);
-		//else
-		//	set_layer_outline_flag(true);
+		set_min_pressure_flag(settings.get_value("lasso.min_pressure_on", true));
 
-		//if(settings.get_value("lasso.advanced_outline",value) && value=="0")
-		//	set_layer_advanced_outline_flag(false);
-		///else
-		//	set_layer_advanced_outline_flag(true);
+		set_min_pressure(settings.get_value("lasso.min_pressure", 0.0));
 
-		if(settings.get_value("lasso.auto_export",value) && value=="1")
-			set_auto_export_flag(true);
-		else
-			set_auto_export_flag(false);
+		set_feather_size(Distance(
+							settings.get_value("lasso.feather", 0.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("lasso.min_pressure_on",value) && value=="0")
-			set_min_pressure_flag(false);
-		else
-			set_min_pressure_flag(true);
+		set_gthres(settings.get_value("lasso.gthreshold", 0.7));
 
-		if(settings.get_value("lasso.min_pressure",value))
-		{
-			Real n = atof(value.c_str());
-			set_min_pressure(n);
-		}else
-			set_min_pressure(0);
+		set_width_max_error(settings.get_value("lasso.widthmaxerror", 1.0));
 
-		if(settings.get_value("lasso.feather",value))
-			set_feather_size(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_feather_size(Distance(0, App::distance_system));
+		set_lthres(settings.get_value("lasso.lthreshold", 20.0));
 
-		if(settings.get_value("lasso.gthreshold",value))
-		{
-			Real n = atof(value.c_str());
-			set_gthres(n);
-		}
-
-		if(settings.get_value("lasso.widthmaxerror",value))
-		{
-			Real n = atof(value.c_str());
-			set_width_max_error(n);
-		}
-
-		if(settings.get_value("lasso.lthreshold",value))
-		{
-			Real n = atof(value.c_str());
-			set_lthres(n);
-		}
-
-		if(settings.get_value("lasso.localize",value) && value == "1")
+		if(settings.get_value("lasso.localize",false))
 			//set_local_error_flag(true);
 			set_local_threshold_flag(true);
 		else
@@ -480,15 +424,12 @@ StateLasso_Context::load_settings()
 			//set_local_threshold_flag(false);
 			set_global_threshold_flag(true);
 
-		if(settings.get_value("lasso.round_ends", value) && value == "1")
-			set_round_ends_flag(true);
-		else
-			set_round_ends_flag(false);
+		set_round_ends_flag(settings.get_value("lasso.round_ends", false));
 
-	  // determine layer flags
-	  layer_region_flag = get_layer_region_flag();
-	  layer_outline_flag = get_layer_outline_flag();
-	  layer_advanced_outline_flag = get_layer_advanced_outline_flag();
+		// determine layer flags
+		layer_region_flag = get_layer_region_flag();
+		layer_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_advanced_outline_flag();
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -443,7 +443,7 @@ StateLasso_Context::save_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("lasso.id",get_id().c_str());
+		settings.set_value("lasso.id",get_id());
 		settings.set_value("lasso.blend",strprintf("%d",19));
 		settings.set_value("lasso.opacity",strprintf("%f",(float)get_opacity()));
 		settings.set_value("lasso.bline_width", bline_width_dist.get_value().get_string());

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -278,80 +278,46 @@ StatePolygon_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
-		if(settings.get_value("polygon.id",value))
-			set_id(value);
-		else
-			set_id("Polygon");
+		set_id(settings.get_value("polygon.id", "Polygon"));
 
-		if(settings.get_value("polygon.blend",value) && value != "")
-			set_blend(atoi(value.c_str()));
-		else
-			set_blend(0);//(int)Color::BLEND_COMPOSITE); //0 should be blend composites value
+		set_blend(settings.get_value("polygon.blend", int(Color::BLEND_COMPOSITE)));
 
-		if(settings.get_value("polygon.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_opacity(settings.get_value("polygon.opacity", 1.0));
 
-		if(settings.get_value("polygon.bline_width",value) && value != "")
-			set_bline_width(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_bline_width(Distance(1, App::distance_system)); // default width
+		set_bline_width(Distance(
+							settings.get_value("polygon.bline_width", 1.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("polygon.feather",value))
-			set_feather_size(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_feather_size(Distance(0, App::distance_system)); // default feather
+		set_feather_size(Distance(
+							settings.get_value("polygon.feather", 0.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("polygon.invert",value) && value != "0")
-			set_invert(true);
-		else
-			set_invert(false);
+		set_invert(settings.get_value("polygon.invert", false));
 
-		if(settings.get_value("polygon.layer_polygon",value) && value=="0")
-			set_layer_polygon_flag(false);
-		else
-			set_layer_polygon_flag(true);
+		set_layer_polygon_flag(settings.get_value("polygon.layer_polygon", true));
 
-		if(settings.get_value("polygon.layer_region",value) && value=="1")
-			set_layer_region_flag(true);
-		else
-			set_layer_region_flag(false);
+		set_layer_region_flag(settings.get_value("polygon.layer_region", false));
 
-		if(settings.get_value("polygon.layer_outline",value) && value=="1")
-			set_layer_outline_flag(true);
-		else
-			set_layer_outline_flag(false);
+		set_layer_outline_flag(settings.get_value("polygon.layer_outline", false));
 
-		if(settings.get_value("polygon.layer_advanced_outline",value) && value=="1")
-			set_layer_advanced_outline_flag(true);
-		else
-			set_layer_advanced_outline_flag(false);
+		set_layer_advanced_outline_flag(settings.get_value("polygon.layer_advanced_outline", false));
 
-		if(settings.get_value("polygon.layer_curve_gradient",value) && value=="1")
-			set_layer_curve_gradient_flag(true);
-		else
-			set_layer_curve_gradient_flag(false);
+		set_layer_curve_gradient_flag(settings.get_value("polygon.layer_curve_gradient", false));
 
-		if(settings.get_value("polygon.layer_plant",value) && value=="1")
-			set_layer_plant_flag(true);
-		else
-			set_layer_plant_flag(false);
+		set_layer_plant_flag(settings.get_value("polygon.layer_plant", false));
 
-		if(settings.get_value("polygon.layer_link_origins",value) && value=="0")
-			set_layer_link_origins_flag(false);
-		else
-			set_layer_link_origins_flag(true);
+		set_layer_link_origins_flag(settings.get_value("polygon.layer_link_origins", true));
 
-	  // determine layer flags
+		// determine layer flags
 		layer_polygon_flag = get_layer_polygon_flag();
-	  layer_region_flag = get_layer_region_flag();
-	  layer_outline_flag = get_layer_outline_flag();
-	  layer_advanced_outline_flag = get_layer_outline_flag();
-	  layer_curve_gradient_flag = get_layer_curve_gradient_flag();
-	  layer_plant_flag = get_layer_plant_flag();
+		layer_region_flag = get_layer_region_flag();
+		layer_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
+		layer_plant_flag = get_layer_plant_flag();
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -328,20 +328,19 @@ StatePolygon_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		settings.set_value("polygon.id",get_id());
-		settings.set_value("polygon.blend",strprintf("%d",get_blend()));
-		settings.set_value("polygon.opacity",strprintf("%f",(float)get_opacity()));
+		settings.set_value("polygon.blend",get_blend());
+		settings.set_value("polygon.opacity",get_opacity());
 		settings.set_value("polygon.bline_width", bline_width_dist.get_value().get_string());
 		settings.set_value("polygon.feather", feather_dist.get_value().get_string());
-		settings.set_value("polygon.invert",get_invert()?"1":"0");
-		settings.set_value("polygon.layer_polygon",get_layer_polygon_flag()?"1":"0");
-		settings.set_value("polygon.layer_outline",get_layer_outline_flag()?"1":"0");
-		settings.set_value("polygon.layer_advanced_outline",get_layer_advanced_outline_flag()?"1":"0");
-		settings.set_value("polygon.layer_region",get_layer_region_flag()?"1":"0");
-		settings.set_value("polygon.layer_curve_gradient",get_layer_curve_gradient_flag()?"1":"0");
-		settings.set_value("polygon.layer_plant",get_layer_plant_flag()?"1":"0");
-		settings.set_value("polygon.layer_link_origins",get_layer_link_origins_flag()?"1":"0");
+		settings.set_value("polygon.invert",get_invert());
+		settings.set_value("polygon.layer_polygon",get_layer_polygon_flag());
+		settings.set_value("polygon.layer_outline",get_layer_outline_flag());
+		settings.set_value("polygon.layer_advanced_outline",get_layer_advanced_outline_flag());
+		settings.set_value("polygon.layer_region",get_layer_region_flag());
+		settings.set_value("polygon.layer_curve_gradient",get_layer_curve_gradient_flag());
+		settings.set_value("polygon.layer_plant",get_layer_plant_flag());
+		settings.set_value("polygon.layer_link_origins",get_layer_link_origins_flag());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -331,7 +331,7 @@ StatePolygon_Context::save_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("polygon.id",get_id().c_str());
+		settings.set_value("polygon.id",get_id());
 		settings.set_value("polygon.blend",strprintf("%d",get_blend()));
 		settings.set_value("polygon.opacity",strprintf("%f",(float)get_opacity()));
 		settings.set_value("polygon.bline_width", bline_width_dist.get_value().get_string());

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -277,8 +277,6 @@ StatePolygon_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		set_id(settings.get_value("polygon.id", "Polygon"));
 
 		set_blend(settings.get_value("polygon.blend", int(Color::BLEND_COMPOSITE)));

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -348,7 +348,7 @@ StateRectangle_Context::save_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("rectangle.id",get_id().c_str());
+		settings.set_value("rectangle.id",get_id());
 		settings.set_value("rectangle.blend",strprintf("%d",get_blend()));
 		settings.set_value("rectangle.opacity",strprintf("%f",(float)get_opacity()));
 		settings.set_value("rectangle.bline_width", bline_width_dist.get_value().get_string());

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -289,86 +289,52 @@ StateRectangle_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
 		//parse the arguments yargh!
-		if(settings.get_value("rectangle.id",value))
-			set_id(value);
-		else
-			set_id("Rectangle");
+		set_id(settings.get_value("rectangle.id", "Rectangle"));
 
-		if(settings.get_value("rectangle.blend",value) && value != "")
-			set_blend(atoi(value.c_str()));
-		else
-			set_blend(0);//(int)Color::BLEND_COMPOSITE); //0 should be blend composites value
+		set_blend(settings.get_value("rectangle.blend", int(Color::BLEND_COMPOSITE)));
 
-		if(settings.get_value("rectangle.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_opacity(settings.get_value("rectangle.opacity", 1.0));
 
-		if(settings.get_value("rectangle.bline_width",value) && value != "")
-			set_bline_width(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_bline_width(Distance(1, App::distance_system)); // default width
+		set_bline_width(Distance(
+							settings.get_value("rectangle.bline_width", 1.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("rectangle.expand",value))
-			set_expand_size(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_expand_size(Distance(0, App::distance_system)); // default expansion
+		set_expand_size(Distance(
+							settings.get_value("rectangle.expand", 0.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("rectangle.feather",value))
-			set_feather_size(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_feather_size(Distance(0, App::distance_system)); // default feather
+		set_feather_size(Distance(
+							settings.get_value("rectangle.feather", 0.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("rectangle.invert",value) && value != "0")
-			set_invert(true);
-		else
-			set_invert(false);
+		set_invert(settings.get_value("rectangle.invert", false));
 
-		if(settings.get_value("rectangle.layer_rectangle",value) && value=="0")
-			set_layer_rectangle_flag(false);
-		else
-			set_layer_rectangle_flag(true);
+		set_layer_rectangle_flag(settings.get_value("rectangle.layer_rectangle", true));
 
-		if(settings.get_value("rectangle.layer_region",value) && value=="1")
-			set_layer_region_flag(true);
-		else
-			set_layer_region_flag(false);
+		set_layer_region_flag(settings.get_value("rectangle.layer_region", false));
 
-		if(settings.get_value("rectangle.layer_outline",value) && value=="1")
-			set_layer_outline_flag(true);
-		else
-			set_layer_outline_flag(false);
+		set_layer_outline_flag(settings.get_value("rectangle.layer_outline", false));
 
-		if(settings.get_value("rectangle.layer_advanced_outline",value) && value=="1")
-			set_layer_advanced_outline_flag(true);
-		else
-			set_layer_advanced_outline_flag(false);
+		set_layer_advanced_outline_flag(settings.get_value("rectangle.layer_advanced_outline", false));
 
-		if(settings.get_value("rectangle.layer_curve_gradient",value) && value=="1")
-			set_layer_curve_gradient_flag(true);
-		else
-			set_layer_curve_gradient_flag(false);
+		set_layer_curve_gradient_flag(settings.get_value("rectangle.layer_curve_gradient", false));
 
-		if(settings.get_value("rectangle.layer_plant",value) && value=="1")
-			set_layer_plant_flag(true);
-		else
-			set_layer_plant_flag(false);
+		set_layer_plant_flag(settings.get_value("rectangle.layer_plant", false));
 
-		if(settings.get_value("rectangle.layer_link_origins",value) && value=="0")
-			set_layer_link_origins_flag(false);
-		else
-			set_layer_link_origins_flag(true);
+		set_layer_link_origins_flag(settings.get_value("rectangle.layer_link_origins", true));
 
-	  // determine layer flags
+		// determine layer flags
 		layer_rectangle_flag = get_layer_rectangle_flag();
-	  layer_region_flag = get_layer_region_flag();
-	  layer_outline_flag = get_layer_outline_flag();
-	  layer_advanced_outline_flag = get_layer_outline_flag();
-	  layer_curve_gradient_flag = get_layer_curve_gradient_flag();
-	  layer_plant_flag = get_layer_plant_flag();
+		layer_region_flag = get_layer_region_flag();
+		layer_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
+		layer_plant_flag = get_layer_plant_flag();
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -288,8 +288,6 @@ StateRectangle_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		//parse the arguments yargh!
 		set_id(settings.get_value("rectangle.id", "Rectangle"));
 

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -345,21 +345,20 @@ StateRectangle_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		settings.set_value("rectangle.id",get_id());
-		settings.set_value("rectangle.blend",strprintf("%d",get_blend()));
-		settings.set_value("rectangle.opacity",strprintf("%f",(float)get_opacity()));
+		settings.set_value("rectangle.blend",get_blend());
+		settings.set_value("rectangle.opacity",get_opacity());
 		settings.set_value("rectangle.bline_width", bline_width_dist.get_value().get_string());
 		settings.set_value("rectangle.expand",expand_dist.get_value().get_string());
 		settings.set_value("rectangle.feather", feather_dist.get_value().get_string());
-		settings.set_value("rectangle.invert",get_invert()?"1":"0");
-		settings.set_value("rectangle.layer_rectangle",get_layer_rectangle_flag()?"1":"0");
-		settings.set_value("rectangle.layer_outline",get_layer_outline_flag()?"1":"0");
-		settings.set_value("rectangle.layer_advanced_outline",get_layer_advanced_outline_flag()?"1":"0");
-		settings.set_value("rectangle.layer_region",get_layer_region_flag()?"1":"0");
-		settings.set_value("rectangle.layer_curve_gradient",get_layer_curve_gradient_flag()?"1":"0");
-		settings.set_value("rectangle.layer_plant",get_layer_plant_flag()?"1":"0");
-		settings.set_value("rectangle.layer_link_origins",get_layer_link_origins_flag()?"1":"0");
+		settings.set_value("rectangle.invert",get_invert());
+		settings.set_value("rectangle.layer_rectangle",get_layer_rectangle_flag());
+		settings.set_value("rectangle.layer_outline",get_layer_outline_flag());
+		settings.set_value("rectangle.layer_advanced_outline",get_layer_advanced_outline_flag());
+		settings.set_value("rectangle.layer_region",get_layer_region_flag());
+		settings.set_value("rectangle.layer_curve_gradient",get_layer_curve_gradient_flag());
+		settings.set_value("rectangle.layer_plant",get_layer_plant_flag());
+		settings.set_value("rectangle.layer_link_origins",get_layer_link_origins_flag());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -165,12 +165,7 @@ StateRotate_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
-
-		if(settings.get_value("rotate.scale",value) && value=="0")
-			set_scale_flag(false);
-		else
-			set_scale_flag(true);
+		set_scale_flag(settings.get_value("rotate.scale", true));
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -164,7 +164,6 @@ StateRotate_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		set_scale_flag(settings.get_value("rotate.scale", true));
 	}
 	catch(...)

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -177,8 +177,7 @@ StateRotate_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("rotate.scale",get_scale_flag()?"1":"0");
+		settings.set_value("rotate.scale",get_scale_flag());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -165,8 +165,7 @@ StateScale_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("scale.lock_aspect",get_aspect_lock_flag()?"1":"0");
+		settings.set_value("scale.lock_aspect",get_aspect_lock_flag());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -152,7 +152,6 @@ StateScale_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		set_aspect_lock_flag(settings.get_value("scale.lock_aspect", true));
 	}
 	catch(...)

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -153,12 +153,7 @@ StateScale_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
-
-		if(settings.get_value("scale.lock_aspect",value) && value=="0")
-			set_aspect_lock_flag(false);
-		else
-			set_aspect_lock_flag(true);
+		set_aspect_lock_flag(settings.get_value("scale.lock_aspect", true));
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -160,12 +160,7 @@ StateSmoothMove_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
-
-		if(settings.get_value("smooth_move.radius",value))
-			set_radius(atof(value.c_str()));
-		else
-			set_radius(1.0f);
+		set_radius(settings.get_value("smooth_move.radius", 1.0));
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -172,8 +172,7 @@ StateSmoothMove_Context::save_settings()
 {
 	try
 	{
-	synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("smooth_move.radius",strprintf("%f",get_radius()));
+		settings.set_value("smooth_move.radius",double(get_radius()));
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -159,7 +159,6 @@ StateSmoothMove_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		set_radius(settings.get_value("smooth_move.radius", 1.0));
 	}
 	catch(...)

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -412,29 +412,28 @@ StateStar_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		settings.set_value("star.id",get_id());
-		settings.set_value("star.blend",strprintf("%d",get_blend()));
-		settings.set_value("star.opacity",strprintf("%f",(float)get_opacity()));
+		settings.set_value("star.blend",get_blend());
+		settings.set_value("star.opacity",get_opacity());
 		settings.set_value("star.bline_width", bline_width_dist.get_value().get_string());
 		settings.set_value("star.feather", feather_dist.get_value().get_string());
-		settings.set_value("star.number_of_points",strprintf("%d",(int)(get_number_of_points() + 0.5)));
-		settings.set_value("star.inner_tangent",strprintf("%f",(float)get_inner_tangent()));
-		settings.set_value("star.outer_tangent",strprintf("%f",(float)get_outer_tangent()));
-		settings.set_value("star.inner_width",strprintf("%f",(float)get_inner_width()));
-		settings.set_value("star.outer_width",strprintf("%f",(float)get_outer_width()));
-		settings.set_value("star.radius_ratio",strprintf("%f",(float)get_radius_ratio()));
-		//settings.set_value("star.angle_offset",strprintf("%f",(float)get_angle_offset()));
-		settings.set_value("star.invert",get_invert()?"1":"0");
-		settings.set_value("star.regular_polygon",get_regular_polygon()?"1":"0");
-		settings.set_value("star.layer_star",get_layer_star_flag()?"1":"0");
-		settings.set_value("star.layer_outline",get_layer_outline_flag()?"1":"0");
-		settings.set_value("star.layer_advanced_outline",get_layer_advanced_outline_flag()?"1":"0");
-		settings.set_value("star.layer_region",get_layer_region_flag()?"1":"0");
-		settings.set_value("star.layer_curve_gradient",get_layer_curve_gradient_flag()?"1":"0");
-		settings.set_value("star.layer_plant",get_layer_plant_flag()?"1":"0");
-		settings.set_value("star.layer_link_origins",get_layer_link_origins_flag()?"1":"0");
-		settings.set_value("star.layer_origins_at_center",get_layer_origins_at_center_flag()?"1":"0");
+		settings.set_value("star.number_of_points",(int)(get_number_of_points() + 0.5));
+		settings.set_value("star.inner_tangent",get_inner_tangent());
+		settings.set_value("star.outer_tangent",get_outer_tangent());
+		settings.set_value("star.inner_width",get_inner_width());
+		settings.set_value("star.outer_width",get_outer_width());
+		settings.set_value("star.radius_ratio",get_radius_ratio());
+		//settings.set_value("star.angle_offset",get_angle_offset()));
+		settings.set_value("star.invert",get_invert());
+		settings.set_value("star.regular_polygon",get_regular_polygon());
+		settings.set_value("star.layer_star",get_layer_star_flag());
+		settings.set_value("star.layer_outline",get_layer_outline_flag());
+		settings.set_value("star.layer_advanced_outline",get_layer_advanced_outline_flag());
+		settings.set_value("star.layer_region",get_layer_region_flag());
+		settings.set_value("star.layer_curve_gradient",get_layer_curve_gradient_flag());
+		settings.set_value("star.layer_plant",get_layer_plant_flag());
+		settings.set_value("star.layer_link_origins",get_layer_link_origins_flag());
+		settings.set_value("star.layer_origins_at_center",get_layer_origins_at_center_flag());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -340,8 +340,6 @@ StateStar_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		//parse the arguments yargh!
 		set_id(settings.get_value("star.id", "Star"));
 

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -341,126 +341,67 @@ StateStar_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
 		//parse the arguments yargh!
-		if(settings.get_value("star.id",value))
-			set_id(value);
-		else
-			set_id("Star");
+		set_id(settings.get_value("star.id", "Star"));
 
-		if(settings.get_value("star.blend",value) && value != "")
-			set_blend(atoi(value.c_str()));
-		else
-			set_blend(0);//(int)Color::BLEND_COMPOSITE); //0 should be blend composites value
+		set_blend(settings.get_value("star.blend", int(Color::BLEND_COMPOSITE)));
 
-		if(settings.get_value("star.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_opacity(settings.get_value("star.opacity", 1.0));
 
-		if(settings.get_value("star.bline_width",value) && value != "")
-			set_bline_width(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_bline_width(Distance(1, App::distance_system)); // default width
+		set_bline_width(Distance(
+							settings.get_value("star.bline_width", 1.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("star.feather",value))
-			set_feather_size(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_feather_size(Distance(0, App::distance_system)); // default feather
+		set_feather_size(Distance(
+							settings.get_value("star.feather", 0.0),
+							App::distance_system)
+						);
 
-		if(settings.get_value("star.number_of_points",value))
-			set_number_of_points(atof(value.c_str()));
-		else
-			set_number_of_points(5);
 
-		if(settings.get_value("star.inner_tangent",value))
-			set_inner_tangent(atof(value.c_str()));
-		else
-			set_inner_tangent(0);
+		set_number_of_points(settings.get_value("star.number_of_points", 5));
 
-		if(settings.get_value("star.outer_tangent",value))
-			set_outer_tangent(atof(value.c_str()));
-		else
-			set_outer_tangent(0);
+		set_inner_tangent(settings.get_value("star.inner_tangent", 0.0));
 
-		if(settings.get_value("star.inner_width",value))
-			set_inner_width(atof(value.c_str()));
-		else
-			set_inner_width(1);
+		set_outer_tangent(settings.get_value("star.outer_tangent", 0.0));
 
-		if(settings.get_value("star.outer_width",value))
-			set_outer_width(atof(value.c_str()));
-		else
-			set_outer_width(1);
+		set_inner_width(settings.get_value("star.inner_width", 1.0));
 
-		if(settings.get_value("star.radius_ratio",value))
-			set_radius_ratio(atof(value.c_str()));
-		else
-			set_radius_ratio(0.5);
+		set_outer_width(settings.get_value("star.outer_width", 1.0));
 
-		//if(settings.get_value("star.angle_offset",value))
-		//	set_angle_offset(atof(value.c_str()));
-		//else
-			set_angle_offset(90.0);
+		set_radius_ratio(settings.get_value("star.radius_ratio", 0.5));
 
-		if(settings.get_value("star.invert",value) && value != "0")
-			set_invert(true);
-		else
-			set_invert(false);
+		//set_angle_offset(settings.get_value("star.angle_offset", 90.0));
+		set_angle_offset(90.0);
 
-		if(settings.get_value("star.regular_polygon",value) && value != "0")
-			set_regular_polygon(true);
-		else
-			set_regular_polygon(false);
+		set_invert(settings.get_value("star.invert", false));
 
-		if(settings.get_value("star.layer_star",value) && value=="0")
-			set_layer_star_flag(false);
-		else
-			set_layer_star_flag(true);
+		set_regular_polygon(settings.get_value("star.regular_polygon", false));
 
-		if(settings.get_value("star.layer_region",value) && value=="1")
-			set_layer_region_flag(true);
-		else
-			set_layer_region_flag(false);
+		set_layer_star_flag(settings.get_value("star.layer_star", true));
 
-		if(settings.get_value("star.layer_outline",value) && value=="1")
-			set_layer_outline_flag(true);
-		else
-			set_layer_outline_flag(false);
+		set_layer_region_flag(settings.get_value("star.layer_region", false));
 
-		if(settings.get_value("star.layer_advanced_outline",value) && value=="1")
-			set_layer_advanced_outline_flag(true);
-		else
-			set_layer_advanced_outline_flag(false);
+		set_layer_outline_flag(settings.get_value("star.layer_outline", false));
 
-		if(settings.get_value("star.layer_curve_gradient",value) && value=="1")
-			set_layer_curve_gradient_flag(true);
-		else
-			set_layer_curve_gradient_flag(false);
+		set_layer_advanced_outline_flag(settings.get_value("star.layer_advanced_outline", false));
 
-		if(settings.get_value("star.layer_plant",value) && value=="1")
-			set_layer_plant_flag(true);
-		else
-			set_layer_plant_flag(false);
+		set_layer_curve_gradient_flag(settings.get_value("star.layer_curve_gradient", false));
 
-		if(settings.get_value("star.layer_link_origins",value) && value=="0")
-			set_layer_link_origins_flag(false);
-		else
-			set_layer_link_origins_flag(true);
+		set_layer_plant_flag(settings.get_value("star.layer_plant", false));
 
-		if(settings.get_value("star.layer_origins_at_center",value) && value=="0")
-			set_layer_origins_at_center_flag(false);
-		else
-			set_layer_origins_at_center_flag(true);
+		set_layer_link_origins_flag(settings.get_value("star.layer_link_origins", true));
 
-	  // determine layer flags
+		set_layer_origins_at_center_flag(settings.get_value("star.layer_origins_at_center", true));
+
+		// determine layer flags
 		layer_star_flag = get_layer_star_flag();
-	  layer_region_flag = get_layer_region_flag();
-	  layer_outline_flag = get_layer_outline_flag();
-	  layer_advanced_outline_flag = get_layer_outline_flag();
-	  layer_curve_gradient_flag = get_layer_curve_gradient_flag();
-	  layer_plant_flag = get_layer_plant_flag();
+		layer_region_flag = get_layer_region_flag();
+		layer_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
+		layer_plant_flag = get_layer_plant_flag();
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -261,16 +261,15 @@ StateText_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		settings.set_value("text.id",get_id());
-		settings.set_value("text.layer_polygon",get_layer_text_flag()?"1":"0");
-		settings.set_value("text.blend",strprintf("%d",get_blend()));
-		settings.set_value("text.opacity",strprintf("%f",(float)get_opacity()));
-		settings.set_value("text.paragraph",get_paragraph_flag()?"1":"0");
-		settings.set_value("text.size_x",strprintf("%f",(float)get_size()[0]));
-		settings.set_value("text.size_y",strprintf("%f",(float)get_size()[1]));
-		settings.set_value("text.orient_x",strprintf("%f",(float)get_orientation()[0]));
-		settings.set_value("text.orient_y",strprintf("%f",(float)get_orientation()[1]));
+		settings.set_value("text.layer_polygon",get_layer_text_flag());
+		settings.set_value("text.blend",get_blend());
+		settings.set_value("text.opacity",get_opacity());
+		settings.set_value("text.paragraph",get_paragraph_flag());
+		settings.set_value("text.size_x",get_size()[0]);
+		settings.set_value("text.size_y",get_size()[1]);
+		settings.set_value("text.orient_x",get_orientation()[0]);
+		settings.set_value("text.orient_y",get_orientation()[1]);
 		settings.set_value("text.family",get_family());
 	}
 	catch(...)

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -223,62 +223,32 @@ StateText_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 		Vector v;
 
 		//parse the arguments yargh!
-		if(settings.get_value("text.id",value))
-			set_id(value);
-		else
-			set_id("Text");
+		set_id(settings.get_value("text.id", "Text"));
 
-		if(settings.get_value("text.blend",value) && value != "")
-			set_blend(atoi(value.c_str()));
-		else
-			set_blend(0);//(int)Color::BLEND_COMPOSITE); //0 should be blend composites value
+		set_blend(settings.get_value("text.blend", Color::BLEND_COMPOSITE));
 
-		if(settings.get_value("text.opacity",value))
-			set_opacity(atof(value.c_str()));
-		else
-			set_opacity(1);
+		set_opacity(settings.get_value("text.opacity", 1.0));
 
-		if(settings.get_value("text.paragraph",value) && value=="1")
-			set_paragraph_flag(true);
-		else
-			set_paragraph_flag(false);
+		set_paragraph_flag(settings.get_value("text.paragraph", false));
 
-		if(settings.get_value("text.size_x",value))
-			v[0] = atof(value.c_str());
-		else
-			v[0] = 0.25;
-		if(settings.get_value("text.size_y",value))
-			v[1] = atof(value.c_str());
-		else
-			v[1] = 0.25;
+		v[0] = settings.get_value("text.size_x", 0.25);
+		v[1] = settings.get_value("text.size_y", 0.25);
 		set_size(v);
 
-		if(settings.get_value("text.orient_x",value))
-			v[0] = atof(value.c_str());
-		else
-			v[0] = 0.5;
-		if(settings.get_value("text.orient_y",value))
-			v[1] = atof(value.c_str());
-		else
-			v[1] = 0.5;
+		v[0] = settings.get_value("text.orient_x", 0.5);
+		v[1] = settings.get_value("text.orient_y", 0.5);
 		set_orientation(v);
 
-		if(settings.get_value("text.family",value))
-			set_family(value);
-		else
-			set_family("Sans Serif");
+		set_family(settings.get_value("text.family", "Sans Serif"));
 
 		// since we have only text layer creation button, always turn it on.
-		if(settings.get_value("text.layer_text",value) && value=="0")
-			set_layer_text_flag(true);
-		else
-			set_layer_text_flag(true);
+//		set_layer_text_flag(settings.get_value("text.layer_text", true));
+		set_layer_text_flag(true);
 
-	  // determine layer flags
+		// determine layer flags
 		layer_text_flag = get_layer_text_flag();
 	}
 	catch(...)

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -222,7 +222,6 @@ StateText_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		Vector v;
 
 		//parse the arguments yargh!

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -179,24 +179,16 @@ StateWidth_Context::load_settings()
 	try
 	{
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		String value;
 
 		//parse the arguments yargh!
-		if(settings.get_value("width.delta",value))
-			set_delta(atof(value.c_str()));
-		else
-			set_delta(6);
+		set_delta(settings.get_value("width.delta", 6.0));
 
-		if(settings.get_value("width.radius",value))
-			set_radius(Distance(atof(value.c_str()), App::distance_system));
-		else
-			set_radius(Distance(60, App::distance_system));
+		set_radius(Distance(
+							settings.get_value("width.radius", 60.0),
+							App::distance_system)
+						);
 
-		//defaults to false
-		if(settings.get_value("width.relative",value) && value == "1")
-			set_relative(true);
-		else
-			set_relative(false);
+		set_relative(settings.get_value("width.relative", false));
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -178,8 +178,6 @@ StateWidth_Context::load_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-
 		//parse the arguments yargh!
 		set_delta(settings.get_value("width.delta", 6.0));
 

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -199,10 +199,9 @@ StateWidth_Context::save_settings()
 {
 	try
 	{
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		settings.set_value("width.delta",strprintf("%f",get_delta()));
+		settings.set_value("width.delta",get_delta());
 		settings.set_value("width.radius",influence_radius->get_value().get_string());
-		settings.set_value("width.relative",get_relative()?"1":"0");
+		settings.set_value("width.relative",get_relative());
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/synfigapp/inputdevice.cpp
+++ b/synfig-studio/src/synfigapp/inputdevice.cpp
@@ -73,7 +73,7 @@ public:
 			}
 			if(key=="bline_width")
 			{
-				value=strprintf("%s",input_device->get_bline_width().get_string().c_str());
+				value=input_device->get_bline_width().get_string();
 				return true;
 			}
 			if(key=="opacity")

--- a/synfig-studio/src/synfigapp/inputdevice.cpp
+++ b/synfig-studio/src/synfigapp/inputdevice.cpp
@@ -61,7 +61,7 @@ public:
 		input_device(input_device) { }
 
 
-	virtual bool get_value(const synfig::String& key, synfig::String& value)const
+	virtual bool get_raw_value(const synfig::String& key, synfig::String& value)const override
 	{
 		try
 		{
@@ -115,7 +115,7 @@ public:
 		{
 			synfig::warning("DeviceSettings: Caught exception when attempting to get value.");
 		}
-		return Settings::get_value(key, value);
+		return Settings::get_raw_value(key, value);
 	}
 
 	void get_mode_value(synfig::String & value) const
@@ -146,7 +146,7 @@ public:
 			value += strprintf(" %u %u", itr->keyval, itr->modifiers);
 	}
 
-	virtual bool set_value(const synfig::String& key,const synfig::String& value)
+	virtual bool set_value(const synfig::String& key,const synfig::String& value) override
 	{
 		try
 		{
@@ -259,7 +259,7 @@ public:
 		input_device->set_keys(keys);
 	}
 
-	virtual KeyList get_key_list()const
+	virtual KeyList get_key_list()const override
 	{
 		KeyList ret(Settings::get_key_list());
 		ret.push_back("outline_color");

--- a/synfig-studio/src/synfigapp/settings.cpp
+++ b/synfig-studio/src/synfigapp/settings.cpp
@@ -71,7 +71,7 @@ synfig::String
 Settings::get_value(const synfig::String& key)const
 {
 	synfig::String value;
-	if(!get_value(key,value))
+	if(!get_raw_value(key,value))
 		return synfig::String();
 	return value;
 }
@@ -89,7 +89,7 @@ Settings::remove_domain(const synfig::String& name)
 }
 
 bool
-Settings::get_value(const synfig::String& key, synfig::String& value)const
+Settings::get_raw_value(const synfig::String& key, synfig::String& value)const
 {
 	// Search for the value in any children domains
 	DomainMap::const_iterator iter;
@@ -101,7 +101,7 @@ Settings::get_value(const synfig::String& key, synfig::String& value)const
 			synfig::String key_(key.begin()+iter->first.size()+1,key.end());
 
 			// If the domain has it, then we have got a hit
-			if(iter->second->get_value(key_,value))
+			if(iter->second->get_raw_value(key_,value))
 				return true;
 		}
 	}
@@ -280,4 +280,51 @@ Settings::load_from_file(const synfig::String& filename, const synfig::String& k
 	if (!key_filter.empty() && !loaded_filter)
 		return false;
 	return true;
+}
+
+double
+Settings::get_value(const synfig::String& key, double default_value) const {
+	synfig::String value;
+	if (!get_raw_value(key, value))
+		return default_value;
+	try {
+		synfig::ChangeLocale l(LC_NUMERIC, "C");
+		return stod(value);
+	} catch (const std::invalid_argument&) {
+		synfig::error("Settings: Invalid argument for %s: %s. Using default value: %s", key.c_str(), value.c_str(), default_value);
+		return default_value;
+	}
+}
+
+int
+Settings::get_value(const synfig::String& key, int default_value) const {
+	synfig::String value;
+	if (!get_raw_value(key, value))
+		return default_value;
+	try {
+		return stoi(value);
+	} catch (const std::invalid_argument&) {
+		synfig::error("Settings: Invalid argument for %s: %s. Using default value: %s", key.c_str(), value.c_str(), default_value);
+		return default_value;
+	}
+}
+
+bool
+Settings::get_value(const synfig::String& key, bool default_value) const {
+	synfig::String value;
+	if (!get_raw_value(key, value) || value.empty())
+		return default_value;
+	return value == "1" || value == "true";
+}
+
+synfig::String
+Settings::get_value(const synfig::String& key, const synfig::String& default_value) const {
+	synfig::String value;
+	return get_raw_value(key, value) ? value : default_value;
+}
+
+synfig::String
+Settings::get_value(const synfig::String &key, const char* default_value) const
+{
+	return get_value(key, synfig::String(default_value));
 }

--- a/synfig-studio/src/synfigapp/settings.cpp
+++ b/synfig-studio/src/synfigapp/settings.cpp
@@ -328,3 +328,32 @@ Settings::get_value(const synfig::String &key, const char* default_value) const
 {
 	return get_value(key, synfig::String(default_value));
 }
+
+bool
+Settings::set_value(const synfig::String &key, double value)
+{
+	std::string v;
+	{
+		synfig::ChangeLocale l(LC_NUMERIC, "C");
+		v = std::to_string(value);
+	}
+	return set_value(key, v);
+}
+
+bool
+Settings::set_value(const synfig::String &key, int value)
+{
+	return set_value(key, strprintf("%d", value));
+}
+
+bool
+Settings::set_value(const synfig::String &key, bool value)
+{
+	return set_value(key, value? "1" : "0");
+}
+
+bool
+Settings::set_value(const synfig::String &key, const char *value)
+{
+	return set_value(key, String(value));
+}

--- a/synfig-studio/src/synfigapp/settings.h
+++ b/synfig-studio/src/synfigapp/settings.h
@@ -30,11 +30,12 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <synfig/string.h>
-#include <map>
 #include <list>
+#include <map>
+
 #include <ETL/stringf>
-#include <string.h>
+#include <synfig/general.h>
+#include <synfig/string.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -61,11 +62,17 @@ public:
 	Settings();
 	virtual ~Settings();
 
-	virtual bool get_value(const synfig::String& key, synfig::String& value)const;
+	virtual bool get_raw_value(const synfig::String& key, synfig::String& value)const;
 	virtual bool set_value(const synfig::String& key,const synfig::String& value);
 	virtual KeyList get_key_list()const;
 
 	synfig::String get_value(const synfig::String& key)const;
+	double get_value(const synfig::String& key, double default_value) const;
+	int get_value(const synfig::String& key, int default_value) const;
+	bool get_value(const synfig::String& key, bool default_value) const;
+	synfig::String get_value(const synfig::String& key, const synfig::String& default_value) const;
+	synfig::String get_value(const synfig::String& key, const char* default_value) const;
+
 	void add_domain(Settings* domain, const synfig::String& name);
 	void remove_domain(const synfig::String& name);
 

--- a/synfig-studio/src/synfigapp/settings.h
+++ b/synfig-studio/src/synfigapp/settings.h
@@ -73,6 +73,13 @@ public:
 	synfig::String get_value(const synfig::String& key, const synfig::String& default_value) const;
 	synfig::String get_value(const synfig::String& key, const char* default_value) const;
 
+	bool set_value(const synfig::String& key, double value);
+	bool set_value(const synfig::String& key, int value);
+	bool set_value(const synfig::String& key, bool value);
+	bool set_value(const synfig::String& key, const char* value);
+	// avoid implicit conversion
+	template <typename T> bool set_value(const synfig::String& key, T value) = delete;
+
 	void add_domain(Settings* domain, const synfig::String& name);
 	void remove_domain(const synfig::String& name);
 


### PR DESCRIPTION
The problem was the LC_NUMERIC locale was changed for loading preferences and the value was set on widget before changing back to proper locale.

This PR reduces the duration of the temporary locale change.