### PR TITLE
fix: Added missing timetrack marks (animated_file timepoints and active points on/off)

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
@@ -167,10 +167,7 @@ get_change_times_from_vdesc(const ValueDesc &v, std::set<Time> &out_times)
 		  || v.get_value_type() == type_bool
 		  || v.get_value_type() == type_canvas )
 		{
-			std::map<Time, ValueBase> x;
-			v.get_value_node()->get_values(x);
-			for(std::map<Time, ValueBase>::const_iterator i = x.begin(); i != x.end(); ++i)
-				out_times.insert(i->first);
+			v.get_value_node()->get_value_change_times(out_times);
 		}
 	}
 }

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -413,6 +413,8 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 		const bool is_user_moving_waypoints = is_dragging && waypoint_sd.get_action() == MOVE;
 		const bool is_user_scaling_waypoints = is_dragging && waypoint_sd.get_action() == SCALE;
 
+		draw_discrete_animated_times(cr, row_info);
+
 		std::vector<std::pair<synfig::TimePoint, synfig::Time>> visible_waypoints;
 		WaypointRenderer::foreach_visible_waypoint(row_info.get_value_desc(), *time_plot_data,
 			[&](const synfig::TimePoint &tp, const synfig::Time &t, void *) -> bool
@@ -770,6 +772,27 @@ void Widget_Timetrack::draw_static_intervals_for_row(const Cairo::RefPtr<Cairo::
 		previous_value = value;
 		previous_time = t;
 
+	}
+}
+
+void
+Widget_Timetrack::draw_discrete_animated_times(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo &row_info) const
+{
+	const synfigapp::ValueDesc &value_desc = row_info.get_value_desc();
+	std::set<synfig::Time> times;
+	if (value_desc.is_value_node()) {
+		const synfig::Type & value_type = value_desc.get_value_type();
+		if (value_type == synfig::type_string
+			|| value_type == synfig::type_bool
+			|| value_type == synfig::type_canvas)
+		{
+			value_desc.get_value_node()->get_value_change_times(times);
+		}
+	}
+	const double yc = row_info.get_geometry().y + row_info.get_geometry().h/2.;
+	for(std::set<synfig::Time>::const_iterator i = times.begin(); i != times.end(); ++i) {
+		cr->arc(1+time_plot_data->get_pixel_t_coord(*i), yc, 2, 0, 2*3.1415);
+		cr->fill();
 	}
 }
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -416,7 +416,7 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 		draw_discrete_animated_times(cr, row_info);
 
 		std::vector<std::pair<synfig::TimePoint, synfig::Time>> visible_waypoints;
-		WaypointRenderer::foreach_visible_waypoint(row_info.get_value_desc(), *time_plot_data,
+		WaypointRenderer::foreach_visible_waypoint(value_desc, *time_plot_data,
 			[&](const synfig::TimePoint &tp, const synfig::Time &t, void *) -> bool
 		{
 			// Don't draw it if it's being moved by user

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -214,6 +214,7 @@ private:
 	void update_param_list_geometries();
 
 	void draw_static_intervals_for_row(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo &row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints) const;
+	void draw_discrete_animated_times(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo &row_info) const;
 	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath &path, const RowInfo &row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints) const;
 	void draw_selected_background(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath &path, const RowInfo &row_info) const;
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -217,6 +217,7 @@ private:
 	void draw_discrete_animated_times(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo &row_info) const;
 	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath &path, const RowInfo &row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints) const;
 	void draw_selected_background(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath &path, const RowInfo &row_info) const;
+	void draw_active_point_status(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo &row_info, const synfigapp::ValueDesc &value_desc);
 
 	bool fetch_waypoints(const WaypointItem &wi, std::set<synfig::Waypoint, std::less<synfig::UniqueID> > &waypoint_set) const;
 	void on_waypoint_clicked(const WaypointItem &wi, unsigned int button, Gdk::Point /*point*/);


### PR DESCRIPTION
CellRenderer_TimeTrack (left) shows time marks for ValueNode_AnimatedFile, but Widget_TimeTrack (right) didn't:
![Captura de tela de 2021-10-24 22-48-55](https://user-images.githubusercontent.com/1323987/138622941-ce3bb7d6-3d94-46ef-b7e3-7781594d6cc0.png)

What do you prefer? Green line or grayish circle?

And now we show the Dynamic List entry status (on/off) as CellRenderer_TimeTrack does (green/red vertical lines):
![Captura de tela de 2021-10-24 22-50-41](https://user-images.githubusercontent.com/1323987/138623035-c206a70c-d5dc-47bc-beff-7e73dae784ee.png)

Traditional TimeTrack also hatches the time span where a Dynamic List entry is kept off. Widget_TimeTrack don't.
I don't like how it currently does. Any suggestion?