### PR TITLE
fix Gtk warning "'GTK_IS_WIDGET (widget)' failed"

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -124,7 +124,6 @@ Widget_Keyframe_List::Widget_Keyframe_List():
 
 Widget_Keyframe_List::~Widget_Keyframe_List()
 {
-	set_time_model(etl::handle<TimeModel>());
 	set_kf_list(NULL);
 	set_canvas_interface(etl::loose_handle<CanvasInterface>());
 }


### PR DESCRIPTION
Reported-by: ice0 (https://github.com/synfig/synfig/pull/2384#issuecomment-951628655)