### PR TITLE
Clear Redo History on new action by default; new user preference

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -803,6 +803,11 @@ public:
 				App::image_editor_path=value;
 				return true;
 			}
+			if(key=="clear_redo_stack_on_new_action")
+			{
+				for (auto instance : App::instance_list)
+					instance->set_clear_redo_stack_on_new_action(value != "0");
+			}
 		}
 		catch(...)
 		{

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -233,6 +233,12 @@ Dialog_Setup::create_system_page(PageInfo pi)
 	toggle_enable_experimental_features.set_halign(Gtk::ALIGN_START);
 	toggle_enable_experimental_features.set_hexpand(false);
 
+	// System - clear_redo_stack_on_new_action
+	attach_label_section(pi.grid, _("Clear redo history on new action"), ++row);
+	pi.grid->attach(toggle_clear_redo_stack_on_new_action, 1, row, 1, 1);
+	toggle_clear_redo_stack_on_new_action.set_halign(Gtk::ALIGN_START);
+	toggle_clear_redo_stack_on_new_action.set_hexpand(false);
+
 	// signal for change resume
 	auto_backup_interval.signal_changed().connect(
 			sigc::bind<int>(sigc::mem_fun(*this, &Dialog_Setup::on_value_change), CHANGE_AUTOBACKUP));
@@ -845,6 +851,7 @@ Dialog_Setup::on_restore_pressed()
 		toggle_restrict_radius_ducks.set_active(true);
 		toggle_animation_thumbnail_preview.set_active(true);
 		toggle_enable_experimental_features.set_active(false);
+		toggle_clear_redo_stack_on_new_action.set_active(true);
 		toggle_use_dark_theme.set_active(false);
 		toggle_show_file_toolbar.set_active(true);
 		listviewtext_brushes_path->clear_items();
@@ -932,6 +939,9 @@ Dialog_Setup::on_apply_pressed()
 
 	// Set the experimental features flag
 	App::enable_experimental_features = toggle_enable_experimental_features.get_active();
+
+	// Set the advanced and risky flag that keeps the Redo stack on new action, instead of clear it
+	synfigapp::Main::settings().set_value("pref.clear_redo_stack_on_new_action", toggle_clear_redo_stack_on_new_action.get_active());
 
 	// Set the dark theme flag
 	App::use_dark_theme               = toggle_use_dark_theme.get_active();
@@ -1212,6 +1222,12 @@ Dialog_Setup::refresh()
 
 	// Refresh the status of the experimental features flag
 	toggle_enable_experimental_features.set_active(App::enable_experimental_features);
+
+	// Refresh the status of the experimental features flag
+	{
+		bool active = synfigapp::Main::settings().get_value("pref.clear_redo_stack_on_new_action", true);
+		toggle_clear_redo_stack_on_new_action.set_active(active);
+	}
 
 	// Refresh the status of the theme flag
 	toggle_use_dark_theme.set_active(App::use_dark_theme);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -134,6 +134,7 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::Switch toggle_restrict_radius_ducks;
 	Gtk::Switch toggle_animation_thumbnail_preview;
 	Gtk::Switch toggle_enable_experimental_features;
+	Gtk::Switch toggle_clear_redo_stack_on_new_action;
 	Gtk::Switch toggle_use_dark_theme;
 	Gtk::Switch toggle_show_file_toolbar;
 

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -73,6 +73,8 @@
 #include <synfig/widthpoint.h>
 #include <synfig/zstreambuf.h>
 
+#include <synfigapp/main.h>
+
 #include <sys/stat.h>
 
 #endif
@@ -101,6 +103,8 @@ Instance::Instance(synfig::Canvas::Handle canvas, synfig::FileSystem::Handle con
 	redo_status_(false)
 {
 	id_=instance_count_++;
+
+	set_clear_redo_stack_on_new_action(true);
 
 	// Connect up all the signals
 	signal_filename_changed().connect(sigc::mem_fun(*this,&studio::Instance::update_all_titles));
@@ -160,6 +164,12 @@ Instance::create(synfig::Canvas::Handle canvas, synfig::FileSystem::Handle conta
 {
 	// Construct a new instance
 	handle<Instance> instance(new Instance(canvas, container));
+
+	// Set the user preference regarding redo-history behavior
+	{
+		bool active = synfigapp::Main::settings().get_value("pref.clear_redo_stack_on_new_action", true);
+		instance->set_clear_redo_stack_on_new_action(active);
+	}
 
 	// Add the new instance to the application's instance list
 	App::instance_list.push_back(instance);


### PR DESCRIPTION
It is dangerous to keep Redo stack when user undoes some stuff and
performs a new action: not very action reacts well to changes of
previous status: some Actions are not stateless and stores some
info/values/pointers when their methods `set_param()` or `prepare()`
are called before perform.

App crash can happen!

So let's prevent this redo-stack-keeper by disabling it by default.

A new user preference is created (in System section) for those who
really want it enabled.

![RedoFeature](https://user-images.githubusercontent.com/5604544/140269370-508c6ece-9206-4e28-8aa6-33cb022d2ad8.png)

