### PR TITLE
Fix various typos

### DIFF
--- a/ChangeLog-development.md
+++ b/ChangeLog-development.md
@@ -69,7 +69,7 @@
 - [`798bfbf`](https://github.com/synfig/synfig/commit/798bfbf95983ff6c01ca019ac72b390fbc259eab) Fixed a crash when trying to import a file into yourself ([#2239](https://github.com/synfig/synfig/issues/2239)) [studio]
 - [`247909c`](https://github.com/synfig/synfig/commit/247909c2cd07a4121192f8ee8eddeb31c800fb86) [Core] ValueNode_AnimatedFile now supports more data types ([#2240](https://github.com/synfig/synfig/issues/2240)) [core]
 - [`4b26b30`](https://github.com/synfig/synfig/commit/4b26b30a6ae4f76bbc3ce8ac21f915f9c1f14b9e) Refresh rend_desc of canvas interface when end time is changed from toolbar ([#2213](https://github.com/synfig/synfig/issues/2213)) [studio]
-- [`101a5aa`](https://github.com/synfig/synfig/commit/101a5aa178019fddcaadf6436ea0c37cc1f5162f) Merge PR [#2236](https://github.com/synfig/synfig/issues/2236): [Lottie exporter] Add animation to addtion/deletion of Bline points [studio]
+- [`101a5aa`](https://github.com/synfig/synfig/commit/101a5aa178019fddcaadf6436ea0c37cc1f5162f) Merge PR [#2236](https://github.com/synfig/synfig/issues/2236): [Lottie exporter] Add animation to addition/deletion of Bline points [studio]
 - [`fb80f27`](https://github.com/synfig/synfig/commit/fb80f27e956d5a8dcc0b1b03db9262bd76388d24) Added Synfig tests to Github CI workflow ([#2238](https://github.com/synfig/synfig/issues/2238))
 - [`4717669`](https://github.com/synfig/synfig/commit/4717669e5b5f8aabe272a8013607c060adcd9409) Disabled some Travis CI build jobs ([#2237](https://github.com/synfig/synfig/issues/2237))
 - [`f32ae7f`](https://github.com/synfig/synfig/commit/f32ae7fbb91f037b0203e1709c32261ee749ee92) [Lottie exporter] Add animation to addition/deletion of Width points and Dash items in advanced outline ([#2233](https://github.com/synfig/synfig/issues/2233)) [studio]
@@ -439,7 +439,7 @@
 - [`e222ce6`](https://github.com/synfig/synfig/commit/e222ce647dc94d4dc332ddd4f969b1844ee18c8c) Fixed travis-ci warnings
 - [`1f08cfc`](https://github.com/synfig/synfig/commit/1f08cfca9c70ea940609324520ecab5559eea885) Remove references to missing translation files ([#1239](https://github.com/synfig/synfig/issues/1239)) [studio]
 - [`eb99ee6`](https://github.com/synfig/synfig/commit/eb99ee6b4847b4b4c575ed576aa55fba5a149ba7) New job for running "autobuild/transifex-push-template.sh" ([#1234](https://github.com/synfig/synfig/issues/1234))
-- [`b380d8a`](https://github.com/synfig/synfig/commit/b380d8a35d882f5d5d839b396a7d3912b8488c9f) keep undo history clean when deleteing multiple curve waypoints ([#1134](https://github.com/synfig/synfig/issues/1134)) [studio]
+- [`b380d8a`](https://github.com/synfig/synfig/commit/b380d8a35d882f5d5d839b396a7d3912b8488c9f) keep undo history clean when deleting multiple curve waypoints ([#1134](https://github.com/synfig/synfig/issues/1134)) [studio]
 - [`c3054c4`](https://github.com/synfig/synfig/commit/c3054c4d648783a1877e42801f97d435ba184303) Merge PR [#1228](https://github.com/synfig/synfig/issues/1228): [CMake] Update CMake script for /share and /etc. [studio]
 - [`50bab45`](https://github.com/synfig/synfig/commit/50bab454ff238af0a286f7a5a81bb7ef45eca914) Merge PR [#1224](https://github.com/synfig/synfig/issues/1224): [CMake] Updated CMake script to change layout of build files. [core]
 - [`9210f30`](https://github.com/synfig/synfig/commit/9210f307e3cf24be53070cc739f52fd8b5e6d48d) Fix typo [studio]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -106,7 +106,7 @@
 - [`bbd7a85`](https://github.com/synfig/synfig/commit/bbd7a85b1f65d2ac02397853b79c19d0f8b672e0) Return true only if id=1 (accept) is clicked ([#1573](https://github.com/synfig/synfig/issues/1573)) [studio]
 - [`9ad7d22`](https://github.com/synfig/synfig/commit/9ad7d22d857c42b49bde109af298c77d661a68b4) Merge PR [#1386](https://github.com/synfig/synfig/issues/1386): Toolbar menu [studio]
 - [`053841b`](https://github.com/synfig/synfig/commit/053841be1bb8b6c75a1dd098c40948d74c22bd46) Year is fixed in About dialog ([#1238](https://github.com/synfig/synfig/issues/1238)) [studio]
-- [`383fcf8`](https://github.com/synfig/synfig/commit/383fcf8) [Autotools] remove support for broken OpenGL renderering ([#2055](https://github.com/synfig/synfig/issues/2055)) [core]
+- [`383fcf8`](https://github.com/synfig/synfig/commit/383fcf8) [Autotools] remove support for broken OpenGL rendering ([#2055](https://github.com/synfig/synfig/issues/2055)) [core]
 - [`19112f1`](https://github.com/synfig/synfig/commit/19112f10adf3b25aad93057d7a0ed03d35b0b2de) Fix crash in Spline Vertex converter ([#1802](https://github.com/synfig/synfig/issues/1802)) [core]
 - [`fb03700`](https://github.com/synfig/synfig/commit/fb037008607153b239cbe7d56fa378cc50655330) Fix crash on unsuccessful action with a clean undo history ([#1643](https://github.com/synfig/synfig/issues/1643)) [studio]
 - [`99a1cde`](https://github.com/synfig/synfig/commit/99a1cde2b1e54540857925e6899deb708e17f305) Export video files with sound ([#1623](https://github.com/synfig/synfig/issues/1623)) [core]

--- a/synfig-core/ChangeLog.old
+++ b/synfig-core/ChangeLog.old
@@ -433,11 +433,11 @@
 2004-01-05 (darco) : Increased threshold for cusp cut-off of tangents are too sharp
 2003-12-29 (darco) : Added support for sharp cusp points (on by default now)
 2003-12-24 (darco) : Adjusted Copyright Notice
-2003-12-24 (darco) : Improved the horizontal placement consistancy of the Text layer.
+2003-12-24 (darco) : Improved the horizontal placement consistency of the Text layer.
 2003-12-24 (darco) : Fix for obscure bug in scale valuenode that would cause a failure to load a saved file
 2003-11-25 (darco) : Improved the Text layer again. *sigh*
-2003-11-20 (darco) : Improved the consistancy of the Text layer again. :P
-2003-11-18 (darco) : Improved the consistancy of the Text layer. You should be able to use it without worrying about the layout going weird anymore.
+2003-11-20 (darco) : Improved the consistency of the Text layer again. :P
+2003-11-18 (darco) : Improved the consistency of the Text layer. You should be able to use it without worrying about the layout going weird anymore.
 2003-11-12 (darco) : Added "--dpi", "--dpi-x", and "--dpi-y" arguments to the SINFG command line tool.  these allow you to change the DPI of what you are rendering.
 2003-11-10 (darco) : Fixed odd animation behavior
 2003-11-10 (darco) : Fixed a bug in the PasteCanvas layer where mouse clicks wouldn't match up if the "origin" was changed from 0,0.
@@ -478,7 +478,7 @@
 2003-05-05 (darco) : The Animated Value Node can now use exported values in waypoints.
 2003-04-23 (darco) : Added "stretch" layer. (Allows distortions to things like circles)
 2003-04-18 (darco) : Added "exposure" parameter to color correct layer
-2003-04-17 (darco) : Added native suport for JPEG files
+2003-04-17 (darco) : Added native support for JPEG files
 2003-04-15 (darco) : The parametric renderer is now multi-threaded, meaning it can take advantage of multiple processors. Doesn't work in Win32.
 2003-04-14 (darco) : Added "ColorCorrect" layer
 2003-04-14 (darco) : Added "bailout" parameter to Mandelbrot and Julia layers. Use larger values to improve smoothing.
@@ -506,7 +506,7 @@
 2003-03-25 (darco) : Added support for linking to DataNodes/Canvases in other Compositions.
 2003-03-24 (darco) : Added support for linking to DataNodes in different Canvases.
 
-2003-03-23 (darco) : Fixed a small bug in circle layer that caused inconsistant results when the feather was set to zero and the parametric renderer used.
+2003-03-23 (darco) : Fixed a small bug in circle layer that caused inconsistent results when the feather was set to zero and the parametric renderer used.
 2003-03-23 (darco) : Added "zoom" parameter to PasteCanvas layer
 
 2003-03-22 (darco) : Fixed color-order bug in ImageMagick importer

--- a/synfig-core/NEWS
+++ b/synfig-core/NEWS
@@ -26,7 +26,7 @@
 - [`23bf66a`](https://github.com/synfig/synfig/commit/23bf66ab53aa7bd3ef3a70fb4488a97b005da3da) Fix animation interpolation for boolean values ([#1826](https://github.com/synfig/synfig/issues/1826))
 - [`985afc4`](https://github.com/synfig/synfig/commit/985afc44935778396406150c130b9653b977def3) fix Duplicate layer ignoring all layers but the first one ([#1829](https://github.com/synfig/synfig/issues/1829))
 - [`a583e73`](https://github.com/synfig/synfig/commit/a583e73d4c47914284b15f4a8d7719eafddfe1b4) autotools: pango and imagemagick c++ flags and libs have been moved to their respective modules ([#1688](https://github.com/synfig/synfig/issues/1688))
-- [`383fcf8`](https://github.com/synfig/synfig/commit/383fcf8) [Autotools] remove support for broken OpenGL renderering ([#2055](https://github.com/synfig/synfig/issues/2055))
+- [`383fcf8`](https://github.com/synfig/synfig/commit/383fcf8) [Autotools] remove support for broken OpenGL rendering ([#2055](https://github.com/synfig/synfig/issues/2055))
 - [`19112f1`](https://github.com/synfig/synfig/commit/19112f10adf3b25aad93057d7a0ed03d35b0b2de) Fix crash in Spline Vertex converter ([#1802](https://github.com/synfig/synfig/issues/1802))
 - [`99a1cde`](https://github.com/synfig/synfig/commit/99a1cde2b1e54540857925e6899deb708e17f305) Export video files with sound ([#1623](https://github.com/synfig/synfig/issues/1623))
 
@@ -467,11 +467,11 @@
 2004-01-05 (darco) : Increased threshold for cusp cut-off of tangents are too sharp
 2003-12-29 (darco) : Added support for sharp cusp points (on by default now)
 2003-12-24 (darco) : Adjusted Copyright Notice
-2003-12-24 (darco) : Improved the horizontal placement consistancy of the Text layer.
+2003-12-24 (darco) : Improved the horizontal placement consistency of the Text layer.
 2003-12-24 (darco) : Fix for obscure bug in scale valuenode that would cause a failure to load a saved file
 2003-11-25 (darco) : Improved the Text layer again. *sigh*
-2003-11-20 (darco) : Improved the consistancy of the Text layer again. :P
-2003-11-18 (darco) : Improved the consistancy of the Text layer. You should be able to use it without worrying about the layout going weird anymore.
+2003-11-20 (darco) : Improved the consistency of the Text layer again. :P
+2003-11-18 (darco) : Improved the consistency of the Text layer. You should be able to use it without worrying about the layout going weird anymore.
 2003-11-12 (darco) : Added "--dpi", "--dpi-x", and "--dpi-y" arguments to the SINFG command line tool.  these allow you to change the DPI of what you are rendering.
 2003-11-10 (darco) : Fixed odd animation behavior
 2003-11-10 (darco) : Fixed a bug in the PasteCanvas layer where mouse clicks wouldn't match up if the "origin" was changed from 0,0.
@@ -512,7 +512,7 @@
 2003-05-05 (darco) : The Animated Value Node can now use exported values in waypoints.
 2003-04-23 (darco) : Added "stretch" layer. (Allows distortions to things like circles)
 2003-04-18 (darco) : Added "exposure" parameter to color correct layer
-2003-04-17 (darco) : Added native suport for JPEG files
+2003-04-17 (darco) : Added native support for JPEG files
 2003-04-15 (darco) : The parametric renderer is now multi-threaded, meaning it can take advantage of multiple processors. Doesn't work in Win32.
 2003-04-14 (darco) : Added "ColorCorrect" layer
 2003-04-14 (darco) : Added "bailout" parameter to Mandelbrot and Julia layers. Use larger values to improve smoothing.
@@ -540,7 +540,7 @@
 2003-03-25 (darco) : Added support for linking to DataNodes/Canvases in other Compositions.
 2003-03-24 (darco) : Added support for linking to DataNodes in different Canvases.
 
-2003-03-23 (darco) : Fixed a small bug in circle layer that caused inconsistant results when the feather was set to zero and the parametric renderer used.
+2003-03-23 (darco) : Fixed a small bug in circle layer that caused inconsistent results when the feather was set to zero and the parametric renderer used.
 2003-03-23 (darco) : Added "zoom" parameter to PasteCanvas layer
 
 2003-03-22 (darco) : Fixed color-order bug in ImageMagick importer

--- a/synfig-studio/ChangeLog.old
+++ b/synfig-studio/ChangeLog.old
@@ -538,7 +538,7 @@
 	* src/gtkmm/layertreestore.cpp: Fixed bug which caused crash on DND layer move 
 	
 2005-11-03	Robert Quattlebaum	<darco@deepdarc.com>
-	* src/gtkmm/render.cpp: Fixed default render file to use the directory seperator for the given OS, rather than just use forward slashes all the time.
+	* src/gtkmm/render.cpp: Fixed default render file to use the directory separator for the given OS, rather than just use forward slashes all the time.
 
 2004-04-26 (darco): Delete button now deletes layers
 2004-04-21 (darco): Various improvements to the dock/dialog system
@@ -576,7 +576,7 @@
 2004-03-05 (darco): Fixed weird tangent bug in BLine tool
 2004-03-05 (darco): You can now change all of the waypoints in a keyframe rather easily by right clicking on the keyframe in the keyframe tab and selecting "Properties".
 2004-03-05 (darco): Keyframe manipulation now much faster
-2004-03-04 (darco): BLine tool will now automaticly create if you leave the tool with something in it
+2004-03-04 (darco): BLine tool will now automatically create if you leave the tool with something in it
 2004-03-04 (darco): You can now close polygons in the polygon tool by clicking on the first point in the polygon
 2004-03-04 (darco): Improved grid snap stuff
 2004-03-02 (darco): Fixed weird selection box when using fill tool
@@ -590,7 +590,7 @@
 2004-02-18 (darco): Added palette dialog
 2004-02-18 (darco): Menus no longer activate the first item in the menu when you click to open it
 2004-02-16 (darco): slight improvement to the way gradients are handled
-2004-02-16 (darco): Added "Apply Deafult Gradient" action for gradient parameters. (just right click on them)
+2004-02-16 (darco): Added "Apply Default Gradient" action for gradient parameters. (just right click on them)
 2004-02-16 (darco): The mouse pointer will now change depending on the currently selected tool.
 2004-02-16 (darco): Moved icons around
 2004-02-16 (darco): File selection dialog box now remembers previous path
@@ -613,19 +613,19 @@
 2004-02-09 (darco) : Negative color values are now clamped off.
 2004-02-07 (darco) : Auto recovery now no longer saves the recovery files in the same directory, which should lead to a more tidy filesystem.
 2004-02-06 (darco) : You can now move multiple layers at once
-2004-02-06 (darco) : Layer heirarchies are now less likely to collapse when moving layers.
+2004-02-06 (darco) : Layer hierarchies are now less likely to collapse when moving layers.
 2004-02-06 (darco) : Raising multiple layers at the same time now works correctly
 2004-02-06 (darco) : Encapsulating no longer puts the encapsulated layer at the top
 2004-02-06 (darco) : Gradient previews are now antialiased
 2004-02-06 (darco) : Fixed odd positioning of dialogs
-2004-02-06 (darco) : Changed the BLine tool to have a more consistant user interface
+2004-02-06 (darco) : Changed the BLine tool to have a more consistent user interface
 2004-02-05 (darco) : Fixed a bug in the text layer regarding the size duck
 2004-01-27 (darco) : Strokes in the draw tool should now draw better and undo better.
 2004-01-27 (darco) : Added "fill last stroke" button to draw tool options
 2004-01-27 (darco) : Auto crash-recovery feature now implemented!
 2004-01-27 (darco) : Canvas should now only redraw when a value is truly changed. (ie: just opening a parameter and not changing it will now no longer force a redraw, or add a new action)
-2004-01-24 (darco) : Improved consistancy of tool options dialog when working with several canvases at the same time
-2004-01-24 (darco) : Fixed a bug with loading sketches where the loaded sketch would dissapear.
+2004-01-24 (darco) : Improved consistency of tool options dialog when working with several canvases at the same time
+2004-01-24 (darco) : Fixed a bug with loading sketches where the loaded sketch would disappear.
 2004-01-23 (darco) : Fixed width duck size bug
 2004-01-23 (darco) : Improved existing icons
 2004-01-23 (darco) : Added new icons
@@ -646,8 +646,8 @@
 2004-01-16 (darco) : Tool Options dialog has been implemented. Currently the only tool that supports it is the sketch tool
 2004-01-16 (darco) : You can now clear the sketch area via the tool options dialog when the sketch tool is selected
 2004-01-16 (darco) : Changes in the color dialog are now immediately reflected in whatever is in context. (As opposed to having to always hit "apply")
-2004-01-16 (darco) : Sketch tool is now persistant. Still needs some work--as it stands, you can't undo or turn off the sketch without closing the file and opening it up again.
-2004-01-15 (darco) : Added preliminary version of the sketch tool. This version doesn't suport colors, or persist across different tools yet. This support is on the way.
+2004-01-16 (darco) : Sketch tool is now persistent. Still needs some work--as it stands, you can't undo or turn off the sketch without closing the file and opening it up again.
+2004-01-15 (darco) : Added preliminary version of the sketch tool. This version doesn't support colors, or persist across different tools yet. This support is on the way.
 2004-01-15 (darco) : Renamed tools
 2004-01-14 (darco) : Updates for supporting new BLines
 2004-01-14 (darco) : Import tool now respects the width and height of a bitmap when placing it
@@ -663,8 +663,8 @@
 2004-01-05 (darco) : You can now draw looped blines in the sketch tool.
 2004-01-02 (adruab) : Fixed weird reversing tangents bug
 2004-01-01 (adruab) : Added tangent breaking to the curve input tool (first post of 2004 :P)
-2003-12-28 (adruab) : Fixed the dumb adaptive tesselator, and put pressure sensitivity back in
-2003-12-28 (adruab) : Finished the "dumb" adaptive curve tesselator (-bugs)
+2003-12-28 (adruab) : Fixed the dumb adaptive tessellator, and put pressure sensitivity back in
+2003-12-28 (adruab) : Finished the "dumb" adaptive curve tessellator (-bugs)
 2003-12-28 (darco) : Added physical dimensions to properties and render dialogs
 2003-12-24 (darco) : The clicking-too-fast bug should be fixed
 2003-12-24 (darco) : Added Fill Tool
@@ -721,7 +721,7 @@
 2003-10-11 (darco) : Fixed some weirdness with the children tab
 2003-10-11 (darco) : Several speed improvements for the tables. This will greatly speed up loading files, editing values, and adjustments to keyframes.
 2003-10-10 (darco) : The "Zoom to 100%" feature can now be accessed by pressing the "`" key. (This is the that has the "~" on it)
-2003-10-10 (darco) : The "Zoom to 100%" feature will not "toggle", meaning that if you are alreay at a "100%" zoom level, then it will return to the previous zoom amount.
+2003-10-10 (darco) : The "Zoom to 100%" feature will not "toggle", meaning that if you are already at a "100%" zoom level, then it will return to the previous zoom amount.
 2003-10-08 (darco) : Fixed first/last point on looped bline not being splitable from the work area duck.
 2003-10-07 (darco) : Fixed weird idle->rendering->idle->rendering switching bug
 2003-10-07 (darco) : Added blend_method option to layer tab
@@ -736,10 +736,10 @@
 2003-10-06 (darco) : Removed activepoint-specific actions for non-animated canvases
 2003-10-04 (darco) : Fixed bug where when dragging a layer below it ends up being one off.
 2003-10-04 (darco) : Added button to toolbox for quickly displaying the color dialog
-2003-10-04 (darco) : Fixed some minor consistancy issues regarding the layer tab. (ie: disconnections not being visible...)
+2003-10-04 (darco) : Fixed some minor consistency issues regarding the layer tab. (ie: disconnections not being visible...)
 2003-10-04 (darco) : You can now sort the ValueNodes in the Children tab
 2003-10-04 (darco) : Fixed bug where changing parameters may not always refresh the work area.
-2003-10-04 (darco) : Hopefuly fixed "dissapearing new layer menu" bug
+2003-10-04 (darco) : Hopefully fixed "disappearing new layer menu" bug
 2003-10-03 (darco) : Preliminary support for editing layer descriptions
 2003-09-30 (darco) : Changing a canvas parameter now no longer requires you to click elsewhere before it takes effect.
 2003-09-30 (darco) : Changing an Enum parameter now no longer requires you to click elsewhere before it takes effect.
@@ -759,16 +759,16 @@
 2003-09-30 (darco) : Improved BLine editing via BLine Rotoscope tool. You now insert points by right clicking on the curve rather than the vertex.
 2003-09-29 (darco) : Improved layer Drag-N-Drop
 2003-09-25 (darco) : Layers can now be rearanged via Drag-N-Drop
-2003-09-25 (darco) : The BLine Rotoscope tool now automaticly uses more reasonable tangents
+2003-09-25 (darco) : The BLine Rotoscope tool now automatically uses more reasonable tangents
 2003-09-24 (darco) : You can now select layers from the work area that are inside inline canvases by just clicking on them.
 2003-09-24 (darco) : Selecting a layer from the work area will now cause the layer tab to scroll to make that layer visible.
 2003-09-24 (darco) : Improved in-line canvas editing (now it doesn't collapse ever time you make a change)
 2003-09-24 (darco) : Fixed the bug where the canvas wouldn't refresh if values were edited too quickly
-2003-09-24 (darco) : Added some icons to dynamicly generated menus
+2003-09-24 (darco) : Added some icons to dynamically generated menus
 2003-09-24 (darco) : Added jump-to-(next/prev)-keyframe feature (Press '[' and ']')
 2003-09-24 (darco) : Added time-zoom feature (Hold down shift and press '-' and '=')
 2003-09-24 (darco) : Fixed lagging duck bug
-2003-09-23 (darco) : Color editor will now intelegently clamp values if necessary
+2003-09-23 (darco) : Color editor will now intelligently clamp values if necessary
 2003-09-23 (darco) : Added "selected color" box to color editing dialog
 2003-09-23 (darco) : Implemented keyboard accelerators for zoom. (GIMP style -- '-' for zoom out and '=' for zoom in)
 2003-09-23 (darco) : Implemented keyboard accelerators for Duck Hiding. (press ALT-1...6)
@@ -788,13 +788,13 @@
 2003-09-01 (darco) : If a given layer has a color parameter, then you can now edit the color of a layer by just selecting the layer and adjusting it's color in the color dialog. You can also adjust the color of all selected layers in this way.
 2003-08-31 (darco) : Added color-selection dialog, improving the ease and intuitiveness of color selection.
 2003-08-18 (darco) : Preliminary support for dynamic point removal.
-2003-08-18 (darco) : Improved support for adding points dynamicly. 
+2003-08-18 (darco) : Improved support for adding points dynamically. 
 2003-08-14 (darco) : Preliminary support for animating the addition and removal of points
-2003-08-12 (darco) : You can now right click on segments! To add a point ot a bline, right click on the segment where you want to add the point, and then select "add point".
+2003-08-12 (darco) : You can now right click on segments! To add a point to a bline, right click on the segment where you want to add the point, and then select "add point".
 2003-08-12 (darco) : You can now click on a layer in the work area and it will be selected. (Not yet supported for all layers)
 2003-08-12 (darco) : Gradient editor now works. Right click on the gradient in the editor to display a menu for adding and removing CPoints.
 2003-08-11 (darco) : You can now see ducks appear as you select children. This greatly improves the ability to edit and work with complex images.
-2003-08-06 (darco) : The canvas browser is now hidden by default. When you first load a canvas, it will pop up automaticlly.
+2003-08-06 (darco) : The canvas browser is now hidden by default. When you first load a canvas, it will pop up automatically.
 2003-08-06 (darco) : Added blacklevel test pattern to the gamma tab of the setup dialog. As with the other patterns, try to make the middle of the square match the outside of the square. The goal is to have the highest blacklevel setting where the blacklevel pattern looks solid black.
 2003-08-06 (darco) : I am currently working on adding support for the color gradient editor. It isn't done yet, but if you double click on a gradient, you can bring up what will be the gradient editor.
 2003-08-06 (darco) : Added "Visually Linear Color Selection" checkbox to the setup. This adjusts all color values that you see so that they are more linear in scale. The default is ON.
@@ -803,7 +803,7 @@
 2003-08-04 (darco) : The setup dialog now saves your changes to disk immediately. This makes is so that if the program crashes, then we don't loose our recently-updated changes
 2003-08-04 (darco) : The setup dialog is now broken down into tabs.
 2003-08-04 (darco) : Improved the speed of the gamma adjustments in the setup dialog.
-2003-08-01 (darco) : Changes made to the setup dialog are now saved to disk, and will be automaticly reloaded upon restarting the program.
+2003-08-01 (darco) : Changes made to the setup dialog are now saved to disk, and will be automatically reloaded upon restarting the program.
 2003-08-01 (darco) : Setup dialog is now implemented, with visual gamma adjustments and the ability to choose the type of timestamp you want
 2003-07-28 (darco) : Added gradients as viewable parameters. (the gradient editor isn't ready yet though)
 2003-07-23 (darco) : Added buttons to the toolbar for poly and bline rotoscope
@@ -870,7 +870,7 @@
 
 2003-03-04 (darco) : Implemented Render Functionality.
 2003-03-04 (darco) : Added support for "angle" type.
-2003-03-04 (darco) : Deselecting a parameter-edit popup will now make it dissapear immediately, rather than after the refresh.
+2003-03-04 (darco) : Deselecting a parameter-edit popup will now make it disappear immediately, rather than after the refresh.
 
 2003-03-01 (darco) : The root canvas on a new composition is now clean, instead of having a mandelbrot set.
 

--- a/synfig-studio/NEWS
+++ b/synfig-studio/NEWS
@@ -626,7 +626,7 @@
 	* src/gtkmm/layertreestore.cpp: Fixed bug which caused crash on DND layer move 
 	
 2005-11-03	Robert Quattlebaum	<darco@deepdarc.com>
-	* src/gtkmm/render.cpp: Fixed default render file to use the directory seperator for the given OS, rather than just use forward slashes all the time.
+	* src/gtkmm/render.cpp: Fixed default render file to use the directory separator for the given OS, rather than just use forward slashes all the time.
 
 2004-04-26 (darco): Delete button now deletes layers
 2004-04-21 (darco): Various improvements to the dock/dialog system
@@ -664,7 +664,7 @@
 2004-03-05 (darco): Fixed weird tangent bug in BLine tool
 2004-03-05 (darco): You can now change all of the waypoints in a keyframe rather easily by right clicking on the keyframe in the keyframe tab and selecting "Properties".
 2004-03-05 (darco): Keyframe manipulation now much faster
-2004-03-04 (darco): BLine tool will now automaticly create if you leave the tool with something in it
+2004-03-04 (darco): BLine tool will now automatically create if you leave the tool with something in it
 2004-03-04 (darco): You can now close polygons in the polygon tool by clicking on the first point in the polygon
 2004-03-04 (darco): Improved grid snap stuff
 2004-03-02 (darco): Fixed weird selection box when using fill tool
@@ -678,7 +678,7 @@
 2004-02-18 (darco): Added palette dialog
 2004-02-18 (darco): Menus no longer activate the first item in the menu when you click to open it
 2004-02-16 (darco): slight improvement to the way gradients are handled
-2004-02-16 (darco): Added "Apply Deafult Gradient" action for gradient parameters. (just right click on them)
+2004-02-16 (darco): Added "Apply Default Gradient" action for gradient parameters. (just right click on them)
 2004-02-16 (darco): The mouse pointer will now change depending on the currently selected tool.
 2004-02-16 (darco): Moved icons around
 2004-02-16 (darco): File selection dialog box now remembers previous path
@@ -701,19 +701,19 @@
 2004-02-09 (darco) : Negative color values are now clamped off.
 2004-02-07 (darco) : Auto recovery now no longer saves the recovery files in the same directory, which should lead to a more tidy filesystem.
 2004-02-06 (darco) : You can now move multiple layers at once
-2004-02-06 (darco) : Layer heirarchies are now less likely to collapse when moving layers.
+2004-02-06 (darco) : Layer hierarchies are now less likely to collapse when moving layers.
 2004-02-06 (darco) : Raising multiple layers at the same time now works correctly
 2004-02-06 (darco) : Encapsulating no longer puts the encapsulated layer at the top
 2004-02-06 (darco) : Gradient previews are now antialiased
 2004-02-06 (darco) : Fixed odd positioning of dialogs
-2004-02-06 (darco) : Changed the BLine tool to have a more consistant user interface
+2004-02-06 (darco) : Changed the BLine tool to have a more consistent user interface
 2004-02-05 (darco) : Fixed a bug in the text layer regarding the size duck
 2004-01-27 (darco) : Strokes in the draw tool should now draw better and undo better.
 2004-01-27 (darco) : Added "fill last stroke" button to draw tool options
 2004-01-27 (darco) : Auto crash-recovery feature now implemented!
 2004-01-27 (darco) : Canvas should now only redraw when a value is truly changed. (ie: just opening a parameter and not changing it will now no longer force a redraw, or add a new action)
-2004-01-24 (darco) : Improved consistancy of tool options dialog when working with several canvases at the same time
-2004-01-24 (darco) : Fixed a bug with loading sketches where the loaded sketch would dissapear.
+2004-01-24 (darco) : Improved consistency of tool options dialog when working with several canvases at the same time
+2004-01-24 (darco) : Fixed a bug with loading sketches where the loaded sketch would disappear.
 2004-01-23 (darco) : Fixed width duck size bug
 2004-01-23 (darco) : Improved existing icons
 2004-01-23 (darco) : Added new icons
@@ -734,8 +734,8 @@
 2004-01-16 (darco) : Tool Options dialog has been implemented. Currently the only tool that supports it is the sketch tool
 2004-01-16 (darco) : You can now clear the sketch area via the tool options dialog when the sketch tool is selected
 2004-01-16 (darco) : Changes in the color dialog are now immediately reflected in whatever is in context. (As opposed to having to always hit "apply")
-2004-01-16 (darco) : Sketch tool is now persistant. Still needs some work--as it stands, you can't undo or turn off the sketch without closing the file and opening it up again.
-2004-01-15 (darco) : Added preliminary version of the sketch tool. This version doesn't suport colors, or persist across different tools yet. This support is on the way.
+2004-01-16 (darco) : Sketch tool is now persistent. Still needs some work--as it stands, you can't undo or turn off the sketch without closing the file and opening it up again.
+2004-01-15 (darco) : Added preliminary version of the sketch tool. This version doesn't support colors, or persist across different tools yet. This support is on the way.
 2004-01-15 (darco) : Renamed tools
 2004-01-14 (darco) : Updates for supporting new BLines
 2004-01-14 (darco) : Import tool now respects the width and height of a bitmap when placing it
@@ -751,8 +751,8 @@
 2004-01-05 (darco) : You can now draw looped blines in the sketch tool.
 2004-01-02 (adruab) : Fixed weird reversing tangents bug
 2004-01-01 (adruab) : Added tangent breaking to the curve input tool (first post of 2004 :P)
-2003-12-28 (adruab) : Fixed the dumb adaptive tesselator, and put pressure sensitivity back in
-2003-12-28 (adruab) : Finished the "dumb" adaptive curve tesselator (-bugs)
+2003-12-28 (adruab) : Fixed the dumb adaptive tessellator, and put pressure sensitivity back in
+2003-12-28 (adruab) : Finished the "dumb" adaptive curve tessellator (-bugs)
 2003-12-28 (darco) : Added physical dimensions to properties and render dialogs
 2003-12-24 (darco) : The clicking-too-fast bug should be fixed
 2003-12-24 (darco) : Added Fill Tool
@@ -809,7 +809,7 @@
 2003-10-11 (darco) : Fixed some weirdness with the children tab
 2003-10-11 (darco) : Several speed improvements for the tables. This will greatly speed up loading files, editing values, and adjustments to keyframes.
 2003-10-10 (darco) : The "Zoom to 100%" feature can now be accessed by pressing the "`" key. (This is the that has the "~" on it)
-2003-10-10 (darco) : The "Zoom to 100%" feature will not "toggle", meaning that if you are alreay at a "100%" zoom level, then it will return to the previous zoom amount.
+2003-10-10 (darco) : The "Zoom to 100%" feature will not "toggle", meaning that if you are already at a "100%" zoom level, then it will return to the previous zoom amount.
 2003-10-08 (darco) : Fixed first/last point on looped bline not being splitable from the work area duck.
 2003-10-07 (darco) : Fixed weird idle->rendering->idle->rendering switching bug
 2003-10-07 (darco) : Added blend_method option to layer tab
@@ -824,10 +824,10 @@
 2003-10-06 (darco) : Removed activepoint-specific actions for non-animated canvases
 2003-10-04 (darco) : Fixed bug where when dragging a layer below it ends up being one off.
 2003-10-04 (darco) : Added button to toolbox for quickly displaying the color dialog
-2003-10-04 (darco) : Fixed some minor consistancy issues regarding the layer tab. (ie: disconnections not being visible...)
+2003-10-04 (darco) : Fixed some minor consistency issues regarding the layer tab. (ie: disconnections not being visible...)
 2003-10-04 (darco) : You can now sort the ValueNodes in the Children tab
 2003-10-04 (darco) : Fixed bug where changing parameters may not always refresh the work area.
-2003-10-04 (darco) : Hopefuly fixed "dissapearing new layer menu" bug
+2003-10-04 (darco) : Hopefully fixed "disappearing new layer menu" bug
 2003-10-03 (darco) : Preliminary support for editing layer descriptions
 2003-09-30 (darco) : Changing a canvas parameter now no longer requires you to click elsewhere before it takes effect.
 2003-09-30 (darco) : Changing an Enum parameter now no longer requires you to click elsewhere before it takes effect.
@@ -847,16 +847,16 @@
 2003-09-30 (darco) : Improved BLine editing via BLine Rotoscope tool. You now insert points by right clicking on the curve rather than the vertex.
 2003-09-29 (darco) : Improved layer Drag-N-Drop
 2003-09-25 (darco) : Layers can now be rearanged via Drag-N-Drop
-2003-09-25 (darco) : The BLine Rotoscope tool now automaticly uses more reasonable tangents
+2003-09-25 (darco) : The BLine Rotoscope tool now automatically uses more reasonable tangents
 2003-09-24 (darco) : You can now select layers from the work area that are inside inline canvases by just clicking on them.
 2003-09-24 (darco) : Selecting a layer from the work area will now cause the layer tab to scroll to make that layer visible.
 2003-09-24 (darco) : Improved in-line canvas editing (now it doesn't collapse ever time you make a change)
 2003-09-24 (darco) : Fixed the bug where the canvas wouldn't refresh if values were edited too quickly
-2003-09-24 (darco) : Added some icons to dynamicly generated menus
+2003-09-24 (darco) : Added some icons to dynamically generated menus
 2003-09-24 (darco) : Added jump-to-(next/prev)-keyframe feature (Press '[' and ']')
 2003-09-24 (darco) : Added time-zoom feature (Hold down shift and press '-' and '=')
 2003-09-24 (darco) : Fixed lagging duck bug
-2003-09-23 (darco) : Color editor will now intelegently clamp values if necessary
+2003-09-23 (darco) : Color editor will now intelligently clamp values if necessary
 2003-09-23 (darco) : Added "selected color" box to color editing dialog
 2003-09-23 (darco) : Implemented keyboard accelerators for zoom. (GIMP style -- '-' for zoom out and '=' for zoom in)
 2003-09-23 (darco) : Implemented keyboard accelerators for Duck Hiding. (press ALT-1...6)
@@ -876,13 +876,13 @@
 2003-09-01 (darco) : If a given layer has a color parameter, then you can now edit the color of a layer by just selecting the layer and adjusting it's color in the color dialog. You can also adjust the color of all selected layers in this way.
 2003-08-31 (darco) : Added color-selection dialog, improving the ease and intuitiveness of color selection.
 2003-08-18 (darco) : Preliminary support for dynamic point removal.
-2003-08-18 (darco) : Improved support for adding points dynamicly. 
+2003-08-18 (darco) : Improved support for adding points dynamically. 
 2003-08-14 (darco) : Preliminary support for animating the addition and removal of points
-2003-08-12 (darco) : You can now right click on segments! To add a point ot a bline, right click on the segment where you want to add the point, and then select "add point".
+2003-08-12 (darco) : You can now right click on segments! To add a point to a bline, right click on the segment where you want to add the point, and then select "add point".
 2003-08-12 (darco) : You can now click on a layer in the work area and it will be selected. (Not yet supported for all layers)
 2003-08-12 (darco) : Gradient editor now works. Right click on the gradient in the editor to display a menu for adding and removing CPoints.
 2003-08-11 (darco) : You can now see ducks appear as you select children. This greatly improves the ability to edit and work with complex images.
-2003-08-06 (darco) : The canvas browser is now hidden by default. When you first load a canvas, it will pop up automaticlly.
+2003-08-06 (darco) : The canvas browser is now hidden by default. When you first load a canvas, it will pop up automatically.
 2003-08-06 (darco) : Added blacklevel test pattern to the gamma tab of the setup dialog. As with the other patterns, try to make the middle of the square match the outside of the square. The goal is to have the highest blacklevel setting where the blacklevel pattern looks solid black.
 2003-08-06 (darco) : I am currently working on adding support for the color gradient editor. It isn't done yet, but if you double click on a gradient, you can bring up what will be the gradient editor.
 2003-08-06 (darco) : Added "Visually Linear Color Selection" checkbox to the setup. This adjusts all color values that you see so that they are more linear in scale. The default is ON.
@@ -891,7 +891,7 @@
 2003-08-04 (darco) : The setup dialog now saves your changes to disk immediately. This makes is so that if the program crashes, then we don't loose our recently-updated changes
 2003-08-04 (darco) : The setup dialog is now broken down into tabs.
 2003-08-04 (darco) : Improved the speed of the gamma adjustments in the setup dialog.
-2003-08-01 (darco) : Changes made to the setup dialog are now saved to disk, and will be automaticly reloaded upon restarting the program.
+2003-08-01 (darco) : Changes made to the setup dialog are now saved to disk, and will be automatically reloaded upon restarting the program.
 2003-08-01 (darco) : Setup dialog is now implemented, with visual gamma adjustments and the ability to choose the type of timestamp you want
 2003-07-28 (darco) : Added gradients as viewable parameters. (the gradient editor isn't ready yet though)
 2003-07-23 (darco) : Added buttons to the toolbar for poly and bline rotoscope
@@ -958,7 +958,7 @@
 
 2003-03-04 (darco) : Implemented Render Functionality.
 2003-03-04 (darco) : Added support for "angle" type.
-2003-03-04 (darco) : Deselecting a parameter-edit popup will now make it dissapear immediately, rather than after the refresh.
+2003-03-04 (darco) : Deselecting a parameter-edit popup will now make it disappear immediately, rather than after the refresh.
 
 2003-03-01 (darco) : The root canvas on a new composition is now clean, instead of having a mandelbrot set.
 

--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -251,7 +251,7 @@ file(MAKE_DIRECTORY ${PIXMAPS_DIR})
 # Implement icon sizes after Synfig Studio uses Gtk::IconTheme
 # For now just render to the default document size like Autotools does
 #
-# Note to protential future contributors:
+# Note to potential future contributors:
 # Not all icons are of aspect 1:1, eg- toggle button chain link
 # so the below code is faulty and needs to be corrected
 #


### PR DESCRIPTION
Found via `codespell -q 3 -L aline,ang,ba,childs,dout,eiter,forse,objext,pevent,shouldbe,thru,uint,unselect,vertexes -S ./synfig-studio/po,./synfig-core/po,/synfig-core/m4,./synfig-osx/,./gtkmm-osx,./bugs,.*.eps,*.sif,./synfig-studio/plugins/lottie-exporter`