### PR TITLE
Add margins to TimeTrack to ease handling of initial waypoint and keyframe

### DIFF
--- a/synfig-studio/src/gui/timeplotdata.cpp
+++ b/synfig-studio/src/gui/timeplotdata.cpp
@@ -53,7 +53,7 @@ namespace studio {
 TimePlotData::TimePlotData(Gtk::Widget* widget, Glib::RefPtr<Gtk::Adjustment> vertical_adjustment) :
 	invalid(true),
 	k(0),
-	extra_margin(0),
+	extra_margin(3),
 	has_vertical(false),
 	widget(widget),
 	vertical_adjustment(vertical_adjustment)
@@ -109,7 +109,7 @@ TimePlotData::set_extra_time_margin(double margin)
 {
 	extra_margin = margin;
 
-	recompute_extra_time();
+	recompute_geometry_data();
 }
 
 void
@@ -159,19 +159,14 @@ TimePlotData::recompute_time_bounds()
 void
 TimePlotData::recompute_geometry_data()
 {
-	k = size.get_x()/(upper - lower);
+	k = (size.get_x()-2*extra_margin)/(upper - lower);
 	dt = 1.0/k;
 
 	if (has_vertical) {
 		range_k = size.get_y()/(range_upper - range_lower);
 	}
 
-	recompute_extra_time(); // k (and lower and upper) changes extra_time
-}
-
-void
-TimePlotData::recompute_extra_time()
-{
+//	recompute_extra_time(); // k (and lower and upper) changes extra_time
 	extra_time = extra_margin/k;
 	lower_ex = lower - extra_time;
 	upper_ex = upper + extra_time;
@@ -238,13 +233,13 @@ TimePlotData::is_y_visible(synfig::Real y) const
 int
 TimePlotData::get_pixel_t_coord(const synfig::Time& t) const
 {
-	return etl::round_to_int((t - lower) * k);
+	return etl::round_to_int((t - lower_ex) * k);
 }
 
 double
 TimePlotData::get_double_pixel_t_coord(const synfig::Time& t) const
 {
-	return round((t - lower) * k);
+	return round((t - lower_ex) * k);
 }
 
 int
@@ -256,7 +251,7 @@ TimePlotData::get_pixel_y_coord(synfig::Real y) const
 synfig::Time
 TimePlotData::get_t_from_pixel_coord(double pixel) const
 {
-	return lower + synfig::Time(pixel/k);
+	return lower_ex + synfig::Time(pixel/k);
 }
 
 double TimePlotData::get_y_from_pixel_coord(double pixel) const

--- a/synfig-studio/src/gui/timeplotdata.h
+++ b/synfig-studio/src/gui/timeplotdata.h
@@ -153,7 +153,6 @@ private:
 
 	void recompute_time_bounds();
 	void recompute_geometry_data();
-	void recompute_extra_time();
 	void recompute_vertical();
 
 	void queue_draw();

--- a/synfig-studio/src/gui/widgets/widget_canvastimeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_canvastimeslider.cpp
@@ -72,8 +72,6 @@ Widget_CanvasTimeslider::Widget_CanvasTimeslider():
 	tooltip.add(thumb);
 
 	add_events(Gdk::POINTER_MOTION_MASK | Gdk::LEAVE_NOTIFY_MASK);
-
-	time_plot_data->set_extra_time_margin(2.0);
 }
 
 Widget_CanvasTimeslider::~Widget_CanvasTimeslider()
@@ -242,6 +240,7 @@ Widget_CanvasTimeslider::draw_background(const Cairo::RefPtr<Cairo::Context> &cr
 	Widget_Timeslider::draw_background(cr);
 
 	if (!time_plot_data->time_model || !canvas_view || !canvas_view->get_work_area()) return;
+
 	Renderer_Canvas::Handle renderer_canvas = canvas_view->get_work_area()->get_renderer_canvas();
 	if (!renderer_canvas) return;
 

--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -499,8 +499,6 @@ Widget_Curves::Widget_Curves()
 
 	set_can_focus(true);
 
-	time_plot_data->set_extra_time_margin(16/2);
-
 	channel_point_sd.set_pan_enabled(true);
 	channel_point_sd.set_zoom_enabled(true);
 	channel_point_sd.set_scroll_enabled(true);

--- a/synfig-studio/src/gui/widgets/widget_timeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.cpp
@@ -166,16 +166,12 @@ Widget_Timeslider::Widget_Timeslider():
 	}
 
 	time_plot_data = new TimePlotData(this);
-	time_plot_data->set_extra_time_margin(get_height());
 
 	// click / scroll / zoom
 	add_events( Gdk::BUTTON_PRESS_MASK
 			  | Gdk::BUTTON_RELEASE_MASK
 			  | Gdk::BUTTON_MOTION_MASK
 			  | Gdk::SCROLL_MASK );
-
-	signal_configure_event().connect(
-		sigc::mem_fun(*this, &Widget_Timeslider::on_configure_event));
 }
 
 Widget_Timeslider::~Widget_Timeslider()
@@ -206,14 +202,6 @@ Widget_Timeslider::draw_background(const Cairo::RefPtr<Cairo::Context> &cr)
 	cr->rectangle(0.0, 0.0, (double)get_width(), (double)get_height());
 	cr->fill();
 	cr->restore();
-}
-
-bool Widget_Timeslider::on_configure_event(GdkEventConfigure* configure)
-{
-	SYNFIG_EXCEPTION_GUARD_BEGIN()
-	time_plot_data->set_extra_time_margin(configure->height);
-	return false;
-	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
 bool

--- a/synfig-studio/src/gui/widgets/widget_timeslider.h
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.h
@@ -75,8 +75,6 @@ protected: // implementation that other interfaces can see
 
 	virtual void draw_background(const Cairo::RefPtr<Cairo::Context> &cr);
 
-	virtual bool on_configure_event(GdkEventConfigure * configure);
-
 public:
 	Widget_Timeslider();
 	~Widget_Timeslider();

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -60,7 +60,6 @@ Widget_Timetrack::Widget_Timetrack()
 {
 	add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK | Gdk::SCROLL_MASK | Gdk::POINTER_MOTION_MASK | Gdk::KEY_PRESS_MASK | Gdk::KEY_RELEASE_MASK);
 	set_can_focus(true);
-	time_plot_data->set_extra_time_margin(16/2);
 	setup_mouse_handler();
 
 	setup_adjustment();


### PR DESCRIPTION
At end too :)

fix #1145

![TimeTrackMargins](https://user-images.githubusercontent.com/5604544/139800406-553e3d44-6425-4691-b7f7-88435f36ff76.png)

