### PR TITLE
Fix distance values on settings

### DIFF
--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -328,10 +328,7 @@ StateBLine_Context::load_settings()
 
 		set_opacity(settings.get_value("bline.opacity", 1.0));
 
-		set_bline_width(Distance(
-							settings.get_value("bline.bline_width", 1.0),
-							App::distance_system)
-						);
+		set_bline_width(settings.get_value("bline.bline_width", Distance("1.0px")));
 
 		set_layer_region_flag(settings.get_value("bline.layer_region", true));
 
@@ -347,10 +344,7 @@ StateBLine_Context::load_settings()
 
 		set_auto_export_flag(settings.get_value("bline.auto_export", false));
 
-		set_feather_size(Distance(
-							settings.get_value("bline.feather", 0.0),
-							App::distance_system)
-						);
+		set_feather_size(settings.get_value("bline.feather", Distance("0.0px")));
 
 		// determine layer flags
 		layer_region_flag = get_layer_region_flag();
@@ -382,8 +376,8 @@ StateBLine_Context::save_settings()
 		settings.set_value("bline.layer_link_origins",get_layer_link_origins_flag());
 		settings.set_value("bline.blend",get_blend());
 		settings.set_value("bline.opacity",get_opacity());
-		settings.set_value("bline.bline_width", bline_width_dist.get_value().get_string());
-		settings.set_value("bline.feather", feather_dist.get_value().get_string());
+		settings.set_value("bline.bline_width", bline_width_dist.get_value());
+		settings.set_value("bline.feather", feather_dist.get_value());
 		settings.set_value("bline.auto_export",get_auto_export_flag());
 
 	}

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -68,7 +68,7 @@ using namespace synfigapp;
 /* === M A C R O S ========================================================= */
 
 #define GAP	(3)
-#define DEFAULT_WIDTH (0.1)
+#define DEFAULT_WIDTH ("0.1u")
 
 /* === G L O B A L S ======================================================= */
 
@@ -158,7 +158,10 @@ public:
 		}else if(skel_deform_bone_width_dist.is_visible()){
 			return get_skel_deform_bone_width();
 		}else{
-			return DEFAULT_WIDTH;
+			if (canvas)
+				return Distance(DEFAULT_WIDTH).get(Distance::SYSTEM_UNITS, get_canvas_view()->get_canvas()->rend_desc());
+			else
+				return Distance(DEFAULT_WIDTH).get();
 		}
 	}
 
@@ -238,15 +241,9 @@ StateBone_Context::load_settings()
 			set_id(settings.get_value("bone.skel_deform_id", _("NewSkeletonDeformation")));
 		}
 
-		set_skel_bone_width(Distance(
-							settings.get_value("bone.skel_bone_width", DEFAULT_WIDTH),
-							Distance::SYSTEM_UNITS)
-						);
+		set_skel_bone_width(settings.get_value("bone.skel_bone_width", Distance(DEFAULT_WIDTH)));
 
-		set_skel_deform_bone_width(Distance(
-							settings.get_value("bone.skel_deform_bone_width", DEFAULT_WIDTH),
-							Distance::SYSTEM_UNITS)
-						);
+		set_skel_deform_bone_width(settings.get_value("bone.skel_deform_bone_width", Distance(DEFAULT_WIDTH)));
 	}
 	catch(...)
 	{
@@ -264,8 +261,8 @@ StateBone_Context::save_settings()
 		else
 			settings.set_value("bone.skel_deform_id",get_id());
 
-		settings.set_value("bone.skel_bone_width",skel_bone_width_dist.get_value().get_string());
-		settings.set_value("bone.skel_deform_bone_width",skel_deform_bone_width_dist.get_value().get_string());
+		settings.set_value("bone.skel_bone_width",skel_bone_width_dist.get_value());
+		settings.set_value("bone.skel_deform_bone_width",skel_deform_bone_width_dist.get_value());
 	}
 	catch (...)
 	{
@@ -278,8 +275,8 @@ StateBone_Context::reset()
 {
 	active_bone = nullptr;
 	set_id(_("NewSkeleton"));
-	set_skel_bone_width(Distance(DEFAULT_WIDTH,Distance::SYSTEM_UNITS)); // default width
-	set_skel_deform_bone_width(Distance(DEFAULT_WIDTH,Distance::SYSTEM_UNITS)); // default width
+	set_skel_bone_width(Distance(DEFAULT_WIDTH)); // default width
+	set_skel_deform_bone_width(Distance(DEFAULT_WIDTH)); // default width
 }
 
 void

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -315,16 +315,9 @@ StateCircle_Context::load_settings()
 
 		set_opacity(settings.get_value("circle.opacity", 1.0));
 
-		set_bline_width(Distance(
-							settings.get_value("circle.bline_width", 1.0),
-							App::distance_system)
-						);
+		set_bline_width(settings.get_value("circle.bline_width", Distance("1.0px")));
 
-		set_feather_size(Distance(
-							settings.get_value("circle.feather", 0.0),
-							App::distance_system)
-						);
-
+		set_feather_size(settings.get_value("circle.feather", Distance("0.0px")));
 
 		set_number_of_bline_points(settings.get_value("circle.number_of_bline_points", 4));
 
@@ -371,8 +364,8 @@ StateCircle_Context::save_settings()
 		settings.set_value("circle.id",get_id());
 		settings.set_value("circle.blend",get_blend());
 		settings.set_value("circle.opacity",get_opacity());
-		settings.set_value("circle.bline_width", bline_width_dist.get_value().get_string());
-		settings.set_value("circle.feather", feather_dist.get_value().get_string());
+		settings.set_value("circle.bline_width", bline_width_dist.get_value());
+		settings.set_value("circle.feather", feather_dist.get_value());
 		settings.set_value("circle.number_of_bline_points",(int)(get_number_of_bline_points() + 0.5));
 		settings.set_value("circle.bline_point_angle_offset",get_bline_point_angle_offset());
 		settings.set_value("circle.invert",get_invert());

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -379,10 +379,7 @@ StateDraw_Context::load_settings()
 
 		set_opacity(settings.get_value("draw.opacity", 1.0));
 
-		set_bline_width(Distance(
-							settings.get_value("draw.bline_width", 1.0),
-							App::distance_system)
-						);
+		set_bline_width(settings.get_value("draw.bline_width", Distance("1.0px")));
 
 		set_pressure_width_flag(settings.get_value("draw.pressure_width", true));
 
@@ -406,10 +403,7 @@ StateDraw_Context::load_settings()
 
 		set_min_pressure(settings.get_value("draw.min_pressure", 0.0));
 
-		set_feather_size(Distance(
-							settings.get_value("draw.feather", 0.0),
-							App::distance_system)
-						);
+		set_feather_size(settings.get_value("draw.feather", Distance("0.0px")));
 
 		set_gthres(settings.get_value("draw.gthreshold", 0.7));
 
@@ -440,7 +434,7 @@ StateDraw_Context::save_settings()
 		settings.set_value("draw.id",get_id());
 		settings.set_value("draw.blend",get_blend());
 		settings.set_value("draw.opacity",get_opacity());
-		settings.set_value("draw.bline_width", bline_width_dist.get_value().get_string());
+		settings.set_value("draw.bline_width", bline_width_dist.get_value());
 		settings.set_value("draw.pressure_width",get_pressure_width_flag());
 		settings.set_value("draw.auto_loop",get_auto_loop_flag());
 		settings.set_value("draw.auto_extend",get_auto_extend_flag());
@@ -451,7 +445,7 @@ StateDraw_Context::save_settings()
 		settings.set_value("draw.layer_link_origins",get_layer_link_origins_flag());
 		settings.set_value("draw.auto_export",get_auto_export_flag());
 		settings.set_value("draw.min_pressure",get_min_pressure());
-		settings.set_value("draw.feather",feather_dist.get_value().get_string());
+		settings.set_value("draw.feather",feather_dist.get_value());
 		settings.set_value("draw.min_pressure_on",get_min_pressure_flag());
 		settings.set_value("draw.gthreshold",get_gthres());
 		settings.set_value("draw.widthmaxerror",get_width_max_error());

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -382,10 +382,7 @@ StateLasso_Context::load_settings()
 
 		set_opacity(settings.get_value("lasso.opacity", 1.0));
 
-		set_bline_width(Distance(
-							settings.get_value("lasso.bline_width", 1.0),
-							App::distance_system)
-						);
+		set_bline_width(settings.get_value("lasso.bline_width", Distance("1.0px")));
 
 		set_pressure_width_flag(settings.get_value("lasso.pressure_width", true));
 
@@ -403,10 +400,7 @@ StateLasso_Context::load_settings()
 
 		set_min_pressure(settings.get_value("lasso.min_pressure", 0.0));
 
-		set_feather_size(Distance(
-							settings.get_value("lasso.feather", 0.0),
-							App::distance_system)
-						);
+		set_feather_size(settings.get_value("lasso.feather", Distance("0.0px")));
 
 		set_gthres(settings.get_value("lasso.gthreshold", 0.7));
 
@@ -443,7 +437,7 @@ StateLasso_Context::save_settings()
 		settings.set_value("lasso.id",get_id());
 		settings.set_value("lasso.blend",int(Color::BLEND_ALPHA_OVER));
 		settings.set_value("lasso.opacity",get_opacity());
-		settings.set_value("lasso.bline_width", bline_width_dist.get_value().get_string());
+		settings.set_value("lasso.bline_width", bline_width_dist.get_value());
 		settings.set_value("lasso.pressure_width",get_pressure_width_flag());
 		settings.set_value("lasso.auto_loop",get_auto_loop_flag());
 		settings.set_value("lasso.auto_extend",get_auto_extend_flag());
@@ -453,7 +447,7 @@ StateLasso_Context::save_settings()
 		settings.set_value("lasso.advanced_outline",get_layer_advanced_outline_flag());
 		settings.set_value("lasso.auto_export",get_auto_export_flag());
 		settings.set_value("lasso.min_pressure",get_min_pressure());
-		settings.set_value("lasso.feather",feather_dist.get_value().get_string());
+		settings.set_value("lasso.feather",feather_dist.get_value());
 		settings.set_value("lasso.min_pressure_on",get_min_pressure_flag());
 		settings.set_value("lasso.gthreshold",get_gthres());
 		settings.set_value("lasso.widthmaxerror",get_width_max_error());

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -283,15 +283,9 @@ StatePolygon_Context::load_settings()
 
 		set_opacity(settings.get_value("polygon.opacity", 1.0));
 
-		set_bline_width(Distance(
-							settings.get_value("polygon.bline_width", 1.0),
-							App::distance_system)
-						);
+		set_bline_width(settings.get_value("polygon.bline_width", Distance("1.0px")));
 
-		set_feather_size(Distance(
-							settings.get_value("polygon.feather", 0.0),
-							App::distance_system)
-						);
+		set_feather_size(settings.get_value("polygon.feather", Distance("0.0px")));
 
 		set_invert(settings.get_value("polygon.invert", false));
 
@@ -331,8 +325,8 @@ StatePolygon_Context::save_settings()
 		settings.set_value("polygon.id",get_id());
 		settings.set_value("polygon.blend",get_blend());
 		settings.set_value("polygon.opacity",get_opacity());
-		settings.set_value("polygon.bline_width", bline_width_dist.get_value().get_string());
-		settings.set_value("polygon.feather", feather_dist.get_value().get_string());
+		settings.set_value("polygon.bline_width", bline_width_dist.get_value());
+		settings.set_value("polygon.feather", feather_dist.get_value());
 		settings.set_value("polygon.invert",get_invert());
 		settings.set_value("polygon.layer_polygon",get_layer_polygon_flag());
 		settings.set_value("polygon.layer_outline",get_layer_outline_flag());

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -295,20 +295,11 @@ StateRectangle_Context::load_settings()
 
 		set_opacity(settings.get_value("rectangle.opacity", 1.0));
 
-		set_bline_width(Distance(
-							settings.get_value("rectangle.bline_width", 1.0),
-							App::distance_system)
-						);
+		set_bline_width(settings.get_value("rectangle.bline_width", Distance("1.0px")));
 
-		set_expand_size(Distance(
-							settings.get_value("rectangle.expand", 0.0),
-							App::distance_system)
-						);
+		set_expand_size(settings.get_value("rectangle.expand", Distance("0.0px")));
 
-		set_feather_size(Distance(
-							settings.get_value("rectangle.feather", 0.0),
-							App::distance_system)
-						);
+		set_feather_size(settings.get_value("rectangle.feather", Distance("0.0px")));
 
 		set_invert(settings.get_value("rectangle.invert", false));
 
@@ -348,9 +339,9 @@ StateRectangle_Context::save_settings()
 		settings.set_value("rectangle.id",get_id());
 		settings.set_value("rectangle.blend",get_blend());
 		settings.set_value("rectangle.opacity",get_opacity());
-		settings.set_value("rectangle.bline_width", bline_width_dist.get_value().get_string());
-		settings.set_value("rectangle.expand",expand_dist.get_value().get_string());
-		settings.set_value("rectangle.feather", feather_dist.get_value().get_string());
+		settings.set_value("rectangle.bline_width", bline_width_dist.get_value());
+		settings.set_value("rectangle.expand",expand_dist.get_value());
+		settings.set_value("rectangle.feather", feather_dist.get_value());
 		settings.set_value("rectangle.invert",get_invert());
 		settings.set_value("rectangle.layer_rectangle",get_layer_rectangle_flag());
 		settings.set_value("rectangle.layer_outline",get_layer_outline_flag());

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -347,16 +347,9 @@ StateStar_Context::load_settings()
 
 		set_opacity(settings.get_value("star.opacity", 1.0));
 
-		set_bline_width(Distance(
-							settings.get_value("star.bline_width", 1.0),
-							App::distance_system)
-						);
+		set_bline_width(settings.get_value("star.bline_width", Distance("1.0px")));
 
-		set_feather_size(Distance(
-							settings.get_value("star.feather", 0.0),
-							App::distance_system)
-						);
-
+		set_feather_size(settings.get_value("star.feather", Distance("0.0px")));
 
 		set_number_of_points(settings.get_value("star.number_of_points", 5));
 
@@ -415,8 +408,8 @@ StateStar_Context::save_settings()
 		settings.set_value("star.id",get_id());
 		settings.set_value("star.blend",get_blend());
 		settings.set_value("star.opacity",get_opacity());
-		settings.set_value("star.bline_width", bline_width_dist.get_value().get_string());
-		settings.set_value("star.feather", feather_dist.get_value().get_string());
+		settings.set_value("star.bline_width", bline_width_dist.get_value());
+		settings.set_value("star.feather", feather_dist.get_value());
 		settings.set_value("star.number_of_points",(int)(get_number_of_points() + 0.5));
 		settings.set_value("star.inner_tangent",get_inner_tangent());
 		settings.set_value("star.outer_tangent",get_outer_tangent());

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -181,10 +181,7 @@ StateWidth_Context::load_settings()
 		//parse the arguments yargh!
 		set_delta(settings.get_value("width.delta", 6.0));
 
-		set_radius(Distance(
-							settings.get_value("width.radius", 60.0),
-							App::distance_system)
-						);
+		set_radius(settings.get_value("width.radius", Distance("60.0px")));
 
 		set_relative(settings.get_value("width.relative", false));
 	}
@@ -200,7 +197,7 @@ StateWidth_Context::save_settings()
 	try
 	{
 		settings.set_value("width.delta",get_delta());
-		settings.set_value("width.radius",influence_radius->get_value().get_string());
+		settings.set_value("width.radius",influence_radius->get_value());
 		settings.set_value("width.relative",get_relative());
 	}
 	catch(...)

--- a/synfig-studio/src/synfigapp/settings.cpp
+++ b/synfig-studio/src/synfigapp/settings.cpp
@@ -317,6 +317,13 @@ Settings::get_value(const synfig::String& key, bool default_value) const {
 	return value == "1" || value == "true";
 }
 
+synfig::Distance
+Settings::get_value(const synfig::String &key, const synfig::Distance &default_value) const
+{
+	synfig::String value;
+	return get_raw_value(key, value) ? Distance(value) : default_value;
+}
+
 synfig::String
 Settings::get_value(const synfig::String& key, const synfig::String& default_value) const {
 	synfig::String value;
@@ -350,6 +357,13 @@ bool
 Settings::set_value(const synfig::String &key, bool value)
 {
 	return set_value(key, value? "1" : "0");
+}
+
+bool
+Settings::set_value(const synfig::String &key, const synfig::Distance &value)
+{
+	ChangeLocale(LC_NUMERIC, "C");
+	return set_value(key, value.get_string());
 }
 
 bool

--- a/synfig-studio/src/synfigapp/settings.h
+++ b/synfig-studio/src/synfigapp/settings.h
@@ -34,7 +34,7 @@
 #include <map>
 
 #include <ETL/stringf>
-#include <synfig/general.h>
+#include <synfig/distance.h>
 #include <synfig/string.h>
 
 /* === M A C R O S ========================================================= */
@@ -70,12 +70,14 @@ public:
 	double get_value(const synfig::String& key, double default_value) const;
 	int get_value(const synfig::String& key, int default_value) const;
 	bool get_value(const synfig::String& key, bool default_value) const;
+	synfig::Distance get_value(const synfig::String& key, const synfig::Distance& default_value) const;
 	synfig::String get_value(const synfig::String& key, const synfig::String& default_value) const;
 	synfig::String get_value(const synfig::String& key, const char* default_value) const;
 
 	bool set_value(const synfig::String& key, double value);
 	bool set_value(const synfig::String& key, int value);
 	bool set_value(const synfig::String& key, bool value);
+	bool set_value(const synfig::String& key, const synfig::Distance& value);
 	bool set_value(const synfig::String& key, const char* value);
 	// avoid implicit conversion
 	template <typename T> bool set_value(const synfig::String& key, T value) = delete;


### PR DESCRIPTION
What of the two commits is best?

Many tools ignore the unit system a preference was saved - that may be different of current App preference when loaded...
So 1 pixel can become the gigantic 1u (60px).

Test it:
1. In `Preferences`, assure the Unit `System` is '`Pixels`'
2. Select `Bline Tool`
3. In `Tool Options Panel`, set `Brush Size` to `1.0 px`
4. Draw any Bline in Work Area
4. Change to `Normal Tool`
5. In `Preferences`, assure the Unit `System` is '`Units`'
6. (optional: close Synfig and reopen it)
6. Select `Bline Tool` again
7. Draw another Bline
8. It's way thicker than before. If you check `Tool Options Panel`, you'll see `Brush Size` as `1.0u`

Mentioned first here:
https://github.com/synfig/synfig/pull/2372#pullrequestreview-783987051
