### PR TITLE
Svg_parser: fix default fill color: black instead of none

### DIFF
--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -307,7 +307,7 @@ Svg_parser::parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style
 		Glib::ustring id  = nodeElement->get_attribute_value("id");
 
 		//style
-		String fill       = style.get("fill", "none");
+		String fill       = style.get("fill", "#000");
 		String stroke     = style.get("stroke", "none");
 
 		//Fill


### PR DESCRIPTION
SVG 1.1: 11.3 Fill Properties
SVG 2: 13.4.1. Specifying fill paint: the ‘fill’ property