### PR TITLE
Fixed build warnings

### DIFF
--- a/synfig-core/src/synfig/filesystemnative.h
+++ b/synfig-core/src/synfig/filesystemnative.h
@@ -54,7 +54,7 @@ namespace synfig
 			friend class FileSystemNative;
 			FILE *file_;
 			ReadStream(FileSystem::Handle file_system, FILE *file);
-			virtual size_t internal_read(void *buffer, size_t size);
+			size_t internal_read(void *buffer, size_t size) override;
 			std::istream::pos_type seekpos(std::istream::pos_type pos, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
 		public:
 			virtual ~ReadStream();

--- a/synfig-core/src/synfig/rendering/software/function/blur.cpp
+++ b/synfig-core/src/synfig/rendering/software/function/blur.cpp
@@ -41,7 +41,7 @@
 
 #include "blurtemplates.h"
 #include "fft.h"
-#include "blur_iir_coefficients.cpp"
+//#include "blur_iir_coefficients.cpp"
 #endif
 
 using namespace std;
@@ -544,7 +544,7 @@ software::Blur::blur_box(const Params &params)
 		params.blend_method,
 		params.amount );
 }
-
+/*
 software::Blur::IIRCoefficients
 software::Blur::get_iir_coefficients(Real radius)
 {
@@ -707,7 +707,7 @@ software::Blur::blur_iir(const Params &params)
 		params.blend,
 		params.blend_method,
 		params.amount );
-}
+}*/
 
 void
 software::Blur::blur(Params params)

--- a/synfig-core/src/synfig/target_multi.cpp
+++ b/synfig-core/src/synfig/target_multi.cpp
@@ -83,7 +83,7 @@ Target_Multi::set_rend_desc(RendDesc *d)
 }
 
 bool
-Target_Multi::init()
+Target_Multi::init(ProgressCallback*)
 {
 	return a->init() && b->init();
 }

--- a/synfig-core/src/synfig/target_multi.h
+++ b/synfig-core/src/synfig/target_multi.h
@@ -54,14 +54,14 @@ public:
 	Target_Multi(Target_Scanline::Handle a,Target_Scanline::Handle b);
 	virtual ~Target_Multi();
 	virtual bool add_frame(const synfig::Surface *surface, ProgressCallback *cb);
-	virtual bool start_frame(ProgressCallback *cb=NULL);
-	virtual void end_frame();
-	virtual Color * start_scanline(int scanline);
-	virtual bool end_scanline();
+	bool start_frame(ProgressCallback *cb = nullptr) override;
+	void end_frame() override;
+	Color * start_scanline(int scanline) override;
+	bool end_scanline() override;
 
-	virtual void set_canvas(etl::handle<Canvas> c);
-	virtual bool set_rend_desc(RendDesc *d);
-	virtual bool init();
+	void set_canvas(etl::handle<Canvas> c) override;
+	bool set_rend_desc(RendDesc* d) override;
+	bool init(ProgressCallback* cb = nullptr) override;
 }; // END of class Target_Multi
 
 }; // END of namespace synfig

--- a/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
@@ -112,7 +112,7 @@ synfig::ValueNode_RadialComposite::operator()(Time t)const
 	Type &type(get_type());
 	if (type == type_vector)
 	{
-		Real mag;
+		Real mag = 0.f;
 		Angle angle;
 		assert(components[0] && components[1]);
 		mag=(*components[0])(t).get(mag);

--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -77,7 +77,7 @@ remove_layers_inside_included_pastelayers(const std::list<Layer::Handle>& layer_
 	}
 
 	std::list<Layer::Handle> clean_layer_list;
-	for (const Layer::Handle layer : layer_list) {
+	for (const Layer::Handle& layer : layer_list) {
 		bool is_inside_a_selected_pastecanvas = false;
 		auto parent_paste_canvas = layer->get_parent_paste_canvas_layer();
 		while (parent_paste_canvas) {

--- a/synfig-studio/src/gui/dialogs/canvasoptions.h
+++ b/synfig-studio/src/gui/dialogs/canvasoptions.h
@@ -62,7 +62,7 @@ class CanvasOptions  :  public Gtk::Dialog
 
 	Gtk::CheckButton * toggle_time_snap;
 
-	const Glib::RefPtr<Gtk::Builder>& builder;
+	const Glib::RefPtr<Gtk::Builder> builder;
 	void set_canvas_view(CanvasView* canvas_view);
 public:
 	CanvasOptions(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& refGlade);

--- a/synfig-studio/src/gui/dialogs/dialog_workspaces.h
+++ b/synfig-studio/src/gui/dialogs/dialog_workspaces.h
@@ -38,7 +38,7 @@ namespace studio
 
 class Dialog_Workspaces : public Gtk::Dialog
 {
-	const Glib::RefPtr<Gtk::Builder>& builder;
+	const Glib::RefPtr<Gtk::Builder> builder;
 
 	Gtk::Button * rename_button;
 	Gtk::Button * delete_button;

--- a/synfig-studio/src/gui/widgets/widget_vector.cpp
+++ b/synfig-studio/src/gui/widgets/widget_vector.cpp
@@ -329,7 +329,7 @@ bool Widget_Vector::on_key_press_event(GdkEventKey* key_event)
 		}
 		return true;
 	}
-	if((key_event->keyval == GDK_KEY_ISO_Left_Tab)) // for Shift+Tab 
+	if (key_event->keyval == GDK_KEY_ISO_Left_Tab) // for Shift+Tab
 	{ 
 		if(entry_y->is_focus()){
 			entry_x->grab_focus();

--- a/synfig-studio/src/gui/widgets/widget_vector.h
+++ b/synfig-studio/src/gui/widgets/widget_vector.h
@@ -87,7 +87,7 @@ public:
 	void on_value_changed();
 	void on_entry_x_changed();
 	void on_entry_y_changed();
-	void on_grab_focus();
+	void on_grab_focus() override;
 
 	void set_value(const synfig::Vector &data);
 	const synfig::Vector &get_value();
@@ -98,7 +98,7 @@ public:
 	~Widget_Vector();
 
 protected:
-	void show_all_vfunc();
+	void show_all_vfunc() override;
 
 // Glade & GtkBuilder related
 public:

--- a/synfig-studio/src/synfigapp/actions/layerduplicate.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerduplicate.cpp
@@ -123,7 +123,7 @@ remove_layers_inside_included_pastelayers(const std::list<Layer::Handle>& layer_
 	}
 
 	std::list<Layer::Handle> clean_layer_list;
-	for (const Layer::Handle layer : layer_list) {
+	for (const Layer::Handle& layer : layer_list) {
 		bool is_inside_a_selected_pastecanvas = false;
 		auto parent_paste_canvas = layer->get_parent_paste_canvas_layer();
 		while (parent_paste_canvas) {


### PR DESCRIPTION
- warning: 'internal_read' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
- warning: variable 'mag' is uninitialized when passed as a const reference argument here [-Wuninitialized-const-reference]
- warning: loop variable 'layer' creates a copy from type 'const Layer::Handle' (aka 'const handle<synfig::Layer>') [-Wrange-loop-construct]
- warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
- commented unused `blur_iir_coefficients.cpp`