### PR TITLE
 Change #include to not... include... harfbuzz or fribidi folder

### DIFF
--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
@@ -46,8 +46,8 @@
 #include <glibmm.h>
 
 #if HAVE_HARFBUZZ
-#include <fribidi/fribidi.h>
-#include <harfbuzz/hb-ft.h>
+#include <fribidi.h>
+#include <hb-ft.h>
 #endif
 
 #include <synfig/canvasfilenaming.h>

--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.h
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.h
@@ -39,7 +39,7 @@
 #include FT_GLYPH_H
 
 #if HAVE_HARFBUZZ
-#include <harfbuzz/hb.h>
+#include <hb.h>
 #endif
 
 /* === M A C R O S ========================================================= */


### PR DESCRIPTION
From ice0 comment on PR #2424:

 For example, currently we are using #include <harfbuzz/hb.h> instead of <hb.h>
 but pkg-config returns `harfbuzz/include/harfbuzz`, not just `harfbuzz/include`.
 This works fine on Linux because all system libraries is already included by compiler.
 This need to be fixed. (TODO)

--

From ice0 comment on PR #2442:

 Please remove prefix from `fribidi` too.

```
pkg-config --cflags fribidi
-I/usr/include/fribidi
```