### PR TITLE
Autotools: remove code for very old libtool versions

### DIFF
--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -543,12 +543,6 @@ AC_SUBST(CXXFLAGS)
 AC_SUBST(CPPFLAGS)
 AC_SUBST(LDFLAGS)
 
-# AC_CONFIG_SUBDIRS(libltdl) is required for libtool 1.5.26 but must not be present for
-# libtool 2.2.4. Problem seems to be that AC_LIB_LTDL (above) now calls AC_CONFIG_SUBDIRS
-# itself, through LTDL_INIT, _LTDL_SETUP, _LTDL_MODE_DISPATCH. We need to check the
-# condition that libltdl has already been registered with AC_CONFIG_SUBDIRS:
-m4_ifdef([_AC_SEEN_TAG(libltdl)], [], [AC_CONFIG_SUBDIRS(libltdl)])
-
 CONFIG_LIBS="-lsynfig"
 CONFIG_CFLAGS="$CONFIG_CFLAGS"
 AC_SUBST(CONFIG_LIBS)


### PR DESCRIPTION
Version 2.2.6 was release in 2008!
https://savannah.gnu.org/forum/forum.php?forum_id=5439