### PR TITLE
Fixed crash when using Draw tool (Fedora/Flatpak)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(MSVC)
 	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 else()
 	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-inline-functions -fno-inline -g -O0 -Wall")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-inline-functions -fno-inline -g -O0 -Wall")
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-inline-functions -fno-inline -g -O0 -Wall -D_GLIBCXX_ASSERTIONS -U_GLIBCXX_USE_DEPRECATED")
 endif(MSVC)
 
 # This can be enabled once the address sanitization related errors are resolved.

--- a/synfig-studio/src/synfigapp/blineconvert.cpp
+++ b/synfig-studio/src/synfigapp/blineconvert.cpp
@@ -560,13 +560,12 @@ synfigapp::BLineConverter::operator()(std::list<synfig::BLinePoint>  &blinepoint
 
 		cum_dist.resize(point_cache.size()); this_dist.resize(point_cache.size());
 		Real d = 0;
-		for(unsigned int i = 0; i < point_cache.size();)
+		for(unsigned int i = 0; i < point_cache.size() - 1;)
 		{
 			d += (this_dist[i] = (p2-p1).mag());
 			cum_dist[i] = d;
 
 			p1=p2;
-			//! \todo is this legal?  it reads off the end of the vector
 			p2=point_cache[++i];
 		}
 	}


### PR DESCRIPTION
This issue is reproduced with Flatpak build and on Fedora.
The reason is that Fedora enables _GLIBCXX_ASSERTIONS  compile flag by default.
https://fedoraproject.org/wiki/Changes/HardeningFlags28

And Synfig crashes when reads off the end of the vector.

So I enabled this flag for CMake debug build too.
This will help us find such problems faster.