### PR TITLE
Added ability for escape key to close  editing box in Value column in the Parameters panel

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -180,15 +180,8 @@ public:
 		{
 			hide();
 			if (parent) parent->grab_focus();
-			if(!property_editing_canceled())
-			{
-				property_editing_canceled() = true;
-				Gtk::CellEditable::editing_done();
-			}
-			else
-			{
-				synfig::error("property_editing_canceled(): Called twice!");
-			}
+			property_editing_canceled() = true;
+			Gtk::CellEditable::editing_done();
 			return true;
 		}
 		return Gtk::EventBox::on_key_press_event(key_event);
@@ -695,22 +688,22 @@ CellRenderer_ValueBase::start_editing_vfunc(
 void
 CellRenderer_ValueBase::on_value_editing_done()
 {
+	if (value_entry && value_entry->property_editing_canceled())
+		return;
+		
 	if (edit_value_done_called)
 	{
 		synfig::error("on_value_editing_done(): Called twice!");
-		//return;
+//		return;
 	}
 
 	edit_value_done_called = true;
 
 	if (value_entry)
 	{
-		if (!value_entry->property_editing_canceled())
-		{
-			ValueBase value(value_entry->get_value());
+		ValueBase value(value_entry->get_value());
 
-			if (saved_data != value)
-				signal_edited_(value_entry->get_path(), value);
-		}
+		if (saved_data != value)
+			signal_edited_(value_entry->get_path(), value);
 	}
 }

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -181,7 +181,7 @@ public:
 			on_editing_done();
 			return true;
 		}
-		return Gtk::EventBox::on_key_release_event(key_event);
+		return Gtk::EventBox::on_key_press_event(key_event);
 		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 	}
 

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -687,8 +687,6 @@ CellRenderer_ValueBase::start_editing_vfunc(
 void
 CellRenderer_ValueBase::on_value_editing_done()
 {
-	std::cout<<"in on_value_editing_done()"<<std::endl;
-	std::cout<<value_entry->property_editing_canceled()<<std::endl;
 	if(value_entry->property_editing_canceled()){
 		CellRenderer::stop_editing(true);
 	}

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -111,7 +111,7 @@ public:
 			synfig::error("on_editing_done(): Called twice!");
 		}
 	}
-	
+
 	void set_parent(Gtk::Widget* x) { parent = x; }
 
 	void on_remove_widget()

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -75,14 +75,12 @@ class studio::ValueBase_Entry : public Gtk::CellEditable, public Gtk::EventBox
 	Widget_ValueBase *valuewidget;
 	Gtk::Widget      *parent;
 	bool              edit_done_called;
-	bool			  edit_canceled_called;
 public:
 	ValueBase_Entry():
 		Glib::ObjectBase(typeid(ValueBase_Entry))
 	{
 		parent           = nullptr;
 		edit_done_called = false;
-		edit_canceled_called = false;
 
 		valuewidget = manage(new class Widget_ValueBase());
 		valuewidget->inside_cellrenderer();
@@ -114,14 +112,16 @@ public:
 		}
 	}
 
+<<<<<<< HEAD
+=======
 	void on_editing_canceled()
 	{
 		hide();
 		if (parent) parent->grab_focus();
 		if (!edit_done_called)
 		{
-			edit_canceled_called = true;
-			//Gtk::CellEditable::on_editing_canceled();
+			edit_done_called = true;
+			Gtk::CellEditable::on_editing_done();
 		}
 		else
 		{
@@ -129,6 +129,7 @@ public:
 		}
 	}
 
+>>>>>>> parent of 17e6817e4 (changed L123 and L124)
 	void set_parent(Gtk::Widget* x) { parent = x; }
 
 	void on_remove_widget()
@@ -195,7 +196,7 @@ public:
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if(key_event->keyval == GDK_KEY_Escape)
 		{
-			on_editing_canceled();
+			on_editing_done();
 			return true;
 		}
 		return Gtk::EventBox::on_key_press_event(key_event);
@@ -279,7 +280,6 @@ CellRenderer_ValueBase::CellRenderer_ValueBase():
 	property_value_desc_      (*this, "value_desc",           synfigapp::ValueDesc()),
 	property_child_param_desc_(*this, "child_param_desc",        synfig::ParamDesc()),
 	edit_value_done_called    (false),
-	edit_value_canceled_called(false),
 	value_entry()
 {
 	CellRendererText::signal_edited().connect(sigc::mem_fun(*this,
@@ -617,7 +617,6 @@ CellRenderer_ValueBase::start_editing_vfunc(
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	edit_value_done_called = false;
-	edit_value_canceled_called = false;
 	// If we aren't editable, then there is nothing to do
 	if (!property_editable())
 		return nullptr;
@@ -694,8 +693,6 @@ CellRenderer_ValueBase::start_editing_vfunc(
 		value_entry->set_parent(&widget);
 		value_entry->show(); // in order to enable "instant"/"single-click" pop-up for enum comboboxes
 		value_entry->signal_editing_done().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_done));
-		CellRenderer::signal_editing_canceled().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_canceled));
-
 		return value_entry;
 	}
 
@@ -721,15 +718,4 @@ CellRenderer_ValueBase::on_value_editing_done()
 		if (saved_data != value)
 			signal_edited_(value_entry->get_path(), value);
 	}
-}
-
-void
-CellRenderer_ValueBase::on_value_editing_canceled()
-{
-	if (edit_value_canceled_called)
-	{
-		synfig::error("on_value_editing_canceled(): Called twice!");
-	}
-
-	edit_value_canceled_called = true;
 }

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -120,8 +120,8 @@ public:
 		if (parent) parent->grab_focus();
 		if (!edit_done_called)
 		{
-			edit_done_called = true;
-			Gtk::CellEditable::on_editing_done();
+			edit_canceled_called = true;
+			//Gtk::CellEditable::on_editing_canceled();
 		}
 		else
 		{

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -112,7 +112,7 @@ public:
 		}
 	}
 
-	bool on_key_release_event(GdkEventKey* key_event)
+	bool on_key_press_event(GdkEventKey* key_event)
 	{
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if(key_event->keyval == GDK_KEY_Escape) 
@@ -139,7 +139,7 @@ public:
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		valuewidget->signal_activate().connect(sigc::mem_fun(*this,
 			&studio::ValueBase_Entry::editing_done));
-		valuewidget->signal_key_press_event().connect(sigc::mem_fun(*this, &studio::ValueBase_Entry::on_key_release_event));
+		valuewidget->signal_key_press_event().connect(sigc::mem_fun(*this, &studio::ValueBase_Entry::on_key_press_event));
 
 		// popup combobox menu if its is a enum editor
 		if (event && event->type == GDK_BUTTON_PRESS && valuewidget) {
@@ -172,7 +172,7 @@ public:
 
 	bool on_event(GdkEvent *event)
 	{
-		SYNFIG_EXCEPTION_GUARD_BEGIN()		
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if (event->any.type == GDK_BUTTON_PRESS
 		 || event->any.type == GDK_2BUTTON_PRESS
 		 || event->any.type == GDK_KEY_PRESS

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -112,18 +112,6 @@ public:
 		}
 	}
 
-	bool on_key_press_event(GdkEventKey* key_event)
-	{
-		SYNFIG_EXCEPTION_GUARD_BEGIN()
-		if(key_event->keyval == GDK_KEY_Escape) 
-		{ 
-			on_editing_done();
-			return true;
-		}
-		return Gtk::EventBox::on_key_release_event(key_event);
-		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
-	}
-
 	void set_parent(Gtk::Widget* x) { parent = x; }
 
 	void on_remove_widget()
@@ -182,6 +170,18 @@ public:
 		 || event->any.type == GDK_3BUTTON_PRESS )
 			return true;
 		return Gtk::EventBox::on_event(event);
+		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
+	}
+
+	bool on_key_press_event(GdkEventKey* key_event)
+	{
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
+		if(key_event->keyval == GDK_KEY_Escape)
+		{
+			on_editing_done();
+			return true;
+		}
+		return Gtk::EventBox::on_key_release_event(key_event);
 		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 	}
 

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -690,7 +690,7 @@ CellRenderer_ValueBase::on_value_editing_done()
 {
 	if (value_entry && value_entry->property_editing_canceled())
 		return;
-		
+
 	if (edit_value_done_called)
 	{
 		synfig::error("on_value_editing_done(): Called twice!");

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -75,12 +75,14 @@ class studio::ValueBase_Entry : public Gtk::CellEditable, public Gtk::EventBox
 	Widget_ValueBase *valuewidget;
 	Gtk::Widget      *parent;
 	bool              edit_done_called;
+	bool			  edit_canceled_called;
 public:
 	ValueBase_Entry():
 		Glib::ObjectBase(typeid(ValueBase_Entry))
 	{
 		parent           = nullptr;
 		edit_done_called = false;
+		edit_canceled_called = false;
 
 		valuewidget = manage(new class Widget_ValueBase());
 		valuewidget->inside_cellrenderer();
@@ -109,6 +111,21 @@ public:
 		else
 		{
 			synfig::error("on_editing_done(): Called twice!");
+		}
+	}
+
+	void on_editing_canceled()
+	{
+		hide();
+		if (parent) parent->grab_focus();
+		if (!edit_done_called)
+		{
+			edit_done_called = true;
+			Gtk::CellEditable::on_editing_done();
+		}
+		else
+		{
+			synfig::error("on_editing_cancelled(): Called twice!");
 		}
 	}
 
@@ -178,7 +195,7 @@ public:
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if(key_event->keyval == GDK_KEY_Escape)
 		{
-			on_editing_done();
+			on_editing_canceled();
 			return true;
 		}
 		return Gtk::EventBox::on_key_press_event(key_event);
@@ -262,6 +279,7 @@ CellRenderer_ValueBase::CellRenderer_ValueBase():
 	property_value_desc_      (*this, "value_desc",           synfigapp::ValueDesc()),
 	property_child_param_desc_(*this, "child_param_desc",        synfig::ParamDesc()),
 	edit_value_done_called    (false),
+	edit_value_canceled_called(false),
 	value_entry()
 {
 	CellRendererText::signal_edited().connect(sigc::mem_fun(*this,
@@ -599,6 +617,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	edit_value_done_called = false;
+	edit_value_canceled_called = false;
 	// If we aren't editable, then there is nothing to do
 	if (!property_editable())
 		return nullptr;
@@ -675,6 +694,8 @@ CellRenderer_ValueBase::start_editing_vfunc(
 		value_entry->set_parent(&widget);
 		value_entry->show(); // in order to enable "instant"/"single-click" pop-up for enum comboboxes
 		value_entry->signal_editing_done().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_done));
+		CellRenderer::signal_editing_canceled().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_canceled));
+
 		return value_entry;
 	}
 
@@ -700,4 +721,15 @@ CellRenderer_ValueBase::on_value_editing_done()
 		if (saved_data != value)
 			signal_edited_(value_entry->get_path(), value);
 	}
+}
+
+void
+CellRenderer_ValueBase::on_value_editing_canceled()
+{
+	if (edit_value_canceled_called)
+	{
+		synfig::error("on_value_editing_canceled(): Called twice!");
+	}
+
+	edit_value_canceled_called = true;
 }

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -178,6 +178,7 @@ public:
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if(key_event->keyval == GDK_KEY_Escape)
 		{
+			property_editing_canceled() = true;
 			on_editing_done();
 			return true;
 		}
@@ -675,6 +676,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 		value_entry->set_parent(&widget);
 		value_entry->show(); // in order to enable "instant"/"single-click" pop-up for enum comboboxes
 		value_entry->signal_editing_done().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_done));
+		CellRenderer::signal_editing_canceled().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_done));
 		return value_entry;
 	}
 
@@ -685,19 +687,27 @@ CellRenderer_ValueBase::start_editing_vfunc(
 void
 CellRenderer_ValueBase::on_value_editing_done()
 {
+	std::cout<<"in on_value_editing_done()"<<std::endl;
+	std::cout<<value_entry->property_editing_canceled()<<std::endl;
+	if(value_entry->property_editing_canceled()){
+		CellRenderer::stop_editing(true);
+	}
+
 	if (edit_value_done_called)
 	{
 		synfig::error("on_value_editing_done(): Called twice!");
-//		return;
+		//return;
 	}
 
 	edit_value_done_called = true;
 
-	if (value_entry)
-	{
-		ValueBase value(value_entry->get_value());
+	if(!value_entry->property_editing_canceled()){
+		if (value_entry)
+		{
+			ValueBase value(value_entry->get_value());
 
-		if (saved_data != value)
-			signal_edited_(value_entry->get_path(), value);
+			if (saved_data != value)
+				signal_edited_(value_entry->get_path(), value);
+		}
 	}
 }

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -181,7 +181,7 @@ public:
 			hide();
 			if (parent) parent->grab_focus();
 			property_editing_canceled() = true;
-			Gtk::CellEditable::editing_done();
+			editing_done();
 			return true;
 		}
 		return Gtk::EventBox::on_key_press_event(key_event);

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -703,9 +703,9 @@ CellRenderer_ValueBase::on_value_editing_done()
 
 	edit_value_done_called = true;
 
-	if(!value_entry->property_editing_canceled())
+	if (value_entry)
 	{
-		if (value_entry)
+		if (!value_entry->property_editing_canceled())
 		{
 			ValueBase value(value_entry->get_value());
 

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -112,6 +112,21 @@ public:
 		}
 	}
 
+	bool on_key_release_event(GdkEventKey* key_event)
+{
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
+	std::cout<<"IN KEY_RELEASE_EVENT"<<std::endl;
+	if(key_event->keyval == GDK_KEY_Escape) 
+	{ 
+		std::cout<<"*********IN GDK_KEY_Escape**********"<<std::endl;
+		on_editing_done();
+		return false;//TODO: SHOULD THIS BE FALSE OR TRUE??
+	}
+		
+	return Gtk::EventBox::on_key_release_event(key_event);
+	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
+}
+
 	void set_parent(Gtk::Widget* x) { parent = x; }
 
 	void on_remove_widget()
@@ -159,7 +174,17 @@ public:
 
 	bool on_event(GdkEvent *event)
 	{
+		std::cout<<event->any.type<<std::endl;
+		//TODO: CHECK THIS FUNCTION
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
+		
+		if(event->any.type == GDK_KEY_RELEASE){ //&& ((GdkEventKey*)event)->keyval == GDK_KEY_Escape ){
+		//	if(event->any.type == ((GdkEventKey*)event)->keyval)
+			std::cout<<((GdkEventKey*)event)->keyval<<std::endl;
+			//on_editing_done();
+			return false;
+		}
+				
 		if (event->any.type == GDK_BUTTON_PRESS
 		 || event->any.type == GDK_2BUTTON_PRESS
 		 || event->any.type == GDK_KEY_PRESS
@@ -583,6 +608,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 	const Gdk::Rectangle&  /*cell_area*/,
 	Gtk::CellRendererState /*flags*/)
 {
+		std::cout<<"in CellRenderer_ValueBase::start_editing_vfunc L583"<<std::endl;
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	edit_value_done_called = false;
 	// If we aren't editable, then there is nothing to do

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -178,8 +178,17 @@ public:
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if(key_event->keyval == GDK_KEY_Escape)
 		{
-			property_editing_canceled() = true;
-			on_editing_done();
+			hide();
+			if (parent) parent->grab_focus();
+			if(!property_editing_canceled())
+			{
+				property_editing_canceled() = true;
+				Gtk::CellEditable::editing_done();	
+			}
+			else
+			{
+				synfig::error("property_editing_canceled(): Called twice!");
+			}
 			return true;
 		}
 		return Gtk::EventBox::on_key_press_event(key_event);
@@ -686,10 +695,6 @@ CellRenderer_ValueBase::start_editing_vfunc(
 void
 CellRenderer_ValueBase::on_value_editing_done()
 {
-	if(value_entry->property_editing_canceled()){
-		CellRenderer::stop_editing(true);
-	}
-
 	if (edit_value_done_called)
 	{
 		synfig::error("on_value_editing_done(): Called twice!");
@@ -698,7 +703,8 @@ CellRenderer_ValueBase::on_value_editing_done()
 
 	edit_value_done_called = true;
 
-	if(!value_entry->property_editing_canceled()){
+	if(!value_entry->property_editing_canceled())
+	{
 		if (value_entry)
 		{
 			ValueBase value(value_entry->get_value());

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -183,7 +183,7 @@ public:
 			if(!property_editing_canceled())
 			{
 				property_editing_canceled() = true;
-				Gtk::CellEditable::editing_done();	
+				Gtk::CellEditable::editing_done();
 			}
 			else
 			{

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -113,19 +113,16 @@ public:
 	}
 
 	bool on_key_release_event(GdkEventKey* key_event)
-{
-	SYNFIG_EXCEPTION_GUARD_BEGIN()
-	std::cout<<"IN KEY_RELEASE_EVENT"<<std::endl;
-	if(key_event->keyval == GDK_KEY_Escape) 
-	{ 
-		std::cout<<"*********IN GDK_KEY_Escape**********"<<std::endl;
-		on_editing_done();
-		return false;//TODO: SHOULD THIS BE FALSE OR TRUE??
+	{
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
+		if(key_event->keyval == GDK_KEY_Escape) 
+		{ 
+			on_editing_done();
+			return true;
+		}
+		return Gtk::EventBox::on_key_release_event(key_event);
+		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 	}
-		
-	return Gtk::EventBox::on_key_release_event(key_event);
-	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
-}
 
 	void set_parent(Gtk::Widget* x) { parent = x; }
 
@@ -142,6 +139,7 @@ public:
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		valuewidget->signal_activate().connect(sigc::mem_fun(*this,
 			&studio::ValueBase_Entry::editing_done));
+		valuewidget->signal_key_press_event().connect(sigc::mem_fun(*this, &studio::ValueBase_Entry::on_key_release_event));
 
 		// popup combobox menu if its is a enum editor
 		if (event && event->type == GDK_BUTTON_PRESS && valuewidget) {
@@ -174,17 +172,7 @@ public:
 
 	bool on_event(GdkEvent *event)
 	{
-		std::cout<<event->any.type<<std::endl;
-		//TODO: CHECK THIS FUNCTION
-		SYNFIG_EXCEPTION_GUARD_BEGIN()
-		
-		if(event->any.type == GDK_KEY_RELEASE){ //&& ((GdkEventKey*)event)->keyval == GDK_KEY_Escape ){
-		//	if(event->any.type == ((GdkEventKey*)event)->keyval)
-			std::cout<<((GdkEventKey*)event)->keyval<<std::endl;
-			//on_editing_done();
-			return false;
-		}
-				
+		SYNFIG_EXCEPTION_GUARD_BEGIN()		
 		if (event->any.type == GDK_BUTTON_PRESS
 		 || event->any.type == GDK_2BUTTON_PRESS
 		 || event->any.type == GDK_KEY_PRESS
@@ -608,7 +596,6 @@ CellRenderer_ValueBase::start_editing_vfunc(
 	const Gdk::Rectangle&  /*cell_area*/,
 	Gtk::CellRendererState /*flags*/)
 {
-		std::cout<<"in CellRenderer_ValueBase::start_editing_vfunc L583"<<std::endl;
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	edit_value_done_called = false;
 	// If we aren't editable, then there is nothing to do

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -676,7 +676,6 @@ CellRenderer_ValueBase::start_editing_vfunc(
 		value_entry->set_parent(&widget);
 		value_entry->show(); // in order to enable "instant"/"single-click" pop-up for enum comboboxes
 		value_entry->signal_editing_done().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_done));
-		CellRenderer::signal_editing_canceled().connect(sigc::mem_fun(*this, &CellRenderer_ValueBase::on_value_editing_done));
 		return value_entry;
 	}
 

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -111,25 +111,7 @@ public:
 			synfig::error("on_editing_done(): Called twice!");
 		}
 	}
-
-<<<<<<< HEAD
-=======
-	void on_editing_canceled()
-	{
-		hide();
-		if (parent) parent->grab_focus();
-		if (!edit_done_called)
-		{
-			edit_done_called = true;
-			Gtk::CellEditable::on_editing_done();
-		}
-		else
-		{
-			synfig::error("on_editing_cancelled(): Called twice!");
-		}
-	}
-
->>>>>>> parent of 17e6817e4 (changed L123 and L124)
+	
 	void set_parent(Gtk::Widget* x) { parent = x; }
 
 	void on_remove_widget()

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
@@ -66,6 +66,7 @@ class CellRenderer_ValueBase : public Gtk::CellRendererText
 	void color_edited   (synfig::Color    color,     Glib::ustring path);
 
 	bool edit_value_done_called;
+	bool edit_value_canceled_called;
 
 	synfig::ValueBase saved_data; //Issues 659, 526, 520
 public:
@@ -93,6 +94,7 @@ public:
 	ValueBase_Entry *value_entry;
 
 	void on_value_editing_done();
+	void on_value_editing_canceled();
 
 protected:
 	virtual void

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
@@ -66,7 +66,6 @@ class CellRenderer_ValueBase : public Gtk::CellRendererText
 	void color_edited   (synfig::Color    color,     Glib::ustring path);
 
 	bool edit_value_done_called;
-	bool edit_value_canceled_called;
 
 	synfig::ValueBase saved_data; //Issues 659, 526, 520
 public:
@@ -94,7 +93,6 @@ public:
 	ValueBase_Entry *value_entry;
 
 	void on_value_editing_done();
-	void on_value_editing_canceled();
 
 protected:
 	virtual void


### PR DESCRIPTION
#2411

I added changes in ```cellrenderer_value.cpp```.  I added the ```on_key_press_event``` method to check for escape key and call ```on_editing_done()```. I also had to add the ```signal_key_press_event()``` for the value widget.

@ice0 @rodolforg Hey guys can you check out these changes? Thanks again for all the advice to get me started.