### PR TITLE
Fixed appdata.xml check CI

### DIFF
--- a/.github/workflows/synfig-tests.yml
+++ b/.github/workflows/synfig-tests.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: "Synfig Studio (Check appdata.xml)"
         run: |
+          sudo apt update
           sudo apt install flatpak
           sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
           sudo flatpak install flathub org.freedesktop.appstream-glib -y


### PR DESCRIPTION
It is currently fails with an error:

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/f/flatpak/flatpak_1.0.9-0ubuntu0.3_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```