### PR TITLE
make UIInterface::confirmation() implementation consistent to signature

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -341,8 +341,8 @@ public:
 	virtual Response confirmation(
 			const std::string &message,
 			const std::string &details,
-			const std::string &cancel,
 			const std::string &confirm,
+			const std::string &cancel,
 			Response dflt
 	)
 	{
@@ -1661,8 +1661,8 @@ App::App(const synfig::String& basepath, int *argc, char ***argv):
 			if (get_ui_interface()->confirmation(
 					_("Auto recovery file(s) found. Do you want to recover unsaved changes?"),
 					_("Synfig Studio seems to have crashed before you could save all your files."),
-					_("Ignore"),
-					_("Recover")
+					_("Recover"),
+					_("Ignore")
 				) == synfigapp::UIInterface::RESPONSE_OK)
 			{
 				int number_recovered;

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -158,8 +158,8 @@ public:
 	virtual Response confirmation(
 			const std::string &message,
 			const std::string &details,
-			const std::string &cancel,
 			const std::string &confirm,
+			const std::string &cancel,
 			Response dflt = RESPONSE_OK )
 	{
 		view->present();
@@ -3928,8 +3928,8 @@ CanvasView::toggle_jack_button()
 		UIInterface::Response answer = get_ui_interface()->confirmation(
 			message,
 			details,
-			_("No"),
 			_("Yes"),
+			_("No"),
 			UIInterface::RESPONSE_OK );
 		if (answer == UIInterface::RESPONSE_OK)
 			set_jack_enabled(!get_jack_enabled());

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -246,8 +246,8 @@ studio::Instance::run_plugin(std::string plugin_id, bool modify_canvas, std::vec
 		int answer = uim->confirmation(
 					message,
 					details,
-					_("Cancel"),
 					_("Proceed"),
+					_("Cancel"),
 					synfigapp::UIInterface::RESPONSE_OK);
 
 		if(answer != synfigapp::UIInterface::RESPONSE_OK)

--- a/synfig-studio/src/synfigapp/action_system.cpp
+++ b/synfig-studio/src/synfigapp/action_system.cpp
@@ -119,8 +119,8 @@ Action::System::perform_action(etl::handle<Action::Base> action)
 		UIInterface::Response response = uim->confirmation(
 			message,
 			details,
-			_("Cancel"),
 			_("Continue"),
+			_("Cancel"),
 			UIInterface::RESPONSE_CANCEL );
 		if (response == UIInterface::RESPONSE_CANCEL)
 			return false;

--- a/synfig-studio/src/synfigapp/actions/valuedescbonelink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescbonelink.cpp
@@ -205,8 +205,8 @@ Action::ValueDescBoneLink::prepare()
 						 etl::strprintf(_("You are trying to link \"origin\" of layer '%s' to a bone.\n\n"
 							"Maybe you intended to link \"transformation\" parameter instead?"),
 							 layer->get_description().c_str()),
-						 _("No"),
 						 _("Yes"),
+						 _("No"),
 						 synfigapp::UIInterface::RESPONSE_OK ))
 				{
 					value_desc = ValueDesc(value_desc.get_layer(), "transformation", value_desc.get_parent_desc());

--- a/synfig-studio/src/synfigapp/actions/valuedescset.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescset.cpp
@@ -923,8 +923,8 @@ Action::ValueDescSet::prepare()
 						  || UIInterface::RESPONSE_OK != get_canvas_interface()->get_ui_interface()->confirmation(
 								 _("You are trying to edit animated parameter while Animation Mode is off.\n\nDo you want to apply offset to this animation?" ),
 								 _("Hint: You can hold Spacebar key while editing parameter to avoid this confirmation dialog."),
-								 _("No"),
 								 _("Yes"),
+								 _("No"),
 								 synfigapp::UIInterface::RESPONSE_OK ))
 						{
 							throw Error(Error::TYPE_UNABLE); // Issue  #693


### PR DESCRIPTION
Base class synfigapp::UIInterface has this method signature:
```
virtual Response confirmation(
			const std::string &message,
			const std::string &details,
			const std::string &confirm,
			const std::string &cancel,
			Response dflt = RESPONSE_OK
) = 0;
```

Somehow the order of button label text parameters was changed for:
- `GlobalUIInterface` (app.cpp)
- `CanvasViewUIInterface` (canvasview.cpp)

And, for that reason, calls from `synfigapp::Action` may have wrong
default responses.