### PR TITLE
refactor: move non-portable popen code to one place

### DIFF
--- a/synfig-core/po/POTFILES.in
+++ b/synfig-core/po/POTFILES.in
@@ -258,6 +258,8 @@ src/synfig/module.cpp
 src/synfig/module.h
 src/synfig/node.cpp
 src/synfig/node.h
+src/synfig/os.cpp
+src/synfig/os.h
 src/synfig/palette.cpp
 src/synfig/palette.h
 src/synfig/paramdesc.cpp

--- a/synfig-core/src/modules/mod_dv/trgt_dv.cpp
+++ b/synfig-core/src/modules/mod_dv/trgt_dv.cpp
@@ -122,8 +122,8 @@ dv_trgt::init(synfig::ProgressCallback * /* cb */)
 	OS::RunArgs args;
 
 	if (wide_aspect)
-		args.push_pair("-w", "1");
-	args.push("-");
+		args.push_back({"-w", "1"});
+	args.push_back("-");
 
 	pipe = OS::run_async("encodedv", args, OS::RUN_MODE_WRITE, {"", filename, ""});
 	if (!pipe || !pipe->is_writable()) {

--- a/synfig-core/src/modules/mod_dv/trgt_dv.cpp
+++ b/synfig-core/src/modules/mod_dv/trgt_dv.cpp
@@ -40,20 +40,6 @@
 
 #include <glib/gstdio.h>
 #include "trgt_dv.h"
-#include <cstdio>
-#include <sys/types.h>
-#if HAVE_SYS_WAIT_H
- #include <sys/wait.h>
-#endif
-#if HAVE_IO_H
- #include <io.h>
-#endif
-#if HAVE_PROCESS_H
- #include <process.h>
-#endif
-#if HAVE_FCNTL_H
- #include <fcntl.h>
-#endif
 #include <algorithm>
 #include <thread>
 
@@ -63,13 +49,6 @@
 
 using namespace synfig;
 using namespace etl;
-
-#if defined(HAVE_FORK) && defined(HAVE_PIPE) && defined(HAVE_WAITPID)
- #define UNIX_PIPE_TO_PROCESSES
- #include <unistd.h>
-#else
- #define WIN32_PIPE_TO_PROCESSES
-#endif
 
 /* === G L O B A L S ======================================================= */
 
@@ -84,7 +63,7 @@ SYNFIG_TARGET_SET_VERSION(dv_trgt,"0.1");
 dv_trgt::dv_trgt(const char *Filename, const synfig::TargetParam & /* params */):
 	imagecount(0),
 	wide_aspect(false),
-	file(nullptr),
+	pipe(nullptr),
 	filename(Filename),
 	buffer(nullptr),
 	color_buffer(nullptr)
@@ -94,16 +73,7 @@ dv_trgt::dv_trgt(const char *Filename, const synfig::TargetParam & /* params */)
 
 dv_trgt::~dv_trgt()
 {
-	if(file){
-#if defined(WIN32_PIPE_TO_PROCESSES)
-		_pclose(file);
-#elif defined(UNIX_PIPE_TO_PROCESSES)
-		fclose(file);
-		int status;
-		waitpid(pid,&status,0);
-#endif
-	}
-	file=nullptr;
+	pipe = nullptr;
 	delete [] buffer;
 	delete [] color_buffer;
 }
@@ -149,90 +119,17 @@ dv_trgt::init(synfig::ProgressCallback * /* cb */)
 {
 	imagecount=desc.get_frame_start();
 
-#if defined(WIN32_PIPE_TO_PROCESSES)
+	OS::RunArgs args;
 
-	std::string command;
+	if (wide_aspect)
+		args.push_pair("-w", "1");
+	args.push("-");
 
-	if(wide_aspect)
-		command=strprintf("encodedv -w 1 - > \"%s\"\n",filename.c_str());
-	else
-		command=strprintf("encodedv - > \"%s\"\n",filename.c_str());
-
-	// Open the pipe to encodedv
-	file = _popen(command.c_str(), POPEN_BINARY_WRITE_TYPE);
-
-	if(!file)
-	{
+	pipe = OS::run_async("encodedv", args, OS::RUN_MODE_WRITE, {"", filename, ""});
+	if (!pipe || !pipe->is_writable()) {
 		synfig::error(_("Unable to open pipe to encodedv"));
 		return false;
 	}
-
-#elif defined(UNIX_PIPE_TO_PROCESSES)
-
-	int p[2];
-
-	if (pipe(p)) {
-		synfig::error(_("Unable to open pipe to encodedv"));
-		return false;
-	};
-
-	pid_t pid = fork();
-
-	if (pid == -1) {
-		synfig::error(_("Unable to open pipe to encodedv"));
-		return false;
-	}
-
-	if (pid == 0){
-		// Child process
-		// Close pipeout, not needed
-		close(p[1]);
-		// Dup pipeout to stdin
-		if( dup2( p[0], STDIN_FILENO ) == -1 ){
-			synfig::error(_("Unable to open pipe to encodedv"));
-			return false;
-		}
-		// Close the unneeded pipeout
-		close(p[0]);
-		// Open filename to stdout
-		FILE* outfile = g_fopen(filename.c_str(),"wb");
-		if(!outfile){
-			synfig::error(_("Unable to open pipe to encodedv"));
-			return false;
-		}
-		int outfilefd = fileno(outfile);
-		if( outfilefd == -1 ){
-			synfig::error(_("Unable to open pipe to encodedv"));
-			return false;
-		}
-		if( dup2( outfilefd, STDOUT_FILENO ) == -1 ){
-			synfig::error(_("Unable to open pipe to encodedv"));
-			return false;
-		}
-
-		if(wide_aspect)
-			execlp("encodedv", "encodedv", "-w", "1", "-", (const char*)nullptr);
-		else
-			execlp("encodedv", "encodedv", "-", (const char*)nullptr);
-		// We should never reach here unless the exec failed
-		synfig::error(_("Unable to open pipe to encodedv"));
-		return false;
-	} else {
-		// Parent process
-		// Close pipein, not needed
-		close(p[0]);
-		// Save pipeout to file handle, will write to it later
-		file = fdopen(p[1], "wb");
-		if (!file) {
-			synfig::error(_("Unable to open pipe to encodedv"));
-			return false;
-		}
-	}
-
-#else
-	#error There are no known APIs for creating child processes
-#endif
-
 
 	// Sleep for a moment to let the pipe catch up
 	std::this_thread::sleep_for(std::chrono::milliseconds(25));
@@ -243,8 +140,8 @@ dv_trgt::init(synfig::ProgressCallback * /* cb */)
 void
 dv_trgt::end_frame()
 {
-	fprintf(file, " ");
-	fflush(file);
+	pipe->printf(" ");
+	pipe->flush();
 	imagecount++;
 }
 
@@ -253,12 +150,12 @@ dv_trgt::start_frame(synfig::ProgressCallback */*callback*/)
 {
 	int w=desc.get_w(),h=desc.get_h();
 
-	if(!file)
+	if (!pipe)
 		return false;
 
-	fprintf(file, "P6\n");
-	fprintf(file, "%d %d\n", w, h);
-	fprintf(file, "%d\n", 255);
+	pipe->printf("P6\n");
+	pipe->printf("%d %d\n", w, h);
+	pipe->printf("%d\n", 255);
 
 	delete [] buffer;
 	buffer=new unsigned char[3*w];
@@ -278,12 +175,12 @@ dv_trgt::start_scanline(int /*scanline*/)
 bool
 dv_trgt::end_scanline()
 {
-	if(!file)
+	if (!pipe)
 		return false;
 
 	color_to_pixelformat(buffer, color_buffer, PF_RGB, 0, desc.get_w());
 
-	if(!fwrite(buffer,1,desc.get_w()*3,file))
+	if (!pipe->write(buffer, 1, desc.get_w() * 3))
 		return false;
 
 	return true;

--- a/synfig-core/src/modules/mod_dv/trgt_dv.h
+++ b/synfig-core/src/modules/mod_dv/trgt_dv.h
@@ -30,10 +30,9 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <synfig/target_scanline.h>
+#include <synfig/os.h>
 #include <synfig/string.h>
-#include <sys/types.h>
-#include <cstdio>
+#include <synfig/target_scanline.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -47,13 +46,9 @@ class dv_trgt : public synfig::Target_Scanline
 	SYNFIG_TARGET_MODULE_EXT
 
 private:
-
-#ifdef HAVE_FORK
-	pid_t pid = -1;
-#endif
 	int imagecount;
 	bool wide_aspect;
-	FILE *file;
+	synfig::OS::RunPipe::Handle pipe;
 	synfig::String filename;
 	unsigned char *buffer;
 	synfig::Color *color_buffer;

--- a/synfig-core/src/modules/mod_ffmpeg/mptr_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/mptr_ffmpeg.cpp
@@ -85,13 +85,14 @@ ffmpeg_mptr::seek_to(const Time& time)
 		const std::string position = time.get_string(Time::FORMAT_NORMAL);
 
 		OS::RunArgs args;
-		args.push_pair("-ss", position);
-		args.push_pair_filename("-i", identifier.filename);
-		args.push_pair("-vframes", "1");
-		args.push("-an");
-		args.push_pair("-f", "image2pipe");
-		args.push_pair("-vcodec", "ppm");
-		args.push("-");
+		args.push_back({"-ss", position});
+		args.push_back("-i");
+		args.push_back(filesystem::Path(identifier.filename));
+		args.push_back({"-vframes", "1"});
+		args.push_back("-an");
+		args.push_back({"-f", "image2pipe"});
+		args.push_back({"-vcodec", "ppm"});
+		args.push_back("-");
 
 #ifdef _WIN32
 		String binary_path = synfig::get_binary_path("");

--- a/synfig-core/src/modules/mod_ffmpeg/mptr_ffmpeg.h
+++ b/synfig-core/src/modules/mod_ffmpeg/mptr_ffmpeg.h
@@ -31,13 +31,13 @@
 /* === H E A D E R S ======================================================= */
 
 #include <synfig/importer.h>
-#include <sys/types.h>
-#include <cstdio>
+#include <synfig/os.h>
+#include <synfig/surface.h>
+
 #ifdef HAVE_TERMIOS_H
 #include <termios.h>
 #endif
 
-#include <synfig/surface.h>
 /* === M A C R O S ========================================================= */
 
 /* === T Y P E D E F S ===================================================== */
@@ -47,12 +47,8 @@
 class ffmpeg_mptr : public synfig::Importer
 {
 	SYNFIG_IMPORTER_MODULE_EXT
-public:
 private:
-#ifdef HAVE_FORK
-	pid_t pid = -1;
-#endif
-	FILE *file;
+	synfig::OS::RunPipe::Handle pipe;
 	int cur_frame;
 	synfig::Surface frame;
 	float fps;

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -184,7 +184,7 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 	const std::vector<std::string> binary_choices = {"ffmpeg", "avconv"};
 	for (const auto& bin_name : binary_choices) {
 		OS::RunArgs args;
-		args.push_filename(bin_name);
+		args.push_back(bin_name);
 		OS::RunPipe::Handle pipe = OS::run_async("which", args, OS::RUN_MODE_READ);
 		if (!pipe) {
 			synfig::error(_("%s: Internal error: couldn't run 'which' async"), "trgt_ffmpeg");
@@ -215,59 +215,59 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 
 	OS::RunArgs vargs;
 	if (with_sound) {
-		vargs.push("-i");
-		vargs.push_filename(sound_filename);
+		vargs.push_back("-i");
+		vargs.push_back(filesystem::Path(sound_filename));
 	}
-	vargs.push("-f");
-	vargs.push("image2pipe");
-	vargs.push("-vcodec");
-	vargs.push(use_alpha ? "pam" : "ppm");
-	vargs.push("-r");
+	vargs.push_back("-f");
+	vargs.push_back("image2pipe");
+	vargs.push_back("-vcodec");
+	vargs.push_back(use_alpha ? "pam" : "ppm");
+	vargs.push_back("-r");
 	{
 		// this should avoid conflicts with locale settings
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		vargs.push("%f", desc.get_frame_rate());
+		vargs.push_back(strprintf("%f", desc.get_frame_rate()));
 	}
-	vargs.push("-i");
-	vargs.push("pipe:");
-	vargs.push("-metadata");
-	vargs.push("title=\"%s\"", get_canvas()->get_name().c_str());
-	vargs.push("-vcodec");
-	vargs.push(video_codec_real);
-	vargs.push("-b:v");
-	vargs.push("%ik", bitrate);
+	vargs.push_back("-i");
+	vargs.push_back("pipe:");
+	vargs.push_back("-metadata");
+	vargs.push_back(strprintf("title=\"%s\"", get_canvas()->get_name().c_str()));
+	vargs.push_back("-vcodec");
+	vargs.push_back(video_codec_real);
+	vargs.push_back("-b:v");
+	vargs.push_back(strprintf("%ik", bitrate));
 	if (video_codec == "libx264-lossless") {
-		vargs.push("-tune");
-		vargs.push("fastdecode");
-		vargs.push("-pix_fmt");
-		vargs.push(use_alpha ? "yuva420p" : "yuv420p");
-		vargs.push("-qp");
-		vargs.push("0");
+		vargs.push_back("-tune");
+		vargs.push_back("fastdecode");
+		vargs.push_back("-pix_fmt");
+		vargs.push_back(use_alpha ? "yuva420p" : "yuv420p");
+		vargs.push_back("-qp");
+		vargs.push_back("0");
 	} else if (use_alpha){
 		if (video_codec == "hap") {
-			vargs.push("-format");
-			vargs.push("hap_alpha");
+			vargs.push_back("-format");
+			vargs.push_back("hap_alpha");
 		}
-		vargs.push("-pix_fmt");
-		vargs.push("yuva420p");
+		vargs.push_back("-pix_fmt");
+		vargs.push_back("yuva420p");
 	}
 	if (with_sound) {
-		vargs.push("-acodec");
+		vargs.push_back("-acodec");
 		// MPEG-1 cannot work with 'le' audio, it requires 'be'
-		vargs.push(video_codec == "mpeg1video" ? "pcm_s16be" : "pcm_s16le");
+		vargs.push_back(video_codec == "mpeg1video" ? "pcm_s16be" : "pcm_s16le");
 	}
-	vargs.push("-y");
-	vargs.push("-t");
+	vargs.push_back("-y");
+	vargs.push_back("-t");
 	{
 		// this should avoid conflicts with locale settings
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		vargs.push((desc.get_time_end()-desc.get_time_start()).get_string(Time::Format::FORMAT_VIDEO));
+		vargs.push_back((desc.get_time_end()-desc.get_time_start()).get_string(Time::Format::FORMAT_VIDEO));
 	}
 	// We need "--" to separate filename from arguments (for the case when filename starts with "-")
 	if ( filename.substr(0,1) == "-" )
-		vargs.push("--");
+		vargs.push_back("--");
 
-	vargs.push_filename(filename);
+	vargs.push_back(filesystem::Path(filename));
 
 	pipe = OS::run_async(ffmpeg_binary_path, vargs, OS::RUN_MODE_WRITE);
 

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.h
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.h
@@ -31,11 +31,9 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <cstdio> // FILE*
-#include <vector>
-
-#include <synfig/target_scanline.h>
+#include <synfig/os.h>
 #include <synfig/string.h>
+#include <synfig/target_scanline.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -50,13 +48,9 @@ class ffmpeg_trgt : public synfig::Target_Scanline
 	SYNFIG_TARGET_MODULE_EXT
 
 private:
-
-#ifdef HAVE_FORK
-	pid_t pid = -1;
-#endif
 	int imagecount;
 	bool multi_image;
-	FILE *file;
+	synfig::OS::RunPipe::Handle pipe;
 	synfig::String filename;
 	synfig::String sound_filename;
 	std::vector<unsigned char> buffer;

--- a/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
@@ -35,20 +35,6 @@
 #endif
 
 #include "mptr_imagemagick.h"
-#include <cstdio>
-#include <sys/types.h>
-#if HAVE_SYS_WAIT_H
- #include <sys/wait.h>
-#endif
-#if HAVE_IO_H
- #include <io.h>
-#endif
-#if HAVE_PROCESS_H
- #include <process.h>
-#endif
-#if HAVE_FCNTL_H
- #include <fcntl.h>
-#endif
 
 #include <ETL/stringf>
 
@@ -56,6 +42,7 @@
 #include <synfig/localization.h>
 #include <synfig/filesystemnative.h>
 #include <synfig/filesystemtemporary.h>
+#include <synfig/os.h>
 
 #endif
 
@@ -63,13 +50,6 @@
 
 using namespace synfig;
 using namespace etl;
-
-#if defined(HAVE_FORK) && defined(HAVE_PIPE) && defined(HAVE_WAITPID)
- #define UNIX_PIPE_TO_PROCESSES
- #include <unistd.h>
-#else
- #define WIN32_PIPE_TO_PROCESSES
-#endif
 
 /* === G L O B A L S ======================================================= */
 
@@ -82,21 +62,12 @@ SYNFIG_IMPORTER_SET_SUPPORTS_FILE_SYSTEM_WRAPPER(imagemagick_mptr, false);
 /* === M E T H O D S ======================================================= */
 
 
-imagemagick_mptr::imagemagick_mptr(const synfig::FileSystem::Identifier &identifier):
-synfig::Importer(identifier),
-file(nullptr)
-//cur_frame(0)
+imagemagick_mptr::imagemagick_mptr(const synfig::FileSystem::Identifier& identifier)
+	: synfig::Importer(identifier)
 { }
 
 imagemagick_mptr::~imagemagick_mptr()
 {
-	if (file) {
-#if defined(WIN32_PIPE_TO_PROCESSES)
-		_pclose(file);
-#elif defined(UNIX_PIPE_TO_PROCESSES)
-		fclose(file);
-#endif
-	}
 }
 
 bool
@@ -128,49 +99,19 @@ imagemagick_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &re
 		}
 	}
 
-#if defined(WIN32_PIPE_TO_PROCESSES)
+	OS::RunArgs args;
+	args.push_filename(filename);
 
-	if(file)
-		_pclose(file);
+	if (filename_extension == ".psd" || filename_extension == ".xcf")
+		args.push("-flatten");
 
-	std::string command;
+	args.push(strprintf("png32:%s", target_filename.c_str()));
 
-	if(identifier.filename.find("psd")!=String::npos)
-		command=strprintf("convert \"%s\" -flatten \"png32:%s\"\n",filename.c_str(),target_filename.c_str());
-	else
-		command=strprintf("convert \"%s\" \"png32:%s\"\n",filename.c_str(),target_filename.c_str());
-
-	if(system(command.c_str())!=0)
-		return false;
-
-#elif defined(UNIX_PIPE_TO_PROCESSES)
-
-	std::string output="png32:"+target_filename;
-
-	pid_t pid = fork();
-
-	if (pid == -1) {
+	bool success = OS::run_sync("convert", args);
+	if (!success) {
+		synfig::error(_("Unable to open convert [ImageMagick]"));
 		return false;
 	}
-
-	if (pid == 0){
-		// Child process
-		if(identifier.filename.find("psd")!=String::npos)
-			execlp("convert", "convert", filename.c_str(), "-flatten", output.c_str(), (const char*)nullptr);
-		else
-			execlp("convert", "convert", filename.c_str(), output.c_str(), (const char*)nullptr);
-		// We should never reach here unless the exec failed
-		return false;
-	}
-
-	int status;
-	waitpid(pid, &status, 0);
-	if( (WIFEXITED(status) && WEXITSTATUS(status) != 0) || !WIFEXITED(status) )
-		return false;
-
-#else
-	#error There are no known APIs for creating child processes
-#endif
 
 	if(is_temporary_file)
 		identifier.file_system->file_remove(filename);

--- a/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
@@ -100,12 +100,12 @@ imagemagick_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &re
 	}
 
 	OS::RunArgs args;
-	args.push_filename(filename);
+	args.push_back(filesystem::Path(filename));
 
 	if (filename_extension == ".psd" || filename_extension == ".xcf")
-		args.push("-flatten");
+		args.push_back("-flatten");
 
-	args.push(strprintf("png32:%s", target_filename.c_str()));
+	args.push_back(strprintf("png32:%s", target_filename.c_str()));
 
 	bool success = OS::run_sync("convert", args);
 	if (!success) {

--- a/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.h
+++ b/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.h
@@ -31,7 +31,6 @@
 /* === H E A D E R S ======================================================= */
 
 #include <synfig/importer.h>
-#include <cstdio>
 #include <synfig/surface.h>
 
 /* === M A C R O S ========================================================= */
@@ -44,8 +43,6 @@ class imagemagick_mptr : public synfig::Importer
 {
 	SYNFIG_IMPORTER_MODULE_EXT
 private:
-	FILE *file;
-	//int cur_frame;
 	synfig::Surface frame;
 
 public:
@@ -53,7 +50,7 @@ public:
 
 	~imagemagick_mptr();
 
-	virtual bool get_frame(synfig::Surface &surface, const synfig::RendDesc &renddesc, synfig::Time time, synfig::ProgressCallback *callback);
+	bool get_frame(synfig::Surface &surface, const synfig::RendDesc &renddesc, synfig::Time time, synfig::ProgressCallback *callback) override;
 };
 
 /* === E N D =============================================================== */

--- a/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
@@ -37,20 +37,7 @@
 #include <synfig/general.h>
 
 #include "trgt_imagemagick.h"
-#include <cstdio>
 
-#if HAVE_SYS_WAIT_H
- #include <sys/wait.h>
-#endif
-#if HAVE_IO_H
- #include <io.h>
-#endif
-#if HAVE_PROCESS_H
- #include <process.h>
-#endif
-#if HAVE_FCNTL_H
- #include <fcntl.h>
-#endif
 #include <ETL/misc>
 #include <ETL/stringf>
 
@@ -60,13 +47,6 @@
 
 using namespace synfig;
 using namespace etl;
-
-#if defined(HAVE_FORK) && defined(HAVE_PIPE) && defined(HAVE_WAITPID)
- #define UNIX_PIPE_TO_PROCESSES
- #include <unistd.h>
-#else
- #define WIN32_PIPE_TO_PROCESSES
-#endif
 
 /* === G L O B A L S ======================================================= */
 
@@ -80,7 +60,7 @@ SYNFIG_TARGET_SET_VERSION(imagemagick_trgt,"0.1");
 imagemagick_trgt::imagemagick_trgt(const char *Filename,  const synfig::TargetParam &params):
 	imagecount(),
 	multi_image(false),
-	file(nullptr),
+	pipe(nullptr),
 	filename(Filename),
 	buffer(nullptr),
 	color_buffer(nullptr),
@@ -90,16 +70,6 @@ imagemagick_trgt::imagemagick_trgt(const char *Filename,  const synfig::TargetPa
 
 imagemagick_trgt::~imagemagick_trgt()
 {
-	if(file){
-#if defined(WIN32_PIPE_TO_PROCESSES)
-		_pclose(file);
-#elif defined(UNIX_PIPE_TO_PROCESSES)
-		fclose(file);
-		int status;
-		waitpid(pid,&status,0);
-#endif
-	}
-	file=nullptr;
 	delete [] buffer;
 	delete [] color_buffer;
 }
@@ -133,19 +103,10 @@ imagemagick_trgt::init(synfig::ProgressCallback * /* cb */)
 void
 imagemagick_trgt::end_frame()
 {
-	if(file)
-	{
-		fputc(0,file);
-		fflush(file);
-#if defined(WIN32_PIPE_TO_PROCESSES)
-		_pclose(file);
-#elif defined(UNIX_PIPE_TO_PROCESSES)
-		fclose(file);
-		int status;
-		waitpid(pid,&status,0);
-#endif
+	if (pipe) {
+		pipe->close();
+		pipe = nullptr;
 	}
-	file=nullptr;
 	imagecount++;
 }
 
@@ -164,85 +125,25 @@ imagemagick_trgt::start_frame(synfig::ProgressCallback *cb)
 	else
 		newfilename = filename;
 
-#if defined(WIN32_PIPE_TO_PROCESSES)
+	OS::RunArgs args;
+	args.push_pair("-depth", "8");
+	args.push_pair("-size", strprintf("%dx%d", desc.get_w(), desc.get_h()));
+	args.push(pixel_size(pf) == 4 ? "rgba:-[0]" : "rgb:-[0]");
+	args.push_pair("-density", strprintf("%dx%d", round_to_int(desc.get_x_res()/39.3700787402), round_to_int(desc.get_y_res()/39.3700787402)));
+	args.push_filename(newfilename);
 
-	std::string command;
+	pipe = OS::run_async("convert", args, OS::RUN_MODE_WRITE);
 
-	command=strprintf("convert -depth 8 -size %dx%d rgb%s:-[0] -density %dx%d \"%s\"\n",
-	                  desc.get_w(), desc.get_h(),                                   // size
-	                  ((pixel_size(pf) == 4) ? "a" : ""),                             // rgba or rgb?
-	                  round_to_int(desc.get_x_res()/39.3700787402), // density
-	                  round_to_int(desc.get_y_res()/39.3700787402),
-	                  newfilename.c_str());
-
-	file=_popen(command.c_str(),POPEN_BINARY_WRITE_TYPE);
-
-#elif defined(UNIX_PIPE_TO_PROCESSES)
-
-	int p[2];
-
-	if (pipe(p)) {
-		if(cb) cb->error(N_(msg));
-		else synfig::error(N_(msg));
-		return false;
-	};
-
-	pid = fork();
-
-	if (pid == -1) {
-		if(cb) cb->error(N_(msg));
-		else synfig::error(N_(msg));
-		return false;
-	}
-
-	if (pid == 0){
-		// Child process
-		// Close pipeout, not needed
-		close(p[1]);
-		// Dup pipeout to stdin
-		if( dup2( p[0], STDIN_FILENO ) == -1 ){
-			if(cb) cb->error(N_(msg));
-			else synfig::error(N_(msg));
-			return false;
-		}
-		// Close the unneeded pipeout
-		close(p[0]);
-		execlp("convert", "convert",
-			"-depth", "8",
-			"-size", strprintf("%dx%d", desc.get_w(), desc.get_h()).c_str(),
-			((pixel_size(pf) == 4) ? "rgba:-[0]" : "rgb:-[0]"),
-			"-density", strprintf("%dx%d", round_to_int(desc.get_x_res()/39.3700787402), round_to_int(desc.get_y_res()/39.3700787402)).c_str(),
-			newfilename.c_str(),
-			(const char*)nullptr);
-		// We should never reach here unless the exec failed
-		if(cb) cb->error(N_(msg));
-		else synfig::error(N_(msg));
-		return false;
-	} else {
-		// Parent process
-		// Close pipein, not needed
-		close(p[0]);
-		// Save pipeout to file handle, will write to it later
-		file = fdopen(p[1], "wb");
-	}
-
-#else
-	#error There are no known APIs for creating child processes
-#endif
-
-	if(!file)
-	{
+	if (!pipe) {
 		if(cb)cb->error(N_(msg));
 		else synfig::error(N_(msg));
 		return false;
 	}
 
-	//etl::yield();
-
 	return true;
 }
 
-Color *
+Color*
 imagemagick_trgt::start_scanline(int /*scanline*/)
 {
 	return color_buffer;
@@ -251,12 +152,12 @@ imagemagick_trgt::start_scanline(int /*scanline*/)
 bool
 imagemagick_trgt::end_scanline(void)
 {
-	if(!file)
+	if (!pipe)
 		return false;
 
 	color_to_pixelformat(buffer, color_buffer, pf, 0, desc.get_w());
 
-	if(!fwrite(buffer,pixel_size(pf),desc.get_w(),file))
+	if (!pipe->write(buffer, pixel_size(pf), desc.get_w()))
 		return false;
 
 	return true;

--- a/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
@@ -126,11 +126,11 @@ imagemagick_trgt::start_frame(synfig::ProgressCallback *cb)
 		newfilename = filename;
 
 	OS::RunArgs args;
-	args.push_pair("-depth", "8");
-	args.push_pair("-size", strprintf("%dx%d", desc.get_w(), desc.get_h()));
-	args.push(pixel_size(pf) == 4 ? "rgba:-[0]" : "rgb:-[0]");
-	args.push_pair("-density", strprintf("%dx%d", round_to_int(desc.get_x_res()/39.3700787402), round_to_int(desc.get_y_res()/39.3700787402)));
-	args.push_filename(newfilename);
+	args.push_back({"-depth", "8"});
+	args.push_back({"-size", strprintf("%dx%d", desc.get_w(), desc.get_h())});
+	args.push_back(pixel_size(pf) == 4 ? "rgba:-[0]" : "rgb:-[0]");
+	args.push_back({"-density", strprintf("%dx%d", round_to_int(desc.get_x_res()/39.3700787402), round_to_int(desc.get_y_res()/39.3700787402))});
+	args.push_back(filesystem::Path(newfilename));
 
 	pipe = OS::run_async("convert", args, OS::RUN_MODE_WRITE);
 

--- a/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.h
+++ b/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.h
@@ -30,10 +30,8 @@
 
 /* === H E A D E R S ======================================================= */
 
+#include <synfig/os.h>
 #include <synfig/target_scanline.h>
-#include <synfig/string.h>
-#include <sys/types.h>
-#include <cstdio>
 
 /* === M A C R O S ========================================================= */
 
@@ -47,13 +45,9 @@ class imagemagick_trgt : public synfig::Target_Scanline
 	SYNFIG_TARGET_MODULE_EXT
 
 private:
-
-#ifdef HAVE_FORK
-	pid_t pid = -1;
-#endif
 	int imagecount;
 	bool multi_image;
-	FILE *file;
+	synfig::OS::RunPipe::Handle pipe;
 	synfig::String filename;
 	unsigned char *buffer;
 	synfig::Color *color_buffer;

--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(libsynfig
         "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/module.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/node.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/os.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/palette.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/paramdesc.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/polynomial_root.cpp"

--- a/synfig-core/src/synfig/Makefile.am
+++ b/synfig-core/src/synfig/Makefile.am
@@ -126,6 +126,7 @@ SYNFIGHEADERS = \
 	valuetransformation.h \
 	soundprocessor.h \
 	canvasfilenaming.h \
+	os.h \
 	token.h \
 	threadpool.h
 
@@ -177,6 +178,7 @@ SYNFIGSOURCES = \
 	valueoperations.cpp \
 	soundprocessor.cpp \
 	canvasfilenaming.cpp \
+	os.cpp \
 	token.cpp \
 	threadpool.cpp
 

--- a/synfig-core/src/synfig/filesystem.h
+++ b/synfig-core/src/synfig/filesystem.h
@@ -246,12 +246,32 @@ namespace synfig
 #endif
 			typedef std::basic_string<value_type> string_type;
 
+			/**
+			 * Store a file system path
+			 * @param path the path in UTF-8 encoding
+			 */
 			Path(const std::string& path);
 
+			// Format observers ------------------
+
+			/** Path as a character string in native encoding */
 			const value_type* c_str() const noexcept;
+			/** Path as a character string in native encoding */
+			const string_type& native() const noexcept;
+			/** Path as a character string in UTF-8 encoding */
+			const std::string& u8string() const;
 
 		private:
-			string_type path_;
+			/** Path in the native encoding */
+			string_type native_path_;
+			/** Path in UTF-8 encoding */
+			std::string path_;
+
+			/** Convert a UTF-8 encoded string into a native-encoded string
+			 *  @param utf8 the string to be converted
+			 *  @return a string in native encoding
+			 */
+			static string_type utf8_to_native(const std::string& utf8);
 		};
 	}
 }

--- a/synfig-core/src/synfig/os.cpp
+++ b/synfig-core/src/synfig/os.cpp
@@ -542,6 +542,24 @@ OS::run_async(std::string binary_path, const RunArgs& binary_args, RunMode mode,
 }
 
 bool
+OS::run_sync(std::string binary_path, const RunArgs& binary_args, const std::string& stdout_redir_file, const std::string& stderr_redir_file)
+{
+	auto run_pipe = OS::RunPipe::create();
+	if (!run_pipe)
+		return false;
+	run_pipe->open(binary_path, binary_args, OS::RunMode::RUN_MODE_READ, {stderr_redir_file, stdout_redir_file, ""});
+	if (!run_pipe->is_open())
+		return false;
+
+	int status = run_pipe->close();
+#ifdef _WIN32
+	return status == 0; // :(
+#else
+	return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+#endif
+}
+
+bool
 OS::launch_file_async(const std::string& file)
 {
 #ifdef _WIN32

--- a/synfig-core/src/synfig/os.cpp
+++ b/synfig-core/src/synfig/os.cpp
@@ -78,116 +78,56 @@ class RunPipeUnix;
 /* === M E T H O D S ======================================================= */
 
 void
-OS::RunArgs::push(const std::vector<std::string>& args)
+OS::RunArgs::push_back(const std::string& arg)
 {
-	run_args_.insert(run_args_.end(), args.begin(), args.end());
+	std::vector<std::string>::push_back(arg);
 }
 
 void
-OS::RunArgs::push(const std::vector<const char *>& args)
+OS::RunArgs::push_back(const char* arg)
 {
-	run_args_.insert(run_args_.end(), args.begin(), args.end());
+	std::vector<std::string>::push_back(std::string(arg));
 }
 
 void
-OS::RunArgs::push(const std::string& item)
-{
-	run_args_.push_back(item);
-}
-
-void
-OS::RunArgs::push(std::string&& item)
-{
-	run_args_.emplace_back(std::move(item));
-}
-
-void
-OS::RunArgs::push(const char* __format, ...)
-{
-	va_list args;
-	va_start(args, __format);
-	run_args_.emplace_back(vstrprintf(__format, args));
-	va_end(args);
-}
-
-void
-OS::RunArgs::push_pair(const std::string& key, const std::string& value)
-{
-	run_args_.push_back(key);
-	run_args_.push_back(value);
-}
-
-void
-OS::RunArgs::push_pair_filename(const std::string& key, const std::string& filename)
-{
-	run_args_.push_back(key);
-	push_filename(filename);
-}
-
-void
-OS::RunArgs::push_filename(const std::string& filename)
+OS::RunArgs::push_back(const synfig::filesystem::Path& filename)
 {
 #ifdef WIN32_PIPE_TO_PROCESSES
-	run_args_.push_back('"' + filename + '"');
+	std::vector<std::string>::push_back('"' + filename.u8string() + '"');
 #else
-	run_args_.push_back(filename);
+	std::vector<std::string>::push_back(filename.u8string());
 #endif
 }
 
 void
-OS::RunArgs::push_filename(std::string&& filename)
+OS::RunArgs::push_back(const std::pair<std::string, synfig::filesystem::Path>& arg_pair)
 {
-#ifdef WIN32_PIPE_TO_PROCESSES
-	run_args_.emplace_back(std::move('"' + filename + '"'));
-#else
-	run_args_.emplace_back(std::move(filename));
-#endif
+	std::vector<std::string>::push_back(arg_pair.first);
+	push_back(arg_pair.second);
 }
 
 void
-OS::RunArgs::push_filename(const char* filename)
+OS::RunArgs::push_back(const std::initializer_list<std::string>& args)
 {
-#ifdef WIN32_PIPE_TO_PROCESSES
-	run_args_.emplace_back(strprintf("\"%s\"", filename));
-#else
-	run_args_.emplace_back(filename);
-#endif
+	insert(end(), args.begin(), args.end());
 }
 
 void
-OS::RunArgs::clear()
+OS::RunArgs::push_back(const std::initializer_list<const char*>& args)
 {
-	run_args_.clear();
+	insert(end(), args.begin(), args.end());
 }
 
 std::string
 OS::RunArgs::get_string() const
 {
 	std::string ret;
-	for (const auto& arg : run_args_) {
+	for (const auto& arg : *this) {
 		ret.append(arg + " ");
 	}
 	if (!ret.empty())
 		ret.pop_back();
 	return ret;
-}
-
-const std::string&
-OS::RunArgs::operator[](RunArgs::size_type i) const
-{
-	return run_args_[i];
-}
-
-bool
-OS::RunArgs::empty() const
-{
-	return run_args_.empty();
-}
-
-OS::RunArgs::size_type
-OS::RunArgs::size() const
-{
-	return run_args_.size();
 }
 
 void

--- a/synfig-core/src/synfig/os.cpp
+++ b/synfig-core/src/synfig/os.cpp
@@ -1,0 +1,555 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file os.cpp
+**	\brief OS specific methods
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	......... ... 2021 Rodolfo Ribeiro Gomes
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include "os.h"
+
+#include <cstdarg>
+
+#include <synfig/filesystem.h>
+#include <synfig/general.h>
+#include <synfig/localization.h>
+
+#if defined(HAVE_FORK) && defined(HAVE_PIPE) && defined(HAVE_WAITPID)
+# define UNIX_PIPE_TO_PROCESSES
+# include <cstdlib> // for system()
+# include <fcntl.h> // for O_ flags
+# include <sys/wait.h> // for waitpid()
+# include <unistd.h> // for popen()
+#elif defined(_WIN32)
+# define WIN32_PIPE_TO_PROCESSES
+# define WIN32_LEAN_AND_MEAN
+# include <windows.h>
+# include <shellapi.h> // for ShellExecuteW
+#else
+# error There are no known APIs for creating child processes
+#endif
+
+#endif
+
+/* === U S I N G =========================================================== */
+
+using namespace synfig;
+
+/* === M A C R O S ========================================================= */
+/* === G L O B A L S ======================================================= */
+
+/* === C L A S S E S ======================================================= */
+
+#ifdef WIN32_PIPE_TO_PROCCESSES
+class RunPipeWin32;
+#else
+class RunPipeUnix;
+#endif
+
+/* === P R O C E D U R E S ================================================= */
+
+/* === M E T H O D S ======================================================= */
+
+void
+OS::RunArgs::push(const std::vector<std::string>& args)
+{
+	run_args_.insert(run_args_.end(), args.begin(), args.end());
+}
+
+void
+OS::RunArgs::push(const std::vector<const char *>& args)
+{
+	run_args_.insert(run_args_.end(), args.begin(), args.end());
+}
+
+void
+OS::RunArgs::push(const std::string& item)
+{
+	run_args_.push_back(item);
+}
+
+void
+OS::RunArgs::push(std::string&& item)
+{
+	run_args_.emplace_back(std::move(item));
+}
+
+void
+OS::RunArgs::push(const char* __format, ...)
+{
+	va_list args;
+	va_start(args, __format);
+	run_args_.emplace_back(vstrprintf(__format, args));
+	va_end(args);
+}
+
+void
+OS::RunArgs::push_pair(const std::string& key, const std::string& value)
+{
+	run_args_.push_back(key);
+	run_args_.push_back(value);
+}
+
+void
+OS::RunArgs::push_pair_filename(const std::string& key, const std::string& filename)
+{
+	run_args_.push_back(key);
+	push_filename(filename);
+}
+
+void
+OS::RunArgs::push_filename(const std::string& filename)
+{
+#ifdef WIN32_PIPE_TO_PROCESSES
+	run_args_.push_back('"' + filename + '"');
+#else
+	run_args_.push_back(filename);
+#endif
+}
+
+void
+OS::RunArgs::push_filename(std::string&& filename)
+{
+#ifdef WIN32_PIPE_TO_PROCESSES
+	run_args_.emplace_back(std::move('"' + filename + '"'));
+#else
+	run_args_.emplace_back(std::move(filename));
+#endif
+}
+
+void
+OS::RunArgs::push_filename(const char* filename)
+{
+#ifdef WIN32_PIPE_TO_PROCESSES
+	run_args_.emplace_back(strprintf("\"%s\"", filename));
+#else
+	run_args_.emplace_back(filename);
+#endif
+}
+
+void
+OS::RunArgs::clear()
+{
+	run_args_.clear();
+}
+
+std::string
+OS::RunArgs::get_string() const
+{
+	std::string ret;
+	for (const auto& arg : run_args_) {
+		ret.append(arg + " ");
+	}
+	if (!ret.empty())
+		ret.pop_back();
+	return ret;
+}
+
+const std::string&
+OS::RunArgs::operator[](RunArgs::size_type i) const
+{
+	return run_args_[i];
+}
+
+bool
+OS::RunArgs::empty() const
+{
+	return run_args_.empty();
+}
+
+OS::RunArgs::size_type
+OS::RunArgs::size() const
+{
+	return run_args_.size();
+}
+
+void
+OS::RunPipe::printf(const char* __format, ...)
+{
+	va_list args;
+	va_start(args, __format);
+	const std::string text = vstrprintf(__format, args);
+	va_end(args);
+	print(text);
+}
+
+const std::string&
+OS::RunPipe::get_command() const
+{
+	return full_command_;
+}
+
+#ifdef WIN32_PIPE_TO_PROCESSES
+class RunPipeWin32 : public OS::RunPipe
+{
+	FILE* file = nullptr;
+	bool initialized = false;
+	bool is_reader = false;
+	bool is_writer = false;
+
+	// RunPipe interface
+public:
+	RunPipeWin32() = default;
+	~RunPipeWin32()
+	{
+		RunPipeWin32::close();
+	}
+
+	bool open(std::string binary_path, const OS::RunArgs& binary_args, OS::RunMode run_mode, const OS::RunRedirectionFiles& redir_files) override
+	{
+		if (initialized) {
+			synfig::error("A pipe should not be initialized twice! Ignored...");
+			return false;
+		}
+		initialized = true;
+
+		String command = '"' + binary_path + '"';
+		command += " " + binary_args.get_string();
+
+		// This covers the dumb cmd.exe behavior.
+		// See: http://eli.thegreenplace.net/2011/01/28/on-spaces-in-the-paths-of-programs-and-files-on-windows/
+		command = "\"" + command + "\"";
+		full_command_ = command;
+
+		const wchar_t* wmode;
+		switch (run_mode) {
+			case OS::RUN_MODE_NONE:
+				break;
+			case OS::RUN_MODE_READ:
+				wmode = L"rb";
+				is_reader = true;
+				break;
+			case OS::RUN_MODE_WRITE:
+				wmode = L"wb";
+				is_writer = true;
+				break;
+			case OS::RUN_MODE_READWRITE:
+				wmode = L"rwb";
+				is_reader = true;
+				is_writer = true;
+				break;
+		}
+
+		const std::wstring wcommand = synfig::filesystem::Path(command).c_str(); // TODO: remove .c_str() when filesystem::Path() improves
+
+		file = _wpopen(wcommand.c_str(), wmode);
+		if (!file) {
+			synfig::error(_("Error while trying to open a pipe: %s"), command.c_str());
+			_wperror(wcommand.c_str());
+		}
+		return file != nullptr;
+	}
+	bool is_readable() const override { return is_reader && file != nullptr; }
+	bool is_writable() const override { return is_writer && file != nullptr; }
+	bool is_open() const override { return file != nullptr; };
+	int close() override
+	{
+		int status = 0;
+		if (file) {
+			status = _pclose(file);
+			file = nullptr;
+		}
+		initialized = false;
+		return status;
+	}
+	void print(const std::string& text) override { fputs(text.c_str(), file); }
+	size_t write(const void* ptr, size_t size, size_t n) override { return fwrite(ptr, size, n, file); }
+
+	void flush() override { fflush(file); }
+
+	std::string read_contents() override
+	{
+		if (!is_reader) {
+			synfig::error("Should not try to readline() a non-readable pipe");
+			return "";
+		}
+		std::string result;
+		char buf[128];
+		while(!feof(file)) {
+			if(fgets(buf, 128, file) != nullptr)
+				result += buf;
+		}
+		return result;
+	}
+	std::string read_contents(size_t max_bytes) override
+	{
+		if (!file) {
+			synfig::error("Should not try to readline(size_t max_bytes) a non-readable pipe");
+			return "";
+		}
+		std::string result;
+		result.reserve(max_bytes);
+		if(fgets(&result[0], max_bytes, file) != nullptr)
+			return result;
+		return "";
+	}
+	int getc() override { return fgetc(file); }
+	int scanf(const char* __format, ...) override
+	{
+		va_list args;
+		va_start(args, __format);
+		int ret = vfscanf(file, __format, args);
+		va_end(args);
+		return ret;
+	}
+	bool eof() const override { return feof(file); };
+};
+#else
+class RunPipeUnix : public OS::RunPipe
+{
+	FILE* read_file = nullptr;
+	FILE* write_file = nullptr;
+	bool initialized = false;
+	pid_t pid = -1;
+
+	// RunPipe interface
+public:
+	RunPipeUnix() = default;
+	~RunPipeUnix()
+	{
+		RunPipeUnix::close();
+	}
+
+	bool open(std::string binary_path, const OS::RunArgs& binary_args, OS::RunMode run_mode, const OS::RunRedirectionFiles& redir_files) override
+	{
+		if (initialized) {
+			synfig::error("A pipe should not be initialized twice! Ignored...");
+			return false;
+		}
+		initialized = true;
+
+		full_command_ = binary_path + " " + binary_args.get_string();
+
+		int p[2];
+
+		if (pipe(p)) {
+			synfig::error(_("Unable to open pipe to %s (no pipe)"), binary_path.c_str());
+			return false;
+		}
+
+		pid = fork();
+
+		if (pid == -1) {
+			synfig::error(_("Unable to open pipe to %s (pid == -1)"), binary_path.c_str());
+			return false;
+		}
+		const bool is_reader = run_mode == OS::RUN_MODE_READ || run_mode == OS::RUN_MODE_READWRITE;
+		const bool is_writer = run_mode == OS::RUN_MODE_WRITE || run_mode == OS::RUN_MODE_READWRITE;
+
+		if (pid == 0) {
+			// Child process
+
+			// If requested, redirect stderr to a file
+			if (!redir_files.std_err.empty()) {
+				mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+				int err_fd = ::open(redir_files.std_err.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mode);
+				if (err_fd == -1) {
+					synfig::error(_("Unable to open file to be stderr: %s [errno: %d]"), redir_files.std_err.c_str(), errno);
+					perror(_("System error message:"));
+					exit(-8000);
+				}
+				// Map err_fd as stderr
+				if (dup2(err_fd, STDERR_FILENO) == -1) {
+					synfig::error(_("Unable to open pipe to %s (dup2( err_fd, STDERR_FILENO ) == -1)"), binary_path.c_str());
+					exit(-9000);
+				}
+			}
+
+			// Redirect stdout to writer-pipe or to a file
+			if (is_reader || !redir_files.std_out.empty()) {
+				if (!redir_files.std_out.empty()) {
+					::close(p[1]);
+					mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+					p[1] = ::open(redir_files.std_out.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mode);
+					if (p[1] == -1) {
+						synfig::error(_("Unable to open file to be stdout: %s [errno: %d]"), redir_files.std_out.c_str(), errno);
+						perror(_("System error message:"));
+						exit(-1000);
+					}
+				}
+				// Map pipeout as stdout
+				if (dup2(p[1], STDOUT_FILENO) == -1) {
+					synfig::error(_("Unable to open pipe to %s (dup2( p[1], STDOUT_FILENO ) == -1)"), binary_path.c_str());
+					exit(-2000);
+				}
+			}
+			// Close the unneeded pipeout/file descriptor
+			::close(p[1]);
+			// Redirect reader-pipe or file as source to stdin
+			if (is_writer || !redir_files.std_in.empty()) {
+				// Dup pipein to stdin
+				if (!redir_files.std_in.empty()) {
+					::close(p[0]);
+					mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+					p[0] = ::open(redir_files.std_in.c_str(), O_RDONLY, mode);
+					if (p[0] == -1) {
+						synfig::error(_("Unable to open file to be stdin: %s [errno: %d]"), redir_files.std_in.c_str(), errno);
+						perror(_("System error message:"));
+						exit(-5000);
+					}
+				}
+				if (dup2(p[0], STDIN_FILENO) == -1) {
+					synfig::error(_("Unable to open pipe to %s (dup2( p[0], STDIN_FILENO ) == -1)"), binary_path.c_str());
+					exit(-6000);
+				}
+			}
+			// Close the unneeded pipein
+			::close(p[0]);
+
+			char *args[binary_args.size()+2];
+			size_t idx = 0;
+			args[idx++] = &binary_path[0];
+			for (size_t i = 0; i < binary_args.size(); i++)
+			{
+				const auto& arg = binary_args[i];
+				args[idx++] = const_cast<char*>(&arg[0]);
+			}
+			args[idx] = nullptr;
+
+			execvp(binary_path.c_str(), args);
+
+			// We should never reach here unless the exec failed
+			synfig::error(_("Unable to open pipe to %s (exec failed)"), binary_path.c_str());
+			return false;
+		} else {
+			// Parent process
+			// Close pipein, not needed
+			if (is_reader)
+				read_file = fdopen(p[0], "r");
+			else
+				::close(p[0]);
+			// Save pipeout to file handle, will write to it later
+			if (is_writer)
+				write_file = fdopen(p[1], "w");
+			else
+				::close(p[1]);
+			return (!is_reader || read_file != nullptr) && (!is_writer || write_file != nullptr);
+		}
+	}
+
+	bool is_readable() const override { return read_file != nullptr; }
+	bool is_writable() const override { return write_file != nullptr; }
+	bool is_open() const override { return read_file != nullptr || write_file != nullptr; };
+	int close() override
+	{
+		if (write_file) {
+			fclose(write_file);
+			write_file = nullptr;
+		}
+		if (read_file) {
+			fclose(read_file);
+			read_file = nullptr;
+		}
+		int status;
+		waitpid(pid, &status, 0);
+
+		initialized = false;
+		return status;
+	}
+
+	void print(const std::string &text) override { fputs(text.c_str(), write_file); }
+
+	size_t write(const void* ptr, size_t size, size_t n) override { return fwrite(ptr, size, n, write_file); }
+
+	void flush() override { fflush(write_file); }
+
+	std::string read_contents() override
+	{
+		if (!read_file) {
+			synfig::error("Should not try to readline() a non-readable pipe");
+			return "";
+		}
+		std::string result;
+		char buf[128];
+		while(!feof(read_file)) {
+			if(fgets(buf, 128, read_file) != nullptr)
+				result += buf;
+		}
+		return result;
+	}
+	std::string read_contents(size_t max_bytes) override
+	{
+		if (!read_file) {
+			synfig::error("Should not try to readline(size_t max_bytes) a non-readable pipe");
+			return "";
+		}
+		std::string result;
+		result.reserve(max_bytes);
+		if(fgets(&result[0], max_bytes, read_file) != nullptr)
+			return result;
+		return "";
+	}
+	int getc() override { return fgetc(read_file); }
+	int scanf(const char* __format, ...) override
+	{
+		va_list args;
+		va_start(args, __format);
+		int ret = vfscanf(read_file, __format, args);
+		va_end(args);
+		return ret;
+	}
+	bool eof() const override { return feof(read_file); };
+};
+#endif
+
+OS::RunPipe::Handle
+OS::RunPipe::create()
+{
+#ifdef WIN32_PIPE_TO_PROCESSES
+	return std::unique_ptr<RunPipe>(new RunPipeWin32());
+#else
+	return std::unique_ptr<RunPipe>(new RunPipeUnix());
+#endif
+}
+
+OS::RunPipe::Handle
+OS::run_async(std::string binary_path, const RunArgs& binary_args, RunMode mode, const RunRedirectionFiles& redir_files)
+{
+	auto run_pipe = OS::RunPipe::create();
+	if (!run_pipe)
+		return nullptr;
+	run_pipe->open(binary_path, binary_args, mode, redir_files);
+	if (!run_pipe->is_open())
+		return nullptr;
+	return run_pipe;
+}
+
+bool
+OS::launch_file_async(const std::string& file)
+{
+#ifdef _WIN32
+	return 32<= INT_PTR( ShellExecuteW(NULL, NULL, synfig::filesystem::Path(file).c_str(), NULL, NULL, SW_SHOW) );
+	// https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutew#return-value
+#elif defined(__APPLE__)
+	return 0 == system(strprintf("open \"%s\"", file.c_str()).c_str());
+#else
+	return 0 == system(strprintf("xdg-open \"%s\"", file.c_str()).c_str());
+#endif
+}

--- a/synfig-core/src/synfig/os.h
+++ b/synfig-core/src/synfig/os.h
@@ -219,6 +219,15 @@ protected:
 /** Run an executable binary with pipes for communication or stdout/stdin redirection to files */
 RunPipe::Handle run_async(std::string binary_path, const RunArgs& binary_args, RunMode mode, const RunRedirectionFiles& redir_files = {});
 
+/**
+ * Run an executable binary.
+ * It returns from the call after the program finishes only.
+ *
+ * Like system() call, but without wchar problems and the chance to log stdout/stderr via redir_files.
+ * @see run_async()
+ */
+bool run_sync(std::string binary_path, const RunArgs& binary_args, const std::string& stdout_redir_file = "", const std::string& stderr_redir_file = "");
+
 /** Launch a file with its default application */
 bool launch_file_async(const std::string& file);
 

--- a/synfig-core/src/synfig/os.h
+++ b/synfig-core/src/synfig/os.h
@@ -1,0 +1,231 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file os.h
+**	\brief OS specific methods
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	......... ... 2021 Rodolfo Ribeiro Gomes
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef SYNFIG_OS_H
+#define SYNFIG_OS_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <memory>
+#include <string>
+#include <vector>
+
+/* === M A C R O S ========================================================= */
+
+/* === T Y P E D E F S ===================================================== */
+
+/* === P R O C E D U R E S ================================================= */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace synfig {
+
+namespace OS {
+
+/**
+ * A list of arguments to a command that will be run via OS::RunPipe
+ */
+class RunArgs
+{
+public:
+	typedef std::vector<std::string>::size_type size_type;
+
+	// Modifiers -------------------------
+
+	void push(const std::vector<std::string>& args);
+	void push(const std::vector<const char*>& args);
+	void push(const std::string& item);
+	void push(std::string&& item);
+	void push(const char *__format, ...);
+	void push_pair(const std::string&  key, const std::string&  value);
+	void push_pair_filename(const std::string&  key, const std::string&  filename);
+	void push_filename(const std::string& filename);
+	void push_filename(std::string&& filename);
+	void push_filename(const char *filename);
+	void clear();
+
+	// Element access --------------------
+
+	const std::string& operator[](size_type i) const;
+
+	// Capacity --------------------------
+
+	bool empty() const;
+	size_type size() const;
+
+	// Query -----------------------------
+
+	/**
+	 * Join the arguments into a single string.
+	 * It uses a single regular space as separator.
+	 */
+	std::string get_string() const;
+
+private:
+	std::vector<std::string> run_args_;
+};
+
+/**
+ * What type of communication the current process
+ * will have with the command run via RunPipe:
+ * - RUN_MODE_NONE: None
+ * - RUN_MODE_READ: current process reads the child process' stdout
+ * - RUN_MODE_WRITE: current process writes to the child process' stdin
+ */
+enum RunMode {
+	RUN_MODE_NONE,
+	RUN_MODE_READ,
+	RUN_MODE_WRITE,
+	RUN_MODE_READWRITE,
+};
+
+/**
+ * If a field is set, it would be the target file of the standard I/O stream
+ * redirection, and it prevents (direct) communication between current and
+ * child process.
+ * Let a field empty/unset, and it will use system standards (stderr, stdout
+ * and stdin file descriptors).
+ */
+struct RunRedirectionFiles
+{
+	std::string std_err;
+	std::string std_out;
+	std::string std_in;
+};
+
+/**
+ * An object that allows to run an external software.
+ * It's possible to transfer data between the current process and external software.
+ *
+ * Example code:
+ *
+ * auto my_pipe = OS::RunPipe::create();
+ *
+ * // Run mybinary.exe without any args.
+ * // It will read stdout output from mybinary.exe
+ * // Redirect stderr of mybinary.exe to stderr.log file.
+ * if (!my_pipe->open("mybinary.exe", {}, OS::RUN_MODE_READ, {"stderr.log", "", ""})) {
+ *   synfig::error("Can't run mybinary.exe!");
+ *   return;
+ * }
+ *
+ * // get (and wait for) all stdout contents from mybinary.exe
+ * auto contents = my_pipe->read_contents();
+ *
+ * my_pipe->close();
+ */
+struct RunPipe {
+	typedef std::unique_ptr<RunPipe> Handle;
+
+	static Handle create();
+
+	virtual ~RunPipe() = default;
+
+	/**
+	 * Run an external software.
+	 * It is possible to read strings it sends to its stdout and
+	 * write strings to its stdin to be read by the running external software.
+	 * @see read_contents(), getc(), printf(), print(), write()
+	 *
+	 * Its stderr and stdout can be logged into files via @a redir_files.
+	 * In the same way, its stdin can be piped from a file too.
+	 * In any of these redirection cases, the equivalent read/write operation
+	 * is not possible anymore.
+	 * Example:
+	 * 1) One can set mode as OS::RUN_MODE_READ and set a redirection file to
+	 * stdout. It could then normally perform read_contents() or getc() calls.
+	 * The stdout strings would be all written into the desired file.
+	 * 2) One can set mode as OS::RUN_MODE_READWRITE and set a redirection file to
+	 * stdout. It could then normally perform write() or print() calls.
+	 * However, even though it should be also a readable pipe (to read data from
+	 * its stdout), the stdout strings would be all written into the desired file,
+	 * as it has been set. So read_contents(), getc() and alike would not work.
+	 *
+	 * You should @c close() this object before calling @c open() again.
+	 *
+	 * @param binary_path The external software path
+	 * @param binary_args The arguments to be passed to external software
+	 * @param mode The communication direction (read/write), if any, between the current process and the external software
+	 * @param redir_files Filenames to log stderr or stdout contents if no direct communication is desired.
+	 *                    If an filename is provided to stdin, it will be the data source for this channel.
+	 * @return true if success; false otherwise.
+	 */
+	virtual bool open(std::string binary_path, const RunArgs& binary_args, RunMode mode, const RunRedirectionFiles& redir_files = {}) = 0;
+	/**
+	 * Stop running the external software.
+	 * @return the exit status.
+	 */
+	virtual int close() = 0;
+
+	// status methods
+	virtual bool is_readable() const = 0;
+	virtual bool is_writable() const = 0;
+	virtual bool is_open() const = 0;
+
+	// write methods
+	virtual void printf(const char *__format, ...);
+	virtual void print(const std::string& text) = 0;
+	virtual size_t write(const void *ptr, size_t size, size_t n) = 0;
+	virtual void flush() = 0;
+
+	// read methods
+	/** read everything coming from stdout (until get an EOF) and return them. */
+	virtual std::string read_contents() = 0;
+	/** read at most @a max_bytes coming from stdout and return them. */
+	virtual std::string read_contents(size_t max_bytes) = 0;
+	/** read a byte coming from stdout. */
+	virtual int getc() = 0;
+	virtual int scanf(const char *__format, ...) = 0;
+	virtual bool eof() const = 0;
+
+	// query methods
+	/**
+	 * The equivalent command line string:
+	 *  binary_path followed by binary_args both provided when open() is called.
+	 */
+	const std::string& get_command() const;
+
+protected:
+	RunPipe() = default;
+
+	std::string full_command_;
+};
+
+/** Run an executable binary with pipes for communication or stdout/stdin redirection to files */
+RunPipe::Handle run_async(std::string binary_path, const RunArgs& binary_args, RunMode mode, const RunRedirectionFiles& redir_files = {});
+
+/** Launch a file with its default application */
+bool launch_file_async(const std::string& file);
+
+} // END of namespace OS
+
+} // END of namespace synfig
+
+/* === E N D =============================================================== */
+
+#endif // SYNFIG_OS_H

--- a/synfig-core/src/synfig/os.h
+++ b/synfig-core/src/synfig/os.h
@@ -35,6 +35,8 @@
 #include <string>
 #include <vector>
 
+#include <synfig/filesystem.h> // synfig::filesystem::Path
+
 /* === M A C R O S ========================================================= */
 
 /* === T Y P E D E F S ===================================================== */
@@ -50,33 +52,16 @@ namespace OS {
 /**
  * A list of arguments to a command that will be run via OS::RunPipe
  */
-class RunArgs
+class RunArgs : public std::vector<std::string>
 {
 public:
-	typedef std::vector<std::string>::size_type size_type;
-
 	// Modifiers -------------------------
-
-	void push(const std::vector<std::string>& args);
-	void push(const std::vector<const char*>& args);
-	void push(const std::string& item);
-	void push(std::string&& item);
-	void push(const char *__format, ...);
-	void push_pair(const std::string&  key, const std::string&  value);
-	void push_pair_filename(const std::string&  key, const std::string&  filename);
-	void push_filename(const std::string& filename);
-	void push_filename(std::string&& filename);
-	void push_filename(const char *filename);
-	void clear();
-
-	// Element access --------------------
-
-	const std::string& operator[](size_type i) const;
-
-	// Capacity --------------------------
-
-	bool empty() const;
-	size_type size() const;
+	void push_back(const std::string& arg);
+	void push_back(const char* arg);
+	void push_back(const synfig::filesystem::Path& file);
+	void push_back(const std::initializer_list<std::string>& args);
+	void push_back(const std::initializer_list<const char*>& args);
+	void push_back(const std::pair<std::string, synfig::filesystem::Path>& arg_pair);
 
 	// Query -----------------------------
 
@@ -85,9 +70,11 @@ public:
 	 * It uses a single regular space as separator.
 	 */
 	std::string get_string() const;
-
-private:
-	std::vector<std::string> run_args_;
+	/**
+	 * Similar to get_string() but with OS native encoding
+	 * (UTF-16 for MS Windows, and UTF-8 for others)
+	 */
+	std::string native() const;
 };
 
 /**

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -144,6 +144,7 @@
 #include <synfig/general.h>
 #include <synfig/layer.h>
 #include <synfig/loadcanvas.h>
+#include <synfig/os.h>
 #include <synfig/savecanvas.h>
 #include <synfig/soundprocessor.h>
 #include <synfig/string_helper.h>


### PR DESCRIPTION
fix #2108

Known issues (they exist even before this PR)

- ImageMagick importer still doesn't use wchar (argument starting with "png32:) (it already didn't work correctly before)
- Windows package does not provide ImageMagick converter.exe (packaging issue; https://github.com/synfig/synfig/pull/2491#issuecomment-1248258741)
- I believe Windows RunPipe version didn't and doesn't provide exit status :( (I tested once by providing an intentionally malformed ffmpeg call) (it already didn't work correctly before)