### PR TITLE
Updated GitHub actions/cache version

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Download ccache archive
         id: ccache-archive
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
         with:
           path: .ccache
           key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ steps.ccache_timestamp.outputs.timestamp }}


### PR DESCRIPTION
Currently build fails with error:
```
Error: Cache upload failed because file read failed with EBADF: bad file descriptor, read
    at ReadStream.<anonymous> (/home/runner/work/_actions/actions/cache/v2.1.3/dist/save/index.js:3305:31)
    at ReadStream.emit (events.js:210:5)
    at internal/fs/streams.js:167:12
    at FSReqCallback.wrapper [as oncomplete] (fs.js:470:5)
```