### PR TITLE
Added Color Action Buttons to ```Gtk::FileChooserDialog```

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2406,7 +2406,7 @@ App::dialog_open_file_ext(const std::string &title, std::vector<std::string> &fi
 	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
 	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
 	context->add_class("destructive-action");
-	
+
 	button = dialog->add_button(_("Import"), Gtk::RESPONSE_ACCEPT);//->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
 	button->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
 	context = button->get_style_context();
@@ -3091,8 +3091,13 @@ App::dialog_save_file(const std::string &title, std::string &filename, std::stri
 	filter_sfg->add_pattern("*.sfg");
 
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
+	context->add_class("destructive-action");
+	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
+	context = button->get_style_context();
+	context->add_class("suggested-action");
 
 	dialog->add_filter(filter_sifz);
 	dialog->add_filter(filter_sif);

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2404,13 +2404,11 @@ App::dialog_open_file_ext(const std::string &title, std::vector<std::string> &fi
 	//Add action button colors
 	Gtk::Button *button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);//->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
 	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
-	context->add_class("destructive-action");
+	button->get_style_context()->add_class("destructive-action");
 
 	button = dialog->add_button(_("Import"), Gtk::RESPONSE_ACCEPT);//->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
 	button->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
-	context = button->get_style_context();
-	context->add_class("suggested-action");
+	button->get_style_context()->add_class("suggested-action");
 
 	dialog->set_select_multiple(allow_multiple_selection);
 
@@ -2571,12 +2569,11 @@ App::dialog_open_file_spal(const std::string &title, std::string &filename, std:
 	//add color action buttons
 	Gtk::Button *button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
 	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
-	context->add_class("destructive-action");
+	button->get_style_context()->add_class("destructive-action");
+
 	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
 	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	context = button->get_style_context();
-	context->add_class("suggested-action");
+	button->get_style_context()->add_class("suggested-action");
 
 
 	Glib::RefPtr<Gtk::FileFilter> filter_supported = Gtk::FileFilter::create();
@@ -2626,8 +2623,15 @@ App::dialog_open_file_sketch(const std::string &title, std::string &filename, st
 
 	dialog->set_transient_for(*App::main_window);
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("destructive-action");
+
+	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
+	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("suggested-action");
 
 	// show only Synfig sketch file (*.sketch)
 	Glib::RefPtr<Gtk::FileFilter> filter_sketch = Gtk::FileFilter::create();
@@ -2665,8 +2669,15 @@ App::dialog_open_file_image(const std::string &title, std::string &filename, std
 
 	dialog->set_transient_for(*App::main_window);
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("destructive-action");
+
+	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
+	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("suggested-action");
 
 	// show only images
 	Glib::RefPtr<Gtk::FileFilter> filter_image = Gtk::FileFilter::create();
@@ -2722,8 +2733,15 @@ App::dialog_open_file_audio(const std::string &title, std::string &filename, std
 
 	dialog->set_transient_for(*App::main_window);
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("destructive-action");
+
+	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
+	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("suggested-action");
 
 	// Audio files
 	Glib::RefPtr<Gtk::FileFilter> filter_audio = Gtk::FileFilter::create();
@@ -2772,8 +2790,15 @@ App::dialog_open_file_image_sequence(const std::string &title, std::set<synfig::
 	dialog->set_transient_for(*App::main_window);
 	dialog->set_current_folder(prev_path);
 	dialog->set_select_multiple(true);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("destructive-action");
+
+	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
+	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("suggested-action");
 
 	// show only images
 	Glib::RefPtr<Gtk::FileFilter> filter_image = Gtk::FileFilter::create();
@@ -2902,12 +2927,11 @@ App::dialog_open_file_with_history_button(const std::string &title, std::string 
 	//add color action buttons
 	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
 	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
-	context->add_class("destructive-action");
+	button->get_style_context()->add_class("destructive-action");
+
 	button = dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT);
 	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	context = button->get_style_context();
-	context->add_class("suggested-action");
+	button->get_style_context()->add_class("suggested-action");
 
 	// File filters
 	// Synfig Documents
@@ -3006,8 +3030,15 @@ App::dialog_open_folder(const std::string &title, std::string &foldername, std::
 
 	dialog->set_transient_for(transientwind);
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("destructive-action");
+
+	button = dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT);
+	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("suggested-action");
 
 	if(dialog->run() == Gtk::RESPONSE_ACCEPT)
 	{
@@ -3091,13 +3122,12 @@ App::dialog_save_file(const std::string &title, std::string &filename, std::stri
 	filter_sfg->add_pattern("*.sfg");
 
 	dialog->set_current_folder(prev_path);
+
 	//add color action buttons
 	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
-	context->add_class("destructive-action");
+	button->get_style_context()->add_class("destructive-action");
 	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
-	context = button->get_style_context();
-	context->add_class("suggested-action");
+	button->get_style_context()->add_class("suggested-action");
 
 	dialog->add_filter(filter_sifz);
 	dialog->add_filter(filter_sif);
@@ -3223,8 +3253,11 @@ App::dialog_export_file(const std::string &title, std::string &filename, std::st
 	}
 
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	button->get_style_context()->add_class("destructive-action");
+	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
+	button->get_style_context()->add_class("suggested-action");
 
 	if (filename.empty()) {
 		dialog->set_filename(prev_path);
@@ -3274,8 +3307,11 @@ App::dialog_save_file_spal(const std::string &title, std::string &filename, std:
 	filter_spal->add_pattern("*.spal");
 
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	button->get_style_context()->add_class("destructive-action");
+	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
+	button->get_style_context()->add_class("suggested-action");
 
 	dialog->add_filter(filter_spal);
 
@@ -3334,8 +3370,11 @@ App::dialog_save_file_sketch(const std::string &title, std::string &filename, st
 	filter_sketch->add_pattern("*.sketch");
 
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	button->get_style_context()->add_class("destructive-action");
+	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
+	button->get_style_context()->add_class("suggested-action");
 
 	dialog->add_filter(filter_sketch);
 
@@ -3390,8 +3429,11 @@ App::dialog_save_file_render(const std::string &title, std::string &filename, st
 	Gtk::FileChooserDialog *dialog = new Gtk::FileChooserDialog(*App::main_window, title, Gtk::FILE_CHOOSER_ACTION_SAVE);
 
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	dialog->add_button(Gtk::Stock::OK,   Gtk::RESPONSE_ACCEPT);
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	button->get_style_context()->add_class("destructive-action");
+	button = dialog->add_button(Gtk::Stock::OK,   Gtk::RESPONSE_ACCEPT);
+	button->get_style_context()->add_class("suggested-action");
 
 	if (filename.empty()) {
 		dialog->set_filename(prev_path);

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2373,13 +2373,8 @@ App::dialog_open_file_ext(const std::string &title, std::vector<std::string> &fi
 	dialog->set_current_folder(prev_path);
 
 	//Add action button colors
-	Gtk::Button *button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);//->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("destructive-action");
-
-	button = dialog->add_button(_("Import"), Gtk::RESPONSE_ACCEPT);//->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
-	button->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("suggested-action");
+	set_button_style_destructive(dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL), "gtk-cancel");
+	set_button_style_suggested(dialog->add_button(_("Import"), Gtk::RESPONSE_ACCEPT), "gtk-open");
 
 	dialog->set_select_multiple(allow_multiple_selection);
 
@@ -2538,14 +2533,8 @@ App::dialog_open_file_spal(const std::string &title, std::string &filename, std:
 	dialog->set_current_folder(prev_path);
 
 	//add color action buttons
-	Gtk::Button *button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
-	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("destructive-action");
-
-	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
-	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("suggested-action");
-
+	set_button_style_destructive(dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL), "gtk-cancel");
+	set_button_style_suggested(dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT), "gtk-open");
 
 	Glib::RefPtr<Gtk::FileFilter> filter_supported = Gtk::FileFilter::create();
 	filter_supported->set_name(_("Palette files (*.spal, *.gpl)"));
@@ -2596,13 +2585,8 @@ App::dialog_open_file_sketch(const std::string &title, std::string &filename, st
 	dialog->set_current_folder(prev_path);
 
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
-	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("destructive-action");
-
-	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
-	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("suggested-action");
+	set_button_style_destructive(dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL), "gtk-cancel");
+	set_button_style_suggested(dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT), "gtk-open");
 
 	// show only Synfig sketch file (*.sketch)
 	Glib::RefPtr<Gtk::FileFilter> filter_sketch = Gtk::FileFilter::create();
@@ -2642,13 +2626,8 @@ App::dialog_open_file_image(const std::string &title, std::string &filename, std
 	dialog->set_current_folder(prev_path);
 
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
-	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("destructive-action");
-
-	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
-	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("suggested-action");
+	set_button_style_destructive(dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL), "gtk-cancel");
+	set_button_style_suggested(dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT), "gtk-open");
 
 	// show only images
 	Glib::RefPtr<Gtk::FileFilter> filter_image = Gtk::FileFilter::create();
@@ -2706,13 +2685,8 @@ App::dialog_open_file_audio(const std::string &title, std::string &filename, std
 	dialog->set_current_folder(prev_path);
 
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
-	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("destructive-action");
-
-	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
-	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("suggested-action");
+	set_button_style_destructive(dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL), "gtk-cancel");
+	set_button_style_suggested(dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT), "gtk-open");
 
 	// Audio files
 	Glib::RefPtr<Gtk::FileFilter> filter_audio = Gtk::FileFilter::create();
@@ -2763,13 +2737,8 @@ App::dialog_open_file_image_sequence(const std::string &title, std::set<synfig::
 	dialog->set_select_multiple(true);
 
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
-	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("destructive-action");
-
-	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
-	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("suggested-action");
+	set_button_style_destructive(dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL), "gtk-cancel");
+	set_button_style_suggested(dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT), "gtk-open");
 
 	// show only images
 	Glib::RefPtr<Gtk::FileFilter> filter_image = Gtk::FileFilter::create();
@@ -2896,13 +2865,8 @@ App::dialog_open_file_with_history_button(const std::string &title, std::string 
 	// TODO: the Open history button should be file type sensitive one.
 	dialog->set_response_sensitive(RESPONSE_ACCEPT_WITH_HISTORY, true);
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
-	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("destructive-action");
-
-	button = dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT);
-	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("suggested-action");
+	set_button_style_destructive(dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL), "gtk-cancel");
+	set_button_style_suggested(dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT), "gtk-open");
 
 	// File filters
 	// Synfig Documents
@@ -3003,13 +2967,8 @@ App::dialog_open_folder(const std::string &title, std::string &foldername, std::
 	dialog->set_current_folder(prev_path);
 
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
-	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("destructive-action");
-
-	button = dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT);
-	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class("suggested-action");
+	set_button_style_destructive(dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL), "gtk-cancel");
+	set_button_style_suggested(dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT), "gtk-open");
 
 	if(dialog->run() == Gtk::RESPONSE_ACCEPT)
 	{
@@ -3095,10 +3054,8 @@ App::dialog_save_file(const std::string &title, std::string &filename, std::stri
 	dialog->set_current_folder(prev_path);
 
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	button->get_style_context()->add_class("destructive-action");
-	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
-	button->get_style_context()->add_class("suggested-action");
+	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL)->get_style_context()->add_class("destructive-action");
+	dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT)->get_style_context()->add_class("suggested-action");
 
 	dialog->add_filter(filter_sifz);
 	dialog->add_filter(filter_sif);
@@ -3225,10 +3182,8 @@ App::dialog_export_file(const std::string &title, std::string &filename, std::st
 
 	dialog->set_current_folder(prev_path);
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	button->get_style_context()->add_class("destructive-action");
-	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
-	button->get_style_context()->add_class("suggested-action");
+	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL)->get_style_context()->add_class("destructive-action");
+	dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT)->get_style_context()->add_class("suggested-action");
 
 	if (filename.empty()) {
 		dialog->set_filename(prev_path);
@@ -3279,10 +3234,8 @@ App::dialog_save_file_spal(const std::string &title, std::string &filename, std:
 
 	dialog->set_current_folder(prev_path);
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	button->get_style_context()->add_class("destructive-action");
-	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
-	button->get_style_context()->add_class("suggested-action");
+	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL)->get_style_context()->add_class("destructive-action");
+	dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT)->get_style_context()->add_class("suggested-action");
 
 	dialog->add_filter(filter_spal);
 
@@ -3342,10 +3295,8 @@ App::dialog_save_file_sketch(const std::string &title, std::string &filename, st
 
 	dialog->set_current_folder(prev_path);
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	button->get_style_context()->add_class("destructive-action");
-	button = dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT);
-	button->get_style_context()->add_class("suggested-action");
+	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL)->get_style_context()->add_class("destructive-action");
+	dialog->add_button(Gtk::Stock::SAVE,   Gtk::RESPONSE_ACCEPT)->get_style_context()->add_class("suggested-action");
 
 	dialog->add_filter(filter_sketch);
 
@@ -3401,10 +3352,8 @@ App::dialog_save_file_render(const std::string &title, std::string &filename, st
 
 	dialog->set_current_folder(prev_path);
 	//add color action buttons
-	Gtk::Button* button = dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-	button->get_style_context()->add_class("destructive-action");
-	button = dialog->add_button(Gtk::Stock::OK,   Gtk::RESPONSE_ACCEPT);
-	button->get_style_context()->add_class("suggested-action");
+	dialog->add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL)->get_style_context()->add_class("destructive-action");
+	dialog->add_button(Gtk::Stock::OK,   Gtk::RESPONSE_ACCEPT)->get_style_context()->add_class("suggested-action");
 
 	if (filename.empty()) {
 		dialog->set_filename(prev_path);
@@ -3631,6 +3580,20 @@ App::dialog_help()
 		dialog.set_title(_("Help"));
 		dialog.run();
 	}
+}
+
+void
+App::set_button_style_destructive(Gtk::Button* button, const Glib::ustring& icon_name)
+{
+	button->set_image_from_icon_name(icon_name, Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("destructive-action");
+}
+
+void
+App::set_button_style_suggested(Gtk::Button* button, const Glib::ustring& icon_name)
+{
+	button->set_image_from_icon_name(icon_name, Gtk::ICON_SIZE_BUTTON);
+	button->get_style_context()->add_class("suggested-action");
 }
 
 #if GTK_CHECK_VERSION(3, 20, 0)

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2400,8 +2400,18 @@ App::dialog_open_file_ext(const std::string &title, std::vector<std::string> &fi
 
 	dialog->set_transient_for(*App::main_window);
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Import"), Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
+
+	//Add action button colors
+	Gtk::Button *button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);//->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
+	context->add_class("destructive-action");
+	
+	button = dialog->add_button(_("Import"), Gtk::RESPONSE_ACCEPT);//->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
+	button->set_image_from_icon_name("gtk-open",   Gtk::ICON_SIZE_BUTTON);
+	context = button->get_style_context();
+	context->add_class("suggested-action");
+
 	dialog->set_select_multiple(allow_multiple_selection);
 
 	// 0 All supported files
@@ -2557,8 +2567,17 @@ App::dialog_open_file_spal(const std::string &title, std::string &filename, std:
 
 	dialog->set_transient_for(*App::main_window);
 	dialog->set_current_folder(prev_path);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+
+	//add color action buttons
+	Gtk::Button *button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
+	context->add_class("destructive-action");
+	button = dialog->add_button(_("Load"),   Gtk::RESPONSE_ACCEPT);
+	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+	context = button->get_style_context();
+	context->add_class("suggested-action");
+
 
 	Glib::RefPtr<Gtk::FileFilter> filter_supported = Gtk::FileFilter::create();
 	filter_supported->set_name(_("Palette files (*.spal, *.gpl)"));
@@ -2875,11 +2894,20 @@ App::dialog_open_file_with_history_button(const std::string &title, std::string 
 
 	dialog->set_transient_for(*App::main_window);
 	dialog->set_current_folder(prev_path);
+
+	//add buttons
 	Gtk::Button* history_button = dialog->add_button(_("Open history"), RESPONSE_ACCEPT_WITH_HISTORY);
 	// TODO: the Open history button should be file type sensitive one.
 	dialog->set_response_sensitive(RESPONSE_ACCEPT_WITH_HISTORY, true);
-	dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT)->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+	//add color action buttons
+	Gtk::Button* button = dialog->add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	button->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	Glib::RefPtr<Gtk::StyleContext> context = button->get_style_context();
+	context->add_class("destructive-action");
+	button = dialog->add_button(_("Open"),   Gtk::RESPONSE_ACCEPT);
+	button->set_image_from_icon_name("gtk-open", Gtk::ICON_SIZE_BUTTON);
+	context = button->get_style_context();
+	context->add_class("suggested-action");
 
 	// File filters
 	// Synfig Documents

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -37,6 +37,7 @@
 #include <gtkmm/box.h>
 #include <gtkmm/main.h>
 #include <gtkmm/uimanager.h>
+#include <gtkmm/button.h>
 
 #include <gui/iconcontroller.h>
 #include <gui/mainwindow.h>
@@ -441,6 +442,9 @@ public:
 	static void dialog_not_implemented();
 
 	static void dialog_help();
+
+	static void set_button_style_destructive(Gtk::Button* button, const Glib::ustring& icon_name);
+	static void set_button_style_suggested(Gtk::Button* button, const Glib::ustring& icon_name);
 
 #if GTK_CHECK_VERSION(3, 20, 0)
 	static void window_shortcuts();

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -660,10 +660,8 @@ Dialog_Setup::select_path_dialog(const std::string &title, std::string &filepath
 	#endif
 
 	//Add response buttons the the dialog:
-	Gtk::Button* button = dialog->add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
-	button->get_style_context()->add_class("destructive-action");
-	button = dialog->add_button(_("Select"), Gtk::RESPONSE_OK);
-	button->get_style_context()->add_class("suggested-action");
+	dialog->add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL)->get_style_context()->add_class("destructive-action");
+	dialog->add_button(_("Select"), Gtk::RESPONSE_OK)->get_style_context()->add_class("suggested-action");
 
   	if(dialog->run() == Gtk::RESPONSE_OK) {
 		filepath = dialog->get_filename();

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -664,7 +664,7 @@ Dialog_Setup::select_path_dialog(const std::string &title, std::string &filepath
 	button->get_style_context()->add_class("destructive-action");
 	button = dialog->add_button(_("Select"), Gtk::RESPONSE_OK);
 	button->get_style_context()->add_class("suggested-action");
-	
+
   	if(dialog->run() == Gtk::RESPONSE_OK) {
 		filepath = dialog->get_filename();
 		filepath = absolute_path(filepath);	//get the absolute path

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -660,8 +660,11 @@ Dialog_Setup::select_path_dialog(const std::string &title, std::string &filepath
 	#endif
 
 	//Add response buttons the the dialog:
-	dialog->add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
-	dialog->add_button(_("Select"), Gtk::RESPONSE_OK);
+	Gtk::Button* button = dialog->add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
+	button->get_style_context()->add_class("destructive-action");
+	button = dialog->add_button(_("Select"), Gtk::RESPONSE_OK);
+	button->get_style_context()->add_class("suggested-action");
+	
   	if(dialog->run() == Gtk::RESPONSE_OK) {
 		filepath = dialog->get_filename();
 		filepath = absolute_path(filepath);	//get the absolute path


### PR DESCRIPTION
fix #2208

I have added the color action buttons to a few of the ```FileChooserDialog``` windows.  I have added the buttons to ```Import```, ```Open```, and ```Save``` ```FileChooserDialog```'s.  I wanted to run it by you first to see if I am doing it the correct way before I continue on adding more color bottons to more ```FileChooserDalog``` windows.  Thanks for your time.