### PR TITLE
Add Color "destructive-action" and "suggested-action" to dialog when trying to quit before saving changes

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -377,6 +377,7 @@ public:
 				const std::string &button1,
 				const std::string &button2,
 				const std::string &button3,
+				bool hasDestructiveAction,
 				Response dflt=RESPONSE_YES
 	)
 	{

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -193,6 +193,7 @@ public:
 				const std::string &button1,
 				const std::string &button2,
 				const std::string &button3,
+				bool hasDestructiveAction,
 				Response dflt=RESPONSE_YES )
 	{
 		view->present();
@@ -207,10 +208,12 @@ public:
 		);
 
 		dialog.set_secondary_text(details);
-		dialog.add_button(button1, RESPONSE_NO);
+		Gtk::Button* no_button = dialog.add_button(button1, RESPONSE_NO);
 		dialog.add_button(button2, RESPONSE_CANCEL);
 		dialog.add_button(button3, RESPONSE_YES);
-
+		//add destructive-action colored button if closed without saving
+		if (hasDestructiveAction)
+			no_button->get_style_context()->add_class("destructive-action");
 		dialog.set_default_response(dflt);
 		dialog.show();
 		int response = dialog.run();
@@ -3638,6 +3641,7 @@ CanvasView::import_sequence()
 				_("No"),
 				_("Cancel"),
 				_("Yes"),
+				false,
 				UIInterface::RESPONSE_NO);
 		if(answer!=UIInterface::RESPONSE_CANCEL){
 			canvas_interface()->import_sequence(filenames, errors, warnings, App::resize_imported_images,answer);

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -813,6 +813,7 @@ Instance::safe_close()
 						_("Close without Saving"),
 						_("Cancel"),
 						_("Save"),
+						true,
 						synfigapp::UIInterface::RESPONSE_YES
 			);
 

--- a/synfig-studio/src/synfigapp/uimanager.cpp
+++ b/synfig-studio/src/synfigapp/uimanager.cpp
@@ -91,6 +91,7 @@ ConsoleUIInterface::yes_no_cancel(
 			const std::string &/*button1*/,
 			const std::string &/*button2*/,
 			const std::string &/*button3*/,
+			bool hasDestructiveAction,
 			Response dflt
 )
 {

--- a/synfig-studio/src/synfigapp/uimanager.h
+++ b/synfig-studio/src/synfigapp/uimanager.h
@@ -70,6 +70,7 @@ public:
 				const std::string &button1,
 				const std::string &button2,
 				const std::string &button3,
+				bool hasDestructiveAction,
 				Response dflt=RESPONSE_YES
 	) = 0;
 };
@@ -93,6 +94,7 @@ public:
 			const std::string &/*button1*/,
 			const std::string &/*button2*/,
 			const std::string &/*button3*/,
+			bool hasDestructiveAction,
 			Response dflt
 	)
 	{ return dflt; }
@@ -127,6 +129,7 @@ public:
 			const std::string &/*button1*/,
 			const std::string &/*button2*/,
 			const std::string &/*button3*/,
+			bool hasDestructiveAction,
 			Response /*dflt*/
 	)
 	{ return RESPONSE_YES; }
@@ -160,6 +163,7 @@ public:
 			const std::string &button1,
 			const std::string &button2,
 			const std::string &button3,
+			bool hasDestructiveAction,
 			Response dflt
 	);
 


### PR DESCRIPTION
fix #2208

@rodolforg Hi Rodolfo, is this the change you are looking for?
This only creates "destructive-action" ```cancel``` button when the user tries to exit without saving.