### PR TITLE
Fixed issue with opening a file from a network folder on Windows

### DIFF
--- a/synfig-core/src/synfig/filesystemnative.cpp
+++ b/synfig-core/src/synfig/filesystemnative.cpp
@@ -89,20 +89,20 @@ FileSystemNative::~FileSystemNative() { }
 
 bool FileSystemNative::is_file(const String &filename)
 {
-	return Gio::File::create_for_path(fix_slashes(filename))->query_file_type()
+	return Gio::File::create_for_path(filename)->query_file_type()
 	    == Gio::FILE_TYPE_REGULAR;
 }
 
 bool FileSystemNative::is_directory(const String &filename)
 {
-	return Gio::File::create_for_path(fix_slashes(filename))->query_file_type()
+	return Gio::File::create_for_path(filename)->query_file_type()
 	    == Gio::FILE_TYPE_DIRECTORY;
 }
 
 bool FileSystemNative::directory_create(const String &dirname)
 {
 	return is_directory(dirname)
-	    || Gio::File::create_for_path(fix_slashes(dirname))->make_directory();
+	    || Gio::File::create_for_path(dirname)->make_directory();
 }
 
 bool FileSystemNative::directory_scan(const String &dirname, FileList &out_files)
@@ -119,7 +119,7 @@ bool FileSystemNative::directory_scan(const String &dirname, FileList &out_files
 
 bool FileSystemNative::file_remove(const String &filename)
 {
-	return 0 == g_remove(fix_slashes(filename).c_str());
+	return 0 == g_remove(filename.c_str());
 }
 
 bool FileSystemNative::file_rename(const String &from_filename, const String &to_filename)
@@ -130,7 +130,7 @@ bool FileSystemNative::file_rename(const String &from_filename, const String &to
 
 FileSystem::ReadStream::Handle FileSystemNative::get_read_stream(const String &filename)
 {
-	FILE *f = g_fopen(fix_slashes(filename).c_str(), "rb");
+	FILE *f = g_fopen(filename.c_str(), "rb");
 	return f == nullptr
 	     ? FileSystem::ReadStream::Handle()
 	     : FileSystem::ReadStream::Handle(new ReadStream(this, f));
@@ -138,7 +138,7 @@ FileSystem::ReadStream::Handle FileSystemNative::get_read_stream(const String &f
 
 FileSystem::WriteStream::Handle FileSystemNative::get_write_stream(const String &filename)
 {
-	FILE *f = g_fopen(fix_slashes(filename).c_str(), "wb");
+	FILE *f = g_fopen(filename.c_str(), "wb");
 	return f == nullptr
 	     ? FileSystem::WriteStream::Handle()
 	     : FileSystem::WriteStream::Handle(new WriteStream(this, f));

--- a/synfig-core/src/synfig/filesystemnative.cpp
+++ b/synfig-core/src/synfig/filesystemnative.cpp
@@ -35,21 +35,16 @@
 #include <giomm.h>
 #include <glibmm.h>
 #include <glib/gstdio.h>
-#include <sys/stat.h>
 
 #include <ETL/stringf>
-#include "general.h"
-#include <synfig/localization.h>
 
 #include "filesystemnative.h"
-#include "guid.h"
 
 #endif
 
 /* === U S I N G =========================================================== */
 
-using namespace etl;
-using namespace synfig;
+namespace synfig {
 
 /* === M A C R O S ========================================================= */
 
@@ -136,7 +131,7 @@ bool FileSystemNative::file_rename(const String &from_filename, const String &to
 FileSystem::ReadStream::Handle FileSystemNative::get_read_stream(const String &filename)
 {
 	FILE *f = g_fopen(fix_slashes(filename).c_str(), "rb");
-	return f == NULL
+	return f == nullptr
 	     ? FileSystem::ReadStream::Handle()
 	     : FileSystem::ReadStream::Handle(new ReadStream(this, f));
 }
@@ -144,7 +139,7 @@ FileSystem::ReadStream::Handle FileSystemNative::get_read_stream(const String &f
 FileSystem::WriteStream::Handle FileSystemNative::get_write_stream(const String &filename)
 {
 	FILE *f = g_fopen(fix_slashes(filename).c_str(), "wb");
-	return f == NULL
+	return f == nullptr
 	     ? FileSystem::WriteStream::Handle()
 	     : FileSystem::WriteStream::Handle(new WriteStream(this, f));
 }
@@ -156,6 +151,4 @@ String FileSystemNative::get_real_uri(const String &filename)
 }
 
 
-/* === E N T R Y P O I N T ================================================= */
-
-
+}


### PR DESCRIPTION
The Windows network path looks like this: `\\NetworkPC\Share`.
`fix_slashes` changes it to `//NetworkPC/Share`, so it can't be
interpreted as a network share no more.

I removed the `fix_slashes` because glib/gio does all the translations itself.

Fix #2212 