### PR TITLE
Re-enable "Create Child Bone" action

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuedesccreatechildbone.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedesccreatechildbone.cpp
@@ -56,7 +56,7 @@ ACTION_INIT(Action::ValueDescCreateChildBone);
 ACTION_SET_NAME(Action::ValueDescCreateChildBone,"ValueDescCreateChildBone");
 ACTION_SET_LOCAL_NAME(Action::ValueDescCreateChildBone,N_("Create Child Bone"));
 ACTION_SET_TASK(Action::ValueDescCreateChildBone,"create_child_bone");
-ACTION_SET_CATEGORY(Action::ValueDescCreateChildBone,Action::CATEGORY_HIDDEN);
+ACTION_SET_CATEGORY(Action::ValueDescCreateChildBone,Action::CATEGORY_VALUEDESC);
 ACTION_SET_PRIORITY(Action::ValueDescCreateChildBone,0);
 ACTION_SET_VERSION(Action::ValueDescCreateChildBone,"0.0");
 


### PR DESCRIPTION
Got a feedback from several Synfig users, who are on latest development snapshot of Synfig:
Many of them got stuck on tutorials because of missing "Create Child Bones" action.
The issue https://github.com/synfig/synfig/issues/1714 confirms that too.

So, it looks like I was wrong when [suggested to disable this](https://github.com/synfig/synfig/issues/1558). ^__^

Let's re-enable this and wait while most tutorials will be updated and people will get used to Skeleton Tool.