### PR TITLE
fix behavior after Tool process a key event: only proceeds when RESULT_OK

### DIFF
--- a/synfig-studio/src/gui/_smach.h
+++ b/synfig-studio/src/gui/_smach.h
@@ -73,10 +73,10 @@ public:
 	{
 		// These values are returned by the event
 		// handlers cast to state pointers.
-		RESULT_ERROR,		//!< General error or malfunction
-		RESULT_OK,			//!< Event has been processed
-		RESULT_ACCEPT,		//!< The event has been explicitly accepted.
-		RESULT_REJECT,		//!< The event has been explicitly rejected.
+		RESULT_ERROR,		//!< Tool/state processed the event and found a general error or malfunction
+		RESULT_OK,			//!< Tool/state processed the event or not, but let it be processed (too) by other handlers in the event pipeline (WorkArea, Gtk App, etc)
+		RESULT_ACCEPT,		//!< Tool/state processed the event and consumed the event
+		RESULT_REJECT,		//!< Tool/state processed the event and/or forbid the event
 
 		RESULT_END			//!< Not a valid result
 	};

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -718,7 +718,7 @@ StateNormal_Context::event_key_down_handler(const Smach::event& x)
 		set_shift_pressed(event.modifier&GDK_SHIFT_MASK);
 		break;
 	}
-	return Smach::RESULT_REJECT;
+	return Smach::RESULT_OK;
 }
 
 Smach::event_result
@@ -747,7 +747,7 @@ StateNormal_Context::event_key_up_handler(const Smach::event& x)
 	default:
 		break;
 	}
-	return Smach::RESULT_REJECT;
+	return Smach::RESULT_OK;
 }
 
 Smach::event_result

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -982,9 +982,13 @@ bool
 WorkArea::on_key_press_event(GdkEventKey* event)
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
-	if (Smach::RESULT_OK == canvas_view->get_smach().process_event(
-		EventKeyboard(EVENT_WORKAREA_KEY_DOWN, event->keyval, Gdk::ModifierType(event->state))))
-			return true;
+	auto event_result = canvas_view->get_smach().process_event(
+		EventKeyboard(EVENT_WORKAREA_KEY_DOWN, event->keyval, Gdk::ModifierType(event->state)));
+	if (event_result != Smach::RESULT_OK)
+		return true;
+
+	// Other possible actions if current state doesn't accept the event but not forbids it
+	// - Nudge selected ducks
 
 	if(get_selected_ducks().empty())
 		return false;
@@ -1039,8 +1043,14 @@ bool
 WorkArea::on_key_release_event(GdkEventKey* event)
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
-	return Smach::RESULT_OK == canvas_view->get_smach().process_event(
+	auto event_result = canvas_view->get_smach().process_event(
 		EventKeyboard(EVENT_WORKAREA_KEY_UP, event->keyval, Gdk::ModifierType(event->state)) );
+	if (event_result != Smach::RESULT_OK)
+		return true;
+
+	// Other possible actions if current state doesn't accept the event but not forbids it
+	// - currently none
+
 	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 


### PR DESCRIPTION
RESULT_ACCEPT: Current Tool/state processed and consumed the event
RESULT_REJECT: Current Tool/state processed and/or forbid the event
RESULT_ERROR: Current Tool/state processed and found an error
RESULT_OK: Current Tool/state processed or not, but let the event be
processed (too) by others in the event pipeline (WorkArea, Gtk App, etc)