### PR TITLE
Quick fix for zstreambuf

### DIFF
--- a/synfig-core/src/synfig/filecontainerzip.cpp
+++ b/synfig-core/src/synfig/filecontainerzip.cpp
@@ -847,7 +847,7 @@ FileSystem::ReadStream::Handle FileContainerZip::get_read_stream(const String &f
 	 && file_is_opened_for_read()
 	 && !file_reading_whole_container_
 	 && file_->second.compression > 0)
-		return new ZReadStream(stream);
+		return new ZReadStream(stream, zstreambuf::compression::deflate);
 	return stream;
 }
 

--- a/synfig-core/src/synfig/filesystemtemporary.cpp
+++ b/synfig-core/src/synfig/filesystemtemporary.cpp
@@ -576,7 +576,7 @@ FileSystemTemporary::open_temporary(const String &filename)
 
 	FileSystem::ReadStream::Handle stream = file_system->get_read_stream(filename);
 	if (!stream) return false;
-	stream = new ZReadStream(stream);
+	stream = new ZReadStream(stream, zstreambuf::compression::gzip);
 
 	xmlpp::DomParser parser;
 	parser.parse_stream(*stream);

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -3498,7 +3498,7 @@ CanvasParser::parse_from_file_as(const FileSystem::Identifier &identifier,const 
 		if (stream)
 		{
 			if (filename_extension(identifier.filename) == ".sifz")
-				stream = FileSystem::ReadStream::Handle(new ZReadStream(stream));
+				stream = FileSystem::ReadStream::Handle(new ZReadStream(stream, zstreambuf::compression::gzip));
 
 			xmlpp::DomParser parser;
 			parser.parse_stream(*stream);

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -317,7 +317,7 @@ studio::Instance::run_plugin(std::string plugin_id, bool modify_canvas, std::vec
 		else
 		{
 			if (filename_ext == ".sifz")
-				stream_in = new ZReadStream(stream_in);
+				stream_in = new ZReadStream(stream_in, synfig::zstreambuf::gzip);
 
 			FileSystem::WriteStream::Handle outfile = FileSystemNative::instance()->get_write_stream(filename_processed);
 			*outfile << stream_in->rdbuf();


### PR DESCRIPTION
The problem was in `inflateInit2` incorrect initialization.
In this case we have no file header, quote from documentation:

> windowBits can also be –8..–15 for raw inflate. In this case, -windowBits
determines the window size. inflate() will then process raw deflate data,
not looking for a zlib or gzip header, not generating a check value, and
not looking for any check values for comparison at the end of the
stream. This is for use with other formats that use the deflate
compressed data format such as zip.

Anyway this change should be tested before the merge.