### PR TITLE
Fixed PVS-Studio warning v656

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_bonelink.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bonelink.cpp
@@ -156,7 +156,7 @@ ValueNode_BoneLink::get_bone_transformation(Time t)const
 		Bone bone      = (*bone_node) (t).get(Bone());
 		bool translate = (*translate_)(t).get(true);
 		bool rotate    = (*rotate_)   (t).get(true);
-		bool skew      = (*rotate_)   (t).get(true);
+		bool skew      = (*skew_)     (t).get(true);
 		bool scale_x   = (*scale_x_)  (t).get(true);
 		bool scale_y   = (*scale_y_)  (t).get(true);
 

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -349,7 +349,7 @@ StateBLine_Context::load_settings()
 		// determine layer flags
 		layer_region_flag = get_layer_region_flag();
 		layer_outline_flag = get_layer_outline_flag();
-		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_advanced_outline_flag();
 		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
 		layer_plant_flag = get_layer_plant_flag();
 

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -345,7 +345,7 @@ StateCircle_Context::load_settings()
 		layer_circle_flag = get_layer_circle_flag();
 		layer_region_flag = get_layer_region_flag();
 		layer_outline_flag = get_layer_outline_flag();
-		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_advanced_outline_flag();
 		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
 		layer_plant_flag = get_layer_plant_flag();
 

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -307,7 +307,7 @@ StatePolygon_Context::load_settings()
 		layer_polygon_flag = get_layer_polygon_flag();
 		layer_region_flag = get_layer_region_flag();
 		layer_outline_flag = get_layer_outline_flag();
-		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_advanced_outline_flag();
 		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
 		layer_plant_flag = get_layer_plant_flag();
 	}

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -321,7 +321,7 @@ StateRectangle_Context::load_settings()
 		layer_rectangle_flag = get_layer_rectangle_flag();
 		layer_region_flag = get_layer_region_flag();
 		layer_outline_flag = get_layer_outline_flag();
-		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_advanced_outline_flag();
 		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
 		layer_plant_flag = get_layer_plant_flag();
 	}

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -390,7 +390,7 @@ StateStar_Context::load_settings()
 		layer_star_flag = get_layer_star_flag();
 		layer_region_flag = get_layer_region_flag();
 		layer_outline_flag = get_layer_outline_flag();
-		layer_advanced_outline_flag = get_layer_outline_flag();
+		layer_advanced_outline_flag = get_layer_advanced_outline_flag();
 		layer_curve_gradient_flag = get_layer_curve_gradient_flag();
 		layer_plant_flag = get_layer_plant_flag();
 	}


### PR DESCRIPTION
V656. Variables are initialized through the call to the same function.
It's probably an error or un-optimized code.

https://pvs-studio.com/en/docs/warnings/v656/