### PR TITLE
ETL test: avoid clash between ETL::hermite and std::hermite

### DIFF
--- a/ETL/test/angle.cpp
+++ b/ETL/test/angle.cpp
@@ -202,7 +202,7 @@ int angle_test()
 
 		affine_combo<angle> combo;
 
-		hermite<angle> hermie(a,b,b.dist(a),b.dist(a));
+		etl::hermite<angle> hermie(a,b,b.dist(a),b.dist(a));
 
 		for(f=0;f<1.001;f+=0.1)
 		{


### PR DESCRIPTION
Part of solution for https://bugs.debian.org/984053