### PR TITLE
[MSYS2] Updated packages list

### DIFF
--- a/1-setup-windows-msys2.sh
+++ b/1-setup-windows-msys2.sh
@@ -24,13 +24,14 @@ pacman -S --needed --noconfirm --color=auto \
 autoconf \
 automake-wrapper \
 intltool \
+libtool \
 make \
 patch \
 tar \
 $MINGW_PACKAGE_PREFIX-gcc \
 $MINGW_PACKAGE_PREFIX-ccache \
 $MINGW_PACKAGE_PREFIX-cmake \
-$MINGW_PACKAGE_PREFIX-libtool \
+$MINGW_PACKAGE_PREFIX-libltdl \
 $MINGW_PACKAGE_PREFIX-make \
 $MINGW_PACKAGE_PREFIX-pkgconf \
 $MINGW_PACKAGE_PREFIX-dlfcn \


### PR DESCRIPTION
MSYS2 moved `libtoolize` to the new `libtool` package and renamed `mingw-w64-x86_64-libtool` to `mingw-w64-x86_64-libltdl`

This should fix the error: `*** No libtoolize nor glibtoolize found, please install the intltool package ***"` when building with autotools on MSYS2 (using `./2-build-debug.sh` script).