### PR TITLE
fix ValueNode local name not being translated

### DIFF
--- a/synfig-core/src/modules/mod_noise/valuenode_random.cpp
+++ b/synfig-core/src/modules/mod_noise/valuenode_random.cpp
@@ -55,7 +55,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Random, RELEASE_VERSION_0_61_08, "random", "Random")
+REGISTER_VALUENODE(ValueNode_Random, RELEASE_VERSION_0_61_08, "random", N_("Random"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -664,7 +664,7 @@ xmlpp::Element* encode_linkable_value_node(xmlpp::Element* root,LinkableValueNod
 
 	String name(value_node->get_name());
 	ReleaseVersion saving_version(get_file_version());
-	ReleaseVersion feature_version(ValueNodeRegistry::book()[name].release_version);
+	ReleaseVersion feature_version(ValueNodeRegistry::book().at(name).release_version);
 
 	if (saving_version < feature_version)
 	{

--- a/synfig-core/src/synfig/valuenode_registry.h
+++ b/synfig-core/src/synfig/valuenode_registry.h
@@ -81,10 +81,15 @@ public:
 
 	struct BookEntry
 	{
+	private:
 		String local_name;
+	public:
 		Factory factory;
 		CheckType check_type;
 		ReleaseVersion release_version; // which version of synfig introduced this valuenode type
+
+		BookEntry(String local_name, Factory factory, CheckType check_type, ReleaseVersion release_version);
+		String get_local_name() const { return localize_name(local_name); }
 	};
 
 	typedef std::map<String,BookEntry> Book;

--- a/synfig-core/src/synfig/valuenodes/valuenode_add.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_add.cpp
@@ -62,7 +62,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Add, RELEASE_VERSION_0_61_07, "add", "Add")
+REGISTER_VALUENODE(ValueNode_Add, RELEASE_VERSION_0_61_07, "add", N_("Add"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_and.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_and.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_And, RELEASE_VERSION_0_62_00, "and", "AND")
+REGISTER_VALUENODE(ValueNode_And, RELEASE_VERSION_0_62_00, "and", N_("AND"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_anglestring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_anglestring.cpp
@@ -52,7 +52,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_AngleString, RELEASE_VERSION_0_61_09, "anglestring", "Angle String")
+REGISTER_VALUENODE(ValueNode_AngleString, RELEASE_VERSION_0_61_09, "anglestring", N_("Angle String"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.cpp
@@ -59,7 +59,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_AnimatedFile, RELEASE_VERSION_1_6_0, "animated_file", "Animation from File")
+REGISTER_VALUENODE(ValueNode_AnimatedFile, RELEASE_VERSION_1_6_0, "animated_file", N_("Animation from File"))
 
 /* === C L A S S E S ======================================================= */
 class ValueNode_AnimatedFile::Internal

--- a/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Atan2, RELEASE_VERSION_0_61_08, "atan2", "aTan2")
+REGISTER_VALUENODE(ValueNode_Atan2, RELEASE_VERSION_0_61_08, "atan2", N_("aTan2"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_average.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_average.cpp
@@ -52,7 +52,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Average, RELEASE_VERSION_1_0, "average", "Average")
+REGISTER_VALUENODE(ValueNode_Average, RELEASE_VERSION_1_0, "average", N_("Average"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -61,7 +61,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_BLine, RELEASE_VERSION_0_61_06, "bline", "Spline")
+REGISTER_VALUENODE(ValueNode_BLine, RELEASE_VERSION_0_61_06, "bline", N_("Spline"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
@@ -55,7 +55,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_BLineCalcTangent, RELEASE_VERSION_0_61_07, "blinecalctangent", "Spline Tangent")
+REGISTER_VALUENODE(ValueNode_BLineCalcTangent, RELEASE_VERSION_0_61_07, "blinecalctangent", N_("Spline Tangent"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
@@ -55,7 +55,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_BLineCalcVertex, RELEASE_VERSION_0_61_07, "blinecalcvertex", "Spline Vertex")
+REGISTER_VALUENODE(ValueNode_BLineCalcVertex, RELEASE_VERSION_0_61_07, "blinecalcvertex", N_("Spline Vertex"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
@@ -55,7 +55,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_BLineCalcWidth, RELEASE_VERSION_0_61_08, "blinecalcwidth", "Spline Width")
+REGISTER_VALUENODE(ValueNode_BLineCalcWidth, RELEASE_VERSION_0_61_08, "blinecalcwidth", N_("Spline Width"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.cpp
@@ -55,7 +55,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_BLineRevTangent, RELEASE_VERSION_0_61_08, "blinerevtangent", "Reverse Tangent")
+REGISTER_VALUENODE(ValueNode_BLineRevTangent, RELEASE_VERSION_0_61_08, "blinerevtangent", N_("Reverse Tangent"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
@@ -69,8 +69,8 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Bone, RELEASE_VERSION_0_62_00, "bone", "Bone")
-REGISTER_VALUENODE(ValueNode_Bone_Root, RELEASE_VERSION_0_62_00, "bone_root", "Root Bone")
+REGISTER_VALUENODE(ValueNode_Bone, RELEASE_VERSION_0_62_00, "bone", N_("Bone"))
+REGISTER_VALUENODE(ValueNode_Bone_Root, RELEASE_VERSION_0_62_00, "bone_root", N_("Root Bone"))
 
 static ValueNode_Bone::CanvasMap canvas_map;
 static int bone_counter;

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.cpp
@@ -58,7 +58,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_BoneInfluence, RELEASE_VERSION_0_62_00, "boneinfluence", "Bone Influence")
+REGISTER_VALUENODE(ValueNode_BoneInfluence, RELEASE_VERSION_0_62_00, "boneinfluence", N_("Bone Influence"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_bonelink.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bonelink.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_BoneLink, RELEASE_VERSION_1_0, "bone_link", "Bone Link")
+REGISTER_VALUENODE(ValueNode_BoneLink, RELEASE_VERSION_1_0, "bone_link", N_("Bone Link"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.cpp
@@ -53,7 +53,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_BoneWeightPair, RELEASE_VERSION_0_62_00, "boneweightpair", "Bone Weight Pair")
+REGISTER_VALUENODE(ValueNode_BoneWeightPair, RELEASE_VERSION_0_62_00, "boneweightpair", N_("Bone Weight Pair"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_compare.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_compare.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Compare, RELEASE_VERSION_0_62_00, "compare", "Compare")
+REGISTER_VALUENODE(ValueNode_Compare, RELEASE_VERSION_0_62_00, "compare", N_("Compare"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
@@ -64,7 +64,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Composite, RELEASE_VERSION_0_61_06, "composite", "Composite")
+REGISTER_VALUENODE(ValueNode_Composite, RELEASE_VERSION_0_61_06, "composite", N_("Composite"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_cos.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_cos.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Cos, RELEASE_VERSION_0_61_08, "cos", "Cos")
+REGISTER_VALUENODE(ValueNode_Cos, RELEASE_VERSION_0_61_08, "cos", N_("Cos"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_derivative.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_derivative.cpp
@@ -141,7 +141,7 @@ using namespace synfig;
 				)
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Derivative, RELEASE_VERSION_1_0, "derivative", "Derivative")
+REGISTER_VALUENODE(ValueNode_Derivative, RELEASE_VERSION_1_0, "derivative", N_("Derivative"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_dilist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dilist.cpp
@@ -58,7 +58,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_DIList, RELEASE_VERSION_0_63_01, "dilist", "DIList")
+REGISTER_VALUENODE(ValueNode_DIList, RELEASE_VERSION_0_63_01, "dilist", N_("DIList"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_DotProduct, RELEASE_VERSION_0_61_09, "dotproduct", "Dot Product")
+REGISTER_VALUENODE(ValueNode_DotProduct, RELEASE_VERSION_0_61_09, "dotproduct", N_("Dot Product"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_duplicate.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_duplicate.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Duplicate, RELEASE_VERSION_0_61_08, "duplicate", "Duplicate")
+REGISTER_VALUENODE(ValueNode_Duplicate, RELEASE_VERSION_0_61_08, "duplicate", N_("Duplicate"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamic.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamic.cpp
@@ -52,7 +52,7 @@ using namespace boost::numeric::odeint;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Dynamic, RELEASE_VERSION_0_61_06, "dynamic", "Dynamic")
+REGISTER_VALUENODE(ValueNode_Dynamic, RELEASE_VERSION_0_61_06, "dynamic", N_("Dynamic"))
 
 
 /* === P R O C E D U R E S ================================================= */

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
@@ -57,7 +57,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_DynamicList, RELEASE_VERSION_0_61_06, "dynamic_list", "Dynamic List")
+REGISTER_VALUENODE(ValueNode_DynamicList, RELEASE_VERSION_0_61_06, "dynamic_list", N_("Dynamic List"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_exp.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_exp.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Exp, RELEASE_VERSION_0_61_07, "exp", "Exponential")
+REGISTER_VALUENODE(ValueNode_Exp, RELEASE_VERSION_0_61_07, "exp", N_("Exponential"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_GradientColor, RELEASE_VERSION_0_61_09, "gradientcolor", "Gradient Color")
+REGISTER_VALUENODE(ValueNode_GradientColor, RELEASE_VERSION_0_61_09, "gradientcolor", N_("Gradient Color"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.cpp
@@ -52,7 +52,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_GradientRotate, RELEASE_VERSION_0_61_06, "gradient_rotate", "Gradient Rotate")
+REGISTER_VALUENODE(ValueNode_GradientRotate, RELEASE_VERSION_0_61_06, "gradient_rotate", N_("Gradient Rotate"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_greyed.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_greyed.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Greyed, RELEASE_VERSION_0_62_00, "greyed", "Greyed")
+REGISTER_VALUENODE(ValueNode_Greyed, RELEASE_VERSION_0_62_00, "greyed", N_("Greyed"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_integer.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_integer.cpp
@@ -54,7 +54,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Integer, RELEASE_VERSION_0_61_08, "fromint", "Integer")
+REGISTER_VALUENODE(ValueNode_Integer, RELEASE_VERSION_0_61_08, "fromint", N_("Integer"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_intstring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_intstring.cpp
@@ -52,7 +52,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_IntString, RELEASE_VERSION_0_61_09, "intstring", "Int String")
+REGISTER_VALUENODE(ValueNode_IntString, RELEASE_VERSION_0_61_09, "intstring", N_("Int String"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_join.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_join.cpp
@@ -52,7 +52,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Join, RELEASE_VERSION_0_61_09, "join", "Joined List")
+REGISTER_VALUENODE(ValueNode_Join, RELEASE_VERSION_0_61_09, "join", N_("Joined List"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_linear.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_linear.cpp
@@ -56,7 +56,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Linear, RELEASE_VERSION_0_61_06, "linear", "Linear")
+REGISTER_VALUENODE(ValueNode_Linear, RELEASE_VERSION_0_61_06, "linear", N_("Linear"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_log.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_log.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Logarithm, RELEASE_VERSION_0_61_09, "logarithm", "Logarithm")
+REGISTER_VALUENODE(ValueNode_Logarithm, RELEASE_VERSION_0_61_09, "logarithm", N_("Logarithm"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_not.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_not.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Not, RELEASE_VERSION_0_62_00, "not", "NOT")
+REGISTER_VALUENODE(ValueNode_Not, RELEASE_VERSION_0_62_00, "not", N_("NOT"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_or.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_or.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Or, RELEASE_VERSION_0_62_00, "or", "OR")
+REGISTER_VALUENODE(ValueNode_Or, RELEASE_VERSION_0_62_00, "or", N_("OR"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_pow.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_pow.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Pow, RELEASE_VERSION_0_62_00, "power", "Power")
+REGISTER_VALUENODE(ValueNode_Pow, RELEASE_VERSION_0_62_00, "power", N_("Power"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
@@ -53,7 +53,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_RadialComposite, RELEASE_VERSION_0_61_06, "radial_composite", "Radial Composite")
+REGISTER_VALUENODE(ValueNode_RadialComposite, RELEASE_VERSION_0_61_06, "radial_composite", N_("Radial Composite"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
@@ -58,7 +58,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Range, RELEASE_VERSION_0_61_07, "range", "Range")
+REGISTER_VALUENODE(ValueNode_Range, RELEASE_VERSION_0_61_07, "range", N_("Range"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
@@ -54,7 +54,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Real, RELEASE_VERSION_0_64_0, "fromreal", "Real")
+REGISTER_VALUENODE(ValueNode_Real, RELEASE_VERSION_0_64_0, "fromreal", N_("Real"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_realstring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_realstring.cpp
@@ -52,7 +52,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_RealString, RELEASE_VERSION_0_61_09, "realstring", "Real String")
+REGISTER_VALUENODE(ValueNode_RealString, RELEASE_VERSION_0_61_09, "realstring", N_("Real String"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Reciprocal, RELEASE_VERSION_0_61_08, "reciprocal", "Reciprocal")
+REGISTER_VALUENODE(ValueNode_Reciprocal, RELEASE_VERSION_0_61_08, "reciprocal", N_("Reciprocal"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_reference.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reference.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Reference, RELEASE_VERSION_0_61_06, "reference", "Reference")
+REGISTER_VALUENODE(ValueNode_Reference, RELEASE_VERSION_0_61_06, "reference", N_("Reference"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.cpp
@@ -53,7 +53,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Repeat_Gradient, RELEASE_VERSION_0_61_07, "repeat_gradient", "Repeat Gradient")
+REGISTER_VALUENODE(ValueNode_Repeat_Gradient, RELEASE_VERSION_0_61_07, "repeat_gradient", N_("Repeat Gradient"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
@@ -66,7 +66,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Reverse, RELEASE_VERSION_1_0_2, "reverse", "Reverse")
+REGISTER_VALUENODE(ValueNode_Reverse, RELEASE_VERSION_1_0_2, "reverse", N_("Reverse"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_scale.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_scale.cpp
@@ -58,7 +58,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Scale, RELEASE_VERSION_0_61_06, "scale", "Scale")
+REGISTER_VALUENODE(ValueNode_Scale, RELEASE_VERSION_0_61_06, "scale", N_("Scale"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.cpp
@@ -55,7 +55,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_SegCalcTangent, RELEASE_VERSION_0_61_06, "segcalctangent", "Segment Tangent")
+REGISTER_VALUENODE(ValueNode_SegCalcTangent, RELEASE_VERSION_0_61_06, "segcalctangent", N_("Segment Tangent"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.cpp
@@ -54,7 +54,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_SegCalcVertex, RELEASE_VERSION_0_61_06, "segcalcvertex", "Segment Vertex")
+REGISTER_VALUENODE(ValueNode_SegCalcVertex, RELEASE_VERSION_0_61_06, "segcalcvertex", N_("Segment Vertex"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_sine.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_sine.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Sine, RELEASE_VERSION_0_61_06, "sine", "Sine")
+REGISTER_VALUENODE(ValueNode_Sine, RELEASE_VERSION_0_61_06, "sine", N_("Sine"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_staticlist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_staticlist.cpp
@@ -60,7 +60,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_StaticList, RELEASE_VERSION_0_62_00, "static_list", "Static List")
+REGISTER_VALUENODE(ValueNode_StaticList, RELEASE_VERSION_0_62_00, "static_list", N_("Static List"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_step.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_step.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Step, RELEASE_VERSION_0_61_08, "step", "Step")
+REGISTER_VALUENODE(ValueNode_Step, RELEASE_VERSION_0_61_08, "step", N_("Step"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_stripes.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_stripes.cpp
@@ -53,7 +53,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Stripes, RELEASE_VERSION_0_61_06, "stripes", "Stripes")
+REGISTER_VALUENODE(ValueNode_Stripes, RELEASE_VERSION_0_61_06, "stripes", N_("Stripes"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
@@ -59,7 +59,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Subtract, RELEASE_VERSION_0_61_06, "subtract", "Subtract")
+REGISTER_VALUENODE(ValueNode_Subtract, RELEASE_VERSION_0_61_06, "subtract", N_("Subtract"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_Switch, RELEASE_VERSION_0_61_08, "switch", "Switch")
+REGISTER_VALUENODE(ValueNode_Switch, RELEASE_VERSION_0_61_08, "switch", N_("Switch"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_timedswap.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timedswap.cpp
@@ -56,7 +56,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_TimedSwap, RELEASE_VERSION_0_61_07, "timed_swap", "Timed Swap")
+REGISTER_VALUENODE(ValueNode_TimedSwap, RELEASE_VERSION_0_61_07, "timed_swap", N_("Timed Swap"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_timeloop.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timeloop.cpp
@@ -50,7 +50,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_TimeLoop, RELEASE_VERSION_0_61_08, "timeloop", "Time Loop")
+REGISTER_VALUENODE(ValueNode_TimeLoop, RELEASE_VERSION_0_61_08, "timeloop", N_("Time Loop"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_timestring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timestring.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_TimeString, RELEASE_VERSION_0_61_09, "timestring", "Time String")
+REGISTER_VALUENODE(ValueNode_TimeString, RELEASE_VERSION_0_61_09, "timestring", N_("Time String"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_twotone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_twotone.cpp
@@ -53,7 +53,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_TwoTone, RELEASE_VERSION_0_61_06, "twotone", "Two-Tone")
+REGISTER_VALUENODE(ValueNode_TwoTone, RELEASE_VERSION_0_61_06, "twotone", N_("Two-Tone"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_VectorAngle, RELEASE_VERSION_0_61_09, "vectorangle", "Vector Angle")
+REGISTER_VALUENODE(ValueNode_VectorAngle, RELEASE_VERSION_0_61_09, "vectorangle", N_("Vector Angle"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_VectorLength, RELEASE_VERSION_0_61_09, "vectorlength", "Vector Length")
+REGISTER_VALUENODE(ValueNode_VectorLength, RELEASE_VERSION_0_61_09, "vectorlength", N_("Vector Length"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorx.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorx.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_VectorX, RELEASE_VERSION_0_61_09, "vectorx", "Vector X")
+REGISTER_VALUENODE(ValueNode_VectorX, RELEASE_VERSION_0_61_09, "vectorx", N_("Vector X"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectory.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectory.cpp
@@ -51,7 +51,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_VectorY, RELEASE_VERSION_0_61_09, "vectory", "Vector Y")
+REGISTER_VALUENODE(ValueNode_VectorY, RELEASE_VERSION_0_61_09, "vectory", N_("Vector Y"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.cpp
@@ -53,7 +53,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_WeightedAverage, RELEASE_VERSION_1_0, "weighted_average", "Weighted Average")
+REGISTER_VALUENODE(ValueNode_WeightedAverage, RELEASE_VERSION_1_0, "weighted_average", N_("Weighted Average"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_wplist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_wplist.cpp
@@ -58,7 +58,7 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
-REGISTER_VALUENODE(ValueNode_WPList, RELEASE_VERSION_0_63_00, "wplist", "WPList")
+REGISTER_VALUENODE(ValueNode_WPList, RELEASE_VERSION_0_63_00, "wplist", N_("WPList"))
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1138,7 +1138,7 @@ Instance::make_param_menu(Gtk::Menu *menu,synfig::Canvas::Handle canvas, synfiga
 		{
 			if(iter->second.check_type(value_desc.get_value_type()))
 			{
-				item = Gtk::manage(new Gtk::MenuItem(iter->second.local_name));
+				item = Gtk::manage(new Gtk::MenuItem(iter->second.get_local_name()));
 				item->signal_activate().connect(
 					sigc::hide_return(
 						sigc::bind(

--- a/synfig-studio/src/synfigapp/actions/valuedescconvert.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescconvert.cpp
@@ -85,7 +85,7 @@ Action::ValueDescConvert::get_local_name()const
 	// TRANSLATORS: This is used in the 'history' dialog when a ValueNode is converted.  The first %s is what is converted, the 2nd is the local name of the ValueNode's type.
 	return strprintf(_("Convert '%s' to ValueNode type '%s'"),
 					 value_desc.get_description().c_str(),
-					 ValueNodeRegistry::book()[type].local_name.c_str());
+					 ValueNodeRegistry::book().at(type).get_local_name().c_str());
 }
 
 Action::ParamVocab


### PR DESCRIPTION
Now ValueNode Converter menu in Synfig Studio shows translated names
as expected.