### PR TITLE
Fixed bug with src offset in blur sw task

### DIFF
--- a/synfig-core/src/synfig/rendering/software/function/blur.cpp
+++ b/synfig-core/src/synfig/rendering/software/function/blur.cpp
@@ -71,11 +71,12 @@ software::Blur::Params::validate()
 	amplified_size[0] = fabs(amplified_size[0]);
 	amplified_size[1] = fabs(amplified_size[1]);
 
+	VectorInt offset = src_offset - dest_rect.get_min();
+
 	extra_size = get_extra_size(type, size);
 	rect_set_intersect(dest_rect, dest_rect, RectInt(0, 0, dest->get_w(), dest->get_h()));
 	if (!dest_rect.valid()) return false;
 
-	VectorInt offset = src_offset - dest_rect.get_min();
 	src_rect = dest_rect + offset;
 	src_rect.minx -= extra_size[0];
 	src_rect.miny -= extra_size[1];
@@ -92,6 +93,8 @@ software::Blur::Params::validate()
 	dest_rect.maxy -= extra_size[1];
 	if (!dest_rect.valid()) return false;
 	if (!rect_contains(RectInt(0, 0, dest->get_w(), dest->get_h()), dest_rect)) return false;
+
+	src_offset = src_rect.get_min() + extra_size;
 
 	return true;
 }


### PR DESCRIPTION
Fixes #2544. `src_offset` is initially set as 
https://github.com/synfig/synfig/blob/17a48a42d5263012c7019749dc40ccf72d9050b5/synfig-core/src/synfig/rendering/software/task/taskblursw.cpp#L79-L80
However,  `Params::validate` expands as the target rect so as to account for the blurring, and hence the offset needs to be reevaluated.

But I'm actually confused here.
As far as I understand, each task has a surface, and a target rectangle that it should update. Tasks can have subtasks, which have their own surfaces, and rectangle which needs to be updated, and then these updates are merged to the parent surface.

In this particular case the blur task blurs the region in its subtask, and writes it to the surface on the parent task. What confuses me is this part
https://github.com/synfig/synfig/blob/17a48a42d5263012c7019749dc40ccf72d9050b5/synfig-core/src/synfig/rendering/software/function/blur.cpp#L78-L86
Here the `validate` function sets the `src_rect` to be equal to `dest_rect` and tries to expand it. I think what should happen is  that `src_rect` should be passed here
https://github.com/synfig/synfig/blob/17a48a42d5263012c7019749dc40ccf72d9050b5/synfig-core/src/synfig/rendering/software/task/taskblursw.cpp#L82-L88
as `sub_task()->target_rect`, and expanded, and not use the whole `target_rect` of the parent. Hope I'm making sense! 