### PR TITLE
Automating build-type selection for c-make 

### DIFF
--- a/2-build-msys-cmake -auto.sh
+++ b/2-build-msys-cmake -auto.sh
@@ -2,6 +2,8 @@
 
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.2.0/lib/pkgconfig"
 mkdir -p cmake-build-msys && cd cmake-build-msys
-cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release ..
+echo type Debug for debug build, or Release for a release build
+read buildType
+cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=$buildType ..
 cmake --build .
 cmake --install . >/dev/null

--- a/2-build-msys-cmake -auto.sh
+++ b/2-build-msys-cmake -auto.sh
@@ -2,8 +2,18 @@
 
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.2.0/lib/pkgconfig"
 mkdir -p cmake-build-msys && cd cmake-build-msys
+for ((;;))
+do
 echo type Debug for debug build, or Release for a release build
 read buildType
+if [[ $buildType = Debug ]]
+then 
+break
+elif [[ $buildType = Release ]]
+then
+break
+fi
+done
 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=$buildType ..
 cmake --build .
 cmake --install . >/dev/null

--- a/2-build-msys-cmake -auto.sh
+++ b/2-build-msys-cmake -auto.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.2.0/lib/pkgconfig"
+mkdir -p cmake-build-msys && cd cmake-build-msys
+cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
+cmake --install . >/dev/null

--- a/2-build-msys-cmake.sh
+++ b/2-build-msys-cmake.sh
@@ -2,8 +2,6 @@
 
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.2.0/lib/pkgconfig"
 mkdir -p cmake-build-msys && cd cmake-build-msys
-echo type Debug for a debug build, or Release for a release build
-read buildType
-cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=$buildType ..
+cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cmake --install . >/dev/null

--- a/2-build-msys-cmake.sh
+++ b/2-build-msys-cmake.sh
@@ -2,6 +2,8 @@
 
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.2.0/lib/pkgconfig"
 mkdir -p cmake-build-msys && cd cmake-build-msys
-cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release ..
+echo type Debug for a debug build, or Release for a release build
+read buildType
+cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=$buildType ..
 cmake --build .
 cmake --install . >/dev/null


### PR DESCRIPTION
This would ask the user to type either "Debug" or "Release" for each respective build. therefore, removing the need to manually change it. At first, I thought of doing this for the original main script but it seems to be causing an issue for appveyor as it stops on the line which requires an input. So to get away from all this mess I just made this a separate one and the original one will be left out for the purpose of the test build to run smoothly and this would be the one provided in the dev-docs 

 Ultimately, if this is to be merged I would update the docs for it and instead provide there this script there mentioning this.