### PR TITLE
Added the ability to set the build type from the command line to the 2-build-msys-cmake.sh script

### DIFF
--- a/2-build-msys-cmake.sh
+++ b/2-build-msys-cmake.sh
@@ -2,13 +2,22 @@
 
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.2.0/lib/pkgconfig"
 mkdir -p cmake-build-msys && cd cmake-build-msys
-if [[ $1 = debug ]]
-then 
-cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Debug ..
+mode="Release"
+if [[ -n $1 ]] 
+then
+ for ((;;)); do
+   if [[ $1 = Debug ]]
+   then
+   mode=$1
+   else 
+   echo type Debug for debug build
+   read mode
+   fi
+   if [[ $mode = Debug ]]
+   then break
+   fi
+done
+fi
+cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=${mode} ..
 cmake --build .
 cmake --install . >/dev/null
-else 
-cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release ..
-cmake --build .
-cmake --install . >/dev/null
-fi 

--- a/2-build-msys-cmake.sh
+++ b/2-build-msys-cmake.sh
@@ -5,18 +5,7 @@ mkdir -p cmake-build-msys && cd cmake-build-msys
 mode="Release"
 if [[ -n $1 ]] 
 then
- for ((;;)); do
-   if [[ $1 = Debug ]]
-   then
-   mode=$1
-   else 
-   echo type Debug for debug build
-   read mode
-   fi
-   if [[ $mode = Debug ]]
-   then break
-   fi
-done
+mode=$1
 fi
 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=${mode} ..
 cmake --build .

--- a/2-build-msys-cmake.sh
+++ b/2-build-msys-cmake.sh
@@ -2,6 +2,13 @@
 
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.2.0/lib/pkgconfig"
 mkdir -p cmake-build-msys && cd cmake-build-msys
+if [[ $1 = debug ]]
+then 
+cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Debug ..
+cmake --build .
+cmake --install . >/dev/null
+else 
 cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cmake --install . >/dev/null
+fi 


### PR DESCRIPTION
this way 
./2-build-msys-cmake.sh    
runs release build which is the default because as @ice0  mentioned "Currently we use Release build on the Windows as default just because of long linking time for Debug build"
and 
./2-build-msys-cmake.sh debug
runs debug build