### PR TITLE
Fixing Rectangle Tool State Indeterminacy

### DIFF
--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -1264,4 +1264,13 @@ StateRectangle_Context::toggle_layer_creation()
   layer_advanced_outline_flag = get_layer_advanced_outline_flag();
   layer_curve_gradient_flag = get_layer_curve_gradient_flag();
   layer_plant_flag = get_layer_plant_flag();
+   
+  // disable focus for buttons where focus makes active/inactive states confusing
+  layer_rectangle_togglebutton.set_can_focus(false);
+  layer_region_togglebutton.set_can_focus(false);
+  layer_outline_togglebutton.set_can_focus(false);
+  layer_advanced_outline_togglebutton.set_can_focus(false);
+  layer_curve_gradient_togglebutton.set_can_focus(false);
+  layer_plant_togglebutton.set_can_focus(false);
+
 }


### PR DESCRIPTION
this I believe solves the bug #2200  . I am proposing this just for the rectangle tool as a demo and if merged I could easily repeat this for all the others which have the same problem.