### PR TITLE
Removing a repeated unused included Header file

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -84,7 +84,6 @@
 #include <gui/dialogs/vectorizersettings.h>
 
 #include <gui/docks/dialog_tooloptions.h>
-#include <gui/docks/dockmanager.h>
 #include <gui/docks/dock_canvases.h>
 #include <gui/docks/dock_children.h>
 #include <gui/docks/dock_curves.h>

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -40,6 +40,7 @@
 #include <gui/iconcontroller.h>
 #include <gui/mainwindow.h>
 #include <gui/pluginmanager.h>
+#include <gui/docks/dockmanager.h>
 
 #include <list>
 #include <set>

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -61,7 +61,6 @@
 #include <gui/app.h>
 #include <gui/dials/keyframedial.h>
 #include <gui/docks/dockbook.h>
-#include <gui/docks/dockmanager.h>
 #include <gui/docks/dock_toolbox.h>
 #include <gui/eventkey.h>
 #include <gui/exception_guard.h>

--- a/synfig-studio/src/gui/mainwindow.cpp
+++ b/synfig-studio/src/gui/mainwindow.cpp
@@ -43,7 +43,6 @@
 #include <gui/dialogs/dialog_input.h>
 #include <gui/docks/dockable.h>
 #include <gui/docks/dockbook.h>
-#include <gui/docks/dockmanager.h>
 #include <gui/exception_guard.h>
 #include <gui/localization.h>
 #include <gui/widgets/widget_time.h>

--- a/synfig-studio/src/gui/modules/mod_palette/mod_palette.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/mod_palette.cpp
@@ -37,7 +37,6 @@
 #include "dock_palbrowse.h"
 
 #include <gui/app.h>
-#include <gui/docks/dockmanager.h>
 
 #endif
 

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -50,7 +50,6 @@
 #include <gui/asyncrenderer.h>
 #include <gui/dialogs/dialog_ffmpegparam.h>
 #include <gui/dialogs/dialog_spritesheetparam.h>
-#include <gui/docks/dockmanager.h>
 #include <gui/docks/dock_info.h>
 #include <gui/localization.h>
 #include <gui/progresslogger.h>

--- a/synfig-studio/src/gui/trees/layergrouptreestore.cpp
+++ b/synfig-studio/src/gui/trees/layergrouptreestore.cpp
@@ -39,7 +39,6 @@
 #include <gtkmm/button.h>
 
 #include <gui/app.h>
-#include <gui/docks/dockmanager.h>
 #include <gui/docks/dockable.h>
 #include <gui/localization.h>
 


### PR DESCRIPTION
The file  <gui/docks/dockmanager.h> was included in multiple files where it wasn't being used directly but removing them caused errors as this file - <gui/docks/dockmanager.h> - was originally included in the app.cpp file instead of app.h header file as @Keyikedalube stated in #2183  . I believe this should close that issue.