### PR TITLE
improve output readability of unit tests with test_base.h

### DIFF
--- a/synfig-core/test/bline.cpp
+++ b/synfig-core/test/bline.cpp
@@ -46,7 +46,7 @@ void fill_list(std::vector<ValueBase> &list) {
 	list.push_back(p);
 }
 
-bool test_bline_length() {
+void test_bline_length() {
 	std::vector<ValueBase> list;
 	fill_list(list);
 	
@@ -84,11 +84,9 @@ bool test_bline_length() {
 	l = bline_length(list, loop, &lengths);
 	ASSERT_EQUAL(1, lengths.size());
 	ASSERT_APPROX_EQUAL_MICRO(0.349854, l);
-
-	return false;
 }
 
-bool test_bline_std_to_hom_without_loop() {
+void test_bline_std_to_hom_without_loop() {
 	std::vector<ValueBase> list;
 	fill_list(list);
 
@@ -111,11 +109,9 @@ bool test_bline_std_to_hom_without_loop() {
 		Real value = synfig::std_to_hom(list, positions[i] + index_offset, true, false);
 		ASSERT_APPROX_EQUAL_MICRO(expected[i] + index_offset, value);
 	}
-
-	return false;
 }
 
-bool test_bline_std_to_hom_with_loop() {
+void test_bline_std_to_hom_with_loop() {
 	std::vector<ValueBase> list;
 	fill_list(list);
 
@@ -138,11 +134,9 @@ bool test_bline_std_to_hom_with_loop() {
 		Real value = synfig::std_to_hom(list, positions[i] + index_offset, true, true);
 		ASSERT_APPROX_EQUAL_MICRO(expected[i] + index_offset, value);
 	}
-
-	return false;
 }
 
-bool test_bline_hom_to_std_without_loop() {
+void test_bline_hom_to_std_without_loop() {
 	std::vector<ValueBase> list;
 	fill_list(list);
 
@@ -165,11 +159,9 @@ bool test_bline_hom_to_std_without_loop() {
 		Real value = synfig::hom_to_std(list, positions[i] + index_offset, true, false);
 		ASSERT_APPROX_EQUAL_MICRO(expected[i] + index_offset, value);
 	}
-
-	return false;
 }
 
-bool test_bline_hom_to_std_with_loop() {
+void test_bline_hom_to_std_with_loop() {
 	std::vector<ValueBase> list;
 	fill_list(list);
 
@@ -192,11 +184,9 @@ bool test_bline_hom_to_std_with_loop() {
 		Real value = synfig::hom_to_std(list, positions[i] + index_offset, true, true);
 		ASSERT_APPROX_EQUAL_MICRO(expected[i] + index_offset, value);
 	}
-
-	return false;
 }
 
-bool test_calc_vertex() {
+void test_calc_vertex() {
 	std::vector<ValueBase> list;
 	BLinePoint p;
 	p.set_vertex(Point(-2.342526, -1.151789));
@@ -241,8 +231,6 @@ bool test_calc_vertex() {
 	bline_calc_vertex->set_link("amount", ValueNode_Const::create(0.507960));
 	vertex = (*bline_calc_vertex)(Time()).get(Vector());
 	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(-0.260716, 0.341317), vertex)
-
-	return false;
 }
 
 

--- a/synfig-core/test/node.cpp
+++ b/synfig-core/test/node.cpp
@@ -49,23 +49,19 @@ protected:
 	}
 };
 
-bool initial_node_guid_is_not_zero() {
+void initial_node_guid_is_not_zero() {
 	NodeX node;
 
 	ASSERT_NOT_EQUAL(GUID::zero(), node.get_guid());
-
-	return false;
 }
 
-bool non_initialized_nodes_have_different_guid() {
+void non_initialized_nodes_have_different_guid() {
 	NodeX node1, node2;
 
 	ASSERT(node1.get_guid() != node2.get_guid());
-
-	return false;
 }
 
-bool set_node_guid_works() {
+void set_node_guid_works() {
 	NodeX node;
 	
 	const GUID initial_guid = node.get_guid();
@@ -76,21 +72,17 @@ bool set_node_guid_works() {
 	node.set_guid(new_guid);
 
 	ASSERT(node.get_guid() == new_guid);
-
-	return false;
 }
 
-bool set_node_guid_first_time_does_not_emit_signal_guid_changed() {
+void set_node_guid_first_time_does_not_emit_signal_guid_changed() {
 	NodeX node;
 
 	GUID new_guid;
 
 	ASSERT_SIGNAL_NOT_EMITTED((&node),signal_guid_changed,,GUID,void, node.set_guid(new_guid));
-
-	return false;
 }
 
-bool set_node_guid_emits_signal_guid_changed() {
+void set_node_guid_emits_signal_guid_changed() {
 	NodeX node;
 
 	GUID new_guid1, new_guid2;
@@ -98,51 +90,41 @@ bool set_node_guid_emits_signal_guid_changed() {
 	node.set_guid(new_guid1);
 
 	ASSERT_SIGNAL_EMITTED((&node),signal_guid_changed,,GUID,void, node.set_guid(new_guid2));
-
-	return false;
 }
 
-bool set_same_node_guid_does_not_emit_signal_guid_changed() {
+void set_same_node_guid_does_not_emit_signal_guid_changed() {
 	NodeX node;
 
 	GUID new_guid;
 	node.set_guid(new_guid);
 
 	ASSERT_SIGNAL_NOT_EMITTED((&node),signal_guid_changed,,GUID,void, node.set_guid(new_guid));
-
-	return false;
 }
 
-bool set_node_guid_does_not_emit_signal_changed() {
+void set_node_guid_does_not_emit_signal_changed() {
 	NodeX node;
 	
 	GUID new_guid;
 
 	ASSERT_SIGNAL_NOT_EMITTED((&node),signal_changed,,,void, node.set_guid(new_guid));
-
-	return false;
 }
 
-bool find_node_works() {
+void find_node_works() {
 	NodeX node;
 	
 	ASSERT(&node == find_node(node.get_guid()));
-	
-	return false;
 }
 
-bool find_node_works_when_node_have_new_guid() {
+void find_node_works_when_node_have_new_guid() {
 	NodeX node;
 	
 	GUID new_guid;
 	node.set_guid(new_guid);
 	
 	ASSERT(&node == find_node(new_guid));
-	
-	return false;
 }
 
-bool find_node_returns_null_on_not_found() {
+void find_node_returns_null_on_not_found() {
 	NodeX node;
 	
 	ASSERT_EQUAL(nullptr, find_node(GUID::zero()));
@@ -150,35 +132,27 @@ bool find_node_returns_null_on_not_found() {
 	GUID not_used_guid;
 
 	ASSERT_EQUAL(nullptr, find_node(not_used_guid));
-
-	return false;
 }
 
-bool deleting_node_emits_signal() {
+void deleting_node_emits_signal() {
 	NodeX *node = new NodeX();
 	
 	ASSERT_SIGNAL_EMITTED(node,signal_deleted,,,void, delete node);
-
-	return false;
 }
 
-bool deleting_node_does_not_emit_signal_changed() {
+void deleting_node_does_not_emit_signal_changed() {
 	NodeX *node = new NodeX();
 	
 	ASSERT_SIGNAL_NOT_EMITTED(node,signal_changed,,,void, delete node);
-
-	return false;
 }
 
-bool initial_node_has_no_parent() {
+void initial_node_has_no_parent() {
 	NodeX node;
 	
 	ASSERT_EQUAL(0, node.parent_count());
-
-	return false;
 }
 
-bool adding_child_node_increases_its_parent_count() {
+void adding_child_node_increases_its_parent_count() {
 	NodeX parent_node1, parent_node2, child_node;
 	
 	parent_node1.add_child(&child_node);
@@ -188,21 +162,17 @@ bool adding_child_node_increases_its_parent_count() {
 	parent_node2.add_child(&child_node);
 	
 	ASSERT_EQUAL(2, child_node.parent_count());
-
-	return false;
 }
 
-bool adding_child_node_adds_itself_as_parent_to_child() {
+void adding_child_node_adds_itself_as_parent_to_child() {
 	NodeX parent_node, child_node;
 	
 	parent_node.add_child(&child_node);
 	
 	ASSERT_EQUAL(1, child_node.parent_set.count(&parent_node));
-
-	return false;
 }
 
-bool adding_child_node_does_not_increase_its_parent_count_if_already_its_parent() {
+void adding_child_node_does_not_increase_its_parent_count_if_already_its_parent() {
 	NodeX parent_node, child_node;
 	
 	parent_node.add_child(&child_node);
@@ -211,11 +181,9 @@ bool adding_child_node_does_not_increase_its_parent_count_if_already_its_parent(
 	
 	ASSERT_EQUAL(1, child_node.parent_count());
 	ASSERT_EQUAL(1, child_node.parent_set.count(&parent_node));
-
-	return false;
 }
 
-bool removing_child_node_decreases_its_parent_count() {
+void removing_child_node_decreases_its_parent_count() {
 	NodeX parent_node1, parent_node2, child_node;
 	
 	parent_node1.add_child(&child_node);
@@ -234,11 +202,9 @@ bool removing_child_node_decreases_its_parent_count() {
 	parent_node2.remove_child(&child_node);
 
 	ASSERT_EQUAL(0, child_node.parent_count());
-
-	return false;
 }
 
-bool removing_child_node_removes_itself_as_parent_from_child() {
+void removing_child_node_removes_itself_as_parent_from_child() {
 	NodeX parent_node, child_node;
 	
 	parent_node.add_child(&child_node);
@@ -246,21 +212,17 @@ bool removing_child_node_removes_itself_as_parent_from_child() {
 	parent_node.remove_child(&child_node);
 
 	ASSERT_EQUAL(0, child_node.parent_set.count(&parent_node));
-
-	return false;
 }
 
-bool removing_child_node_does_not_decrease_its_parent_count_if_not_its_parent() {
+void removing_child_node_does_not_decrease_its_parent_count_if_not_its_parent() {
 	NodeX parent_node, child_node;
 	
 	parent_node.remove_child(&child_node);
 
 	ASSERT_EQUAL(0, child_node.parent_count());
-
-	return false;
 }
 
-bool deleting_node_removes_it_as_parent_from_its_children() {
+void deleting_node_removes_it_as_parent_from_its_children() {
 	NodeX *parent_node = new NodeX();
 	
 	NodeX child_node;
@@ -273,50 +235,40 @@ bool deleting_node_removes_it_as_parent_from_its_children() {
 
 	ASSERT_EQUAL(0, child_node.parent_count());
 	ASSERT_EQUAL(0, child_node.parent_set.count(parent_node));
-
-	return false;
 }
 
-bool marking_node_as_changed_changes_the_last_time_changed() {
+void marking_node_as_changed_changes_the_last_time_changed() {
 	NodeX node;
 
 	auto last_time = node.get_time_last_changed();
 	node.changed();
 
 	ASSERT(last_time < node.get_time_last_changed());
-
-	return false;
 }
 
-bool marking_node_as_changed_emits_signal_changed() {
+void marking_node_as_changed_emits_signal_changed() {
 	NodeX node;
 
 	ASSERT_SIGNAL_EMITTED((&node),signal_changed,,,void, node.changed());
-
-	return false;
 }
 
-bool marking_child_node_as_changed_emits_signal_changed() {
+void marking_child_node_as_changed_emits_signal_changed() {
 	NodeX parent_node, child_node;
 
 	parent_node.add_child(&child_node);
 
 	ASSERT_SIGNAL_EMITTED((&parent_node),signal_changed,,,void, child_node.changed());
-
-	return false;
 }
 
-bool marking_child_node_as_changed_emits_signal_child_changed() {
+void marking_child_node_as_changed_emits_signal_child_changed() {
 	NodeX parent_node, child_node;
 
 	parent_node.add_child(&child_node);
 
 	ASSERT_SIGNAL_EMITTED((&parent_node),signal_child_changed,,const Node*,void, child_node.changed());
-
-	return false;
 }
 
-bool get_times_is_cached() {
+void get_times_is_cached() {
 	NodeX node;
 
 	node.x_times.insert(TimePoint(Time(3)));
@@ -326,11 +278,9 @@ bool get_times_is_cached() {
 	node.x_times.insert(TimePoint(Time(4)));
 
 	ASSERT_EQUAL(1, node.get_times().size());
-
-	return false;
 }
 
-bool marking_node_as_changed_updates_times_cache() {
+void marking_node_as_changed_updates_times_cache() {
 	NodeX node;
 
 	node.x_times.insert(TimePoint(Time(3)));
@@ -341,8 +291,6 @@ bool marking_node_as_changed_updates_times_cache() {
 
 	node.changed();
 	ASSERT_EQUAL(2, node.get_times().size());
-
-	return false;
 }
 
 int main() {

--- a/synfig-core/test/test_base.h
+++ b/synfig-core/test/test_base.h
@@ -22,11 +22,25 @@
 #ifndef SYNFIG_TESTBASE_H
 #define SYNFIG_TESTBASE_H
 
-#include <iostream> // std::cerr
 #include <cstdlib> // std::abs
+#include <iostream> // std::cerr
+#include <sstream>
 
 #include <synfig/general.h> // synfig::error , synfig::info
 #include <synfig/vector.h>
+
+struct SynfigTestException : public std::exception
+{
+	std::string function;
+	int line;
+	std::string message;
+
+	SynfigTestException(std::string function, int line, std::string message)
+		: function(function), line(line), message(message)
+	{}
+
+	const char* what() const noexcept override { return message.c_str(); }
+};
 
 std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 {
@@ -35,64 +49,66 @@ std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 }
 
 #define ERROR_MESSAGE_TWO_VALUES(a, b) \
-	std::cerr.precision(8); \
-	std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - expected " << a << ", but got " << b << std::endl;
+	std::ostringstream oss; \
+	oss.precision(8); \
+	oss << "\t - expected " << a << ", but got " << b << std::endl; \
+	throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 
 #define ASSERT(value) {\
 	if (!(value)) { \
-		std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - not TRUE: " << #value << std::endl; \
-		return true; \
+		std::ostringstream oss; \
+		oss << "\t - not TRUE: " << #value << std::endl; \
+		throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 	} \
 }
 
 #define ASSERT_FALSE(value) {\
 	if (value) { \
-		std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - not FALSE: " << #value << std::endl; \
-		return true; \
+		std::ostringstream oss; \
+		oss << "\t - not FALSE: " << #value << std::endl; \
+		throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 	} \
 }
 
 #define ASSERT_EQUAL(expected, value) {\
 	if (expected != value) { \
 		ERROR_MESSAGE_TWO_VALUES(expected, value) \
-		return true; \
 	} \
 }
 
 #define ASSERT_NOT_EQUAL(not_acceptable, value) {\
 	if (not_acceptable == value) { \
-		std::cerr.precision(8); \
-		std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - must not be equal" << std::endl; \
-		return true; \
+		std::ostringstream oss; \
+		oss.precision(8); \
+		oss << "\t - must not be equal: " #value << " vs. " << not_acceptable << std::endl; \
+		throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 	} \
 }
 
 #define ASSERT_APPROX_EQUAL(expected, value) {\
 	if (!synfig::approximate_equal(expected, value)) { \
 		ERROR_MESSAGE_TWO_VALUES(expected, value) \
-		return true; \
 	} \
 }
 
 #define ASSERT_APPROX_EQUAL_MICRO(expected, value) {\
 	if (std::abs(expected - value) > 1e-6) { \
 		ERROR_MESSAGE_TWO_VALUES(expected, value) \
-		return true; \
 	} \
 }
 
 #define ASSERT_VECTOR_APPROX_EQUAL_MICRO(expected, value) {\
 	if (std::abs(expected[0] - value[0]) > 2e-6 || std::abs(expected[1] - value[1]) > 2e-6) { \
 		ERROR_MESSAGE_TWO_VALUES(expected, value) \
-		return true; \
 	} \
 }
 
 #define ASSERT_EXCEPTION_THROWN(expected, action) {\
 	try {\
 		action; \
-		std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - expected exception " << #expected << " was not thrown" << std::endl; \
-		return true; \
+		std::ostringstream oss; \
+		oss << "\t - expected exception " << #expected << " was not thrown" << std::endl; \
+		throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 	} catch (expected &ex) { \
 	} \
 }
@@ -101,8 +117,9 @@ std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 	try {\
 		action; \
 	} catch (not_expected &ex) { \
-		std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - it should not throw exception " << #not_expected << std::endl; \
-		return true; \
+		std::ostringstream oss; \
+		oss << "\t - it should not throw exception " << #not_expected << std::endl; \
+		throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 	} \
 }
 
@@ -110,8 +127,9 @@ std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 	try {\
 		action; \
 	} catch (...) { \
-		std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - it should not throw any exception" << std::endl; \
-		return true; \
+		std::ostringstream oss; \
+		oss << "\t - it should not throw any exception" << std::endl; \
+		throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 	} \
 }
 
@@ -125,8 +143,9 @@ std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 	ACTION; \
 	tst_conn.disconnect(); \
 	if (!tst_signal_emitted) { \
-		std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - expected signal " << #SIGNAL_NAME << " was not called" << std::endl; \
-		return true; \
+		std::ostringstream oss; \
+		oss << "\t - expected signal " << #SIGNAL_NAME << " was not called" << std::endl; \
+		throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 	} \
 }
 
@@ -140,41 +159,74 @@ std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 	ACTION; \
 	tst_conn.disconnect(); \
 	if (tst_signal_emitted) { \
-		std::cerr << __FUNCTION__ << ":" << __LINE__ << std::endl << "\t - expected signal " << #SIGNAL_NAME << " was called" << std::endl; \
-		return true; \
+		std::ostringstream oss; \
+		oss << "\t - not-expected signal was called: " << #SIGNAL_NAME << std::endl; \
+		throw SynfigTestException{__FUNCTION__, __LINE__, oss.str()}; \
 	} \
 }
 
 #define TEST_FUNCTION(function_name) {\
-	bool fail = function_name(); \
-	if (fail) { \
-		synfig::error("%s FAILED", #function_name); \
-		tst_failures++; \
-	} else { \
-		tst_successes++; \
+	std::string error_msg; \
+	try { \
+		function_name(); \
+		tst_statistics__.successes++; \
+		std::cout << "."; \
+	} catch (SynfigTestException& exc) { \
+		tst_statistics__.failures++; \
+		std::cout << "F"; \
+		tst_statistics__.errors.push_back(exc); \
+	} catch (std::logic_error& exc) { \
+		error_msg = "<Unexpected std::logic_error thrown>: "; \
+		error_msg += exc.what(); \
+	} catch (std::runtime_error& exc) { \
+		error_msg = "<Unexpected std::runtime_error thrown>: "; \
+		error_msg += exc.what(); \
+	} catch (std::exception& exc) { \
+		error_msg = "<Unexpected std::exception thrown>: "; \
+		error_msg += exc.what(); \
+	} catch (...) { \
+		error_msg = "<Unexpected and unknown exception thrown>"; \
+	} \
+\
+	if (!error_msg.empty()) { \
+		tst_statistics__.exception_thrown++; \
+		std::cout << "X"; \
+		tst_statistics__.errors.push_back({#function_name, -1, error_msg}); \
 	} \
 }
 
 #define TEST_SUITE_BEGIN() \
 	int tst_exit_status = 0; \
 	{ \
-		int tst_successes = 0; \
-		int tst_failures = 0; \
-		bool tst_exception_thrown = false; \
-		try {
+		struct tst_statistics__ { \
+			int successes = 0; \
+			int failures = 0; \
+			int exception_thrown = 0; \
+			std::vector<SynfigTestException> errors; \
+		} tst_statistics__; \
+		{
 
 #define TEST_SUITE_END() \
-		} catch (...) { \
-			synfig::error("Some exception has been thrown."); \
-			tst_exception_thrown = true; \
 		} \
-		if (tst_exception_thrown) \
-			synfig::error("Test interrupted due to an exception thrown (%i errors and %i successful tests until then)", tst_failures, tst_successes); \
-		else if (tst_failures) \
-			synfig::error("Test finished with %i errors and %i successful tests", tst_failures, tst_successes); \
+		std::cout << std::endl; \
+		for (const auto& err : tst_statistics__.errors) { \
+			if (err.line < 0) \
+				synfig::error("ERROR:\n %s", err.function.c_str()); \
+			else \
+				synfig::warning("FAILURE:\n %s:%i", err.function.c_str(), err.line); \
+			std::cerr << err.message << std::endl; \
+		} \
+		std::cerr << std::endl << "========================================================================" << std::endl; \
+		if (tst_statistics__.exception_thrown) \
+			synfig::error("Statistics:\n %i tests were interrupted by unexpected exceptions thrown.\n %i tests failed.\n %i successful tests)", \
+				tst_statistics__.exception_thrown, tst_statistics__.failures, tst_statistics__.successes); \
+		else if (tst_statistics__.failures) \
+			synfig::warning("Statistics:\n %i tests failed.\n %i successful tests", \
+				tst_statistics__.failures, tst_statistics__.successes); \
 		else \
-			synfig::info("Success (%i tests)", tst_successes); \
-		tst_exit_status = tst_exception_thrown? 2 : (tst_failures ? 1 : 0); \
+			synfig::info("Success (%i tests)", tst_statistics__.successes); \
+		std::cerr << "========================================================================" << std::endl; \
+		tst_exit_status = tst_statistics__.exception_thrown? 2 : (tst_statistics__.failures ? 1 : 0); \
 	}
 
 #endif // SYNFIG_TESTBASE_H


### PR DESCRIPTION
Although the programming interface didn't change,
test functions are not required to return a bool value anymore