### PR TITLE
Allow to call regression test script outside of Travis

### DIFF
--- a/autobuild/synfigrenderer-regression-test.sh
+++ b/autobuild/synfigrenderer-regression-test.sh
@@ -2,8 +2,17 @@
 
 set -x
 
-export PATH="${TRAVIS_BUILD_DIR}/_production/build/bin:$PATH"
+export SCRIPTPATH=$(cd `dirname "$0"`; pwd)
+
+export PATH="${SCRIPTPATH}/../_production/build/bin:$PATH"
 
 ccache -s # show ccache stats
-git clone https://gitlab.com/synfig/synfig-tests.git
+cd "${SCRIPTPATH}/../_production/"
+if [ ! -d synfig-tests ]; then
+    git clone https://gitlab.com/synfig/synfig-tests.git
+else
+    cd synfig-tests
+    git pull
+    cd ..
+fi
 bash ./synfig-tests/test-rendering.sh results


### PR DESCRIPTION
We do not use Travis anymore, so let's allow to call regression test script without TRAVIS_BUILD_DIR variable.

This is useful for running tests locally.

Also, I have added condition to avoid re-downloading whole tests repository every time.