### PR TITLE
Fix crash when deleting last waypoint

### DIFF
--- a/synfig-studio/src/synfigapp/value_desc.cpp
+++ b/synfig-studio/src/synfigapp/value_desc.cpp
@@ -57,7 +57,11 @@ SYNFIGAPP_EXPORT const ValueDesc ValueDesc::blank;
 void ValueDesc::on_id_changed()
 {
 	try {
-		name = get_value_node()->get_id();
+		synfig::ValueNode::Handle value_node = get_value_node();
+		if (value_node)
+				name = value_node->get_id();
+		else
+				name.clear();
 	} catch (Exception::IDNotFound &) {
 		name.clear();
 	}

--- a/synfig-studio/src/synfigapp/value_desc.h
+++ b/synfig-studio/src/synfigapp/value_desc.h
@@ -130,7 +130,7 @@ public:
 
 		if (id_changed_connection.connected())
 			id_changed_connection.disconnect();
-		if (other.id_changed_connection.connected())
+		if (other.id_changed_connection.connected() && is_valid())
 			id_changed_connection = get_value_node()->signal_id_changed().connect(sigc::mem_fun(*this, &ValueDesc::on_id_changed));
 
 		return *this;
@@ -212,7 +212,7 @@ public:
 		parent_desc(other.parent_desc),
 		links_count(0)
 	{
-		if (other.id_changed_connection.connected())
+		if (other.id_changed_connection.connected() && is_valid())
 			id_changed_connection = get_value_node()->signal_id_changed().connect(sigc::mem_fun(*this, &ValueDesc::on_id_changed));
 		if (parent_desc) parent_desc->links_count++;
 	}
@@ -260,9 +260,10 @@ public:
 
 	bool
 	is_value_node()const
-		{ return parent_is_value_node()
+		{ return (parent_is_value_node()
 		      || parent_is_canvas()
-			  || (parent_is_layer() && layer->dynamic_param_list().count(name) > 0);
+			  || (parent_is_layer() && layer->dynamic_param_list().count(name) > 0))
+              && is_valid();
 		}
 	bool
 	is_const()const
@@ -355,6 +356,8 @@ public:
 	synfig::ValueNode::Handle
 	get_value_node()const
 	{
+		if (!is_value_node()) return nullptr;
+
 		if(parent_is_canvas())
 			return canvas->find_value_node(name,false);
 		if(parent_is_layer() && layer->dynamic_param_list().count(name))


### PR DESCRIPTION
Fixes #1701,  As far as I understand, the problem is that when the last waypoint is removed, the node representing the exported value is replaced, as in here
https://github.com/synfig/synfig/blob/f64f99f020f0689fb006969a7c649c101c52d066/synfig-studio/src/synfigapp/actions/waypointremove.cpp#L137-L163
The old `ValueNode` is removed from the canvas, and hence invalidating all the `ValueDesc`s that point to it. A signal is emitted of the change, for which the different tree stores handle. Many of the tree stores don't handle the event instantly, but instead wait for a period of time, then handles it as in here
https://github.com/synfig/synfig/blob/f64f99f020f0689fb006969a7c649c101c52d066/synfig-studio/src/gui/trees/childrentreestore.cpp#L299-L309 
The problem happens when the invalidated `ValueDesc` is accessed (for example before the treestore is updated.)
I found this to happen in `Dialog_Waypoint`:
https://github.com/synfig/synfig/blob/f64f99f020f0689fb006969a7c649c101c52d066/synfig-studio/src/gui/dialogs/dialog_waypoint.cpp#L145-L154
And also when a redraw event is called which accesses the invalid `ValueDesc` through any of the (yet not updated due to signal timeout) treestores.

My fix was to add checks for invalid `ValueDesc`, and eventually when all signals are handled, this invalid object won't be accessed.  