### PR TITLE
Added support for `Ctr+Enter` to complete text input in Text tool dialog

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3766,7 +3766,7 @@ App::on_key_pressed(GdkEventKey *ev)
            (ev->keyval == (0xff8d)||(0xfe34)||(0xfd1e)) &&
            (ev->state == GDK_CONTROL_MASK) )  //pressing control and enter
       {
-        ok_button->clicked();
+        //ok_button->clicked();
         std::cout << "hey";
         return true;
       }

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3754,25 +3754,7 @@ App::dialog_sets_entry(const std::string &action, const std::string &content, st
 	return true;
 }
 
-bool App::response_ok_activate_check = 0 ;
 
-bool
-App::on_key_pressed(GdkEventKey *ev)
-  {
-
-    SYNFIG_EXCEPTION_GUARD_BEGIN()
-      if (  (ev->type == GDK_KEY_PRESS) &&
-           (ev->keyval == (gdk_keyval_from_name("s"))) &&
-           (ev->state == GDK_CONTROL_MASK) )  //pressing control and enter
-      {
-        response_ok_activate_check =1 ;
-       //  std::cout << "hey";
-        return true;
-      }
-
-      return false;
-      SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
- }
 
 bool
 App::dialog_paragraph(const std::string &title, const std::string &message,std::string &text)
@@ -3796,28 +3778,31 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	dialog.add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
 	dialog.add_button(_("OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
-    //Gtk::Button* ok_button = dialog.add_button(_("Ok"), Gtk::RESPONSE_OK);
-	dialog.set_default_response(Gtk::RESPONSE_OK);
+    dialog.set_default_response(Gtk::RESPONSE_OK);
 
-    dialog.signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //catching key-press event
+
+    text_view.signal_key_press_event().connect( [&](GdkEventKey *ev) {
+        SYNFIG_EXCEPTION_GUARD_BEGIN()
+          if (  (ev->type == GDK_KEY_PRESS) &&
+               (ev->keyval == (GDK_KEY_Return) || ev->keyval == (GDK_KEY_KP_Enter) || ev->keyval == (gdk_keyval_from_name("s")) ) &&
+               (ev->state == GDK_CONTROL_MASK) )  //pressing control and enter
+          {
+            dialog.response(-5);
+            return true;
+          }
+
+            return false;
+          SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
+    } );
 
 	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
-
-    if (response_ok_activate_check == 1)
-             {
-              // ok_button->clicked();
-               dialog.response(Gtk::RESPONSE_OK ) ;
-             //   std::cout<<" response emitted ";
-             }
 
 
 	if(dialog.run()!=Gtk::RESPONSE_OK)
 		return false;
 
-	text=text_buffer->get_text();
-
-    response_ok_activate_check = 0 ;
+    text=text_buffer->get_text();
 
 	return true;
 }

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3776,7 +3776,7 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	dialog.add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
 	dialog.add_button(_("OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
-    dialog.set_default_response(Gtk::RESPONSE_OK);
+	dialog.set_default_response(Gtk::RESPONSE_OK);
 
 	text_view.signal_key_press_event().connect(( [&](GdkEventKey *ev) {
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3835,7 +3835,27 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 	dialog.add_button(_("_OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
 	dialog.set_default_response(Gtk::RESPONSE_OK);
 
-	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
+    bool on_key_pressed(GdkEventKey*);  //f dec hbd
+
+    signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //hbd
+
+
+    on_key_pressed(GdkEventKey* ev)
+   {
+       SYNFIG_EXCEPTION_GUARD_BEGIN()
+       if (ev->keyval == gdk_keyval_from_name("Enter")  )
+       {
+           Gtk::RESPONSE_OK ;
+           return true;
+       }
+
+       return false;
+       SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
+  }
+
+
+
+    //text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 
 	if(dialog.run()!=Gtk::RESPONSE_OK)
@@ -3845,6 +3865,8 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	return true;
 }
+
+
 
 std::string
 App::get_temporary_directory()

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3763,11 +3763,12 @@ App::on_key_pressed(GdkEventKey *ev)
 
     SYNFIG_EXCEPTION_GUARD_BEGIN()
       if (  (ev->type == GDK_KEY_PRESS) &&
-           (ev->keyval == (0xff8d)||(0xfe34)||(0xfd1e)) &&
+           (ev->keyval == (gdk_keyval_from_name("s"))) &&
            (ev->state == GDK_CONTROL_MASK) )  //pressing control and enter
       {
-        //ok_button->clicked();
-        std::cout << "hey";
+     // dialog.Gtk::Dialog::response(-5) ;
+        response_ok_activate_check =1 ;
+         std::cout << "hey";
         return true;
       }
 
@@ -3797,13 +3798,20 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	dialog.add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
     dialog.add_button(_("OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
-    Gtk::Button* ok_button = dialog.add_button(_("Ok"), Gtk::RESPONSE_OK);
-	dialog.set_default_response(Gtk::RESPONSE_OK);
+    //Gtk::Button* ok_button = dialog.add_button(_("Ok"), Gtk::RESPONSE_OK);
+
+    dialog.set_default_response(Gtk::RESPONSE_OK);
 
     //text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 
     dialog.signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //catching key-press event
+    if (response_ok_activate_check == 1)
+     {
+      // ok_button->clicked();
+       dialog.response(Gtk::RESPONSE_OK ) ;
+        std::cout<<" response emitted ";
+     }
 
 
 	if(dialog.run()!=Gtk::RESPONSE_OK)
@@ -3812,6 +3820,7 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 	text=text_buffer->get_text();
 
 	return true;
+    response_ok_activate_check = 0 ;
 }
 
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3778,7 +3778,7 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 	dialog.add_button(_("_OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
 	dialog.set_default_response(Gtk::RESPONSE_OK);
 
-	text_view.signal_key_press_event().connect(( [&](GdkEventKey *ev) {
+	text_view.signal_key_press_event().connect(( [&dialog](GdkEventKey *ev) {
 
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
 		if ((ev->type == GDK_KEY_PRESS) &&
@@ -3791,8 +3791,6 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 
 	}), false );
-
-
 	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -146,7 +146,6 @@
 #include <synfig/version.h>
 #include <gui/exception_guard.h>
 
-
 #include <synfigapp/action.h>
 #include <synfigapp/canvasinterface.h>
 #include <synfigapp/main.h>
@@ -3755,7 +3754,7 @@ App::dialog_sets_entry(const std::string &action, const std::string &content, st
 	return true;
 }
 
-//gdk_keyval_from_name("Return")
+bool App::response_ok_activate_check = 0 ;
 
 bool
 App::on_key_pressed(GdkEventKey *ev)
@@ -3766,15 +3765,15 @@ App::on_key_pressed(GdkEventKey *ev)
            (ev->keyval == (gdk_keyval_from_name("s"))) &&
            (ev->state == GDK_CONTROL_MASK) )  //pressing control and enter
       {
-     // dialog.Gtk::Dialog::response(-5) ;
         response_ok_activate_check =1 ;
-         std::cout << "hey";
+       //  std::cout << "hey";
         return true;
       }
 
       return false;
       SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
  }
+
 
 bool
 App::dialog_paragraph(const std::string &title, const std::string &message,std::string &text)
@@ -3797,34 +3796,31 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 	dialog.get_content_area()->pack_start(text_view);
 
 	dialog.add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-    dialog.add_button(_("OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
+	dialog.add_button(_("OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
     //Gtk::Button* ok_button = dialog.add_button(_("Ok"), Gtk::RESPONSE_OK);
+	dialog.set_default_response(Gtk::RESPONSE_OK);
 
-    dialog.set_default_response(Gtk::RESPONSE_OK);
+     dialog.signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //catching key-press event
 
-    //text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
+	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 
-    dialog.signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //catching key-press event
     if (response_ok_activate_check == 1)
-     {
-      // ok_button->clicked();
-       dialog.response(Gtk::RESPONSE_OK ) ;
-        std::cout<<" response emitted ";
-     }
-
+         {
+          // ok_button->clicked();
+           dialog.response(Gtk::RESPONSE_OK ) ;
+         //   std::cout<<" response emitted ";
+         }
 
 	if(dialog.run()!=Gtk::RESPONSE_OK)
 		return false;
 
 	text=text_buffer->get_text();
-	
-	response_ok_activate_check = 0 ;
+
+    response_ok_activate_check = 0 ;
 
 	return true;
 }
-
-
 
 std::string
 App::get_temporary_directory()

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3790,6 +3790,7 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 			}
 			return false;
 		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
+
 	}), false );
 
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3800,34 +3800,10 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
     Gtk::Button* ok_button = dialog.add_button(_("Ok"), Gtk::RESPONSE_OK);
 	dialog.set_default_response(Gtk::RESPONSE_OK);
 
-    bool on_key_pressed(GdkEventKey*);  //f dec hbd
-
-    signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //hbd
-
-
-    on_key_pressed(GdkEventKey* ev)
-   {
-       SYNFIG_EXCEPTION_GUARD_BEGIN()
-       if (ev->keyval == gdk_keyval_from_name("Enter")  )
-       {
-           Gtk::RESPONSE_OK ;
-           return true;
-       }
-
-       return false;
-       SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
-  }
-
-
-
     //text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 
-    dialog.signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //hbd
-
-   // GdkEventKey *ev ;
-
-   // on_key_pressed(ev);
+    dialog.signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //catching key-press event
 
 
 	if(dialog.run()!=Gtk::RESPONSE_OK)

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3781,14 +3781,13 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 	text_view.signal_key_press_event().connect(( [&](GdkEventKey *ev) {
 
 		SYNFIG_EXCEPTION_GUARD_BEGIN()
-		if (	(ev->type == GDK_KEY_PRESS) &&
-				(ev->keyval == (GDK_KEY_Return) || ev->keyval == (GDK_KEY_KP_Enter) ) &&
-				(ev->state == GDK_CONTROL_MASK) )
-			{
-			dialog.response(Gtk::RESPONSE_OK);
-			return true;
-			}
-			return false;
+		if ((ev->type == GDK_KEY_PRESS) &&
+		    (ev->keyval == (GDK_KEY_Return) || ev->keyval == (GDK_KEY_KP_Enter)) &&
+		    (ev->state == GDK_CONTROL_MASK)){
+				dialog.response(Gtk::RESPONSE_OK);
+				return true;
+		}
+		return false;
 		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 
 	}), false );

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3818,9 +3818,10 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 		return false;
 
 	text=text_buffer->get_text();
+	
+	response_ok_activate_check = 0 ;
 
 	return true;
-    response_ok_activate_check = 0 ;
 }
 
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3774,7 +3774,6 @@ App::on_key_pressed(GdkEventKey *ev)
       SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
  }
 
-
 bool
 App::dialog_paragraph(const std::string &title, const std::string &message,std::string &text)
 {
@@ -3800,17 +3799,18 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
     //Gtk::Button* ok_button = dialog.add_button(_("Ok"), Gtk::RESPONSE_OK);
 	dialog.set_default_response(Gtk::RESPONSE_OK);
 
-     dialog.signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //catching key-press event
+    dialog.signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); //catching key-press event
 
 	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 
     if (response_ok_activate_check == 1)
-         {
-          // ok_button->clicked();
-           dialog.response(Gtk::RESPONSE_OK ) ;
-         //   std::cout<<" response emitted ";
-         }
+             {
+              // ok_button->clicked();
+               dialog.response(Gtk::RESPONSE_OK ) ;
+             //   std::cout<<" response emitted ";
+             }
+
 
 	if(dialog.run()!=Gtk::RESPONSE_OK)
 		return false;

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3754,8 +3754,6 @@ App::dialog_sets_entry(const std::string &action, const std::string &content, st
 	return true;
 }
 
-
-
 bool
 App::dialog_paragraph(const std::string &title, const std::string &message,std::string &text)
 {
@@ -3780,29 +3778,28 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 	dialog.add_button(_("OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
     dialog.set_default_response(Gtk::RESPONSE_OK);
 
+	text_view.signal_key_press_event().connect(( [&](GdkEventKey *ev) {
 
-    text_view.signal_key_press_event().connect( [&](GdkEventKey *ev) {
-        SYNFIG_EXCEPTION_GUARD_BEGIN()
-          if (  (ev->type == GDK_KEY_PRESS) &&
-               (ev->keyval == (GDK_KEY_Return) || ev->keyval == (GDK_KEY_KP_Enter) || ev->keyval == (gdk_keyval_from_name("s")) ) &&
-               (ev->state == GDK_CONTROL_MASK) )  //pressing control and enter
-          {
-            dialog.response(-5);
-            return true;
-          }
+		SYNFIG_EXCEPTION_GUARD_BEGIN()
+		if (	(ev->type == GDK_KEY_PRESS) &&
+				(ev->keyval == (GDK_KEY_Return) || ev->keyval == (GDK_KEY_KP_Enter) ) &&
+				(ev->state == GDK_CONTROL_MASK) )
+			{
+			dialog.response(-5);
+			return true;
+			}
+			return false;
+		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
+	}), false );
 
-            return false;
-          SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
-    } );
 
 	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 
-
 	if(dialog.run()!=Gtk::RESPONSE_OK)
 		return false;
 
-    text=text_buffer->get_text();
+	text=text_buffer->get_text();
 
 	return true;
 }

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3774,8 +3774,8 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	dialog.get_content_area()->pack_start(text_view);
 
-	dialog.add_button(_("Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
-	dialog.add_button(_("OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
+	dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
+	dialog.add_button(_("_OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
 	dialog.set_default_response(Gtk::RESPONSE_OK);
 
 	text_view.signal_key_press_event().connect(( [&](GdkEventKey *ev) {
@@ -3785,7 +3785,7 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 				(ev->keyval == (GDK_KEY_Return) || ev->keyval == (GDK_KEY_KP_Enter) ) &&
 				(ev->state == GDK_CONTROL_MASK) )
 			{
-			dialog.response(-5);
+			dialog.response(Gtk::RESPONSE_OK);
 			return true;
 			}
 			return false;

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -452,9 +452,6 @@ public:
 
 	static bool dialog_paragraph(const std::string &title, const std::string &message,std::string &text);
 
-
-
-
 	static void dialog_not_implemented();
 
 	static void dialog_help();

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -450,8 +450,13 @@ public:
 	static bool dialog_entry(const std::string &action, const std::string &content, std::string &text, const std::string &button1, const std::string &button2);
 	static bool dialog_sets_entry(const std::string &action, const std::string &content, std::string &text, const std::string &button1, const std::string &button2);
 
-	static bool dialog_paragraph(const std::string &title, const std::string &message,std::string &text);
+    static bool dialog_paragraph(const std::string &title, const std::string &message,std::string &text);
     static bool   on_key_pressed(GdkEventKey *ev);
+     static   bool response_ok_activate_check ;
+   //  static void on_my_insert_at_cursor(const Glib::ustring& );
+    // static bool im_context_filter_keypress	( const Glib::RefPtr< GdkEventKey >&(ev) );
+
+
 
 	static void dialog_not_implemented();
 

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -451,8 +451,8 @@ public:
 	static bool dialog_sets_entry(const std::string &action, const std::string &content, std::string &text, const std::string &button1, const std::string &button2);
 
 	static bool dialog_paragraph(const std::string &title, const std::string &message,std::string &text);
-    static bool   on_key_pressed(GdkEventKey *ev);
-    static bool response_ok_activate_check ;
+
+
 
 
 	static void dialog_not_implemented();

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -451,6 +451,7 @@ public:
 	static bool dialog_sets_entry(const std::string &action, const std::string &content, std::string &text, const std::string &button1, const std::string &button2);
 
 	static bool dialog_paragraph(const std::string &title, const std::string &message,std::string &text);
+    static bool   on_key_pressed(GdkEventKey *ev);
 
 	static void dialog_not_implemented();
 

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -450,12 +450,9 @@ public:
 	static bool dialog_entry(const std::string &action, const std::string &content, std::string &text, const std::string &button1, const std::string &button2);
 	static bool dialog_sets_entry(const std::string &action, const std::string &content, std::string &text, const std::string &button1, const std::string &button2);
 
-    static bool dialog_paragraph(const std::string &title, const std::string &message,std::string &text);
+	static bool dialog_paragraph(const std::string &title, const std::string &message,std::string &text);
     static bool   on_key_pressed(GdkEventKey *ev);
-     static   bool response_ok_activate_check ;
-   //  static void on_my_insert_at_cursor(const Glib::ustring& );
-    // static bool im_context_filter_keypress	( const Glib::RefPtr< GdkEventKey >&(ev) );
-
+    static bool response_ok_activate_check ;
 
 
 	static void dialog_not_implemented();


### PR DESCRIPTION
Fix #2041 
Hey so I have been trying to do this for a bit, I started first with trying to implement accelerators but then realized that they are more for "menu" related buttons and such. So I was thinking of catching keypress events and then if the correct key is pressed then the text will be applied. However, in the process of implementing i'm facing multiple isssues.

1- `signal_key_press_event().connect(sigc::ptr_fun(&on_key_pressed)); `    in all other places where this is implemented its always done in the constructor of the class related to it. for example for dialog-preview it is in its constructor. also in gtkmm documentation it mentions it being placed in the constructor. by placing it here the build gives out an error :'signal_key_press_event' was not declared in this scope
the problem here is that dialog-paragraph is a method not a class so I cant really place it in its constructor. to which I have thought of trying to place it instead in the app class constructor (since it is the class which includes this method)... still to no successs

I'm getting puzzled here as to what I could do or where to place it.

2-also for the line 3785
 I'm getting two errors "expected primary-expression before '*' token" and "ev was not declared in this scope"


p.s
the body of "on_key_pressed" is not really made at all I'm focusing now on how to actually apply this method.