### PR TITLE
Palette editor invert option

### DIFF
--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -188,6 +188,7 @@ set(ICONS
 	resize_transparent_icon
 	select_all_child_layers_icon
 	set_fill_color
+	invert_icon
 	set_icon
 	set_outline_color
 	show_grid_icon

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -54,6 +54,7 @@ EXTRA_DIST = \
 	wallpaper.sif \
 	rename_icon.sif \
 	set_fill_color.sif \
+	invert_icon.sif \
 	set_outline_color.sif \
 	duck_position_icon.sif \
 	duck_vertex_icon.sif \
@@ -242,6 +243,7 @@ ICONS = \
 	\
 	rename_icon.$(EXT) \
 	set_fill_color.$(EXT) \
+	invert_icon.$(EXT) \
 	set_outline_color.$(EXT) \
 	duck_position_icon.$(EXT) \
 	duck_vertex_icon.$(EXT) \

--- a/synfig-studio/images/invert_icon.sif
+++ b/synfig-studio/images/invert_icon.sif
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.2" width="128" height="128" xres="2834.645691" yres="2834.645691" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>Synfig Studio: Tool: Width Icon</name>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="0"/>
+  <meta name="grid_size" content="0.250000 0.250000"/>
+  <meta name="grid_snap" content="0"/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="1"/>
+  <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
+  <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <layer type="rectangle" active="true" exclude_from_rendering="false" version="0.2" desc="RightBlackSide">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="color">
+      <color>
+        <r>0.000000</r>
+        <g>0.000000</g>
+        <b>0.000000</b>
+        <a>1.000000</a>
+      </color>
+    </param>
+    <param name="point1">
+      <vector>
+        <x>-1.0000000000</x>
+        <y>1.0000000000</y>
+      </vector>
+    </param>
+    <param name="point2">
+      <vector>
+        <x>1.0000000000</x>
+        <y>-1.0000000000</y>
+      </vector>
+    </param>
+    <param name="expand">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="invert">
+      <bool value="false"/>
+    </param>
+    <param name="feather_x">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="feather_y">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="bevel">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="bevCircle">
+      <bool value="true"/>
+    </param>
+  </layer>
+  <layer type="rectangle" active="true" exclude_from_rendering="false" version="0.2" desc="LeftWhiteSide">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="color">
+      <color>
+        <r>1.000000</r>
+        <g>1.000000</g>
+        <b>1.000000</b>
+        <a>1.000000</a>
+      </color>
+    </param>
+    <param name="point1">
+      <vector>
+        <x>-0.8126249909</x>
+        <y>0.8125000000</y>
+      </vector>
+    </param>
+    <param name="point2">
+      <vector>
+        <x>0.0000000000</x>
+        <y>-0.8125000000</y>
+      </vector>
+    </param>
+    <param name="expand">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="invert">
+      <bool value="false"/>
+    </param>
+    <param name="feather_x">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="feather_y">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="bevel">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="bevCircle">
+      <bool value="true"/>
+    </param>
+  </layer>
+</canvas>

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -271,6 +271,7 @@ IconController::init_icons(const synfig::String& path_to_icons)
 
 	INIT_STOCK_ICON(set_outline_color, "set_outline_color." IMAGE_EXT, _("Set as Outline"));
 	INIT_STOCK_ICON(set_fill_color, "set_fill_color." IMAGE_EXT, _("Set as Fill"));
+	INIT_STOCK_ICON(invert, "invert_icon." IMAGE_EXT, _("Invert Color"));
 
 	INIT_STOCK_ICON(animate_seek_begin, "animate_seek_begin_icon." IMAGE_EXT, _("Seek to Begin"));
 	INIT_STOCK_ICON(animate_seek_prev_keyframe, "animate_seek_prev_keyframe_icon." IMAGE_EXT, _("Seek to Previous Keyframe"));

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -329,6 +329,14 @@ Dock_PalEdit::show_menu(int i)
 	item->show_all();
 	menu->append(*item);
 
+	item = manage(new Gtk::ImageMenuItem(Gtk::StockID("synfig-invert")));
+	item->signal_activate().connect(
+		sigc::bind(
+			sigc::mem_fun(*this,&studio::Dock_PalEdit::invert_color),
+			i ));
+	item->show_all();
+	menu->append(*item);
+
 	item = manage(new Gtk::ImageMenuItem(Gtk::StockID("gtk-delete")));
 	item->signal_activate().connect(
 		sigc::bind(
@@ -367,6 +375,16 @@ void
 Dock_PalEdit::erase_color(int i)
 {
 	palette_.erase(palette_.begin()+i);
+	signal_changed()();
+	refresh();
+}
+
+void
+Dock_PalEdit::invert_color(int i)
+{
+	palette_[i].color.set_r(1.00f-palette_[i].color.get_r());
+	palette_[i].color.set_g(1.00f-palette_[i].color.get_g());
+	palette_[i].color.set_b(1.00f-palette_[i].color.get_b());
 	signal_changed()();
 	refresh();
 }

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
@@ -77,6 +77,7 @@ private:
 	int add_color(const synfig::Color& x);
 	void set_color(synfig::Color x, int i);
 	void erase_color(int i);
+	void invert_color(int i);
 
 	void select_fill_color(int i);
 	void select_outline_color(int i);


### PR DESCRIPTION
Added the ability to right click a color in the palette editor and invert it's RGB values (basically 255-current value). Does not affect alpha.