### PR TITLE
[CMake] Added option to link with tcmalloc library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(STUDIO_VERSION_MAJOR 1)
 set(STUDIO_VERSION_MINOR 5)
 set(STUDIO_VERSION_PATCH 0)
 
+option(ENABLE_TCMALLOC "Enable use of tcmalloc library" OFF)
+
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE Debug)
 endif()
@@ -68,6 +70,11 @@ message("-- CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
 if (${ENABLE_TESTS})
 	enable_testing()
+endif()
+
+if(ENABLE_TCMALLOC)
+	find_library(TCMALLOC_LIBRARY NAMES tcmalloc libtcmalloc.so.4 REQUIRED)
+	message(STATUS "TCMALLOC_LIBRARY: ${TCMALLOC_LIBRARY}")
 endif()
 
 include(SynfigFindGit)

--- a/synfig-core/src/tool/CMakeLists.txt
+++ b/synfig-core/src/tool/CMakeLists.txt
@@ -19,6 +19,9 @@ target_sources(synfig_bin
 )
 
 target_link_libraries(synfig_bin PRIVATE synfig)
+if(TCMALLOC_LIBRARY)
+    target_link_libraries(synfig_bin PRIVATE ${TCMALLOC_LIBRARY})
+endif()
 
 install (
     TARGETS synfig_bin

--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -87,7 +87,7 @@ target_include_directories(synfigstudio PRIVATE ${MLT_INCLUDE_DIRS}) # required 
 
 # on MacOS/Brew FontConfig located in non-standard folder
 # so we need to add it's path to target
-target_link_libraries(synfigstudio
+target_link_libraries(synfigstudio PRIVATE
 	${FONT_CONFIG_LDFLAGS}
 	${GTKMM_LIBRARIES}
 	${Gettext_LIBRARIES}
@@ -97,6 +97,10 @@ target_link_libraries(synfigstudio
 	synfig
 	synfigapp
 )
+
+if(TCMALLOC_LIBRARY)
+	target_link_libraries(synfigstudio PRIVATE ${TCMALLOC_LIBRARY})
+endif()
 
 install(
 	TARGETS synfigstudio


### PR DESCRIPTION
Added option to link with tcmalloc library.
This should help debug memory leaks.
Usage:
1. install google-perf-tools package
```
sudo apt-get install google-perftools
```

2. Enable linking with tcmalloc library:
```
cmake -DENABLE_TCMALLOC=ON ...
```
This option just adds `-ltcmalloc` to `synfig` and `synfigstudio` binaries.

3. Build binaries and enable heap profiling:
```
env HEAPPROFILE=synfig ./synfig ...
```

This should create `synfig.00xx.heap` files in current folder while running.

More details about tcmalloc options here:
https://gperftools.github.io/gperftools/heapprofile.html

4. Install visualizer dependencies (gv, graphviz):
```
sudo apt install graphviz gv
```

5. Comparing profiles:
```
google-pprof --gv --base=synfig.0002.heap ./synfigstudio synfig.0004.heap
```
This will show where memory is allocated.