### PR TITLE
feat: Reproducible build

### DIFF
--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -375,15 +375,15 @@ void SynfigCommandLineParser::process_trivial_info_options()
 #ifdef DEVEL_VERSION
 		std::cout << std::endl << DEVEL_VERSION << std::endl << std::endl;
 #endif
-		std::cout << "Compiled on " __DATE__ /* " at "__TIME__ */;
+		std::cout << "Compiled on " << get_build_date();
 #ifdef __GNUC__
 		std::cout << " with GCC " << __VERSION__;
-#endif
-#ifdef _MSC_VER
+#elif defined(__clang__)
+		std::cout << " with Clang " << __VERSION__;
+#elif defined(_MSC_VER)
 		std::cout << " with Microsoft Visual C++ "
 			 << (_MSC_VER>>8) << '.' << (_MSC_VER&255);
-#endif
-#ifdef __TCPLUSPLUS__
+#elif defined(__TCPLUSPLUS__)
 		std::cout << " with Borland Turbo C++ "
 			 << (__TCPLUSPLUS__>>8) << '.'
 			 << ((__TCPLUSPLUS__&255)>>4) << '.'

--- a/synfig-studio/src/gui/dialogs/about.cpp
+++ b/synfig-studio/src/gui/dialogs/about.cpp
@@ -37,6 +37,8 @@
 // This is generated at make time from .git or autorevision.conf
 #include <autorevision.h>
 
+#include <ctime>
+
 #include <gtkmm/image.h>
 
 #include <gui/app.h>
@@ -312,8 +314,25 @@ About::About()
 	#endif
 
 	extra_info += "\n";
+	{
+		const int max_date_length = 50;
+		char date_str[max_date_length];
 
-	extra_info += etl::strprintf(_("Built on %s" /* at %s */ "\n\n"), __DATE__ /* , __TIME__ */ );
+		// https://reproducible-builds.org/specs/source-date-epoch/
+		if (char* source_date_epoch = getenv("SOURCE_DATE_EPOCH")) {
+			std::istringstream iss(source_date_epoch);
+			std::time_t t;
+			iss >> t;
+			if (iss.fail()
+			    || !iss.eof()
+			    || !std::strftime(date_str, sizeof(date_str), "%x", std::localtime(&t))) {
+				    std::strncpy(date_str, _("Unknown build date"), max_date_length-1);
+			}
+		} else
+			std::strncpy(date_str, __DATE__, max_date_length-1);
+
+		extra_info += etl::strprintf(_("Built on %s\n\n"), date_str );
+	}
 
 	extra_info += etl::strprintf(_("Built with:\n"));
 	extra_info += etl::strprintf(_("ETL %s\n"), ETL_VERSION);


### PR DESCRIPTION
Reasoning is stated here: https://reproducible-builds.org/.

UPD:
Build can be reproduced by setting environment variable `SOURCE_DATE_EPOCH`