### PR TITLE
Fix various typos

### DIFF
--- a/synfig-core/src/synfig/synfig_iterations.h
+++ b/synfig-core/src/synfig/synfig_iterations.h
@@ -58,7 +58,7 @@ typedef std::function<void(Layer::LooseHandle, const TraverseLayerStatus&)> Trav
 /// Search for layers listed/pointed by another (via Canvas-type parameters)
 /// Normally used for Layer_PasteCanvas, but another ones may have canvases
 ///
-/// \param layer The starting point to scannning
+/// \param layer The starting point to scanning
 /// \param callback A functor called at each layer found
 void traverse_layers(Layer::Handle layer, TraverseLayerCallback callback);
 

--- a/synfig-core/src/synfig/valuenode.h
+++ b/synfig-core/src/synfig/valuenode.h
@@ -356,7 +356,7 @@ protected:
 *
 * 	This Value Node is calculated based on a math calculation or a time
 * 	evaluation of the linked Value Nodes. It is commonly known as
-* 	Converted Value Nodes. The derived clases defines the behavior.
+* 	Converted Value Nodes. The derived classes defines the behavior.
 */
 class LinkableValueNode : public ValueNode
 {

--- a/synfig-core/src/synfig/vector.h
+++ b/synfig-core/src/synfig/vector.h
@@ -1,6 +1,6 @@
 /* === S Y N F I G ========================================================= */
 /*!	\file vector.h
-**	\brief Various discreet type definitions
+**	\brief Various discrete type definitions
 **
 **	\legal
 **	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley

--- a/synfig-studio/docs/bones_gui.txt
+++ b/synfig-studio/docs/bones_gui.txt
@@ -142,7 +142,7 @@ SETUP AND ANIMATED SKELETONS
 
 By using the ALT-7 keyboard combintation the user sees the setup or the
 non setup skeletons.
-When the user is creating the skeleton and is modifiying it in non
+When the user is creating the skeleton and is modifying it in non
 animation mode then the setuo and the non setup skeletons should be the
 same. In this way the workflow for this creation of the skeleton will be:
 

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -103,7 +103,7 @@ class studio::StateBone_Context : public sigc::trackable
 	// Toolbox settings
 	synfigapp::Settings& settings;
 
-	// holder of optons
+	// holder of options
 	Gtk::Grid options_table;
 
 	// title

--- a/synfig-studio/src/synfigapp/wplistconverter.h
+++ b/synfig-studio/src/synfigapp/wplistconverter.h
@@ -54,9 +54,9 @@ private:
 	std::vector<synfig::Real> widths;
 	//! The processed result of the widthpoints
 	std::vector<synfig::WidthPoint> work_out;
-	//! Calculated cummulated distances to origin
+	//! Calculated cumulated distances to origin
 	std::vector<synfig::Real> distances;
-	//! Calculated cummulated distances to origin normalized
+	//! Calculated cumulated distances to origin normalized
 	std::vector<synfig::Real> norm_distances;
 	//! The error value at each position: ek[k]=w[k]-wp_out.width[k]
 	std::vector<synfig::Real> ek;


### PR DESCRIPTION
Found via `codespell -q 3 -L aline,ang,ba,childs,dout,eiter,forse,objext,pard,parms,pevent,propertyst,ro,shouldbe,thru,uint,unselect,vertexes -S ./synfig-studio/po,./synfig-core/po,/synfig-core/m4,./synfig-osx/,./gtkmm-osx,./bugs,.*.eps,*.sif,./synfig-studio/plugins/lottie-exporter`