### PR TITLE
Fixed bline test on i386

### DIFF
--- a/synfig-core/test/bline.cpp
+++ b/synfig-core/test/bline.cpp
@@ -93,17 +93,17 @@ bool test_bline_length() {
 
 	Real l = bline_length(list, loop, &lengths);
 	ASSERT_EQUAL(2, lengths.size());
-	ASSERT_APPROX_EQUAL(1.0, lengths[0]);
-	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
-	ASSERT_APPROX_EQUAL(2.0, l);
+	ASSERT_APPROX_EQUAL_MICRO(1.0, lengths[0]);
+	ASSERT_APPROX_EQUAL_MICRO(1.0, lengths[1]);
+	ASSERT_APPROX_EQUAL_MICRO(2.0, l);
 
 	loop = true;
 	l = bline_length(list, loop, &lengths);
 	ASSERT_EQUAL(3, lengths.size());
-	ASSERT_APPROX_EQUAL(1.0, lengths[0]);
-	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
-	ASSERT_APPROX_EQUAL(2.0, lengths[2]);
-	ASSERT_APPROX_EQUAL(4.0, l);
+	ASSERT_APPROX_EQUAL_MICRO(1.0, lengths[0]);
+	ASSERT_APPROX_EQUAL_MICRO(1.0, lengths[1]);
+	ASSERT_APPROX_EQUAL_MICRO(2.0, lengths[2]);
+	ASSERT_APPROX_EQUAL_MICRO(4.0, l);
 
 	BLinePoint p1;
 	p1.set_tangent1(Point(-1,0));


### PR DESCRIPTION
`find_distance` in `ETL/_bezier.h` actually returns a float.

_bezier.h
```
typedef float distance_type;
...
distance_type find_distance(time_type r, time_type s, int steps=7)const
```

Floating point precision is between 6 and 9 decimal digits, so I just reduced precision requirement for test to the lowest possible precision.

https://en.wikipedia.org/wiki/Single-precision_floating-point_format

Fix #2606