### PR TITLE
Fix module search path for Lottie Exporter

### DIFF
--- a/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
+++ b/synfig-studio/plugins/lottie-exporter/lottie-exporter.py
@@ -8,9 +8,12 @@ output  : FILE_NAME.json
 
 Supported Layers are mentioned below
 """
+
 import os
-import json
 import sys
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+
+import json
 import logging
 from lxml import etree
 from canvas import gen_canvas


### PR DESCRIPTION
This fix is required after upgrade of Python version in Windows build of Synfig - https://github.com/morevnaproject/morevna-builds/pull/67

I have updated to Python version 3.8.10 ("embed" build), and after that  Lottie Exporter throws an error that it unable to find "canvas" module. The "canvas.py" file is in the same directory as main plugin file and Python should find it. But probably the "embed" version of Python have different behavior. So, I have added plugin dir to python's module search path.

Other Synfig's default plugins are okay (they do not import custom modules).