### PR TITLE
Added basic support for Gtk theme

### DIFF
--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -242,7 +242,8 @@ set(IMAGES
 	${ICONS}
 )
 
-set(PIXMAPS_DIR ${SYNFIG_BUILD_ROOT}/share/synfig/icons/classic)
+set(THEME_DIR ${SYNFIG_BUILD_ROOT}/share/synfig/icons/classic)
+set(PIXMAPS_DIR ${THEME_DIR}/128x128)
 
 file(MAKE_DIRECTORY ${PIXMAPS_DIR})
 
@@ -287,7 +288,7 @@ foreach (IMAGE IN ITEMS ${IMAGES})
 	list(APPEND PIXMAPS ${PIXMAPS_DIR}/${IMAGE}.png)
 	install(
 		FILES ${PIXMAPS_DIR}/${IMAGE}.png
-		DESTINATION share/synfig/icons/classic
+		DESTINATION share/synfig/icons/classic/128x128
 	)
 endforeach()
 
@@ -301,6 +302,10 @@ install(
 	FILES ${CMAKE_CURRENT_SOURCE_DIR}/org.synfig.SynfigStudio.svg
 	DESTINATION share/icons/hicolor/scalable/apps
 )
+
+# index.theme
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/index.theme ${SYNFIG_BUILD_ROOT}/share/synfig/icons/classic/index.theme COPYONLY)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/index.theme DESTINATION share/synfig/icons/classic)
 
 # Synfig Splash Screen
 if(${CMAKE_BUILD_TYPE} MATCHES Debug)
@@ -334,14 +339,14 @@ install(
 # WIN32 Icon
 if(WIN32)
 	add_custom_command(
-		OUTPUT ${PIXMAPS_DIR}/synfig_icon.ico
-		COMMAND synfig_bin ${CMAKE_CURRENT_SOURCE_DIR}/synfig_icon.sif -o ${PIXMAPS_DIR}/synfig_icon.ico --time 0f --quiet
+		OUTPUT ${THEME_DIR}/synfig_icon.ico
+		COMMAND synfig_bin ${CMAKE_CURRENT_SOURCE_DIR}/synfig_icon.sif -o ${THEME_DIR}/synfig_icon.ico --time 0f --quiet
 		DEPENDS ${SYNFIG_SPLASH_SCREEN} synfig_bin
 	)
 
-	list(APPEND PIXMAPS ${PIXMAPS_DIR}/synfig_icon.ico)
+	list(APPEND PIXMAPS ${THEME_DIR}/synfig_icon.ico)
 	install(
-		FILES ${PIXMAPS_DIR}/synfig_icon.ico
+		FILES ${THEME_DIR}/synfig_icon.ico
 		DESTINATION share/pixmaps/synfigstudio
 	)
 endif()

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -198,7 +198,8 @@ EXTRA_DIST = \
 	time_track_icon.sif \
 	\
 	utils_chain_link_icons.sif \
-	utils_timetrack_align_icon.sif
+	utils_timetrack_align_icon.sif \
+	index.theme
 
 IMAGES = \
 	installer_logo.bmp \
@@ -442,7 +443,10 @@ appicondir= $(datadir)/icons/hicolor
 imagedir = $(synfig_datadir)/images
 image_DATA = $(IMAGES)
 
-iconsdir = $(synfig_datadir)/icons/classic
+themedir = $(synfig_datadir)/icons/classic
+theme_DATA = index.theme
+
+iconsdir = $(themedir)/128x128
 icons_DATA = $(ICONS)
 
 win32iconsdir = $(datadir)/pixmaps

--- a/synfig-studio/images/index.theme
+++ b/synfig-studio/images/index.theme
@@ -1,0 +1,14 @@
+[Icon Theme]
+
+Name=Classic
+Comment=Synfig classic icon theme
+Hidden=true
+Directories=128x128
+Example=synfig_icon
+
+[128x128]
+Size=128
+MinSize=12
+MaxSize=128
+Context=Actions
+Type=Scalable

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -151,6 +151,7 @@
 #include <synfigapp/settings.h>
 
 #include <thread>
+#include <gtkmm/icontheme.h>
 
 #ifdef _WIN32
 
@@ -1439,7 +1440,12 @@ void App::init(const synfig::String& rootpath)
 
 	String path_to_user_plugins = synfigapp::Main::get_user_app_directory()
 		+ ETL_DIRECTORY_SEPARATOR + "plugins";
-	
+
+	// Add Synfig theme path to IconTheme
+	auto icon_theme = Gtk::IconTheme::get_default();
+	icon_theme->append_search_path(ResourceHelper::get_theme_path());
+	App::set_icon_theme("classic");
+
 	// icons
 	init_icons(path_to_icons + ETL_DIRECTORY_SEPARATOR);
 
@@ -4410,4 +4416,22 @@ studio::App::check_python_version(String path)
 #else
 	return false;
 #endif
+}
+
+// Almost all GTK methods using icons from the default GTK theme.
+// Unfortunately, we can't change the IconTheme name if we get it
+// from the default screen with the `Gtk::IconTheme::get_default()`
+// method.
+// https://docs.gtk.org/gtk3/method.IconTheme.set_custom_theme.html
+// > Sets the name of the icon theme that the GtkIconTheme object uses
+// > overriding system configuration. This function cannot be called on
+// > the icon theme objects returned from gtk_icon_theme_get_default()
+// > and gtk_icon_theme_get_for_screen().
+//
+// Also, I didn't find a way to change the app IconTheme to a custom
+// one. However, we can change the IconTheme for the default screen
+// using the `Gtk::Settings` object.
+void studio::App::set_icon_theme(const std::string& name) {
+	auto settings = Gtk::Settings::get_default();
+	settings->property_gtk_icon_theme_name() = name;
 }

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -484,6 +484,8 @@ public:
 
 	static void process_all_events();
 	static bool check_python_version( std::string path);
+
+	static void set_icon_theme(const std::string& name);
 }; // END of class App
 
 	void delete_widget(Gtk::Widget *widget);

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1466,7 +1466,7 @@ CanvasView::init_menus()
 	action_group->add( Gtk::Action::create("save", Gtk::StockID("synfig-save"), _("Save"), _("Save")),
 		hide_return(sigc::mem_fun(*get_instance().get(), &Instance::save))
 	);
-	action_group->add( Gtk::Action::create("save-as", Gtk::StockID("synfig-save_as"), _("Save As..."), _("Save As")),
+	action_group->add( Gtk::Action::create_with_icon_name("save-as", "action_doc_saveas_icon", _("Save As..."), _("Save As")),
 		sigc::hide_return(sigc::mem_fun(*get_instance().get(), &Instance::dialog_save_as))
 	);
 	action_group->add( Gtk::Action::create("export", Gtk::StockID("synfig-export"), _("Export..."), _("Export")),

--- a/synfig-studio/src/gui/resourcehelper.cpp
+++ b/synfig-studio/src/gui/resourcehelper.cpp
@@ -71,11 +71,13 @@ synfig::String studio::ResourceHelper::get_synfig_data_path()
 	return synfig_datadir;
 }
 
+std::string studio::ResourceHelper::get_theme_path() {
+	return get_synfig_data_path() + "/icons/" ;
+}
+
 synfig::String studio::ResourceHelper::get_icon_path()
 {
-	std::string iconpath = get_synfig_data_path() + ETL_DIRECTORY_SEPARATOR + "icons";
-	iconpath += ETL_DIRECTORY_SEPARATOR + App::get_synfig_icon_theme();
-	return iconpath;
+	return get_theme_path() + App::get_synfig_icon_theme() + "/128x128";
 }
 
 synfig::String studio::ResourceHelper::get_icon_path(const synfig::String& icon_filename)

--- a/synfig-studio/src/gui/resourcehelper.h
+++ b/synfig-studio/src/gui/resourcehelper.h
@@ -39,6 +39,7 @@ public:
 
 	static synfig::String get_synfig_data_path();
 
+	static std::string get_theme_path();
 	static synfig::String get_icon_path();
 	static synfig::String get_icon_path(const synfig::String& icon_filename);
 


### PR DESCRIPTION
- Icons moved to `128x128` folder
- Added index.theme
- `File -> Save as` icon switched to IconTheme icon (as example)

This PR will allow seamless transition to Gtk::IconTheme.

**Details:**
Almost all GTK methods using icons from the default GTK theme.
Unfortunately, we can't change the IconTheme name if we get it from the default screen with the `Gtk::IconTheme::get_default()` method (https://docs.gtk.org/gtk3/method.IconTheme.set_custom_theme.html)

> Sets the name of the icon theme that the GtkIconTheme object uses overriding system configuration. This function cannot be called on the icon theme objects returned from gtk_icon_theme_get_default() and gtk_icon_theme_get_for_screen().

Also, I didn't find a way to change the app IconTheme to a custom one. 
However, we can change the IconTheme for the default screen using the `Gtk::Settings` object.

It also fixes the problem with blurry icons on HiDPI screens. As you can see, the IconTheme icon is no longer blurry.

![Screenshot_34](https://user-images.githubusercontent.com/5604544/166481979-daf7ab62-355d-41fd-ab11-67842af28a95.png)

P.S. I'm not sure if I copied the file in Automake correctly, so any help is appreciated.