### PR TITLE
Fixed video render with FFmpeg version 3

### DIFF
--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -286,7 +286,7 @@ ffmpeg_trgt::init(ProgressCallback *cb=NULL)
 	vargs.emplace_back(video_codec == "mpeg1video" ? "pcm_s16be" : "pcm_s16le");
 	vargs.emplace_back("-y");
 	vargs.emplace_back("-t");
-	vargs.emplace_back((desc.get_time_end()-desc.get_time_start()).get_string());
+	vargs.emplace_back((desc.get_time_end()-desc.get_time_start()).get_string(Time::Format::FORMAT_VIDEO));
 	// We need "--" to separate filename from arguments (for the case when filename starts with "-")
 	if ( filename.substr(0,1) == "-" )
 		vargs.emplace_back("--");


### PR DESCRIPTION
Time format has been changed to the correct one.

Fix #2608 