### PR TITLE
fix: memory leak when the load default palette button is repeatedly pressed

### DIFF
--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -376,6 +376,11 @@ Dock_PalEdit::refresh()
 {
 	const int width(12);
 
+	// Free table children from memory
+	std::vector<Widget*> children = table.get_children();
+	for(Widget* child : children)
+		delete child;
+
 	// Clear the table
 	table.foreach(sigc::mem_fun(table,&Gtk::Table::remove));
 


### PR DESCRIPTION
The most major memory leak in the refresh() function has been fixed, however some other memory leaks seem to still be there.