### PR TITLE
Replacement of deprecated Gtk Arrow

### DIFF
--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -212,6 +212,7 @@ IconController::init_icons(const synfig::String& path_to_icons)
 	INIT_STOCK_ICON(set_outline_color, "set_outline_color." IMAGE_EXT, _("Set as Outline"));
 	INIT_STOCK_ICON(set_fill_color, "set_fill_color." IMAGE_EXT, _("Set as Fill"));
 
+	INIT_STOCK_ICON(right_arrow, "chevron_right_arrow_icon." IMAGE_EXT, _(""));
 	INIT_STOCK_ICON(animate_seek_begin, "animate_seek_begin_icon." IMAGE_EXT, _("Seek to Begin"));
 	INIT_STOCK_ICON(animate_seek_prev_keyframe, "animate_seek_prev_keyframe_icon." IMAGE_EXT, _("Seek to Previous Keyframe"));
 	INIT_STOCK_ICON(animate_seek_prev_frame, "animate_seek_prev_frame_icon." IMAGE_EXT, _("Seek to Previous Frame"));

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -225,8 +225,7 @@ WorkArea::WorkArea(etl::loose_handle<synfigapp::CanvasInterface> canvas_interfac
 	vruler->set_vexpand(true);
 
 	// Create the menu button
-
-	Gtk::Arrow *menubutton = manage(new Gtk::Arrow(Gtk::ARROW_RIGHT, Gtk::SHADOW_OUT));
+	Gtk::Image *menubutton = manage(new Gtk::Image(Gtk::StockID("synfig-right_arrow"), Gtk::IconSize::from_name("synfig-small_icon")));
 	menubutton->set_size_request(18, 18);
 	Gtk::EventBox *menubutton_box = manage(new Gtk::EventBox());
 	menubutton_box->add(*menubutton);


### PR DESCRIPTION
A quick switch from the deprecated gtk arrow to gtk image.
before :
<img width="572" alt="gtk_arrow_og" src="https://user-images.githubusercontent.com/100296264/169286865-e703e8eb-9acc-441b-905b-0e211480d78e.png">
after: 
<img width="572" alt="latest_arrow" src="https://user-images.githubusercontent.com/100296264/169286888-02605c5f-2d38-48f1-bb7c-70563de78df9.png">

I manually added the icon myself to my icons folder though so it still has to be added somewhere  in the build files but I'm not at all familiar with c-make or the build process as a whole so if anyone can point it out a bit it would be appreciated and this would be done basically. 
however, what I'm guessing needs to be done should be in makefiles.am file and maybe the icon itself is added as a SIF file. however I'm not sure where I could convert the icon which is a .png file to a SIF file. I will be looking into these but it would save a lot if anyone helps 😄 
