### PR TITLE
Fixed issue with autosave not working when interval is set to 15 seconds

### DIFF
--- a/synfig-studio/src/gui/autorecover.cpp
+++ b/synfig-studio/src/gui/autorecover.cpp
@@ -58,10 +58,10 @@ using namespace studio;
 
 /* === M E T H O D S ======================================================= */
 
-AutoRecover::AutoRecover():
-	enabled(1),
-	timeout_ms(15000)
-{ }
+AutoRecover::AutoRecover()
+{
+	set_timer(true, 15000);
+}
 
 AutoRecover::~AutoRecover()
 {
@@ -75,6 +75,7 @@ AutoRecover::set_timer(bool enabled, int timeout_ms)
 	if (this->enabled != enabled || this->timeout_ms != timeout_ms)
 	{
 		bool env_enabled = !getenv("SYNFIG_DISABLE_AUTO_SAVE");
+		// if the timer was enabled then disconnect it
 		if (this->enabled && this->timeout_ms > 0 && env_enabled)
 			connection.disconnect();
 

--- a/synfig-studio/src/gui/autorecover.h
+++ b/synfig-studio/src/gui/autorecover.h
@@ -43,8 +43,8 @@ namespace studio {
 
 class AutoRecover
 {
-	bool enabled;
-	int timeout_ms;
+	bool enabled = false;
+	int timeout_ms = 0;
 	sigc::connection connection;
 
 	void set_timer(bool enabled, int timeout_ms);


### PR DESCRIPTION
The problem was in this condition:
```
	if (this->enabled != enabled || this->timeout_ms != timeout_ms)
	{
		bool env_enabled = !getenv("SYNFIG_DISABLE_AUTO_SAVE");
		if (this->enabled && this->timeout_ms > 0 && env_enabled)
```
Since the timer was enabled by default (a05eaa2), this condition did not work and the signal was not connected.

Fix #2646