### PR TITLE
fix: Synfig does not start if the OS username contains non-Latin characters (Windows)

### DIFF
--- a/synfig-core/src/synfig/debug/log.cpp
+++ b/synfig-core/src/synfig/debug/log.cpp
@@ -37,6 +37,7 @@
 #include <fstream>
 
 #include "log.h"
+#include "synfig/filesystemnative.h"
 
 #include <ETL/stringf>
 #include <synfig/general.h>
@@ -62,7 +63,7 @@ std::mutex Log::mutex;
 void Log::append_line_to_file(const String &logfile, const String &str)
 {
 	std::lock_guard<std::mutex> lock(mutex);
-	std::ofstream f(logfile.c_str(), std::ios_base::app);
+	std::ofstream f(FileSystemNative::path(logfile).c_str(), std::ios_base::app);
 	f << str << std::endl;
 }
 

--- a/synfig-core/src/synfig/debug/log.cpp
+++ b/synfig-core/src/synfig/debug/log.cpp
@@ -37,9 +37,9 @@
 #include <fstream>
 
 #include "log.h"
-#include "synfig/filesystemnative.h"
 
 #include <ETL/stringf>
+#include <synfig/filesystem.h>
 #include <synfig/general.h>
 
 #endif
@@ -63,7 +63,7 @@ std::mutex Log::mutex;
 void Log::append_line_to_file(const String &logfile, const String &str)
 {
 	std::lock_guard<std::mutex> lock(mutex);
-	std::ofstream f(FileSystemNative::path(logfile).c_str(), std::ios_base::app);
+	std::ofstream f(synfig::filesystem::Path(logfile).c_str(), std::ios_base::app);
 	f << str << std::endl;
 }
 

--- a/synfig-core/src/synfig/filesystem.cpp
+++ b/synfig-core/src/synfig/filesystem.cpp
@@ -31,6 +31,11 @@
 #ifdef HAVE_CONFIG_H
 #	include <config.h>
 #endif
+#ifdef _WIN32
+#include <codecvt>
+#include <locale>
+#include "general.h" // synfig::error(...)
+#endif
 
 #include <glibmm.h>
 #include <cstdio>
@@ -236,6 +241,28 @@ String FileSystem::get_real_filename(const String &filename) {
 	return Glib::filename_from_uri(get_real_uri(filename));
 }
 
+filesystem::Path::Path(const std::string& path)
+{
+#ifdef _WIN32
+	// Windows uses UTF-16 for filenames, so we need to convert it from UTF-8 before using it.
+	try {
+		std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wcu8;
+		path_ = wcu8.from_bytes(path);
+	} catch (const std::range_error& exception) {
+		synfig::error("Failed to convert path (%s)", path.c_str());
+		throw;
+	}
+#else
+	// For other OS, just return the file name as is
+	path_ = path;
+#endif
+}
+
+const filesystem::Path::value_type*
+filesystem::Path::c_str() const noexcept
+{
+	return path_.c_str();
+}
 
 /* === E N T R Y P O I N T ================================================= */
 

--- a/synfig-core/src/synfig/filesystem.h
+++ b/synfig-core/src/synfig/filesystem.h
@@ -235,6 +235,25 @@ namespace synfig
 		virtual FileSystem::WriteStream::Handle get_write_stream(const String &/*filename*/)
 			{ return WriteStream::Handle(); }
 	};
+
+	namespace filesystem {
+		class Path {
+		public:
+#ifdef _WIN32
+			typedef wchar_t	value_type;
+#else
+			typedef char value_type;
+#endif
+			typedef std::basic_string<value_type> string_type;
+
+			Path(const std::string& path);
+
+			const value_type* c_str() const noexcept;
+
+		private:
+			string_type path_;
+		};
+	}
 }
 
 /* === E N D =============================================================== */

--- a/synfig-core/src/synfig/filesystemnative.h
+++ b/synfig-core/src/synfig/filesystemnative.h
@@ -31,6 +31,12 @@
 /* === H E A D E R S ======================================================= */
 
 #include "filesystem.h"
+#include "general.h" // synfig::error(...)
+
+#ifdef _WIN32
+#include <codecvt>
+#include <locale>
+#endif
 
 /* === M A C R O S ========================================================= */
 
@@ -95,6 +101,23 @@ namespace synfig
 		virtual FileSystem::ReadStream::Handle get_read_stream(const String &filename);
 		virtual FileSystem::WriteStream::Handle get_write_stream(const String &filename);
 		virtual String get_real_uri(const String &filename);
+#ifdef _WIN32
+		// Windows uses UTF-16 for filenames, so we need to convert it from UTF-8 before using it.
+		static std::wstring path(const std::string& path) {
+			try {
+				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wcu8;
+				return wcu8.from_bytes(path);
+			} catch (const std::range_error& exception) {
+				synfig::error("Failed to convert path (%s)", path.c_str());
+				throw;
+			}
+		}
+#else
+		// For other OS, just return the file name as is
+		static std::string path(const std::string& path) {
+			return path;
+		}
+#endif
 	};
 
 }

--- a/synfig-core/src/synfig/filesystemnative.h
+++ b/synfig-core/src/synfig/filesystemnative.h
@@ -31,12 +31,6 @@
 /* === H E A D E R S ======================================================= */
 
 #include "filesystem.h"
-#include "general.h" // synfig::error(...)
-
-#ifdef _WIN32
-#include <codecvt>
-#include <locale>
-#endif
 
 /* === M A C R O S ========================================================= */
 
@@ -101,23 +95,6 @@ namespace synfig
 		virtual FileSystem::ReadStream::Handle get_read_stream(const String &filename);
 		virtual FileSystem::WriteStream::Handle get_write_stream(const String &filename);
 		virtual String get_real_uri(const String &filename);
-#ifdef _WIN32
-		// Windows uses UTF-16 for filenames, so we need to convert it from UTF-8 before using it.
-		static std::wstring path(const std::string& path) {
-			try {
-				std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wcu8;
-				return wcu8.from_bytes(path);
-			} catch (const std::range_error& exception) {
-				synfig::error("Failed to convert path (%s)", path.c_str());
-				throw;
-			}
-		}
-#else
-		// For other OS, just return the file name as is
-		static std::string path(const std::string& path) {
-			return path;
-		}
-#endif
 	};
 
 }

--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -190,7 +190,7 @@ static void broken_pipe_signal (int /*sig*/)  {
 
 bool retrieve_modules_to_load(String filename,std::list<String> &modules_to_load)
 {
-	std::ifstream file(FileSystemNative::path(filename).c_str());
+	std::ifstream file(synfig::filesystem::Path(filename).c_str());
 
 	if(!file)
 	{

--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -190,7 +190,7 @@ static void broken_pipe_signal (int /*sig*/)  {
 
 bool retrieve_modules_to_load(String filename,std::list<String> &modules_to_load)
 {
-	std::ifstream file(Glib::locale_from_utf8(filename).c_str());
+	std::ifstream file(FileSystemNative::path(filename).c_str());
 
 	if(!file)
 	{
@@ -335,8 +335,11 @@ synfig::Main::Main(const synfig::String& rootpath,ProgressCallback *cb):
 	else
 	{
 		locations.push_back("./" MODULE_LIST_FILENAME);
-		if(getenv("HOME"))
-			locations.push_back(strprintf("%s/.local/share/synfig/%s", getenv("HOME"), MODULE_LIST_FILENAME));
+		const std::string home = Glib::getenv("HOME");
+		if (!home.empty()) {
+			locations.push_back(strprintf("%s/.local/share/synfig/%s", home.c_str(), MODULE_LIST_FILENAME));
+		}
+
 	#ifdef SYSCONFDIR
 		locations.push_back(SYSCONFDIR"/" MODULE_LIST_FILENAME);
 	#endif

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1965,7 +1965,7 @@ App::save_settings()
 		{
 			std::string filename=get_config_file("language");
 
-			std::ofstream file(FileSystemNative::path(filename).c_str());
+			std::ofstream file(synfig::filesystem::Path(filename).c_str());
 
 			if(!file)
 			{
@@ -1977,7 +1977,7 @@ App::save_settings()
 		do{
 			std::string filename=get_config_file("recentfiles");
 
-			std::ofstream file(FileSystemNative::path(filename).c_str());
+			std::ofstream file(synfig::filesystem::Path(filename).c_str());
 
 			if(!file)
 			{
@@ -2063,7 +2063,7 @@ App::load_file_window_size()
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		{
 			std::string filename=get_config_file("recentfiles");
-			std::ifstream file(FileSystemNative::path(filename).c_str());
+			std::ifstream file(synfig::filesystem::Path(filename).c_str());
 
 			while(file)
 			{
@@ -2090,7 +2090,7 @@ App::load_language_settings()
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		{
 			std::string filename=get_config_file("language");
-			std::ifstream file(FileSystemNative::path(filename).c_str());
+			std::ifstream file(synfig::filesystem::Path(filename).c_str());
 
 			while(file)
 			{

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1965,7 +1965,7 @@ App::save_settings()
 		{
 			std::string filename=get_config_file("language");
 
-			std::ofstream file(filename.c_str());
+			std::ofstream file(FileSystemNative::path(filename).c_str());
 
 			if(!file)
 			{
@@ -1977,7 +1977,7 @@ App::save_settings()
 		do{
 			std::string filename=get_config_file("recentfiles");
 
-			std::ofstream file(filename.c_str());
+			std::ofstream file(FileSystemNative::path(filename).c_str());
 
 			if(!file)
 			{
@@ -2063,7 +2063,7 @@ App::load_file_window_size()
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		{
 			std::string filename=get_config_file("recentfiles");
-			std::ifstream file(filename.c_str());
+			std::ifstream file(FileSystemNative::path(filename).c_str());
 
 			while(file)
 			{
@@ -2090,7 +2090,7 @@ App::load_language_settings()
 		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
 		{
 			std::string filename=get_config_file("language");
-			std::ifstream file(filename.c_str());
+			std::ifstream file(FileSystemNative::path(filename).c_str());
 
 			while(file)
 			{

--- a/synfig-studio/src/gui/duckmatic.cpp
+++ b/synfig-studio/src/gui/duckmatic.cpp
@@ -1478,7 +1478,7 @@ bool
 Duckmatic::save_sketch(const synfig::String& filename)const
 {
 	ChangeLocale change_locale(LC_NUMERIC, "C");
-	std::ofstream file(FileSystemNative::path(filename).c_str());
+	std::ofstream file(synfig::filesystem::Path(filename).c_str());
 
 	if(!file)return false;
 
@@ -1512,7 +1512,7 @@ bool
 Duckmatic::load_sketch(const synfig::String& filename)
 {
 	ChangeLocale change_locale(LC_NUMERIC, "C");
-	std::ifstream file(FileSystemNative::path(filename).c_str());
+	std::ifstream file(synfig::filesystem::Path(filename).c_str());
 
 	if(!file)
 		return false;

--- a/synfig-studio/src/gui/duckmatic.cpp
+++ b/synfig-studio/src/gui/duckmatic.cpp
@@ -1478,7 +1478,7 @@ bool
 Duckmatic::save_sketch(const synfig::String& filename)const
 {
 	ChangeLocale change_locale(LC_NUMERIC, "C");
-	std::ofstream file(filename.c_str());
+	std::ofstream file(FileSystemNative::path(filename).c_str());
 
 	if(!file)return false;
 
@@ -1512,7 +1512,7 @@ bool
 Duckmatic::load_sketch(const synfig::String& filename)
 {
 	ChangeLocale change_locale(LC_NUMERIC, "C");
-	std::ifstream file(filename.c_str());
+	std::ifstream file(FileSystemNative::path(filename).c_str());
 
 	if(!file)
 		return false;

--- a/synfig-studio/src/gui/workspacehandler.cpp
+++ b/synfig-studio/src/gui/workspacehandler.cpp
@@ -33,6 +33,7 @@
 # endif
 
 #include "workspacehandler.h"
+#include "synfig/filesystemnative.h"
 
 #include <fstream>
 
@@ -122,7 +123,7 @@ WorkspaceHandler::get_name_list(std::vector<std::string>& list)
 bool
 WorkspaceHandler::save(const std::string& filename)
 {
-	std::ofstream ofs(filename);
+	std::ofstream ofs(synfig::FileSystemNative::path(filename).c_str());
 	if (!ofs) {
 		synfig::error(_("Can't save custom workspaces"));
 		return false;
@@ -136,7 +137,7 @@ WorkspaceHandler::save(const std::string& filename)
 void
 WorkspaceHandler::load(const std::string& filename)
 {
-	std::ifstream ifs(filename);
+	std::ifstream ifs(synfig::FileSystemNative::path(filename).c_str());
 	std::string line;
 	int count = 0;
 	while (ifs && !ifs.eof()) {

--- a/synfig-studio/src/gui/workspacehandler.cpp
+++ b/synfig-studio/src/gui/workspacehandler.cpp
@@ -33,11 +33,11 @@
 # endif
 
 #include "workspacehandler.h"
-#include "synfig/filesystemnative.h"
 
 #include <fstream>
 
 #include <gui/localization.h>
+#include <synfig/filesystem.h>
 #include <synfig/general.h>
 #include <synfig/string_helper.h>
 #endif
@@ -123,7 +123,7 @@ WorkspaceHandler::get_name_list(std::vector<std::string>& list)
 bool
 WorkspaceHandler::save(const std::string& filename)
 {
-	std::ofstream ofs(synfig::FileSystemNative::path(filename).c_str());
+	std::ofstream ofs(synfig::filesystem::Path(filename).c_str());
 	if (!ofs) {
 		synfig::error(_("Can't save custom workspaces"));
 		return false;
@@ -137,7 +137,7 @@ WorkspaceHandler::save(const std::string& filename)
 void
 WorkspaceHandler::load(const std::string& filename)
 {
-	std::ifstream ifs(synfig::FileSystemNative::path(filename).c_str());
+	std::ifstream ifs(synfig::filesystem::Path(filename).c_str());
 	std::string line;
 	int count = 0;
 	while (ifs && !ifs.eof()) {

--- a/synfig-studio/src/synfigapp/main.cpp
+++ b/synfig-studio/src/synfigapp/main.cpp
@@ -415,11 +415,9 @@ synfigapp::Main::set_state(synfig::String state)
 synfig::String
 synfigapp::Main::get_user_app_directory()
 {
-	String dir;
-	if (char* synfig_user_settings_dir = getenv("SYNFIG_USER_SETTINGS")) {
-		dir =  Glib::locale_to_utf8(String(synfig_user_settings_dir));
-	} else {
-		dir = Glib::get_home_dir()+ETL_DIRECTORY_SEPARATOR+SYNFIG_USER_APP_DIR;
+	std::string dir = Glib::getenv("SYNFIG_USER_SETTINGS");
+	if (!dir.empty()) {
+		return dir;
 	}
-	return dir;
+	return Glib::get_home_dir()+ETL_DIRECTORY_SEPARATOR+SYNFIG_USER_APP_DIR;
 }

--- a/synfig-studio/src/synfigapp/settings.cpp
+++ b/synfig-studio/src/synfigapp/settings.cpp
@@ -38,7 +38,7 @@
 #include <algorithm>
 #include <sys/stat.h>
 #include "settings.h"
-#include "synfig/filesystemnative.h"
+#include <synfig/filesystem.h>
 #include <synfig/general.h>
 #include <synfig/guid.h>
 
@@ -192,7 +192,7 @@ Settings::save_to_file(const synfig::String& filename)const
 
 	try
 	{
-		std::ofstream file(FileSystemNative::path(tmp_filename).c_str());
+		std::ofstream file(synfig::filesystem::Path(tmp_filename).c_str());
 
 		if(!file) {
 			synfig::warning(_("Can't save settings to file %s!"), filename.c_str());
@@ -225,7 +225,7 @@ Settings::save_to_file(const synfig::String& filename)const
 bool
 Settings::load_from_file(const synfig::String& filename, const synfig::String& key_filter )
 {
-	std::ifstream file(FileSystemNative::path(filename).c_str());
+	std::ifstream file(synfig::filesystem::Path(filename).c_str());
 
 	if(!file) {
 		synfig::warning(_("Can't load settings from file %s!"), filename.c_str());


### PR DESCRIPTION
Finally, I found a proper solution for the problem with file paths
containing non-Latin characters in Windows.

The main problem was that we are working with UTF-8, while on Windows
filenames use UTF-16. To work with files, we use the Glibmm wrapper,
which performs correct path conversion, but in some cases we need
standard cpp `std::fstream` objects.

Unfortunately, the standard implementation does not support `std::wstring`
paths. C++17 introduced support through the use of `std::filesystem::path`,
but since we continue to support c++11, this option is not suitable for us.

Luckily, both MSVC and MinGW support a non-standard constructor overload
using wchar_t, and on Windows we can use it. All that is required is to convert
the path to UTF-16 for Windows and leave it as is for other operating systems.

For this, a special method `FileSystemNative::path(...)` has been added, which
does all the necessary work of converting the path when necessary.