### PR TITLE
Fixed an issue with plugins not working when path to Python contains spaces (Windows)

### DIFF
--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -494,7 +494,7 @@ public:
 	static void setup_changed();
 
 	static void process_all_events();
-	static bool check_python_version( std::string path);
+	static bool check_python_version(const std::string& path);
 }; // END of class App
 
 	void delete_widget(Gtk::Widget *widget);


### PR DESCRIPTION
Original issue: https://github.com/synfig/synfig/issues/2596

The problem was the different approach to path handling between
`popen` and `Glib::spawn`.
`popen` requires the binary path to be quoted, while `Glib::spawn`
requires the path to be unquoted (it just fails with an error if the
path contains quotes).

As a result, quoted paths were handled correctly when detecting
the Python version, but didn't work when running plugins, and
vice versa.

Fixed by changing `popen` to `Glib::spawn` so paths are handled
uniformly now.

This should also fix non-working plugins in MSVC builds.