### PR TITLE
fix: Missing menu in Synfig when path to plugins contains non-Latin symbols (Windows)

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -878,6 +878,14 @@ public:
 
 App::Preferences App::_preferences;
 
+static void add_ui_from_string(const std::string& ui_info) {
+	try	{
+		App::ui_manager()->add_ui_from_string(ui_info);
+	} catch(const Glib::Error& ex) {
+		synfig::error("building menus and toolbars failed: " + ex.what() + "\n\n" + ui_info);
+	}
+}
+
 void
 init_ui_manager()
 {
@@ -1266,21 +1274,12 @@ DEFINE_ACTION("keyframe-properties", _("Properties"))
 
 	#undef DEFINE_ACTION
 
-	try
-	{
-		actions_action_group->set_sensitive(false);
-		App::ui_manager()->set_add_tearoffs(false);
-		App::ui_manager()->insert_action_group(menus_action_group,1);
-		App::ui_manager()->insert_action_group(actions_action_group,1);
-		App::ui_manager()->add_ui_from_string(ui_info);
-		App::ui_manager()->add_ui_from_string(hidden_ui_info);
-
-		//App::ui_manager()->get_accel_group()->unlock();
-	}
-	catch(const Glib::Error& ex)
-	{
-		synfig::error("building menus and toolbars failed: " + ex.what());
-	}
+	actions_action_group->set_sensitive(false);
+	App::ui_manager()->set_add_tearoffs(false);
+	App::ui_manager()->insert_action_group(menus_action_group,1);
+	App::ui_manager()->insert_action_group(actions_action_group,1);
+	add_ui_from_string(ui_info);
+	add_ui_from_string(hidden_ui_info);
 
 	auto default_accel_map = App::get_default_accel_map();
 	for (const auto& accel_item : default_accel_map) {

--- a/synfig-studio/src/gui/pluginmanager.cpp
+++ b/synfig-studio/src/gui/pluginmanager.cpp
@@ -179,7 +179,8 @@ studio::PluginManager::load_plugin( const std::string &file, const std::string &
 {
 	synfig::info("   Loading plugin: %s", etl::basename(plugindir).c_str());
 
-	std::string id = file;
+	static int plugin_count = 0;
+	const std::string id = "plugin" + std::to_string(++plugin_count);
 
 	// parse xml file
 	try


### PR DESCRIPTION
![Screenshot_49](https://user-images.githubusercontent.com/5604544/170628153-f75d542c-03b1-4286-ba02-06ff9b4026e5.png)

It shows an error on start:
```
synfig(23672) [10:56:14] info: Init UI Manager...
synfig(23672) [10:56:14] error: building menus and toolbars failed: Error on line 1 char 10067: Document ended unexpectedly with elements still open в?" в??toolbarв?? was the last element opened
```

After adding the output with invalid XML, we can see where the problem
is:
```
<menuitem action='C:/msys64/...<Non-Latin path>...\plugins\add-skeleton-simple/plugin.xml'/>
```

The most interesting thing here is the slashes. According to the Gtk
documentation (https://docs.gtk.org/gtk3/class.UIManager.html):

> The name and action attributes must not contain “/” characters after
> parsing (since that would mess up path lookup) and must be usable
> as XML attributes when enclosed in doublequotes, thus they must
> not “”” characters or references to the " entity.

Unfortunately, I haven't found anything about non-ASCII characters in
`action` attribute, so I propose to use plugin folder name here (instead 
of path to plugin).