### PR TITLE
Fixed incorrect lines offset in Graphs Panel

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -712,7 +712,7 @@ Widget_Curves::on_draw(const Cairo::RefPtr<Cairo::Context> &cr)
 			points[c].reserve(w);
 		}
 
-		Time t = time_plot_data->lower;
+		Time t = time_plot_data->lower_ex;
 		for(int j = 0; j < w; ++j, t += time_plot_data->dt) {
 			for(size_t c = 0; c < channels; ++c) {
 				Real y = curve_it->get_value(c, t, time_plot_data->dt);


### PR DESCRIPTION
Fix #2648

![Screenshot_46](https://user-images.githubusercontent.com/5604544/170720814-4829e991-1818-4b5e-9c96-f8bf041d9631.png)

P.S. I didn't check the code, just guess.