### PR TITLE
Replaced deprecated Gtk::StockId in FrameDial icons

### DIFF
--- a/synfig-studio/src/gui/dials/framedial.cpp
+++ b/synfig-studio/src/gui/dials/framedial.cpp
@@ -38,7 +38,6 @@
 #include "framedial.h"
 
 #include <gtkmm/separator.h>
-#include <gtkmm/stock.h>
 
 #include <gui/localization.h>
 
@@ -57,19 +56,19 @@ using namespace studio;
 /* === M E T H O D S ======================================================= */
 
 FrameDial::FrameDial():
-	seek_begin         (create_button("synfig-animate_seek_begin"         , _("Seek to begin")            )),
-	seek_prev_keyframe (create_button("synfig-animate_seek_prev_keyframe" , _("Seek to previous keyframe"))),
-	seek_prev_frame    (create_button("synfig-animate_seek_prev_frame"    , _("Seek to previous frame")   )),
-	play               (create_button("synfig-animate_play"               , _("Play")                     )),
-	pause              (create_button("synfig-animate_pause"              , _("Pause")                    )),
-	seek_next_frame    (create_button("synfig-animate_seek_next_frame"    , _("Seek to next frame")       )),
-	seek_next_keyframe (create_button("synfig-animate_seek_next_keyframe" , _("Seek to next keyframe")    )),
-	seek_end           (create_button("synfig-animate_seek_end"           , _("Seek to end")              )),
+	seek_begin         (create_button("animate_seek_begin_icon"         , _("Seek to begin")            )),
+	seek_prev_keyframe (create_button("animate_seek_prev_keyframe_icon" , _("Seek to previous keyframe"))),
+	seek_prev_frame    (create_button("animate_seek_prev_frame_icon"    , _("Seek to previous frame")   )),
+	play               (create_button("animate_play_icon"               , _("Play")                     )),
+	pause              (create_button("animate_pause_icon"              , _("Pause")                    )),
+	seek_next_frame    (create_button("animate_seek_next_frame_icon"    , _("Seek to next frame")       )),
+	seek_next_keyframe (create_button("animate_seek_next_keyframe_icon" , _("Seek to next keyframe")    )),
+	seek_end           (create_button("animate_seek_end_icon"           , _("Seek to end")              )),
 	end_time           (create_end_time_entry(                              _("End Time")                 )),
-	repeat             (create_toggle("synfig-animate_loop"               , _("Loop")                     , true)),
-	bound_lower        (create_button("synfig-animate_bound_lower"        , _("Set lower playback bound") , true)),
-	bounds_enable      (create_toggle("synfig-animate_bounds"             , _("Enable playback bounds")   )),
-	bound_upper        (create_button("synfig-animate_bound_upper"        , _("Set upper playback bound") ))
+	repeat             (create_toggle("animate_loop_icon"               , _("Loop")                     , true)),
+	bound_lower        (create_button("animate_bound_lower_icon"        , _("Set lower playback bound") , true)),
+	bounds_enable      (create_toggle("animate_bounds_icon"             , _("Enable playback bounds")   )),
+	bound_upper        (create_button("animate_bound_upper_icon"        , _("Set upper playback bound") ))
 {
 	repeat->signal_toggled().connect(
 		sigc::mem_fun(*this, &FrameDial::on_repeat_toggled) );
@@ -95,18 +94,9 @@ FrameDial::create_separator()
 }
 
 void
-FrameDial::init_button(Gtk::Button &button, const char *stockid, const char *tooltip)
+FrameDial::init_button(Gtk::Button& button, const std::string& icon_name, const std::string& tooltip)
 {
-	Gtk::IconSize iconsize = Gtk::IconSize::from_name("synfig-small_icon_16x16");
-
-	Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID(stockid), iconsize));
-	icon->set_margin_start(0);
-	icon->set_margin_end(0);
-	icon->set_margin_top(0);
-	icon->set_margin_bottom(0);
-	icon->show();
-
-	button.add(*icon);
+	button.set_image_from_icon_name(icon_name);
 	button.set_tooltip_text(tooltip);
 	button.set_relief(Gtk::RELIEF_NONE);
 	button.show();
@@ -114,20 +104,20 @@ FrameDial::init_button(Gtk::Button &button, const char *stockid, const char *too
 }
 
 Gtk::Button*
-FrameDial::create_button(const char *stockid, const char *tooltip, bool separator)
+FrameDial::create_button(const std::string& icon_name, const std::string& tooltip, bool separator)
 {
 	if (separator) create_separator();
 	Gtk::Button *button = manage(new class Gtk::Button());
-	init_button(*button, stockid, tooltip);
+	init_button(*button, icon_name, tooltip);
 	return button;
 }
 
 Gtk::ToggleButton*
-FrameDial::create_toggle(const char *stockid, const char *tooltip, bool separator)
+FrameDial::create_toggle(const std::string& icon_name, const std::string& tooltip, bool separator)
 {
 	if (separator) create_separator();
 	Gtk::ToggleButton *toggle = manage(new class Gtk::ToggleButton());
-	init_button(*toggle, stockid, tooltip);
+	init_button(*toggle, icon_name, tooltip);
 	return toggle;
 }
 

--- a/synfig-studio/src/gui/dials/framedial.h
+++ b/synfig-studio/src/gui/dials/framedial.h
@@ -67,10 +67,10 @@ private:
 	sigc::signal<void, bool> signal_repeat_;
 	sigc::signal<void, bool> signal_bounds_enable_;
 
-	void init_button(Gtk::Button &button, const char *stockid, const char *tooltip);
+	void init_button(Gtk::Button &button, const std::string& icon_name, const std::string& tooltip);
 	void create_separator();
-	Gtk::Button *create_button(const char *stockid, const char *tooltip, bool separator = false);
-	Gtk::ToggleButton *create_toggle(const char *stockid, const char *tooltip, bool separator = false);
+	Gtk::Button* create_button(const std::string& icon_name, const std::string& tooltip, bool separator = false);
+	Gtk::ToggleButton* create_toggle(const std::string& icon_name, const std::string& tooltip, bool separator = false);
 
 	void on_repeat_toggled();
 	void on_bounds_toggled();


### PR DESCRIPTION
Before:
![Screenshot_7](https://user-images.githubusercontent.com/5604544/170812100-9b3b12d7-cac2-42f2-8c61-3927d60cf535.png)

After:
![Screenshot_8](https://user-images.githubusercontent.com/5604544/170812104-208e062f-edae-4093-aad9-182efed61ee6.png)

