### PR TITLE
Replaced deprecated Gtk::StockID in KeyFrameDial

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -984,13 +984,12 @@ CanvasView::create_time_bar()
 	separator->show();
 
 	//Setup the KeyFrameDial widget
-	KeyFrameDial *keyframedial = Gtk::manage(new class KeyFrameDial());
+	keyframedial = Gtk::manage(new KeyFrameDial());
 	keyframedial->signal_toggle_keyframe_past().connect(sigc::mem_fun(*this, &CanvasView::toggle_past_keyframe_button));
 	keyframedial->signal_toggle_keyframe_future().connect(sigc::mem_fun(*this, &CanvasView::toggle_future_keyframe_button));
+	keyframedial->set_margin_start(4);
 	keyframedial->set_margin_end(4);
 	keyframedial->show();
-	pastkeyframebutton=keyframedial->get_toggle_pastbutton();
-	futurekeyframebutton=keyframedial->get_toggle_futurebutton();
 
 	//Adjust both widgets to be the same as the
 	int header_height = 0;
@@ -2443,46 +2442,7 @@ CanvasView::on_mode_changed(CanvasInterface::Mode mode)
 		animatebutton->set_active(false);
 	}
 	//Keyframe lock icons
-	if(mode&MODE_ANIMATE_FUTURE)
-	{
-		Gtk::Image *icon;
-		icon=manage(new Gtk::Image(Gtk::StockID("synfig-keyframe_lock_future_on"),iconsize));
-		futurekeyframebutton->remove();
-		futurekeyframebutton->add(*icon);
-		futurekeyframebutton->set_tooltip_text(_("Unlock future keyframes"));
-		icon->show();
-		futurekeyframebutton->set_active(true);
-	}
-	else
-	{
-		Gtk::Image *icon;
-		icon=manage(new Gtk::Image(Gtk::StockID("synfig-keyframe_lock_future_off"),iconsize));
-		futurekeyframebutton->remove();
-		futurekeyframebutton->add(*icon);
-		futurekeyframebutton->set_tooltip_text(_("Lock future keyframes"));
-		icon->show();
-		futurekeyframebutton->set_active(false);
-	}
-	if(mode&MODE_ANIMATE_PAST)
-	{
-		Gtk::Image *icon;
-		icon=manage(new Gtk::Image(Gtk::StockID("synfig-keyframe_lock_past_on"),iconsize));
-		pastkeyframebutton->remove();
-		pastkeyframebutton->add(*icon);
-		pastkeyframebutton->set_tooltip_text(_("Unlock past keyframes"));
-		icon->show();
-		pastkeyframebutton->set_active(true);
-	}
-	else
-	{
-		Gtk::Image *icon;
-		icon=manage(new Gtk::Image(Gtk::StockID("synfig-keyframe_lock_past_off"),iconsize));
-		pastkeyframebutton->remove();
-		pastkeyframebutton->add(*icon);
-		pastkeyframebutton->set_tooltip_text(_("Lock past keyframes"));
-		icon->show();
-		pastkeyframebutton->set_active(false);
-	}
+	keyframedial->on_mode_changed(mode);
 
 	work_area->queue_draw();
 	toggling_animate_mode_=false;

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -125,6 +125,7 @@ class Widget_Time;
 class Dock_Layers;
 class Dock_Children;
 class Dock_Keyframes;
+class KeyFrameDial;
 
 class LockDucks: public etl::shared_object {
 private:
@@ -290,8 +291,7 @@ private:
 	Gtk::ToggleButton *timetrackbutton;
 	Gtk::Grid *timetrack;
 	Gtk::Button *keyframebutton;
-	Gtk::ToggleButton *pastkeyframebutton;
-	Gtk::ToggleButton *futurekeyframebutton;
+	KeyFrameDial *keyframedial;
 	bool toggling_animate_mode_;
 	FrameDial *framedial;
 	JackDial *jackdial;

--- a/synfig-studio/src/gui/dials/keyframedial.cpp
+++ b/synfig-studio/src/gui/dials/keyframedial.cpp
@@ -36,9 +36,6 @@
 
 #include "keyframedial.h"
 
-#include <gtkmm/image.h>
-#include <gtkmm/stock.h>
-
 #include <gui/localization.h>
 
 #endif
@@ -55,31 +52,51 @@ using namespace studio;
 
 /* === M E T H O D S ======================================================= */
 
-KeyFrameDial::KeyFrameDial(): Gtk::Grid()
+static Gtk::ToggleButton*
+create_toggle_button(const std::string& icon_name, const std::string& tooltip)
 {
-	toggle_keyframe_past = create_icon(Gtk::ICON_SIZE_BUTTON, "synfig-keyframe_lock_past_on",_("Unlock past keyframe"));
-	toggle_keyframe_future = create_icon(Gtk::ICON_SIZE_BUTTON, "synfig-keyframe_lock_future_on",_("Unlock future keyframe"));
-	attach(*toggle_keyframe_past, 0, 0, 1, 1);
-	attach(*toggle_keyframe_future, 1, 0, 1, 1);
-}
-
-Gtk::ToggleButton *
-KeyFrameDial::create_icon(Gtk::IconSize iconsize, const char * stockid,
-		const char * tooltip)
-{
-	iconsize = Gtk::IconSize::from_name("synfig-small_icon_16x16");
-	Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID(stockid), iconsize));
 	Gtk::ToggleButton *button = manage(new class Gtk::ToggleButton());
-	button->add(*icon);
 	button->set_tooltip_text(tooltip);
-	icon->set_margin_start(0);
-	icon->set_margin_end(0);
-	icon->set_margin_top(0);
-	icon->set_margin_bottom(0);
-	icon->show();
+	button->set_image_from_icon_name(icon_name);
 	button->set_relief(Gtk::RELIEF_NONE);
 	button->set_active();
 	button->show();
 
 	return button;
+}
+
+void KeyFrameDial::on_mode_changed(synfigapp::EditMode mode)
+{
+	if (mode & synfigapp::EditMode::MODE_ANIMATE_FUTURE)
+	{
+		toggle_keyframe_future->set_image_from_icon_name("keyframe_lock_future_on_icon");
+		toggle_keyframe_future->set_tooltip_text(_("Unlock future keyframes"));
+		toggle_keyframe_future->set_active(true);
+	}
+	else
+	{
+		toggle_keyframe_future->set_image_from_icon_name("keyframe_lock_future_off_icon");
+		toggle_keyframe_future->set_tooltip_text(_("Lock future keyframes"));
+		toggle_keyframe_future->set_active(false);
+	}
+
+	if (mode & synfigapp::EditMode::MODE_ANIMATE_PAST)
+	{
+		toggle_keyframe_past->set_image_from_icon_name("keyframe_lock_past_on_icon");
+		toggle_keyframe_past->set_tooltip_text(_("Unlock past keyframes"));
+		toggle_keyframe_past->set_active(true);
+	}
+	else
+	{
+		toggle_keyframe_past->set_image_from_icon_name("keyframe_lock_past_off_icon");
+		toggle_keyframe_past->set_tooltip_text(_("Lock past keyframes"));
+		toggle_keyframe_past->set_active(false);
+	}
+}
+KeyFrameDial::KeyFrameDial(): Gtk::Box(Gtk::Orientation::ORIENTATION_HORIZONTAL, 1)
+{
+	toggle_keyframe_past = create_toggle_button("keyframe_lock_past_on_icon",_("Unlock past keyframe"));
+	toggle_keyframe_future = create_toggle_button("keyframe_lock_future_on_icon",_("Unlock future keyframe"));
+	add(*toggle_keyframe_past);
+	add(*toggle_keyframe_future);
 }

--- a/synfig-studio/src/gui/dials/keyframedial.h
+++ b/synfig-studio/src/gui/dials/keyframedial.h
@@ -33,8 +33,9 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <gtkmm/grid.h>
+#include <gtkmm/box.h>
 #include <gtkmm/togglebutton.h>
+#include <synfigapp/editmode.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -45,24 +46,21 @@
 namespace studio
 {
 
-class KeyFrameDial : public Gtk::Grid
+class KeyFrameDial : public Gtk::Box
 {
 	Gtk::ToggleButton *toggle_keyframe_past;
 	Gtk::ToggleButton *toggle_keyframe_future;
 
-	Gtk::ToggleButton *create_icon(Gtk::IconSize iconsize, const char * stockid, const char * tooltip);
-
 public:
 
 	KeyFrameDial();
-	Glib::SignalProxy0<void> signal_toggle_keyframe_past() { return toggle_keyframe_past->signal_toggled(); }
-	Glib::SignalProxy0<void> signal_toggle_keyframe_future() { return toggle_keyframe_future->signal_toggled(); }
-	Gtk::ToggleButton *get_toggle_pastbutton() { return toggle_keyframe_past; }
-	Gtk::ToggleButton *get_toggle_futurebutton() { return toggle_keyframe_future; }
+	void on_mode_changed(synfigapp::EditMode mode); // Updates button icons/state
+	Glib::SignalProxy<void> signal_toggle_keyframe_past() { return toggle_keyframe_past->signal_toggled(); }
+	Glib::SignalProxy<void> signal_toggle_keyframe_future() { return toggle_keyframe_future->signal_toggled(); }
 
 }; // END of class KeyFrameDial
 
-}; // END of namespace studio
+} // END of namespace studio
 
 
 /* === E N D =============================================================== */


### PR DESCRIPTION
Before:
![Screenshot_11](https://user-images.githubusercontent.com/5604544/171340152-aff281f3-4008-4a9f-b7d6-863f5d7e8ba5.png)

After:
![Screenshot_27](https://user-images.githubusercontent.com/5604544/171340450-db2e2e98-d4c8-4751-a903-3a2b3e77705e.png)


Also made a small refactoring of the KeyFrameDial class.

P.S. Switched from `Gtk::Grid` to `Gtk::Box` due to unknown button size change.
The problem is described here: https://discourse.gnome.org/t/gtk-button-size-inside-gtk-grid-container/10015
