### PR TITLE
Replaced deprecated Gtk::StockID in Dockables

### DIFF
--- a/synfig-studio/src/gui/docks/dockable.cpp
+++ b/synfig-studio/src/gui/docks/dockable.cpp
@@ -213,7 +213,7 @@ Dockable::set_toolbar(Gtk::Toolbar& toolbar)
 }
 
 Gtk::ToolButton*
-Dockable::add_button(const Gtk::StockID& stock_id, const synfig::String& tooltip)
+Dockable::add_button(const std::string& icon_name, const synfig::String& tooltip)
 {
 	if (!toolbar_container) reset_toolbar();
 	Gtk::Toolbar *toolbar = dynamic_cast<Gtk::Toolbar*>(toolbar_container->get_child());
@@ -222,7 +222,8 @@ Dockable::add_button(const Gtk::StockID& stock_id, const synfig::String& tooltip
 		set_toolbar(*toolbar);
 	}
 
-	Gtk::ToolButton* ret(manage(new Gtk::ToolButton(stock_id)));
+	Gtk::ToolButton* ret(manage(new Gtk::ToolButton()));
+	ret->set_icon_name(icon_name);
 	ret->set_tooltip_text(tooltip);
 	ret->show();
 	toolbar->set_has_tooltip();

--- a/synfig-studio/src/gui/docks/dockable.h
+++ b/synfig-studio/src/gui/docks/dockable.h
@@ -87,7 +87,7 @@ public:
 
 	void add(Gtk::Widget& x);
 	void set_toolbar(Gtk::Toolbar& toolbar);
-	Gtk::ToolButton* add_button(const Gtk::StockID& stock_id, const synfig::String& tooltip = synfig::String());
+	Gtk::ToolButton* add_button(const std::string& icon_name, const synfig::String& tooltip = synfig::String());
 
 	void reset_container();
 	void reset_toolbar();

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -612,7 +612,7 @@ StateBLine_Context::refresh_tool_options()
 	App::dialog_tool_options->set_icon("tool_spline_icon");
 
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("gtk-execute"),
+		"system-run",
 		_("Make Spline")
 	)->signal_clicked().connect(
 		sigc::hide_return(sigc::mem_fun(
@@ -622,7 +622,7 @@ StateBLine_Context::refresh_tool_options()
 	);
 
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("gtk-clear"),
+		"edit-clear",
 		_("Clear current Spline")
 	)->signal_clicked().connect(
 		sigc::mem_fun(

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -470,7 +470,7 @@ StateBone_Context::refresh_tool_options()
 	App::dialog_tool_options->set_name("bone");
 
 	App::dialog_tool_options->add_button(
-			Gtk::StockID("gtk-clear"),
+			"edit-clear",
 			_("Clear current Skeleton")
 	)->signal_clicked().connect(
 			sigc::mem_fun(

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -813,7 +813,7 @@ StateDraw_Context::refresh_tool_options()
 	App::dialog_tool_options->set_icon("tool_draw_icon");
 
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("synfig-fill"),
+		"tool_fill_icon",
 		_("Fill Last Stroke")
 	)->signal_clicked().connect(
 		sigc::mem_fun(

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -567,7 +567,7 @@ StatePolygon_Context::refresh_tool_options()
 	App::dialog_tool_options->set_icon("tool_polyline_icon");
 
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("gtk-execute"),
+		"system-run",
 		_("Make Polygon")
 	)->signal_clicked().connect(
 		sigc::mem_fun(
@@ -577,7 +577,7 @@ StatePolygon_Context::refresh_tool_options()
 	);
 
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("gtk-clear"),
+		"edit-clear",
 		_("Clear current Polygon")
 	)->signal_clicked().connect(
 		sigc::mem_fun(

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -324,7 +324,7 @@ StateSketch_Context::refresh_tool_options()
 	App::dialog_tool_options->set_icon("tool_sketch_icon");
 
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("gtk-undo"),
+		"edit-undo",
 		_("Undo Last Stroke")
 	)->signal_clicked().connect(
 		sigc::mem_fun(
@@ -333,7 +333,7 @@ StateSketch_Context::refresh_tool_options()
 		)
 	);
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("gtk-clear"),
+		"edit-clear",
 		_("Clear Sketch")
 	)->signal_clicked().connect(
 		sigc::mem_fun(
@@ -342,7 +342,7 @@ StateSketch_Context::refresh_tool_options()
 		)
 	);
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("gtk-save-as"),
+		"document-save-as",
 		_("Save Sketch As...")
 	)->signal_clicked().connect(
 		sigc::mem_fun(
@@ -352,7 +352,7 @@ StateSketch_Context::refresh_tool_options()
 	);
 
 	App::dialog_tool_options->add_button(
-		Gtk::StockID("gtk-open"),
+		"document-open",
 		_("Open a Sketch")
 	)->signal_clicked().connect(
 		sigc::mem_fun(


### PR DESCRIPTION
Sketch, Polygon, Spline and Bone tools visually not changed, because Gtk stocks are drawn correctly.

Draw before:
![Screenshot_42](https://user-images.githubusercontent.com/5604544/171546262-4909ebed-bdce-455e-af54-32d493d7e759.png)

Draw after:
![Screenshot_37](https://user-images.githubusercontent.com/5604544/171546277-54783543-1c9e-47f6-a91f-6b90fc436999.png)



