### PR TITLE
Replaced deprecated Gtk::StockID in Preview window

### DIFF
--- a/synfig-studio/src/gui/preview.h
+++ b/synfig-studio/src/gui/preview.h
@@ -194,7 +194,7 @@ class Widget_Preview : public Gtk::Table
 	Gtk::DrawingArea	draw_area;
 	Glib::RefPtr<Gtk::Adjustment> adj_time_scrub; //the adjustment for the managed scrollbar
 	Gtk::Scale		scr_time_scrub;
-	Gtk::ToggleButton	b_loop;
+	Gtk::ToggleButton*	b_loop;
 	Gtk::ScrolledWindow	preview_window;
 	//Glib::RefPtr<Gdk::GC>		gc_area;
 	Glib::RefPtr<Gdk::Pixbuf>	currentbuf;
@@ -272,8 +272,8 @@ public:
 
 	void stoprender();
 
-	bool get_loop_flag() const {return b_loop.get_active();}
-	void set_loop_flag(bool b) {return b_loop.set_active(b);}
+	bool get_loop_flag() const {return b_loop->get_active();}
+	void set_loop_flag(bool b) {return b_loop->set_active(b);}
 
 	void on_dialog_show();
 	void on_dialog_hide();


### PR DESCRIPTION
Before:

![Screenshot_45](https://user-images.githubusercontent.com/5604544/171552370-38f862ed-51ed-41c3-8138-607c8e7fe02d.png)

After:

![Screenshot_47](https://user-images.githubusercontent.com/5604544/171553259-a3408a98-2573-423f-bc3e-e9e75ffa7609.png)



P.S. Jack icon will be fixed later.