### PR TITLE
refactor: Replaced deprecated Gtk::StockID in Jack widget

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -519,8 +519,6 @@ CanvasView::CanvasView(etl::loose_handle<Instance> instance,etl::handle<CanvasIn
 	time_model_              (new TimeModel()),
 	statusbar                (manage(new class Gtk::Statusbar())),
 	progressbar              (manage(new class Gtk::ProgressBar())),
-	jackbutton               (NULL),
-	offset_widget            (NULL),
 	toggleducksdial          (Gtk::IconSize::from_name("synfig-small_icon_16x16")),
 	resolutiondial           (Gtk::IconSize::from_name("synfig-small_icon_16x16")),
 	future_onion_adjustment_ (Gtk::Adjustment::create(0,0,ONION_SKIN_FUTURE,1,1,0)),
@@ -806,47 +804,12 @@ void CanvasView::set_jack_enabled(bool value)
 			jack_client_close(jack_client);
 			jack_client = NULL;
 		}
-
-		jackbutton->set_sensitive(!jack_is_locked());
 	}
 
 	if (jack_enabled != value)
 	{
 		jack_enabled = value;
-
-		Gtk::IconSize iconsize=Gtk::IconSize::from_name("synfig-small_icon_16x16");
-		Gtk::Image *icon;
-		offset_widget = jackdial->get_offsetwidget();
-
-		if (jackbutton->get_active() != jack_enabled)
-			jackbutton->set_active(jack_enabled);
-
-		if (jack_enabled)
-		{
-			icon = manage(new Gtk::Image(Gtk::StockID("synfig-jack"),iconsize));
-			jackbutton->remove();
-			jackbutton->add(*icon);
-			jackbutton->set_tooltip_text(_("Disable JACK"));
-			icon->set_margin_start(0);
-			icon->set_margin_end(0);
-			icon->set_margin_top(0);
-			icon->set_margin_bottom(0);
-			icon->show();
-			offset_widget->show();
-		}
-		else
-		{
-			icon = manage(new Gtk::Image(Gtk::StockID("synfig-jack"),iconsize));
-			jackbutton->remove();
-			jackbutton->add(*icon);
-			jackbutton->set_tooltip_text(_("Enable JACK"));
-			icon->set_margin_start(0);
-			icon->set_margin_end(0);
-			icon->set_margin_top(0);
-			icon->set_margin_bottom(0);
-			icon->show();
-			offset_widget->hide();
-		}
+		jackdial->set_state(jack_enabled);
 	}
 }
 #endif
@@ -1004,7 +967,6 @@ CanvasView::create_time_bar()
 	jackdial = manage(new class JackDial());
 
 	#ifdef WITH_JACK
-	jackbutton = jackdial->get_toggle_jackbutton();
 	jackdial->signal_toggle_jack().connect(sigc::mem_fun(*this, &CanvasView::toggle_jack_button));
 	jackdial->signal_offset_changed().connect(sigc::mem_fun(*this, &CanvasView::on_jack_offset_changed));
 	jackdial->set_fps(get_canvas()->rend_desc().get_frame_rate());
@@ -3948,7 +3910,7 @@ CanvasView::toggle_jack_button()
 
 		// Update button state
 		toggling_jack = true;
-		jackdial->get_toggle_jackbutton()->set_active(get_jack_enabled());
+		jackdial->set_state(get_jack_enabled());
 		toggling_jack = false;
 	}
 }

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -295,8 +295,6 @@ private:
 	bool toggling_animate_mode_;
 	FrameDial *framedial;
 	JackDial *jackdial;
-	Gtk::ToggleButton *jackbutton;
-	Widget_Time *offset_widget;
 	ToggleDucksDial toggleducksdial;
 	bool toggling_ducks_;
 	ResolutionDial resolutiondial;

--- a/synfig-studio/src/gui/dialogs/dialog_preview.h
+++ b/synfig-studio/src/gui/dialogs/dialog_preview.h
@@ -33,6 +33,7 @@
 #include <gtkmm/builder.h>
 #include <gtkmm/checkbutton.h>
 #include <gtkmm/dialog.h>
+#include <gtkmm/grid.h>
 
 #include <gui/dialogsettings.h>
 #include <gui/preview.h>

--- a/synfig-studio/src/gui/dials/jackdial.cpp
+++ b/synfig-studio/src/gui/dials/jackdial.cpp
@@ -36,11 +36,6 @@
 #endif
 
 #include "jackdial.h"
-
-#include <gtkmm/image.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/alignment.h>
-
 #include <gui/localization.h>
 #endif
 
@@ -56,40 +51,51 @@ using namespace studio;
 
 /* === M E T H O D S ======================================================= */
 
-JackDial::JackDial(): Gtk::Grid()
+// TODO(ice0): duplicated code
+static Gtk::ToggleButton*
+create_toggle_button(const std::string& icon_name, const std::string& tooltip)
 {
-	Gtk::IconSize iconsize=Gtk::IconSize::from_name("synfig-small_icon_16x16");
-	toggle_jack = create_icon(iconsize, "synfig-jack",_("Disable JACK"));
-	offset = manage(new Widget_Time());
-	offset->set_value(synfig::Time(0.0));
-	offset->set_size_request(0,-1); // request horizontal shrink
-	offset->set_width_chars(6);
-	offset->set_tooltip_text(_("JACK Offset"));
-
-	attach(*toggle_jack, 0, 0, 1, 1);
-	attach(*offset, 1, 0, 1, 1);
-
-	offset->hide();
-#ifndef WITH_JACK
-	offset->set_sensitive(false);
-#endif
-}
-
-Gtk::ToggleButton *
-JackDial::create_icon(Gtk::IconSize iconsize, const char *stockid, const char *tooltip)
-{
-	iconsize = Gtk::IconSize::from_name("synfig-small_icon_16x16");
-	Gtk::Image *icon = manage(new Gtk::Image(Gtk::StockID(stockid), iconsize));
 	Gtk::ToggleButton *button = manage(new class Gtk::ToggleButton());
-	button->add(*icon);
 	button->set_tooltip_text(tooltip);
-	icon->set_margin_start(0);
-	icon->set_margin_end(0);
-	icon->set_margin_top(0);
-	icon->set_margin_bottom(0);
-	icon->show();
+	button->set_image_from_icon_name(icon_name);
 	button->set_relief(Gtk::RELIEF_NONE);
+	button->set_active();
 	button->show();
 
 	return button;
+}
+
+void
+JackDial::set_state(bool enabled)
+{
+	// start
+	if (enabled) {
+		toggle_jack_button->set_tooltip_text(_("Disable JACK"));
+	} else {
+		toggle_jack_button->set_tooltip_text(_("Enable JACK"));
+	}
+	toggle_jack_button->set_active(enabled);
+	offset_widget->set_visible(enabled);
+}
+
+JackDial::JackDial(): Gtk::Box()
+{
+	offset_widget = manage(new Widget_Time());
+	offset_widget->set_value(synfig::Time(0.0));
+	//offset_widget->set_size_request(0,-1); // request horizontal shrink
+	offset_widget->set_width_chars(6);
+	offset_widget->set_tooltip_text(_("JACK Offset"));
+
+	toggle_jack_button = create_toggle_button("jack_icon", "");
+	set_state(false);
+
+	add(*toggle_jack_button);
+	add(*offset_widget);
+	toggle_jack_button->set_margin_start(8);
+	toggle_jack_button->set_margin_end(4);
+
+	offset_widget->hide();
+#ifndef WITH_JACK
+	offset_widget->set_sensitive(false);
+#endif
 }

--- a/synfig-studio/src/gui/dials/jackdial.h
+++ b/synfig-studio/src/gui/dials/jackdial.h
@@ -33,7 +33,7 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <gtkmm/grid.h>
+#include <gtkmm/box.h>
 #include <gtkmm/togglebutton.h>
 
 #include <gui/widgets/widget_time.h>
@@ -47,24 +47,21 @@
 namespace studio
 {
 
-class JackDial : public Gtk::Grid
+class JackDial : public Gtk::Box
 {
-	Gtk::ToggleButton *toggle_jack;
-	Widget_Time *offset;
-
-	Gtk::ToggleButton *create_icon(Gtk::IconSize iconsize, const char * stockid, const char * tooltip);
+	Gtk::ToggleButton* toggle_jack_button;
+	Widget_Time* offset_widget;
 
 public:
 	JackDial();
-	Glib::SignalProxy0<void> signal_toggle_jack() { return toggle_jack->signal_toggled(); }
-	Gtk::ToggleButton *get_toggle_jackbutton() { return toggle_jack; }
-	Widget_Time *get_offsetwidget() { return offset; }
+	void set_state(bool enabled);
+	Glib::SignalProxy<void> signal_toggle_jack() { return toggle_jack_button->signal_toggled(); }
 
-	sigc::signal<void>& signal_offset_changed()      { return offset->signal_value_changed(); }
+	sigc::signal<void>& signal_offset_changed()      { return offset_widget->signal_value_changed(); }
 
-	void set_offset(const synfig::Time &value)       { offset->set_value(value); }
-	synfig::Time get_offset() const                  { return offset->get_value(); }
-	void set_fps(float value)                        { offset->set_fps(value); }
+	void set_offset(const synfig::Time &value)       { offset_widget->set_value(value); }
+	synfig::Time get_offset() const                  { return offset_widget->get_value(); }
+	void set_fps(float value)                        { offset_widget->set_fps(value); }
 }; // END of class JackDial
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -348,11 +348,8 @@ Widget_Preview::Widget_Preview():
 	jack_initial_time(0)
 #ifdef WITH_JACK
 	,
-	jackbutton(),
-	offset_widget(),
-
+	jack_client(nullptr),
 	jack_is_playing(false),
-	jack_client(NULL),
 	jack_synchronizing(false)
 #endif
 {
@@ -506,7 +503,6 @@ Widget_Preview::Widget_Preview():
 	jack_dispatcher.connect(sigc::mem_fun(*this, &Widget_Preview::on_jack_sync));
 	jack_dispatcher.connect(sigc::mem_fun(*this, &Widget_Preview::on_jack_sync));
 
-	jackbutton = jackdial->get_toggle_jackbutton();
 	jackdial->signal_toggle_jack().connect(sigc::mem_fun(*this, &studio::Widget_Preview::toggle_jack_button));
 	jackdial->signal_offset_changed().connect(sigc::mem_fun(*this, &studio::Widget_Preview::on_jack_offset_changed));
 #endif
@@ -1333,38 +1329,7 @@ void Widget_Preview::set_jack_enabled(bool value) {
 
 	//jackdial->toggle_enable_jack(jack_enabled);
 
-	Gtk::IconSize iconsize=Gtk::IconSize::from_name("synfig-small_icon_16x16");
-	Gtk::Image *icon;
-	offset_widget = jackdial->get_offsetwidget();
-
-	if (jackbutton->get_active())
-	{
-		icon = manage(new Gtk::Image(Gtk::StockID("synfig-jack"),iconsize));
-		jackbutton->remove();
-		jackbutton->add(*icon);
-		jackbutton->set_tooltip_text(_("Disable JACK"));
-		icon->set_margin_start(0);
-		icon->set_margin_end(0);
-		icon->set_margin_top(0);
-		icon->set_margin_bottom(0);
-		icon->show();
-
-		offset_widget->show();
-	}
-	else
-	{
-		icon = manage(new Gtk::Image(Gtk::StockID("synfig-jack"),iconsize));
-		jackbutton->remove();
-		jackbutton->add(*icon);
-		jackbutton->set_tooltip_text(_("Enable JACK"));
-		icon->set_margin_start(0);
-		icon->set_margin_end(0);
-		icon->set_margin_top(0);
-		icon->set_margin_bottom(0);
-		icon->show();
-
-		offset_widget->hide();
-	}
+	jackdial->set_state(jack_enabled);
 #endif
 
 	if (preview) preview->get_canvasview()->set_jack_enabled_in_preview( get_jack_enabled() );

--- a/synfig-studio/src/gui/preview.h
+++ b/synfig-studio/src/gui/preview.h
@@ -320,8 +320,6 @@ private:
 	void set_jack_enabled(bool value);
 
 #ifdef WITH_JACK
-	Gtk::ToggleButton *jackbutton;
-	Widget_Time *offset_widget;
 	void toggle_jack_button();
 	void on_jack_offset_changed();
 


### PR DESCRIPTION
Before (main window):

![Screenshot_50](https://user-images.githubusercontent.com/5604544/171796792-b8684dde-c6e0-4dee-8d32-7b3630593242.png)

After (main window):

![Screenshot_49](https://user-images.githubusercontent.com/5604544/171796813-80914b6e-22fb-41fe-bbc0-a37af5eb7efe.png)

Before (Preview window):

![Screenshot_51](https://user-images.githubusercontent.com/5604544/171796795-ec30b2ef-f2b1-4c1b-89b4-c022e7a24942.png)

After (Preview window):
![Screenshot_48](https://user-images.githubusercontent.com/5604544/171796815-24558691-c364-4106-96df-d0f5cb4e811d.png)

