### PR TITLE
refactor: Replaced deprecated Gtk::StockID in WidgetLink

### DIFF
--- a/synfig-studio/src/gui/renddesc.cpp
+++ b/synfig-studio/src/gui/renddesc.cpp
@@ -45,6 +45,7 @@
 #include <gtkmm/stylecontext.h>
 
 #include <gui/localization.h>
+#include <gui/widgets/widget_link.h>
 
 #endif
 

--- a/synfig-studio/src/gui/renddesc.h
+++ b/synfig-studio/src/gui/renddesc.h
@@ -37,7 +37,6 @@
 #include <gtkmm/scale.h>
 #include <gtkmm/spinbutton.h>
 
-#include <gui/widgets/widget_link.h>
 #include <gui/widgets/widget_time.h>
 #include <gui/widgets/widget_vector.h>
 
@@ -50,6 +49,8 @@
 /* === C L A S S E S & S T R U C T S ======================================= */
 
 namespace studio {
+
+class Widget_Link;
 
 class Widget_RendDesc : public Gtk::Notebook
 {

--- a/synfig-studio/src/gui/widgets/widget_link.cpp
+++ b/synfig-studio/src/gui/widgets/widget_link.cpp
@@ -34,14 +34,11 @@
 
 #include <synfig/general.h>
 
-#include <gtkmm/stock.h>
 #include "widgets/widget_link.h"
 
 #endif
 
 /* === U S I N G =========================================================== */
-
-using namespace studio;
 
 /* === M A C R O S ========================================================= */
 
@@ -57,62 +54,27 @@ namespace studio {
 
 Widget_Link::Widget_Link(const std::string &tlt_inactive, const std::string &tlt_active)
 {
-	const Glib::RefPtr<Gtk::StyleContext> context = get_style_context();
-
-	// hardfixed icon size. chain icon is not a square but a rectangle.
-	Glib::RefPtr<Gtk::IconSet> chain_icon = Gtk::IconSet::lookup_default(Gtk::StockID("synfig-utils_chain_link_off"));
-	Glib::RefPtr<Gdk::Pixbuf> chain_icon_pixbuff = chain_icon->render_icon_pixbuf(context, (Gtk::IconSize)-1);
-	Glib::RefPtr<Gdk::Pixbuf> chain_icon_pixbuff_scaled = chain_icon_pixbuff->scale_simple(16, 32, Gdk::INTERP_BILINEAR);
-	// not use manage() otherwise the not-shown icon at exit wouldn't be deleted...
-	icon_off_ = new Gtk::Image(chain_icon_pixbuff_scaled);
-
-	chain_icon = Gtk::IconSet::lookup_default(Gtk::StockID("synfig-utils_chain_link_on"));
-	chain_icon_pixbuff_scaled = chain_icon->render_icon_pixbuf(context, (Gtk::IconSize)-1)->scale_simple(16, 32, Gdk::INTERP_BILINEAR);
-	// not use manage() otherwise the not-shown icon at exit wouldn't be deleted...
-	icon_on_ = new Gtk::Image(chain_icon_pixbuff_scaled);
-
-	icon_off_->set_margin_start(0);
-	icon_off_->set_margin_end(0);
-	icon_off_->set_margin_top(0);
-	icon_off_->set_margin_bottom(0);
-	icon_on_->set_margin_start(0);
-	icon_on_->set_margin_end(0);
-	icon_on_->set_margin_top(0);
-	icon_on_->set_margin_bottom(0);
-
-	icon_off_->show();
-	add(*icon_off_);
 	set_relief(Gtk::RELIEF_NONE);
 
 	tooltip_inactive_ = tlt_inactive;
 	tooltip_active_ = tlt_active;
-	set_tooltip_text(tooltip_inactive_);
+	Widget_Link::on_toggled();
 }
 
-Widget_Link::~Widget_Link() {
-	delete icon_on_;
-	delete icon_off_;
-}
-
-}
-
+Widget_Link::~Widget_Link() = default;
 
 void Widget_Link::on_toggled()
 {
-	Gtk::Image *icon;
-
 	if(get_active())
 	{
-		icon= icon_on_;
+		set_image_from_icon_name("utils_chain_link_on_icon", Gtk::BuiltinIconSize::ICON_SIZE_BUTTON);
 		set_tooltip_text(tooltip_active_);
 	}
 	else
 	{
-		icon=icon_off_;
+		set_image_from_icon_name("utils_chain_link_off_icon", Gtk::BuiltinIconSize::ICON_SIZE_BUTTON);
 		set_tooltip_text(tooltip_inactive_);
 	}
+}
 
-	remove();
-	add(*icon);
-	icon->show();
 }

--- a/synfig-studio/src/gui/widgets/widget_link.h
+++ b/synfig-studio/src/gui/widgets/widget_link.h
@@ -46,11 +46,8 @@ class Widget_Link: public Gtk::ToggleButton
 	synfig::String tooltip_inactive_;
 	synfig::String tooltip_active_;
 
-	Gtk::Image *icon_off_;
-	Gtk::Image *icon_on_;
-
 protected:
-	void on_toggled();
+	void on_toggled() override;
 
 public:
 	Widget_Link(const std::string &tlt_inactive, const std::string &tlt_active);


### PR DESCRIPTION
Before:
![Screenshot_52](https://user-images.githubusercontent.com/5604544/171982700-fc84292b-a1f9-4528-8228-bb51e7a182ba.png)

After:
![Screenshot_53](https://user-images.githubusercontent.com/5604544/171982701-ddaaa59b-2d45-4b05-b038-b8349290d978.png)

