### PR TITLE
refactor: Replaced deprecated Gtk::StockID in Widget Interpolation

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_enum.cpp
+++ b/synfig-studio/src/gui/widgets/widget_enum.cpp
@@ -59,7 +59,12 @@ Widget_Enum::Widget_Enum():
 
 	enum_TreeModel = Gtk::ListStore::create(enum_model);
 	set_model(enum_TreeModel);
-	pack_start(enum_model.icon, false);
+
+	Gtk::CellRendererPixbuf* pixbuf_cell_renderer = manage(new Gtk::CellRendererPixbuf());
+
+	pack_start(*pixbuf_cell_renderer, true);
+	add_attribute(pixbuf_cell_renderer->property_icon_name(), enum_model.icon_name);
+
 	pack_start(enum_model.local_name, true);
 	this->set_wrap_width(1); // https://github.com/synfig/synfig/issues/650
 
@@ -75,7 +80,7 @@ void
 Widget_Enum::set_param_desc(const synfig::ParamDesc &x)
 {
 	param_desc=x;
-	// First clear the current items in the ComobBox
+	// First clear the current items in the ComboBox
 	enum_TreeModel->clear();
 	std::list<synfig::ParamDesc::EnumData> enum_list=param_desc.get_enum_list();
 	std::list<synfig::ParamDesc::EnumData>::iterator iter;
@@ -90,14 +95,14 @@ Widget_Enum::set_param_desc(const synfig::ParamDesc &x)
 }
 
 void
-Widget_Enum::set_icon(Gtk::TreeNodeChildren::size_type index, const Glib::RefPtr<Gdk::Pixbuf> &icon)
+Widget_Enum::set_icon(Gtk::TreeNodeChildren::size_type index, const std::string& icon_name)
 {
 	// check if the index is valid
 	if(index > enum_TreeModel->children().size()-1 )
 		return;
 	Glib::ustring path(strprintf("%d", index).c_str());
 	Gtk::TreeModel::Row row = *(enum_TreeModel->get_iter(path));
-	row[enum_model.icon]=icon;
+	row[enum_model.icon_name] = icon_name;
 }
 
 void

--- a/synfig-studio/src/gui/widgets/widget_enum.h
+++ b/synfig-studio/src/gui/widgets/widget_enum.h
@@ -46,14 +46,14 @@ class Widget_Enum : public Gtk::ComboBox
 	synfig::ParamDesc param_desc;
 	int value;
 protected:
-class Model : public Gtk::TreeModel::ColumnRecord
+class Model : public Gtk::ListStore::ColumnRecord
 	{
 		public:
 
 		Model()
-		{ add(icon); add(value); add(local_name); }
+		{ add(icon_name); add(value); add(local_name); }
 
-		Gtk::TreeModelColumn<Glib::RefPtr<Gdk::Pixbuf> > icon;
+		Gtk::TreeModelColumn<Glib::ustring> icon_name;
 		Gtk::TreeModelColumn<int> value;
 		Gtk::TreeModelColumn<Glib::ustring> local_name;
 	};
@@ -66,7 +66,7 @@ public:
 	~Widget_Enum();
 
 	void set_param_desc(const synfig::ParamDesc &x);
-	void set_icon(Gtk::TreeNodeChildren::size_type index,const Glib::RefPtr<Gdk::Pixbuf> &icon);
+	void set_icon(Gtk::TreeNodeChildren::size_type index, const std::string& icon_name);
 	void refresh();
 
 	void set_value(int data);

--- a/synfig-studio/src/gui/widgets/widget_interpolation.cpp
+++ b/synfig-studio/src/gui/widgets/widget_interpolation.cpp
@@ -33,6 +33,7 @@
 
 #include "widget_interpolation.h"
 
+#include <gui/iconcontroller.h>
 #include <gui/localization.h>
 
 #include <synfig/paramdesc.h>
@@ -44,32 +45,19 @@ using namespace studio;
 
 Widget_Interpolation::Widget_Interpolation(Side side)
 {
-	set_param_desc(
-		ParamDesc("interpolation")
-			.set_hint("enum")
-			.add_enum_value(INTERPOLATION_CLAMPED,"clamped",_("Clamped"))
-			.add_enum_value(INTERPOLATION_TCB,"auto",_("TCB"))
-			.add_enum_value(INTERPOLATION_CONSTANT,"constant",_("Constant"))
-			.add_enum_value(INTERPOLATION_HALT,"ease",
-							side == SIDE_BOTH? _("Ease In/Out") : (
-							side == SIDE_BEFORE? _("Ease In") :
-												 _("Ease Out")))
-			.add_enum_value(INTERPOLATION_LINEAR,"linear",_("Linear"))
-	);
-	set_icons();
-}
+	const auto interpolation = ParamDesc("interpolation")
+		.set_hint("enum")
+		.add_enum_value(INTERPOLATION_CLAMPED,  "clamped",  _("Clamped"))
+		.add_enum_value(INTERPOLATION_TCB,      "auto",     _("TCB"))
+		.add_enum_value(INTERPOLATION_CONSTANT, "constant", _("Constant"))
+		.add_enum_value(INTERPOLATION_HALT,     "ease",
+						side == SIDE_BOTH? _("Ease In/Out") : (
+						side == SIDE_BEFORE? _("Ease In") : _("Ease Out")))
+		.add_enum_value(INTERPOLATION_LINEAR,   "linear",   _("Linear"));
 
-void Widget_Interpolation::set_icons()
-{
-	const unsigned int num_interpolations = 5;
-	// Must follow the same order of ParamDesc "interpolation" enum:
-	const char* interpolation_icons[num_interpolations] = {
-		"synfig-interpolation_type_clamped",
-		"synfig-interpolation_type_tcb",
-		"synfig-interpolation_type_const",
-		"synfig-interpolation_type_ease",
-		"synfig-interpolation_type_linear"
-	};
-	for (auto i = 0; i < num_interpolations; ++i)
-		set_icon(i, Gtk::Button().render_icon_pixbuf(Gtk::StockID(interpolation_icons[i]),Gtk::ICON_SIZE_MENU));
+	set_param_desc(interpolation);
+	int i = 0;
+	for (const auto& item : interpolation.get_enum_list()) {
+		set_icon(i++, interpolation_icon_name(static_cast<synfig::Interpolation>(item.value)));
+	}
 }

--- a/synfig-studio/src/gui/widgets/widget_interpolation.h
+++ b/synfig-studio/src/gui/widgets/widget_interpolation.h
@@ -43,8 +43,6 @@ public:
 	/// \param side What side of waypoint the interpolation affects
 	Widget_Interpolation(Side side);
 
-protected:
-	void set_icons();
 };
 
 }


### PR DESCRIPTION
Before:
![Screenshot_54](https://user-images.githubusercontent.com/5604544/171983457-670a4465-9ac3-463b-8212-b5a49d0a791f.png)

After:
![Screenshot_55](https://user-images.githubusercontent.com/5604544/171983460-2de77f14-95c5-4ec5-9c18-2bb1e68f7018.png)
