### PR TITLE
refactor: Replaced deprecated Gtk::StockID in Layers panel

### DIFF
--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -165,10 +165,11 @@ LayerTree::create_layer_tree()
 	}
 
 	{	// --- I C O N --------------------------------------------------------
-		int index;
 		// Set up the icon cell-renderer
-		index=layer_tree_view().append_column(_("Icon"),layer_model.icon);
-		Gtk::TreeView::Column* column = layer_tree_view().get_column(index-1);
+		Gtk::CellRendererPixbuf* pixbuf_cell_renderer = manage(new Gtk::CellRendererPixbuf());
+		Gtk::TreeViewColumn* column = manage(new Gtk::TreeViewColumn(_("Icon"), *pixbuf_cell_renderer));
+		layer_tree_view().append_column(*column);
+		column->add_attribute(*pixbuf_cell_renderer, "icon_name", layer_model.icon_name);
 		layer_tree_view().set_expander_column(*column);
 	}
 	{	// --- N A M E --------------------------------------------------------

--- a/synfig-studio/src/gui/trees/layertreestore.cpp
+++ b/synfig-studio/src/gui/trees/layertreestore.cpp
@@ -83,9 +83,8 @@ retrieve_layers_from_dragging(const Gtk::SelectionData &selection_data, synfigap
 
 static LayerTreeStore::Model& ModelHack()
 {
-	static LayerTreeStore::Model* model(0);
-	if(!model)model=new LayerTreeStore::Model;
-	return *model;
+	static LayerTreeStore::Model model;
+	return model;
 }
 
 LayerTreeStore::LayerTreeStore(etl::loose_handle<synfigapp::CanvasInterface> canvas_interface_):
@@ -93,7 +92,6 @@ LayerTreeStore::LayerTreeStore(etl::loose_handle<synfigapp::CanvasInterface> can
 	queued					(false),
 	canvas_interface_		(canvas_interface_)
 {
-	layer_icon=Gtk::Button().render_icon_pixbuf(Gtk::StockID("synfig-layer"),Gtk::ICON_SIZE_SMALL_TOOLBAR);
 
 	// Connect Signals to Terminals
 	canvas_interface()->signal_layer_status_changed().connect(sigc::mem_fun(*this,&studio::LayerTreeStore::on_layer_status_changed));
@@ -274,8 +272,8 @@ LayerTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int column
 			if (column == model.strikethrough.index())
 				set_gvalue_tpl<bool>(value, false);
 			else
-			if (column == model.icon.index())
-				set_gvalue_tpl< Glib::RefPtr<Gdk::Pixbuf> >(value, get_tree_pixbuf_layer(layer->get_name()));
+			if (column == model.icon_name.index())
+				set_gvalue_tpl<Glib::ustring>(value, layer_icon_name(layer->get_name()), true);
 			else
 				Gtk::TreeStore::get_value_vfunc(iter,column,value);
 
@@ -309,8 +307,8 @@ LayerTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int column
 				set_gvalue_tpl<Pango::Weight>(value, weight);
 			}
 			else
-			if (column == model.icon.index())
-				set_gvalue_tpl< Glib::RefPtr<Gdk::Pixbuf> >(value, get_tree_pixbuf_layer("ghost_group"));
+			if (column == model.icon_name.index())
+				set_gvalue_tpl<Glib::ustring>(value, layer_icon_name("ghost_group"), true);
 			else
 				Gtk::TreeStore::get_value_vfunc(iter,column,value);
 

--- a/synfig-studio/src/gui/trees/layertreestore.h
+++ b/synfig-studio/src/gui/trees/layertreestore.h
@@ -43,7 +43,7 @@
 
 namespace studio {
 
-class LayerTreeStore : virtual public Gtk::TreeStore
+class LayerTreeStore : public Gtk::TreeStore
 {
 	/*
  -- ** -- P U B L I C   T Y P E S ---------------------------------------------
@@ -60,7 +60,7 @@ public:
 	class Model : public Gtk::TreeModel::ColumnRecord
 	{
 	public:
-		Gtk::TreeModelColumn<Glib::RefPtr<Gdk::Pixbuf> > icon;
+		Gtk::TreeModelColumn<Glib::ustring> icon_name;
 		Gtk::TreeModelColumn<Glib::ustring> label;
 		Gtk::TreeModelColumn<Glib::ustring> name;
 		Gtk::TreeModelColumn<Glib::ustring> id;
@@ -90,7 +90,7 @@ public:
 
 		Model()
 		{
-			add(icon);
+			add(icon_name);
 			add(label);
 			add(name);
 			add(id);
@@ -138,7 +138,6 @@ private:
 
 	etl::loose_handle<synfigapp::CanvasInterface> canvas_interface_;
 
-	Glib::RefPtr<Gdk::Pixbuf> layer_icon;
 
 	/*
  -- ** -- P R I V A T E   M E T H O D S ---------------------------------------
@@ -155,7 +154,7 @@ private:
 	void set_gvalue_tpl(Glib::ValueBase& value, const T &v, bool use_assign_operator = false) const;
 
 	virtual void  set_value_impl (const Gtk::TreeModel::iterator& row, int column, const Glib::ValueBase& value);
-	virtual void  get_value_vfunc (const Gtk::TreeModel::iterator& iter, int column, Glib::ValueBase& value)const;
+	void get_value_vfunc (const Gtk::TreeModel::iterator& iter, int column, Glib::ValueBase& value) const override;
 
 	virtual bool  row_draggable_vfunc (const TreeModel::Path& path)const;
 	virtual bool  drag_data_get_vfunc (const TreeModel::Path& path, Gtk::SelectionData& selection_data)const;


### PR DESCRIPTION
Before:
![Screenshot_56](https://user-images.githubusercontent.com/5604544/171997676-d4537722-ebba-49d4-9e96-ee4956a18918.png)


After:
![Screenshot_57](https://user-images.githubusercontent.com/5604544/171997678-e4d41c56-92aa-4092-b0af-0722f2f40a58.png)

