### PR TITLE
refactor: Replaced deprecated Gtk::StockID in Parameters panel

### DIFF
--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -70,7 +70,6 @@ using namespace synfig;
 /* === M E T H O D S ======================================================= */
 
 static std::map< int, Glib::RefPtr<Gdk::Pixbuf> > _tree_pixbuf_table_value_type;
-static Glib::RefPtr<Gdk::Pixbuf> _tree_pixbuf_table_interpolation[NUM_INTERPOLATION_TYPES];
 
 IconController::IconController()
 {
@@ -80,8 +79,6 @@ IconController::IconController()
 IconController::~IconController()
 {
 	_tree_pixbuf_table_value_type.clear();
-	for(int i(0);i<((int)INTERPOLATION_CLAMPED+1);i++)
-		_tree_pixbuf_table_interpolation[i]=Glib::RefPtr<Gdk::Pixbuf>();
 
 	icon_factory->remove_default();
 }
@@ -280,11 +277,6 @@ IconController::init_icons(const synfig::String& path_to_icons)
 			icon = Gtk::IconTheme::get_default()->load_icon("image-missing", height_small_toolbar, Gtk::ICON_LOOKUP_FORCE_SIZE);
 		_tree_pixbuf_table_value_type[type->identifier] = icon;
 	}
-
-	for(int i(0);i<((int)INTERPOLATION_CLAMPED+1);i++) {
-		Glib::RefPtr<Gdk::Pixbuf> icon = Gtk::IconTheme::get_default()->load_icon(interpolation_icon_name(Interpolation(i)), height_small_toolbar, Gtk::ICON_LOOKUP_FORCE_SIZE);
-		_tree_pixbuf_table_interpolation[i] = icon;
-	}
 }
 
 Glib::RefPtr<Gdk::Cursor>
@@ -383,12 +375,6 @@ studio::get_tree_pixbuf(Type &type)
 {
 	//return Gtk::Button().render_icon_pixbuf(value_icon(type),Gtk::ICON_SIZE_SMALL_TOOLBAR);
 	return _tree_pixbuf_table_value_type[type.identifier];
-}
-
-Glib::RefPtr<Gdk::Pixbuf>
-studio::get_interpolation_pixbuf(synfig::Interpolation type)
-{
-	return _tree_pixbuf_table_interpolation[int(type)];
 }
 
 #ifdef _WIN32

--- a/synfig-studio/src/gui/iconcontroller.h
+++ b/synfig-studio/src/gui/iconcontroller.h
@@ -70,7 +70,6 @@ std::string value_icon_name(synfig::Type &type);
 std::string interpolation_icon_name(synfig::Interpolation type);
 std::string valuenode_icon_name(etl::handle<synfig::ValueNode> value_node);
 Glib::RefPtr<Gdk::Pixbuf> get_tree_pixbuf(synfig::Type &type);
-Glib::RefPtr<Gdk::Pixbuf> get_interpolation_pixbuf(synfig::Interpolation itype);
 Gtk::StockID get_action_stock_id(const synfigapp::Action::BookEntry& action);
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/trees/canvastreestore.cpp
+++ b/synfig-studio/src/gui/trees/canvastreestore.cpp
@@ -91,6 +91,22 @@ CanvasTreeStore::expandable_bone_parent(ValueNode::Handle node)
 	return node;
 }
 
+// TODO(ice0): duplicate
+template<typename T>
+static void set_gvalue_tpl(Glib::ValueBase& value, const T &v, bool use_assign_operator)
+{
+	Glib::Value<T> x;
+	g_value_init(x.gobj(), x.value_type());
+
+	x.set(v);
+
+	g_value_init(value.gobj(), x.value_type());
+	if (use_assign_operator)
+		value = x;
+	else
+		g_value_copy(x.gobj(), value.gobj());
+}
+
 void
 CanvasTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int column, Glib::ValueBase& value)const
 {
@@ -325,35 +341,22 @@ CanvasTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int colum
 		g_value_copy(x.gobj(),value.gobj());
 	}
 	else
-	if(column==model.icon.index())
+	if(column==model.icon_name.index())
 	{
 		synfigapp::ValueDesc value_desc((*iter)[model.value_desc]);
 		if(!value_desc)
 			return Gtk::TreeStore::get_value_vfunc(iter,column,value);
 
-		Glib::Value<Glib::RefPtr<Gdk::Pixbuf> > x;
-		g_value_init(x.gobj(),x.value_type());
-
-		x.set(get_tree_pixbuf(value_desc.get_value_type()));
-
-		g_value_init(value.gobj(),x.value_type());
-		g_value_copy(x.gobj(),value.gobj());
+		set_gvalue_tpl<Glib::ustring>(value, value_icon_name(value_desc.get_value_type()), true);
 	}
 	else
-	if(column==model.interpolation_icon.index())
+	if(column==model.interpolation_icon_name.index())
 	{
 		synfigapp::ValueDesc value_desc((*iter)[model.value_desc]);
 		if(!value_desc)
 			return Gtk::TreeStore::get_value_vfunc(iter,column,value);
-		
-		Glib::Value<Glib::RefPtr<Gdk::Pixbuf> > x;
-		g_value_init(x.gobj(),x.value_type());
-		
-		x.set(get_interpolation_pixbuf(value_desc.get_interpolation()));
-		
-		g_value_init(value.gobj(),x.value_type());
-		g_value_copy(x.gobj(),value.gobj());
-		
+
+		set_gvalue_tpl<Glib::ustring>(value, interpolation_icon_name(value_desc.get_interpolation()), true);
 	}
 	else
 	if(column==model.is_static.index())

--- a/synfig-studio/src/gui/trees/canvastreestore.h
+++ b/synfig-studio/src/gui/trees/canvastreestore.h
@@ -69,7 +69,7 @@ public:
 	class Model : public Gtk::TreeModel::ColumnRecord
 	{
 	public:
-		Gtk::TreeModelColumn<Glib::RefPtr<Gdk::Pixbuf> > icon;
+		Gtk::TreeModelColumn<Glib::ustring> icon_name;
 		Gtk::TreeModelColumn<Glib::ustring> label;
 		Gtk::TreeModelColumn<Glib::ustring> name;
 		Gtk::TreeModelColumn<Glib::ustring> id;
@@ -94,7 +94,7 @@ public:
 
 		Gtk::TreeModelColumn<Glib::ustring> tooltip;
 		
-		Gtk::TreeModelColumn<Glib::RefPtr<Gdk::Pixbuf> > interpolation_icon;
+		Gtk::TreeModelColumn<Glib::ustring> interpolation_icon_name;
 		Gtk::TreeModelColumn<bool> is_static;
 		Gtk::TreeModelColumn<bool> interpolation_icon_visible;
 
@@ -103,7 +103,7 @@ public:
 			add(value);
 			add(name);
 			add(label);
-			add(icon);
+			add(icon_name);
 			add(type);
 			add(id);
 			add(canvas);
@@ -120,7 +120,7 @@ public:
 			add(link_id);
 
 			add(tooltip);
-			add(interpolation_icon);
+			add(interpolation_icon_name);
 			add(is_static);
 			add(interpolation_icon_visible);
 		}

--- a/synfig-studio/src/gui/trees/childrentree.cpp
+++ b/synfig-studio/src/gui/trees/childrentree.cpp
@@ -69,7 +69,7 @@ ChildrenTree::ChildrenTree()
 		// Set up the icon cell-renderer
 		Gtk::CellRendererPixbuf* icon_cellrenderer = Gtk::manage( new Gtk::CellRendererPixbuf() );
 		column->pack_start(*icon_cellrenderer,false);
-		column->add_attribute(icon_cellrenderer->property_pixbuf(), model.icon);
+		column->add_attribute(*icon_cellrenderer, "icon_name", model.icon_name);
 
 		// Pack the label into the column
 		column->pack_start(model.label,true);

--- a/synfig-studio/src/gui/trees/childrentreestore.cpp
+++ b/synfig-studio/src/gui/trees/childrentreestore.cpp
@@ -189,7 +189,7 @@ ChildrenTreeStore::on_canvas_added(synfig::Canvas::Handle canvas)
 {
 	Gtk::TreeRow row = *(prepend(canvas_row.children()));
 
-	row[model.icon] = Gtk::Button().render_icon_pixbuf(Gtk::StockID("synfig-type_canvas"),Gtk::ICON_SIZE_SMALL_TOOLBAR);
+	row[model.icon_name] = "type_canvas_icon";
 	row[model.id] = canvas->get_id();
 	row[model.name] = canvas->get_name();
 

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -250,7 +250,7 @@ LayerTree::create_param_tree()
 		// Set up the icon cell-renderer
 		Gtk::CellRendererPixbuf* icon_cellrenderer = Gtk::manage( new Gtk::CellRendererPixbuf() );
 		column->pack_start(*icon_cellrenderer,false);
-		column->add_attribute(icon_cellrenderer->property_pixbuf(), param_model.icon);
+		column->add_attribute(*icon_cellrenderer, "icon_name", param_model.icon_name);
 
 		// Pack the label into the column
 		//column->pack_start(layer_model.label,true);
@@ -265,7 +265,7 @@ LayerTree::create_param_tree()
 		// Set up the value-node icon cell-renderer to be on the far right
 		Gtk::CellRendererPixbuf* valuenode_icon_cellrenderer = Gtk::manage( new Gtk::CellRendererPixbuf() );
 		column->pack_end(*valuenode_icon_cellrenderer,false);
-		valuenode_icon_cellrenderer->property_pixbuf()=Gtk::Button().render_icon_pixbuf(Gtk::StockID("synfig-value_node"),icon_size);
+		valuenode_icon_cellrenderer->property_icon_name() = "valuenode_icon";
 		column->add_attribute(valuenode_icon_cellrenderer->property_visible(), param_model.is_shared);
 
 		// Finish setting up the column
@@ -309,13 +309,13 @@ LayerTree::create_param_tree()
 		// Set up the interpolation icon cell-renderer to be on the far right
 		Gtk::CellRendererPixbuf* interpolation_icon_cellrenderer = Gtk::manage( new Gtk::CellRendererPixbuf() );
 		column->pack_end(*interpolation_icon_cellrenderer,false);
-		column->add_attribute(interpolation_icon_cellrenderer->property_pixbuf(),param_model.interpolation_icon);
+		column->add_attribute(*interpolation_icon_cellrenderer, "icon_name", param_model.interpolation_icon_name);
 		column->add_attribute(interpolation_icon_cellrenderer->property_visible(), param_model.interpolation_icon_visible);
 
 		// Set up the static icon cell-renderer to be on the far right
 		Gtk::CellRendererPixbuf* static_icon_cellrenderer = Gtk::manage( new Gtk::CellRendererPixbuf() );
 		column->pack_end(*static_icon_cellrenderer,false);
-		static_icon_cellrenderer->property_pixbuf()=Gtk::Button().render_icon_pixbuf(Gtk::StockID("synfig-valuenode_forbidanimation"),icon_size);
+		static_icon_cellrenderer->property_icon_name() = "valuenode_forbidanimation_icon";
 		column->add_attribute(static_icon_cellrenderer->property_visible(), param_model.is_static);
 
 		// Finish setting up the column


### PR DESCRIPTION
**Link icon:**
Right click on parameter -> Export Value to project library

**Interpolation icon:** 
Right click on parameter -> Interpolation -> TCB

**Static icon:** 
Right click on parameter -> Forbid Animation

Before:
![Screenshot_59](https://user-images.githubusercontent.com/5604544/172033799-fffcc837-2274-4ffd-a265-33b588328f09.png)

After:
![Screenshot_60](https://user-images.githubusercontent.com/5604544/172033800-31c1dc67-e91d-4a0a-a5da-238403a3c876.png)

