### PR TITLE
fix: Fixed build warnings (GCC 9.4.0)

### DIFF
--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -71,7 +71,7 @@ remove_layers_inside_included_pastelayers(const std::list<Layer::Handle>& layer_
 {
 	std::vector<Layer::Handle> layerpastecanvas_list;
 	for (const auto& layer : layer_list) {
-		if (Layer_PasteCanvas* pastecanvas = dynamic_cast<Layer_PasteCanvas*>(layer.get())) {
+		if (dynamic_cast<Layer_PasteCanvas*>(layer.get())) {
 			layerpastecanvas_list.push_back(layer);
 		}
 	}

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3772,7 +3772,7 @@ CanvasView::set_ext_widget(const String& x, Gtk::Widget* y, bool own)
 	ext_widget_book_[x].set(y, own);
 	if(x=="layers_cmp")
 	{
-		if (layer_tree=dynamic_cast<LayerTree*>(y)) {
+		if ((layer_tree=dynamic_cast<LayerTree*>(y))) {
 			layer_tree->get_selection()->signal_changed().connect(SLOT_EVENT(EVENT_LAYER_SELECTION_CHANGED));
 			layer_tree->get_selection()->signal_changed().connect(SLOT_EVENT(EVENT_REFRESH_DUCKS));
 			layer_tree->signal_layer_user_click().connect(sigc::mem_fun(*this, &CanvasView::on_layer_user_click));
@@ -3782,7 +3782,7 @@ CanvasView::set_ext_widget(const String& x, Gtk::Widget* y, bool own)
 	}
 	if(x=="children")
 	{
-		if (children_tree=dynamic_cast<ChildrenTree*>(y)) {
+		if ((children_tree=dynamic_cast<ChildrenTree*>(y))) {
 			children_tree->signal_user_click().connect(sigc::mem_fun(*this, &CanvasView::on_children_user_click));
 			children_tree->signal_waypoint_clicked_childrentree().connect(sigc::mem_fun(*this, &CanvasView::on_waypoint_clicked_canvasview));
 			children_tree->get_selection()->signal_changed().connect(SLOT_EVENT(EVENT_REFRESH_DUCKS));

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -426,7 +426,7 @@ StateBone_Context::StateBone_Context(CanvasView *canvas_view) :
 	Layer::Handle layer = get_canvas_interface()->get_selection_manager()->get_selected_layer();
 
 	if(Layer_SkeletonDeformation::Handle::cast_dynamic(layer)){
-		get_work_area()->set_type_mask(get_work_area()->get_type_mask() - Duck::TYPE_TANGENT | (Duck::TYPE_WIDTH | Duck::TYPE_WIDTHPOINT_POSITION));
+		get_work_area()->set_type_mask((get_work_area()->get_type_mask() - Duck::TYPE_TANGENT) | (Duck::TYPE_WIDTH | Duck::TYPE_WIDTHPOINT_POSITION));
 		get_canvas_view()->toggle_duck_mask(Duck::TYPE_NONE);
 		layer->disable();
 		get_canvas_interface()->signal_layer_status_changed()(layer,false);
@@ -899,7 +899,7 @@ StateBone_Context::find_bone(Point point,Layer::Handle layer) const
 		}
 	}
 	if(std::fabs(close_line)<=0.2){
-		if (ret >=0 && ret < bone_list.size()) {
+		if (ret >=0 && ret < static_cast<int>(bone_list.size())) {
 			ValueNode_StaticList::Handle list_node;
 			list_node=ValueNode_StaticList::Handle::cast_dynamic(list_desc.get_value_node());
 			if (is_skeleton_deform_layer)

--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -446,7 +446,7 @@ StateBrush_Context::load_settings()
 		{
 			String value;
 			App::brushes_path.clear();
-			int count = atoi(value.c_str());
+			//int count = atoi(value.c_str());
 			for(int i = 0; i < brush_path_count; ++i)
 				if(settings.get_raw_value(strprintf("brush.path_%d", i),value))
 					App::brushes_path.insert(value);

--- a/synfig-studio/src/synfigapp/actions/layerduplicate.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerduplicate.cpp
@@ -123,7 +123,7 @@ remove_layers_inside_included_pastelayers(const std::list<Layer::Handle>& layer_
 {
 	std::vector<Layer::Handle> layerpastecanvas_list;
 	for (const auto& layer : layer_list) {
-		if (Layer_PasteCanvas* pastecanvas = dynamic_cast<Layer_PasteCanvas*>(layer.get())) {
+		if (dynamic_cast<Layer_PasteCanvas*>(layer.get())) {
 			layerpastecanvas_list.push_back(layer);
 		}
 	}


### PR DESCRIPTION
- warning: unused variable `pastecanvas` [-Wunused-variable]
- warning: suggest parentheses around assignment used as
truth value [-Wparentheses]
- warning: comparison of integer expressions of different
signedness: `int` and `std::vector<synfig::Bone>::size_type`
{aka `long unsigned int`} [-Wsign-compare]
- warning: suggest parentheses around arithmetic
in operand of `|` [-Wparentheses]