### PR TITLE
build: Use CMake's PkgConfig imported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.6)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 project(synfig-studio)

--- a/ETL/test/CMakeLists.txt
+++ b/ETL/test/CMakeLists.txt
@@ -19,12 +19,11 @@ add_test(NAME test_hermite COMMAND hermite)
 # temporary dependency for `etl::current_working_directory()`
 include(FindPkgConfig)
 if(PKG_CONFIG_FOUND)
-	pkg_check_modules(GLIBMM REQUIRED glibmm-2.4)
+	pkg_check_modules(GLIBMM REQUIRED IMPORTED_TARGET glibmm-2.4)
 endif()
 
 add_executable(stringf stringf.cpp)
-target_include_directories(stringf PRIVATE ${GLIBMM_INCLUDE_DIRS})
-target_link_libraries(stringf PRIVATE ${GLIBMM_LDFLAGS})
+target_link_libraries(stringf PRIVATE PkgConfig::GLIBMM)
 add_test(NAME test_stringf COMMAND stringf)
 
 add_executable(pen pen.cpp)

--- a/synfig-core/src/CMakeLists.txt
+++ b/synfig-core/src/CMakeLists.txt
@@ -140,25 +140,25 @@ else()
 	message(STATUS "Building with pkg-config...")
 	include(FindPkgConfig)
     if(PKG_CONFIG_FOUND)
-		pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
-		pkg_check_modules(GLIB REQUIRED glib-2.0)
-		pkg_check_modules(GLIBMM REQUIRED glibmm-2.4)
-		pkg_check_modules(GIOMM REQUIRED giomm-2.4)
-		pkg_check_modules(LIBXML REQUIRED libxml++-2.6)
-		pkg_search_module(MLT mlt++-7 mlt++)
-		pkg_check_modules(FFTW REQUIRED fftw3)
-		pkg_check_modules(LIBPNG REQUIRED libpng) # for mod_png
+		pkg_check_modules(SIGCPP REQUIRED IMPORTED_TARGET sigc++-2.0)
+		pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+		pkg_check_modules(GLIBMM REQUIRED IMPORTED_TARGET glibmm-2.4)
+		pkg_check_modules(GIOMM REQUIRED IMPORTED_TARGET giomm-2.4)
+		pkg_check_modules(XMLPP REQUIRED IMPORTED_TARGET libxml++-2.6)
+		pkg_search_module(MLT IMPORTED_TARGET mlt++-7 mlt++)
+		pkg_check_modules(FFTW REQUIRED IMPORTED_TARGET fftw3)
+		pkg_check_modules(LIBPNG REQUIRED IMPORTED_TARGET libpng) # for mod_png
 		#TODO(ice0): find solution for libmng
-		pkg_check_modules(LIBMNG libmng) # for mod_mng (set as optional as it is not correctly installed in Debian)
-		pkg_check_modules(LIBJPEG REQUIRED libjpeg) # for mod_mng
-		pkg_check_modules(OPENEXR OpenEXR) # for mod_openexr
-		pkg_check_modules(MAGICKCORE REQUIRED MagickCore) # for Magick++
+		pkg_check_modules(LIBMNG IMPORTED_TARGET libmng) # for mod_mng (set as optional as it is not correctly installed in Debian)
+		pkg_check_modules(LIBJPEG REQUIRED IMPORTED_TARGET libjpeg) # for mod_mng
+		pkg_check_modules(OPENEXR IMPORTED_TARGET OpenEXR) # for mod_openexr
+		pkg_check_modules(MAGICKCORE IMPORTED_TARGET MagickCore) # for Magick++
 
 		## TODO: move to module where it is actually required
-		pkg_check_modules(FT REQUIRED freetype2) # for lyr_freetype
-		pkg_check_modules(FONT_CONFIG fontconfig) # for FontConfig
-		pkg_check_modules(FRIBIDI REQUIRED fribidi)
-		pkg_check_modules(HARFBUZZ REQUIRED harfbuzz)
+		pkg_check_modules(FT REQUIRED IMPORTED_TARGET freetype2) # for lyr_freetype
+		pkg_check_modules(FONT_CONFIG IMPORTED_TARGET fontconfig) # for FontConfig
+		pkg_check_modules(FRIBIDI REQUIRED IMPORTED_TARGET fribidi)
+		pkg_check_modules(HARFBUZZ REQUIRED IMPORTED_TARGET harfbuzz)
 	endif()
 endif()
 

--- a/synfig-core/src/modules/CMakeLists.txt
+++ b/synfig-core/src/modules/CMakeLists.txt
@@ -30,7 +30,6 @@ set(MODS_ENABLED
     mod_geometry
     mod_gif
     mod_gradient
-    mod_imagemagick
     mod_jpeg
 #    mod_libavcodec # - build failure
 #    mod_magickpp # - made optional
@@ -55,7 +54,6 @@ if(MSVC)
 			mod_geometry
 			mod_gif
 			mod_gradient
-			mod_imagemagick
 			mod_jpeg
 			#    mod_libavcodec # - build failure
 			#    mod_magickpp # - made optional
@@ -68,6 +66,11 @@ if(MSVC)
 			mod_yuv420p
 	)
 endif()
+
+if (MAGICKCORE_FOUND)
+  set(MODS_ENABLED ${MODS_ENABLED}  mod_imagemagick)
+endif()
+
 if(LIBMNG_FOUND)
   list(APPEND MODS_ENABLED mod_mng)
 else()

--- a/synfig-core/src/modules/CMakeLists.txt
+++ b/synfig-core/src/modules/CMakeLists.txt
@@ -30,6 +30,7 @@ set(MODS_ENABLED
     mod_geometry
     mod_gif
     mod_gradient
+    mod_imagemagick
     mod_jpeg
 #    mod_libavcodec # - build failure
 #    mod_magickpp # - made optional
@@ -54,6 +55,7 @@ if(MSVC)
 			mod_geometry
 			mod_gif
 			mod_gradient
+			mod_imagemagick
 			mod_jpeg
 			#    mod_libavcodec # - build failure
 			#    mod_magickpp # - made optional
@@ -66,11 +68,6 @@ if(MSVC)
 			mod_yuv420p
 	)
 endif()
-
-if (MAGICKCORE_FOUND)
-  set(MODS_ENABLED ${MODS_ENABLED}  mod_imagemagick)
-endif()
-
 if(LIBMNG_FOUND)
   list(APPEND MODS_ENABLED mod_mng)
 else()

--- a/synfig-core/src/modules/lyr_freetype/CMakeLists.txt
+++ b/synfig-core/src/modules/lyr_freetype/CMakeLists.txt
@@ -5,15 +5,22 @@ add_library(lyr_freetype MODULE
 
 if(FONT_CONFIG_FOUND)
   add_definitions(-DWITH_FONTCONFIG)
+  target_link_libraries(lyr_freetype PkgConfig::FONT_CONFIG)
 endif()
 
 if (HARFBUZZ_FOUND)
-	target_compile_definitions(lyr_freetype PUBLIC -DHAVE_HARFBUZZ=1)
+  target_compile_definitions(lyr_freetype PUBLIC -DHAVE_HARFBUZZ=1)
+  target_link_libraries(lyr_freetype PkgConfig::HARFBUZZ)
 endif()
 
-target_include_directories(lyr_freetype PRIVATE ${FT_INCLUDE_DIRS} ${FONT_CONFIG_INCLUDE_DIRS} ${HARFBUZZ_INCLUDE_DIRS} ${FRIBIDI_INCLUDE_DIRS})
+if (FRIBIDI_STATIC_LIBRARIES)
+  target_compile_definitions(lyr_freetype PRIVATE -DFRIBIDI_LIB_STATIC)
+endif()
 
-target_link_libraries(lyr_freetype synfig ${FT_LDFLAGS} ${FONT_CONFIG_LDFLAGS} ${HARFBUZZ_LDFLAGS} ${FRIBIDI_LDFLAGS})
+target_link_libraries(lyr_freetype synfig
+  PkgConfig::FT
+  PkgConfig::FRIBIDI
+)
 
 install (
     TARGETS lyr_freetype

--- a/synfig-core/src/modules/lyr_freetype/CMakeLists.txt
+++ b/synfig-core/src/modules/lyr_freetype/CMakeLists.txt
@@ -4,22 +4,22 @@ add_library(lyr_freetype MODULE
 )
 
 if(FONT_CONFIG_FOUND)
-  add_definitions(-DWITH_FONTCONFIG)
-  target_link_libraries(lyr_freetype PkgConfig::FONT_CONFIG)
+	add_definitions(-DWITH_FONTCONFIG)
+	target_link_libraries(lyr_freetype PkgConfig::FONT_CONFIG)
 endif()
 
 if (HARFBUZZ_FOUND)
-  target_compile_definitions(lyr_freetype PUBLIC -DHAVE_HARFBUZZ=1)
-  target_link_libraries(lyr_freetype PkgConfig::HARFBUZZ)
+	target_compile_definitions(lyr_freetype PUBLIC -DHAVE_HARFBUZZ=1)
+	target_link_libraries(lyr_freetype PkgConfig::HARFBUZZ)
 endif()
 
 if (FRIBIDI_STATIC_LIBRARIES)
-  target_compile_definitions(lyr_freetype PRIVATE -DFRIBIDI_LIB_STATIC)
+	target_compile_definitions(lyr_freetype PRIVATE -DFRIBIDI_LIB_STATIC)
 endif()
 
 target_link_libraries(lyr_freetype synfig
-  PkgConfig::FT
-  PkgConfig::FRIBIDI
+	PkgConfig::FT
+	PkgConfig::FRIBIDI
 )
 
 install (

--- a/synfig-core/src/modules/lyr_std/CMakeLists.txt
+++ b/synfig-core/src/modules/lyr_std/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(lyr_std MODULE
         "${CMAKE_CURRENT_LIST_DIR}/zoom.cpp"
 )
 
-target_link_libraries(lyr_std synfig ${GLIBMM_LINK_LIBRARIES})
+target_link_libraries(lyr_std synfig)
 
 install (
     TARGETS lyr_std

--- a/synfig-core/src/modules/mod_jpeg/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_jpeg/CMakeLists.txt
@@ -4,8 +4,7 @@ add_library(mod_jpeg MODULE
         "${CMAKE_CURRENT_LIST_DIR}/trgt_jpeg.cpp"
 )
 
-target_compile_options(mod_jpeg PRIVATE ${LIBJPEG_CFLAGS})
-target_link_libraries(mod_jpeg synfig ${LIBJPEG_LINK_LIBRARIES})
+target_link_libraries(mod_jpeg synfig PkgConfig::LIBJPEG)
 
 install (
     TARGETS mod_jpeg

--- a/synfig-core/src/modules/mod_mng/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_mng/CMakeLists.txt
@@ -3,8 +3,7 @@ add_library(mod_mng MODULE
         "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
 )
 
-target_compile_options(mod_mng PRIVATE ${LIBMNG_CFLAGS})
-target_link_libraries(mod_mng PRIVATE synfig ${LIBMNG_LINK_LIBRARIES})
+target_link_libraries(mod_mng PRIVATE synfig PkgConfig::LIBMNG)
 
 install (
     TARGETS mod_mng

--- a/synfig-core/src/modules/mod_openexr/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_openexr/CMakeLists.txt
@@ -5,9 +5,7 @@ add_library(mod_openexr MODULE
 )
 
 message(STATUS "OpenEXR include: ${OPENEXR_INCLUDE_DIRS}")
-
-target_compile_options(mod_openexr PRIVATE ${OPENEXR_CFLAGS})
-target_link_libraries(mod_openexr PRIVATE synfig ${OPENEXR_LINK_LIBRARIES})
+target_link_libraries(mod_openexr PRIVATE synfig PkgConfig::OPENEXR)
 
 install (
     TARGETS mod_openexr

--- a/synfig-core/src/modules/mod_png/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_png/CMakeLists.txt
@@ -5,8 +5,7 @@ add_library(mod_png MODULE
         "${CMAKE_CURRENT_LIST_DIR}/trgt_png.cpp"
 )
 
-target_compile_options(mod_png PRIVATE ${LIBPNG_CFLAGS})
-target_link_libraries(mod_png synfig ${LIBPNG_LINK_LIBRARIES})
+target_link_libraries(mod_png synfig PkgConfig::LIBPNG)
 
 install (
     TARGETS mod_png

--- a/synfig-core/src/modules/mod_svg/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_svg/CMakeLists.txt
@@ -4,8 +4,7 @@ add_library(mod_svg MODULE
         "${CMAKE_CURRENT_LIST_DIR}/svg_parser.cpp"
 )
 
-target_include_directories(mod_svg SYSTEM PRIVATE ${LIBXML_INCLUDE_DIRS})
-target_link_libraries(mod_svg PRIVATE synfig ${LIBXML_LINK_LIBRARIES})
+target_link_libraries(mod_svg PRIVATE synfig)
 
 install (
     TARGETS mod_svg

--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -14,7 +14,6 @@ message(STATUS "MLT DIR: ${MLT_INCLUDE_DIRS}")
 # compiler automatically finds ltdl.h header. But on MacOS, CMake overrides the system directory
 # using the `-sysroot` flag, and this header cannot be found. (https://gitlab.kitware.com/cmake/cmake/-/issues/19120)
 # So, we need to manually find it.
-
 if(APPLE OR VCPKG_TOOLCHAIN)
     find_path(LTDL_INCLUDE_DIRS ltdl.h)
     find_library(LTDL_LIBRARIES ltdl)
@@ -24,18 +23,7 @@ else()
     set(LTDL_LIBRARIES ltdl)
 endif()
 
-target_include_directories(synfig
-#    SYSTEM BEFORE PUBLIC
-SYSTEM PUBLIC
-        ${LIBXML_INCLUDE_DIRS}
-PUBLIC
-        ${SIGCPP_INCLUDE_DIRS}
-        ${GLIBMM_INCLUDE_DIRS}
-        ${GIOMM_INCLUDE_DIRS}
-        ${MLT_INCLUDE_DIRS}
-        ${FFTW_INCLUDE_DIRS}
-        ${LTDL_INCLUDE_DIRS}
-)
+target_include_directories(synfig PUBLIC ${LTDL_INCLUDE_DIRS})
 
 target_sources(synfig
     PRIVATE
@@ -130,17 +118,19 @@ include(debug/CMakeLists.txt)
 
 target_link_libraries(synfig
     PUBLIC
-        ${SIGCPP_LINK_LIBRARIES}
-        ${GLIBMM_LINK_LIBRARIES}
-        ${GIOMM_LINK_LIBRARIES}
-        ${LIBXML_LINK_LIBRARIES}
-        ${XMLPP_LIBRARIES}
-        ${MLT_LINK_LIBRARIES}
-        ${ZLIB_LIBRARIES}
-        ${FFTW_LINK_LIBRARIES}
+        PkgConfig::SIGCPP
+        PkgConfig::GLIBMM
+        PkgConfig::GIOMM
+        PkgConfig::XMLPP
+        PkgConfig::FFTW
+        ZLIB::ZLIB
         ${LTDL_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
 )
+
+if (MLT_FOUND)
+  target_link_libraries(synfig PUBLIC PkgConfig::MLT)
+endif ()
 
 ## Install headers
 ## TODO: find a better way to do that, maybe?

--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -14,6 +14,7 @@ message(STATUS "MLT DIR: ${MLT_INCLUDE_DIRS}")
 # compiler automatically finds ltdl.h header. But on MacOS, CMake overrides the system directory
 # using the `-sysroot` flag, and this header cannot be found. (https://gitlab.kitware.com/cmake/cmake/-/issues/19120)
 # So, we need to manually find it.
+
 if(APPLE OR VCPKG_TOOLCHAIN)
     find_path(LTDL_INCLUDE_DIRS ltdl.h)
     find_library(LTDL_LIBRARIES ltdl)
@@ -116,20 +117,19 @@ include(valuenodes/CMakeLists.txt)
 ## TODO: check if we need this for release build
 include(debug/CMakeLists.txt)
 
-target_link_libraries(synfig
-    PUBLIC
-        PkgConfig::SIGCPP
-        PkgConfig::GLIBMM
-        PkgConfig::GIOMM
-        PkgConfig::XMLPP
-        PkgConfig::FFTW
-        ZLIB::ZLIB
-        ${LTDL_LIBRARIES}
-        ${CMAKE_THREAD_LIBS_INIT}
+target_link_libraries(synfig PUBLIC
+	PkgConfig::SIGCPP
+	PkgConfig::GLIBMM
+	PkgConfig::GIOMM
+	PkgConfig::XMLPP
+	PkgConfig::FFTW
+	ZLIB::ZLIB
+	${LTDL_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
 )
 
 if (MLT_FOUND)
-  target_link_libraries(synfig PUBLIC PkgConfig::MLT)
+	target_link_libraries(synfig PUBLIC PkgConfig::MLT)
 endif ()
 
 ## Install headers

--- a/synfig-studio/src/CMakeLists.txt
+++ b/synfig-studio/src/CMakeLists.txt
@@ -29,16 +29,12 @@ else()
 	## TODO: check if we really need to find deps common with synfig core
 	include(FindPkgConfig)
 	if(PKG_CONFIG_FOUND)
-		pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
-		pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
-		pkg_check_modules(LIBXML REQUIRED libxml++-2.6)
-		pkg_search_module(MLT mlt++-7 mlt++) # required for widget_soundwave
+		pkg_check_modules(SIGCPP REQUIRED IMPORTED_TARGET sigc++-2.0)
+		pkg_check_modules(GTKMM REQUIRED IMPORTED_TARGET gtkmm-3.0)
+		pkg_check_modules(XMLPP REQUIRED IMPORTED_TARGET libxml++-2.6)
+		pkg_check_modules(FONT_CONFIG IMPORTED_TARGET fontconfig) # for FontConfig
+		pkg_search_module(MLT IMPORTED_TARGET mlt++-7 mlt++) # required for widget_soundwave
 	endif()
-
-	foreach(pkg_config_lib SIGCPP GTKMM LIBXML MLT FFTW)
-		include_directories(${${pkg_config_lib}_INCLUDE_DIRS})
-		link_directories(${${pkg_config_lib}_LIBRARY_DIRS})
-	endforeach()
 endif()
 
 if(FONT_CONFIG_FOUND)
@@ -66,11 +62,6 @@ configure_file(config.h.cmake.in config.h)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
-include_directories(
-        ${SIGCPP_INCLUDE_DIRS}
-        ${GTKMM_INCLUDE_DIRS}
-)
 
 ##
 ## Search path for libs (needed to link with libsynfig)

--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -88,15 +88,19 @@ target_include_directories(synfigstudio PRIVATE ${MLT_INCLUDE_DIRS}) # required 
 # on MacOS/Brew FontConfig located in non-standard folder
 # so we need to add it's path to target
 target_link_libraries(synfigstudio PRIVATE
-	${FONT_CONFIG_LDFLAGS}
-	${GTKMM_LIBRARIES}
-	${Gettext_LIBRARIES}
-	${MLT_LIBRARIES} # required for widget_soundwave
-	${LIBXML_LIBRARIES} # required for gui/pluginmanager
-	${FONT_CONFIG_LIBRARIES}
-	synfig
-	synfigapp
+  PkgConfig::GTKMM
+  PkgConfig::XMLPP
+  synfig
+  synfigapp
 )
+
+if (FONT_CONFIG_FOUND)
+  target_link_libraries(synfigstudio PRIVATE PkgConfig::FONT_CONFIG)
+endif ()
+
+if (MLT_FOUND)
+  target_link_libraries(synfigstudio PRIVATE PkgConfig::MLT)
+endif ()
 
 if(TCMALLOC_LIBRARY)
 	target_link_libraries(synfigstudio PRIVATE ${TCMALLOC_LIBRARY})

--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -88,18 +88,18 @@ target_include_directories(synfigstudio PRIVATE ${MLT_INCLUDE_DIRS}) # required 
 # on MacOS/Brew FontConfig located in non-standard folder
 # so we need to add it's path to target
 target_link_libraries(synfigstudio PRIVATE
-  PkgConfig::GTKMM
-  PkgConfig::XMLPP
-  synfig
-  synfigapp
+	PkgConfig::GTKMM
+	PkgConfig::XMLPP
+	synfig
+	synfigapp
 )
 
 if (FONT_CONFIG_FOUND)
-  target_link_libraries(synfigstudio PRIVATE PkgConfig::FONT_CONFIG)
+	target_link_libraries(synfigstudio PRIVATE PkgConfig::FONT_CONFIG)
 endif ()
 
 if (MLT_FOUND)
-  target_link_libraries(synfigstudio PRIVATE PkgConfig::MLT)
+	target_link_libraries(synfigstudio PRIVATE PkgConfig::MLT)
 endif ()
 
 if(TCMALLOC_LIBRARY)


### PR DESCRIPTION
The combination of `<TARGET>_LIBRARIES` and `<TARGET>_LDFLAGS` doesn't work with msvc since cmake doesn't modify all the flags to be msvc-style. `<TARGET>_LINK_LIBRARIES` would work, but it was first documented in cmake 3.12.
The alternative is PkgConfig targets, which was introduced in cmake 3.6, and it is actually more modern-cmake like.