### PR TITLE
refactor: Replaced deprecated Gtk::StockID in Filename widget

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_filename.cpp
+++ b/synfig-studio/src/gui/widgets/widget_filename.cpp
@@ -60,9 +60,8 @@ using namespace studio;
 Widget_Filename::Widget_Filename()
 {
 	entry_filename=manage(new Gtk::Entry());
-	icon_browse = manage(new Gtk::Image(Gtk::StockID("synfig-open"), Gtk::ICON_SIZE_SMALL_TOOLBAR));
 	button_choose=manage(new Gtk::Button());
-	button_choose->add(*icon_browse);
+	button_choose->set_image_from_icon_name("action_doc_open_icon");
 
 	set_hexpand(true);
 	entry_filename->set_hexpand(true);
@@ -72,7 +71,6 @@ Widget_Filename::Widget_Filename()
 
 	entry_filename->show();
 	button_choose->show();
-	icon_browse->show();
 
 	button_choose->signal_clicked().connect(sigc::mem_fun(*this, &studio::Widget_Filename::on_button_choose_pressed));
 	//entry_filename->signal_value_changed().connect(sigc::mem_fun(*this, &studio::Widget_Filename::on_value_changed));

--- a/synfig-studio/src/gui/widgets/widget_filename.h
+++ b/synfig-studio/src/gui/widgets/widget_filename.h
@@ -49,7 +49,6 @@ class Widget_Filename : public Gtk::Grid
 {
 	Gtk::Entry *entry_filename;
 	Gtk::Button *button_choose;
-	Gtk::Image *icon_browse;
 	etl::handle<synfig::Canvas> canvas;
 
 	void on_button_choose_pressed();


### PR DESCRIPTION
Before:

![Screenshot_68](https://user-images.githubusercontent.com/5604544/173212711-e9647030-db9b-4116-8f56-6652d0d26c40.png)

After:

![Screenshot_69](https://user-images.githubusercontent.com/5604544/173212714-1588a742-f552-4848-8a1b-83cc51ec4ab2.png)
