### PR TITLE
refactor: Replaced deprecated Gtk::StockID in Sets panel

### DIFF
--- a/synfig-studio/src/gui/trees/layergrouptree.cpp
+++ b/synfig-studio/src/gui/trees/layergrouptree.cpp
@@ -75,9 +75,10 @@ LayerGroupTree::LayerGroupTree()
 		append_column(*column);
 	}
 	{	// --- I C O N --------------------------------------------------------
-		int index;
-		index=append_column(_(" "),model.icon);
-		Gtk::TreeView::Column* column = get_column(index-1);
+		Gtk::CellRendererPixbuf* cell_renderer_icon = Gtk::manage(new Gtk::CellRendererPixbuf());
+		Gtk::TreeViewColumn* column = manage(new Gtk::TreeViewColumn(" ", *cell_renderer_icon));
+		append_column(*column);
+		column->add_attribute(cell_renderer_icon->property_icon_name(), model.icon_name);
 		set_expander_column(*column);
 	}
 	{	// --- N A M E --------------------------------------------------------

--- a/synfig-studio/src/gui/trees/layergrouptreestore.h
+++ b/synfig-studio/src/gui/trees/layergrouptreestore.h
@@ -54,7 +54,7 @@ public:
 	class Model : public Gtk::TreeModel::ColumnRecord
 	{
 	public:
-		Gtk::TreeModelColumn<Glib::RefPtr<Gdk::Pixbuf> > icon;
+		Gtk::TreeModelColumn<Glib::ustring> icon_name;
 		Gtk::TreeModelColumn<Glib::ustring> label;
 		Gtk::TreeModelColumn<Glib::ustring> tooltip;
 
@@ -75,7 +75,7 @@ public:
 
 		Model()
 		{
-			add(icon);
+			add(icon_name);
 			add(label);
 			add(group_name);
 			add(parent_group_name);
@@ -100,7 +100,7 @@ public:
 	//! TreeModel for the layers
 	const Model model;
 
-	bool rebuilding;
+	bool rebuilding = false;
 
 	/*
  -- ** -- P R I V A T E   D A T A ---------------------------------------------
@@ -109,9 +109,6 @@ public:
 private:
 
 	etl::loose_handle<synfigapp::CanvasInterface> canvas_interface_;
-
-	Glib::RefPtr<Gdk::Pixbuf> layer_icon;
-	Glib::RefPtr<Gdk::Pixbuf> group_icon;
 
 	/*
  -- ** -- P R I V A T E   M E T H O D S ---------------------------------------


### PR DESCRIPTION
Before:

![Screenshot_72](https://user-images.githubusercontent.com/5604544/173213297-461fd4f7-9241-4f25-bf8a-3ffae6685af7.png)


After:

![Screenshot_71](https://user-images.githubusercontent.com/5604544/173213301-18180c0b-39be-4681-8785-4338121f6eb4.png)

@rodolforg @morevnaproject 
P.S. Maybe rename `LayerGroupTree` to `LayerSetsTree`?