### PR TITLE
refactor: removed deprecated std::unary_function and std::binary_function classes

### DIFF
--- a/ETL/ETL/_angle.h
+++ b/ETL/ETL/_angle.h
@@ -475,7 +475,7 @@ struct affine_combo<etl::angle, T>
 };
 
 template <>
-struct distance_func<etl::angle> : public std::binary_function<etl::angle, etl::angle, etl::angle>
+struct distance_func<etl::angle>
 {
 	etl::angle operator()(const etl::angle &a,const etl::angle &b)const
 	{

--- a/ETL/ETL/_bezier.h
+++ b/ETL/ETL/_bezier.h
@@ -74,7 +74,7 @@ template<typename V,typename T> class bezier;
 // This generic implementation uses the DeCasteljau algorithm.
 // Works for just about anything that has an affine combination function
 template <typename V,typename T=float>
-class bezier_base : public std::unary_function<T,V>
+class bezier_base
 {
 public:
 	typedef V value_type;
@@ -230,7 +230,7 @@ public:
 #if 1
 // Fast float implementation of a cubic bezier curve
 template <>
-class bezier_base<float,float> : public std::unary_function<float,float>
+class bezier_base<float,float>
 {
 public:
 	typedef float value_type;
@@ -310,7 +310,7 @@ public:
 
 // Fast double implementation of a cubic bezier curve
 template <>
-class bezier_base<double,float> : public std::unary_function<float,double>
+class bezier_base<double,float>
 {
 public:
 	typedef double value_type;

--- a/ETL/ETL/_calculus.h
+++ b/ETL/ETL/_calculus.h
@@ -50,50 +50,50 @@
 namespace etl {
 
 template <typename T>
-class derivative : public std::unary_function<typename T::argument_type,typename T::result_type>
+class derivative
 {
 	T func;
-	typename T::argument_type epsilon;
+	typename T::time_type epsilon;
 public:
-	explicit derivative(const T &x, const typename T::argument_type &epsilon=0.000001):func(x),epsilon(epsilon) { }
+	explicit derivative(const T &x, const typename T::time_type& epsilon=0.000001):func(x),epsilon(epsilon) { }
 
-	typename T::result_type
-	operator()(const typename T::argument_type &x)const
+	typename T::value_type
+	operator()(const typename T::time_type &x)const
 	{
 		return (func(x+epsilon)-func(x))/epsilon;
 	}
 };
 
 template <typename T>
-class derivative<hermite<T> > : public std::unary_function<typename hermite<T>::argument_type,typename hermite<T>::result_type>
+class derivative<hermite<T> >
 {
 	hermite<T> func;
 public:
 	explicit derivative(const hermite<T> &x):func(x) { }
 
-	typename hermite<T>::result_type
-	operator()(const typename hermite<T>::argument_type &x)const
+	typename hermite<T>::value_type
+	operator()(const typename hermite<T>::time_type &x)const
 	{
 		T a = func[0], b = func[1], c = func[2], d = func[3];
-		typename hermite<T>::argument_type y(1-x);
+		typename hermite<T>::time_type y(1-x);
 		return ((b-a)*y*y + (c-b)*x*y*2 + (d-c)*x*x) * 3;
 	}
 };
 
 template <typename T>
-class integral : public std::binary_function<typename T::argument_type,typename T::argument_type,typename T::result_type>
+class integral
 {
 	T func;
 	int samples;
 public:
 	explicit integral(const T &x, const int &samples=500):func(x),samples(samples) { }
 
-	typename T::result_type
-	operator()(typename T::argument_type x,typename T::argument_type y)const
+	typename T::value_type
+	operator()(typename T::time_type x,typename T::time_type y)const
 	{
-		typename T::result_type ret=0;
+		typename T::value_type ret=0;
 		int i=samples;
-		const typename T::argument_type increment=(y-x)/i;
+		const typename T::time_type increment=(y-x)/i;
 
 		for(;i;i--,x+=increment)
 			ret+=(func(x)+func(x+increment))*increment/2;

--- a/ETL/ETL/_curve_func.h
+++ b/ETL/ETL/_curve_func.h
@@ -58,7 +58,7 @@ struct affine_combo
 };
 
 template <class T, class K=float>
-struct distance_func : public std::binary_function<T, T, K>
+struct distance_func
 {
 	K operator()(const T &a,const T &b)const
 	{

--- a/ETL/ETL/_hermite.h
+++ b/ETL/ETL/_hermite.h
@@ -48,7 +48,7 @@ namespace etl {
 
 /*
 template <typename T>
-class hermite_base : std::unary_function<float,T>
+class hermite_base
 {
 public:
 	typedef T value_type;

--- a/synfig-core/src/synfig/real.h
+++ b/synfig-core/src/synfig/real.h
@@ -190,7 +190,7 @@ inline T approximate_ceil_hp(const T &a)
 	{ return approximate_ceil_custom(a, real_high_precision<T>()); }
 
 template<typename T, bool func(const T&, const T&)>
-struct RealFunctionWrapper : public std::binary_function<T,T,bool>
+struct RealFunctionWrapper
 	{ bool operator() (const T &a, const T &b) const { return func(a, b); } };
 
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedinterface.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedinterface.cpp
@@ -81,32 +81,32 @@ struct timecmp
 };
 
 template<class T>
-struct subtractor: public std::binary_function<T, T, T>
+struct subtractor
 	{ T operator()(const T &a,const T &b)const { return a-b; } };
 
 template<>
-struct subtractor<Angle>: public std::binary_function<Angle, Angle, Angle>
+struct subtractor<Angle>
 	{ Angle operator()(const Angle &a,const Angle &b)const { return a.dist(b); } };
 
 
 template<class T>
-struct magnitude: public std::unary_function<float, T>
+struct magnitude
 	{ float operator()(const T &a)const { return std::fabs(a); } };
 
 template<>
-struct magnitude<Angle>: public std::unary_function<float, Angle>
+struct magnitude<Angle>
 	{ float operator()(const Angle &a)const { return std::fabs(Angle::rad(a).get()); } };
 
 template<>
-struct magnitude<Vector>: public std::unary_function<float, Vector>
+struct magnitude<Vector>
 	{ float operator()(const Vector &a)const { return a.mag(); } };
 
 template<>
-struct magnitude<Color>: public std::unary_function<float, Color>
+struct magnitude<Color>
 	{ float operator()(const Color &a)const { return std::fabs(a.get_y()); } };
 
 template<>
-struct magnitude<Gradient> : public std::unary_function<float, Gradient>
+struct magnitude<Gradient>
 	{ float operator()(const Gradient &a)const { return a.mag(); } };
 
 

--- a/synfig-core/src/synfig/vector.h
+++ b/synfig-core/src/synfig/vector.h
@@ -483,7 +483,7 @@ abs(const synfig::Vector &rhs)
 namespace etl {
 
 template <>
-class bezier_base<synfig::Vector,float> : public std::unary_function<float,synfig::Vector>
+class bezier_base<synfig::Vector,float>
 {
 public:
 	typedef synfig::Vector value_type;


### PR DESCRIPTION
`std::unary_function` and `std::binary_function` just need to define 3 types:

`unary_function` provides only two types - `argument_type` and `result_type` -
defined by the template parameters.
(https://en.cppreference.com/w/cpp/utility/functional/unary_function).

`binary_function` provides only three types - `first_argument_type`,
`second_argument_type` and `result_type` - defined by the template parameters.
(https://en.cppreference.com/w/cpp/utility/functional/binary_function)

Based on this code:
```
class bezier_base<synfig::Vector,float> : public std::unary_function<float,synfig::Vector>
{
public:
	typedef synfig::Vector value_type;
	typedef float time_type;
```

we can assume what:
```
using argument_type = time_type;
using result_type = value_type;
```

So I just replaced `argument_type` and `result_type`
with the corresponding types.

Fix #2692