### PR TITLE
refactor: Replaced deprecated Gtk::StockID in ResolutionDial

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -60,6 +60,7 @@
 
 #include <gui/app.h>
 #include <gui/dials/keyframedial.h>
+#include <gui/dials/resolutiondial.h>
 #include <gui/docks/dockbook.h>
 #include <gui/docks/dockmanager.h>
 #include <gui/docks/dock_toolbox.h>
@@ -520,7 +521,7 @@ CanvasView::CanvasView(etl::loose_handle<Instance> instance,etl::handle<CanvasIn
 	statusbar                (manage(new class Gtk::Statusbar())),
 	progressbar              (manage(new class Gtk::ProgressBar())),
 	toggleducksdial          (Gtk::IconSize::from_name("synfig-small_icon_16x16")),
-	resolutiondial           (Gtk::IconSize::from_name("synfig-small_icon_16x16")),
+	resolutiondial_          (new studio::ResolutionDial()),
 	future_onion_adjustment_ (Gtk::Adjustment::create(0,0,ONION_SKIN_FUTURE,1,1,0)),
 	past_onion_adjustment_   (Gtk::Adjustment::create(1,0,ONION_SKIN_PAST,1,1,0)),
 
@@ -715,6 +716,7 @@ CanvasView::~CanvasView()
 	canvas_interface()->signal_dirty_preview().clear();
 
 	delete canvas_options;
+	delete resolutiondial_;
 
 	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
 		info("CanvasView::~CanvasView(): Deleted");
@@ -1176,14 +1178,14 @@ CanvasView::create_top_toolbar()
 	displaybar->append(*create_tool_separator());
 
 	// ResolutionDial widget
-	resolutiondial.update_lowres(work_area->get_low_resolution_flag());
-	resolutiondial.signal_increase_resolution().connect(
+	resolutiondial_->update_lowres(work_area->get_low_resolution_flag());
+	resolutiondial_->signal_increase_resolution().connect(
 		sigc::mem_fun(*this, &CanvasView::decrease_low_res_pixel_size));
-	resolutiondial.signal_decrease_resolution().connect(
+	resolutiondial_->signal_decrease_resolution().connect(
 		sigc::mem_fun(*this, &CanvasView::increase_low_res_pixel_size));
-	resolutiondial.signal_use_low_resolution().connect(
+	resolutiondial_->signal_use_low_resolution().connect(
 		sigc::mem_fun(*this, &CanvasView::toggle_low_res_pixel_flag));
-	resolutiondial.insert_to_toolbar(*displaybar);
+	resolutiondial_->insert_to_toolbar(*displaybar);
 
 	// Separator
 	displaybar->append(*create_tool_separator());
@@ -2554,7 +2556,7 @@ CanvasView::decrease_low_res_pixel_size()
 	Glib::RefPtr<Gtk::ToggleAction> action = Glib::RefPtr<Gtk::ToggleAction>::cast_dynamic(action_group->get_action("toggle-low-res"));
 	action->set_active(work_area->get_low_resolution_flag());
 	// Update toggle low res button
-	resolutiondial.update_lowres(work_area->get_low_resolution_flag());
+	resolutiondial_->update_lowres(work_area->get_low_resolution_flag());
 	changing_resolution_=false;
 }
 
@@ -2574,7 +2576,7 @@ CanvasView::increase_low_res_pixel_size()
 		Glib::RefPtr<Gtk::ToggleAction> action = Glib::RefPtr<Gtk::ToggleAction>::cast_dynamic(action_group->get_action("toggle-low-res"));
 		action->set_active(true);
 		// Update the toggle low res button
-		resolutiondial.update_lowres(true);
+		resolutiondial_->update_lowres(true);
 		changing_resolution_=false;
 		return;
 	}
@@ -2593,7 +2595,7 @@ CanvasView::increase_low_res_pixel_size()
 	Glib::RefPtr<Gtk::ToggleAction> action = Glib::RefPtr<Gtk::ToggleAction>::cast_dynamic(action_group->get_action("toggle-low-res"));
 	action->set_active(work_area->get_low_resolution_flag());
 	// Update toggle low res button
-	resolutiondial.update_lowres(work_area->get_low_resolution_flag());
+	resolutiondial_->update_lowres(work_area->get_low_resolution_flag());
 	changing_resolution_=false;
 }
 
@@ -2605,7 +2607,7 @@ CanvasView::toggle_low_res_pixel_flag()
 	changing_resolution_=true;
 	work_area->toggle_low_resolution_flag();
 	// Update the toggle low res button
-	resolutiondial.update_lowres(work_area->get_low_resolution_flag());
+	resolutiondial_->update_lowres(work_area->get_low_resolution_flag());
 	// Update the "toggle-low-res" action
 	Glib::RefPtr<Gtk::ToggleAction> action = Glib::RefPtr<Gtk::ToggleAction>::cast_dynamic(action_group->get_action("toggle-low-res"));
 	action->set_active(work_area->get_low_resolution_flag());

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -77,7 +77,6 @@
 #include "dialogs/dialog_waypoint.h"
 #include "dials/framedial.h"
 #include "dials/jackdial.h"
-#include "dials/resolutiondial.h"
 #include "dials/toggleducksdial.h"
 #include "docks/dockable.h"
 #include "helpers.h"
@@ -120,6 +119,7 @@ class WorkArea;
 class Widget_Enum;
 class Preview;
 struct PreviewInfo;
+class ResolutionDial;
 class Widget_CanvasTimeslider;
 class Widget_Time;
 class Dock_Layers;
@@ -297,7 +297,7 @@ private:
 	JackDial *jackdial;
 	ToggleDucksDial toggleducksdial;
 	bool toggling_ducks_;
-	ResolutionDial resolutiondial;
+	ResolutionDial* resolutiondial_;
 	bool changing_resolution_;
 	Glib::RefPtr<Gtk::Adjustment> future_onion_adjustment_;
 	Glib::RefPtr<Gtk::Adjustment> past_onion_adjustment_;

--- a/synfig-studio/src/gui/dials/resolutiondial.cpp
+++ b/synfig-studio/src/gui/dials/resolutiondial.cpp
@@ -36,9 +36,6 @@
 
 #include "resolutiondial.h"
 
-#include <gtkmm/image.h>
-#include <gtkmm/stock.h>
-
 #include <gui/localization.h>
 
 #endif
@@ -53,12 +50,33 @@ using namespace studio;
 
 /* === P R O C E D U R E S ================================================= */
 
+static void
+init_button(Gtk::ToolButton& button, const std::string& icon_name, const std::string& label, const std::string& tooltip)
+{
+	button.set_icon_name(icon_name);
+	button.set_label(label);
+	button.set_tooltip_text(tooltip);
+	button.show();
+}
+
+static void
+init_toggle_button(Gtk::ToggleToolButton& button, const std::string& label, const std::string& tooltip)
+{
+	// For label left/right padding
+	button.set_name("low-resolution");
+
+	button.set_label(label);
+	button.set_tooltip_text(tooltip);
+	button.set_is_important(true);
+	button.show();
+}
+
 /* === M E T H O D S ======================================================= */
 
-ResolutionDial::ResolutionDial(const Gtk::IconSize &size)
+ResolutionDial::ResolutionDial()
 {
-	init_button(increase_resolution, size, Gtk::StockID("synfig-increase_resolution"), _("Increase Resolution"), _("Increase Display Resolution"));
-	init_button(decrease_resolution, size, Gtk::StockID("synfig-decrease_resolution"), _("Decrease Resolution"), _("Decrease Display Resolution"));
+	init_button(increase_resolution, "incr_resolution_icon", _("Increase Resolution"), _("Increase Display Resolution"));
+	init_button(decrease_resolution, "decr_resolution_icon", _("Decrease Resolution"), _("Decrease Display Resolution"));
 	init_toggle_button(use_low_resolution, _("Low Res"), _("Use Low Resolution when enabled"));
 }
 
@@ -79,34 +97,6 @@ ResolutionDial::remove_from_toolbar(Gtk::Toolbar &toolbar)
 	toolbar.remove(decrease_resolution);
 	toolbar.remove(use_low_resolution);
 	toolbar.remove(increase_resolution);
-}
-
-void
-ResolutionDial::init_button(Gtk::ToolButton &button, Gtk::IconSize size, const Gtk::StockID & stockid, const char *label, const char *tooltip)
-{
-	Gtk::Image *icon = manage(new Gtk::Image(stockid, size));
-	icon->set_margin_start(0);
-	icon->set_margin_end(0);
-	icon->set_margin_top(0);
-	icon->set_margin_bottom(0);
-	icon->show();
-
-	button.set_icon_widget(*icon);
-	button.set_label(label);
-	button.set_tooltip_text(tooltip);
-	button.show();
-}
-
-void
-ResolutionDial::init_toggle_button(Gtk::ToggleToolButton &button, const char *label, const char *tooltip)
-{
-	// For label left/right padding
-	button.set_name("low-resolution");
-
-	button.set_label(label);
-	button.set_tooltip_text(tooltip);
-	button.set_is_important(true);
-	button.show();
 }
 
 void

--- a/synfig-studio/src/gui/dials/resolutiondial.h
+++ b/synfig-studio/src/gui/dials/resolutiondial.h
@@ -36,7 +36,6 @@
 #include <gtkmm/toolbar.h>
 #include <gtkmm/toolbutton.h>
 #include <gtkmm/toggletoolbutton.h>
-#include <gui/duckmatic.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -53,11 +52,8 @@ class ResolutionDial
 	Gtk::ToolButton decrease_resolution;
 	Gtk::ToggleToolButton use_low_resolution;
 
-	void init_button(Gtk::ToolButton &button, Gtk::IconSize size, const Gtk::StockID &stockid, const char *text, const char *tooltip);
-	void init_toggle_button(Gtk::ToggleToolButton &button, const char *label, const char *tooltip);
-
 public:
-	ResolutionDial(const Gtk::IconSize &size);
+	ResolutionDial();
 
 	void insert_to_toolbar(Gtk::Toolbar &toolbar, int index = -1);
 	void remove_from_toolbar(Gtk::Toolbar &toolbar);
@@ -69,7 +65,7 @@ public:
 
 }; // END of class ResolutionDial
 
-}; // END of namespace studio
+} // END of namespace studio
 
 
 /* === E N D =============================================================== */


### PR DESCRIPTION
Before:
![Screenshot_79](https://user-images.githubusercontent.com/5604544/174424617-bc1d180a-0347-47c6-8841-6e2c776a47b7.png)

After:
![Screenshot_80](https://user-images.githubusercontent.com/5604544/174424621-34bf3893-fc57-4052-95e6-09f6caba1567.png)

