### PR TITLE
refactor(core)!: rename ValueNode::is_descendant() to is_ancestor_of()

### DIFF
--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -200,7 +200,7 @@ ValueNode::get_description(bool show_exported_name)const
 }
 
 bool
-ValueNode::is_descendant(ValueNode::Handle value_node_dest) const
+ValueNode::is_ancestor_of(ValueNode::Handle value_node_dest) const
 {
 	if (this == value_node_dest)
 		return true;
@@ -211,7 +211,7 @@ ValueNode::is_descendant(ValueNode::Handle value_node_dest) const
 
 	ValueNode::Handle value_node_parent;
 	value_node_parent = value_node_dest->find_first_parent_of_type<ValueNode>([=](ValueNode::Handle node) {
-		return is_descendant(node);
+		return is_ancestor_of(node);
 	});
 
 	return value_node_parent? true : false;

--- a/synfig-core/src/synfig/valuenode.h
+++ b/synfig-core/src/synfig/valuenode.h
@@ -226,8 +226,8 @@ public:
 	//! Returns \true if the Value Node has an ID (has been exported)
 	bool is_exported()const { return !get_id().empty(); }
 
-	//! Check recursively if \value_node_dest is a descendant of the Value Node
-	bool is_descendant(ValueNode::Handle value_node_dest) const;
+	//! Check recursively if \c value_node_dest is a descendant of this Value Node (or this value node itself)
+	bool is_ancestor_of(ValueNode::Handle value_node_dest) const;
 
 	//! Returns the type of the ValueNode
 	Type& get_type()const { return *type; }

--- a/synfig-studio/src/synfigapp/actions/valuedescconnect.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescconnect.cpp
@@ -109,16 +109,15 @@ Action::ValueDescConnect::is_candidate(const ParamList &x)
 {
 	if(candidate_check(get_param_vocab(),x))
 	{
-	    ValueDesc value_desc(x.find("dest")->second.get_value_desc());
-	    ValueNode::Handle value_node(x.find("src")->second.get_value_node());
+		ValueDesc value_desc(x.find("dest")->second.get_value_desc());
+		ValueNode::Handle value_node(x.find("src")->second.get_value_node());
 
-	    //! forbid recursive linking (fix #48)
-	    if (value_desc.parent_is_value_node())
-	    {
-	        ValueNode* vn = dynamic_cast<ValueNode*>(value_node.get());
-	        if (vn && vn->is_descendant(value_desc.get_parent_value_node()))
-	            return false;
-	    }
+		//! forbid recursive linking (fix #48)
+		if (value_desc.parent_is_value_node())
+		{
+			if (value_node && value_node->is_ancestor_of(value_desc.get_parent_value_node()))
+				return false;
+		}
 
 
 		// don't show the option of connecting to an existing Index parameter of the Duplicate layer


### PR DESCRIPTION
(fix some indentation too)

BREAKING CHANGE: Synfig API change: method renamed for better understanding