### PR TITLE
refactor: remove `ETL_DIRECTORY_SEPARATORS`; use them directly

### DIFF
--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -332,15 +332,15 @@ cleanup_path(std::string path)
 				// path[i-1] is not a separator (double separators removed already),
 				// so path[i-1] is part of valid directory entry,
 				// also is not a special entry ('.' or '..'), see previous case and stage "remove '.'"
-				size_t pos = path.find_last_of(ETL_DIRECTORY_SEPARATORS, i-1);
-				if (pos == std::string::npos) {
+				size_t dir_separator_pos = path.find_last_of("/\\", i-1);
+				if (dir_separator_pos == std::string::npos) {
 					path.erase(0, i+3 >= (int)path.size() ? i+3 : i+4);
 					i = 0;
 				}
 				else
 				{
-					path.erase(pos + 1, (i+3 >= (int)path.size() ? i+3 : i+4) - (int)pos - 1);
-					i = (int)pos;
+					path.erase(dir_separator_pos + 1, (i+3 >= (int)path.size() ? i+3 : i+4) - (int)dir_separator_pos - 1);
+					i = (int)dir_separator_pos;
 				}
 			}
         }

--- a/ETL/ETL/etl_config.h
+++ b/ETL/ETL/etl_config.h
@@ -3,8 +3,6 @@
 
 #include <ETL/etl_profile.h>
 
-#define ETL_DIRECTORY_SEPARATORS	"/\\"
-
 #define ETL_DIRECTORY_SEPARATOR		'/'
 
 #endif

--- a/synfig-studio/src/gui/mainwindow.cpp
+++ b/synfig-studio/src/gui/mainwindow.cpp
@@ -327,12 +327,12 @@ MainWindow::make_short_filenames(
 			fullname = fullname.substr(7);
 		while(j < (int)fullname.size())
 		{
-			size_t k = fullname.find_first_of(ETL_DIRECTORY_SEPARATORS, j);
-			if (k == std::string::npos) k = fullname.size();
-			std::string sub = fullname.substr(j, k - j);
+			size_t dir_separator_pos = fullname.find_first_of("/\\", j);
+			if (dir_separator_pos == std::string::npos) dir_separator_pos = fullname.size();
+			std::string sub = fullname.substr(j, dir_separator_pos - j);
 			if (!sub.empty() && sub != "...")
 				dirs[i].insert(dirs[i].begin(), sub);
-			j = (int)k + 1;
+			j = (int)dir_separator_pos + 1;
 		}
 
 		dirflags[i].resize(dirs[i].size(), false);


### PR DESCRIPTION
Low macro usage