### PR TITLE
refactor!: rename etl::clock to synfig::clock

### DIFF
--- a/ETL/ETL/CMakeLists.txt
+++ b/ETL/ETL/CMakeLists.txt
@@ -10,7 +10,6 @@ set(ETL_HEADERS
         "${CMAKE_CURRENT_LIST_DIR}/misc"
         "${CMAKE_CURRENT_LIST_DIR}/hermite"
         "${CMAKE_CURRENT_LIST_DIR}/surface"
-        "${CMAKE_CURRENT_LIST_DIR}/clock"
         "${CMAKE_CURRENT_LIST_DIR}/stringf"
         "${CMAKE_CURRENT_LIST_DIR}/boxblur"
         "${CMAKE_CURRENT_LIST_DIR}/ref_count"

--- a/ETL/ETL/Makefile.am
+++ b/ETL/ETL/Makefile.am
@@ -14,7 +14,6 @@ etl_HEADERS = \
 	_ref_count.h \
 	angle \
 	handle \
-	clock \
 	hermite \
 	calculus \
 	stringf \

--- a/ETL/test/CMakeLists.txt
+++ b/ETL/test/CMakeLists.txt
@@ -7,9 +7,6 @@ include_directories(${PROJECT_SOURCE_DIR})
 add_executable(angle angle.cpp)
 add_test(NAME test_angle COMMAND angle)
 
-add_executable(clock clock.cpp)
-add_test(NAME test_clock COMMAND clock)
-
 add_executable(handle handle.cpp)
 add_test(NAME test_handle COMMAND handle)
 
@@ -32,11 +29,8 @@ add_test(NAME test_pen COMMAND pen)
 add_executable(surface surface.cpp)
 add_test(NAME test_surface COMMAND surface)
 
-add_executable(benchmark benchmark.cpp)
-add_test(NAME test_benchmark COMMAND benchmark)
-
 set_target_properties(
-		angle clock handle hermite stringf pen surface benchmark
+		angle handle hermite stringf pen surface
 		PROPERTIES
 		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test
 )

--- a/ETL/test/Makefile.am
+++ b/ETL/test/Makefile.am
@@ -11,31 +11,25 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/ETL
 
 TESTS = \
-	clock \
 	handle \
 	angle \
 	hermite \
 	stringf \
 	pen \
-	surface \
-	benchmark
+	surface
 
 check_PROGRAMS = \
 	handle \
-	clock \
 	angle \
 	hermite \
 	stringf \
 	pen \
-	surface \
-	benchmark
+	surface
 
-benchmark_SOURCES=benchmark.cpp
 surface_SOURCES=surface.cpp
 pen_SOURCES=pen.cpp
 handle_SOURCES=handle.cpp
 angle_SOURCES=angle.cpp
-clock_SOURCES=clock.cpp
 hermite_SOURCES=hermite.cpp
 stringf_SOURCES=stringf.cpp
 

--- a/synfig-core/src/synfig/Makefile.am
+++ b/synfig-core/src/synfig/Makefile.am
@@ -60,6 +60,7 @@ VALUESOURCES = \
 SYNFIGHEADERS = \
 	angle.h \
 	canvasbase.h \
+	clock.h \
 	general.h \
 	localization.h \
 	progresscallback.h \

--- a/synfig-core/src/synfig/clock.h
+++ b/synfig-core/src/synfig/clock.h
@@ -1,7 +1,6 @@
-// <clock> -*- C++ -*-
-/*! ========================================================================
-** Extended Template and Library
-** Clock Abstraction
+/* === S Y N F I G ========================================================= */
+/*!	\file clock.h
+**	\brief A timer class
 **
 ** Copyright (c) 2002 Robert B. Quattlebaum Jr.
 **
@@ -24,14 +23,18 @@
 
 /* === S T A R T =========================================================== */
 
-#ifndef __ETL__CLOCK__
-#define __ETL__CLOCK__
+#ifndef SYNFIG_CLOCK_H
+#define SYNFIG_CLOCK_H
 
 /* === H E A D E R S ======================================================= */
 
 #include <chrono>
 
-namespace etl {
+/* === T Y P E D E F S ===================================================== */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace synfig {
 
 	class clock {
 		std::chrono::time_point<std::chrono::steady_clock> base_time_;
@@ -44,12 +47,10 @@ namespace etl {
 		void reset() {
 			base_time_ = std::chrono::steady_clock::now();
 		}
-		//{ get_current_time(base_time); }
 
 		float operator()() const {
 			return std::chrono::duration<float>(std::chrono::steady_clock::now() - base_time_).count();
 		}
-		//{ return this->timestamp_to_seconds(get_current_time()-base_time); }
 
 		float pop_time() {
 			// Grab the old base time
@@ -62,8 +63,6 @@ namespace etl {
 		}
 	};
 }
-
-//using etl::clock;
 
 /* === E N D =============================================================== */
 

--- a/synfig-core/src/synfig/target_tile.cpp
+++ b/synfig-core/src/synfig/target_tile.cpp
@@ -37,7 +37,7 @@
 #include <vector>
 #include <algorithm>
 
-#include <ETL/clock>
+#include "synfig/clock.h"
 
 #include "target_tile.h"
 
@@ -177,7 +177,7 @@ synfig::Target_Tile::render_frame_(Canvas::Handle canvas, ContextParams context_
 {
 	const RendDesc &rend_desc(desc);
 
-	etl::clock tile_timer;
+	synfig::clock tile_timer;
 	tile_timer.reset();
 
 	// Gather tiles

--- a/synfig-core/test/Makefile.am
+++ b/synfig-core/test/Makefile.am
@@ -7,13 +7,18 @@ AM_LDFLAGS = \
 check_PROGRAMS=$(TESTS)
 
 TESTS = \
+	benchmark \
 	bline \
 	bone \
+	clock \
 	node
+
+benchmark_SOURCES=benchmark.cpp
 
 bone_SOURCES=bone.cpp
 
 bline_SOURCES=bline.cpp
 
+clock_SOURCES=clock.cpp
 
 node_SOURCES=node.cpp

--- a/synfig-core/test/benchmark.cpp
+++ b/synfig-core/test/benchmark.cpp
@@ -1,7 +1,8 @@
-/*! ========================================================================
-** Extended Template and Library Test Suite
-** Hermite Curve Test
+/* === S Y N F I G ========================================================= */
+/*!	\file benchmark.cpp
+**	\brief Benchmark test
 **
+**	\legal
 ** Copyright (c) 2002 Robert B. Quattlebaum Jr.
 **
 ** This file is part of Synfig.
@@ -23,13 +24,15 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <ETL/clock>
+#include <cstdio>
+
 #include <ETL/hermite>
 #include <ETL/angle>
 #include <ETL/surface>
 #include <ETL/gaussian>
 #include <ETL/calculus>
-#include <stdio.h>
+
+#include <synfig/clock.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -126,7 +129,7 @@ void angle_atan2_speed_test(void)
 int surface_and_gaussian_blur_test()
 {
 	int ret=0;
-	etl::clock MyTimer;
+	synfig::clock MyTimer;
 	float endtime;
 
 	{
@@ -157,7 +160,7 @@ int hermite_int_test()
 	hermite<int>::time_type f;
 	int i;
 
-	etl::clock timer;
+	synfig::clock timer;
 	float t;
 
 	Hermie.p1()=0;
@@ -196,7 +199,7 @@ int hermite_float_test(void)
 	float f; int i;
 
 	hermite<float> Hermie;
-	etl::clock timer;
+	synfig::clock timer;
 	double t;
 
 	Hermie.p1()=0;
@@ -235,7 +238,7 @@ int hermite_double_test(void)
 	float f;
 
 	hermite<double> Hermie;
-	etl::clock timer;
+	synfig::clock timer;
 	double t;
 
 	Hermie.p1()=0;
@@ -272,7 +275,7 @@ int hermite_angle_test(void)
 	float f;
 
 	hermite<angle> Hermie;
-	etl::clock timer;
+	synfig::clock timer;
 	angle tmp;
 	double t;
 

--- a/synfig-core/test/clock.cpp
+++ b/synfig-core/test/clock.cpp
@@ -1,6 +1,6 @@
-/*! ========================================================================
-** Extended Template and Library Test Suite
-** Clock Test
+/* === S Y N F I G ========================================================= */
+/*!	\file clock.cpp
+**	\brief Clock Test
 **
 ** Copyright (c) 2002 Robert B. Quattlebaum Jr.
 **
@@ -23,8 +23,9 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <ETL/clock>
-#include <stdio.h>
+#include <synfig/clock.h>
+
+#include <cstdio>
 #include <chrono>
 #include <thread>
 
@@ -40,7 +41,7 @@ int basic_test(void)
 {
 	int ret=0;
 
-	etl::clock timer;
+	synfig::clock timer;
 	float amount, total;
 
 	for(amount=3.0;amount>=0.00015;amount/=2.0)

--- a/synfig-studio/src/gui/asyncrenderer.cpp
+++ b/synfig-studio/src/gui/asyncrenderer.cpp
@@ -35,8 +35,7 @@
 
 #include "asyncrenderer.h"
 
-#include <ETL/clock>
-
+#include <synfig/clock.h>
 #include <synfig/context.h>
 #include <synfig/general.h>
 #include <synfig/target_scanline.h>

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -58,9 +58,8 @@
 #include <gtkmm/toolbutton.h>
 #include <gtkmm/uimanager.h>
 
-#include <ETL/clock>
-
 #include <synfig/canvas.h>
+#include <synfig/clock.h>
 #include <synfig/context.h>
 #include <synfig/rect.h>
 #include <synfig/soundprocessor.h>
@@ -357,7 +356,7 @@ private:
 
 	etl::handle<LockDucks> ducks_playing_lock;
 	sigc::connection playing_connection;
-	etl::clock playing_timer;
+	synfig::clock playing_timer;
 	synfig::Time playing_time;
 
 	sigc::signal<void> signal_deleted_;

--- a/synfig-studio/src/gui/preview.h
+++ b/synfig-studio/src/gui/preview.h
@@ -29,7 +29,6 @@
 #define __SYNFIG_PREVIEW_H
 
 /* === H E A D E R S ======================================================= */
-#include <ETL/clock> /* indirectly includes winnt.h on WIN32 - needs to be included before gtkmm headers, which fix this */
 #include <ETL/handle>
 
 #include <gdkmm/pixbuf.h>
@@ -52,6 +51,7 @@
 #endif
 
 #include <synfig/canvas.h>
+#include <synfig/clock.h>
 #include <synfig/soundprocessor.h>
 #include <synfig/time.h>
 
@@ -218,7 +218,7 @@ class Widget_Preview : public Gtk::Table
 	bool	toolbarisshown;
 
 	//for accurate time tracking
-	etl::clock	timer;
+	synfig::clock timer;
 
 	//int		curindex; //for later
 	sigc::connection	timecon;

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -34,8 +34,6 @@
 #	include <config.h>
 #endif
 
-#include <ETL/clock>
-
 #include <gui/app.h>
 #include <gui/canvasview.h>
 #include <gui/docks/dock_toolbox.h>
@@ -49,6 +47,7 @@
 #include <gui/workarea.h>
 
 #include <synfig/blinepoint.h>
+#include <synfig/clock.h>
 #include <synfig/general.h>
 #include <synfig/valuenodes/valuenode_wplist.h>
 
@@ -86,8 +85,7 @@ class studio::StateWidth_Context : public sigc::trackable
 
 	std::map<handle<Duck>,Real>	changetable;
 
-	etl::clock	clocktime;
-	// Real		lastt; // unused
+	synfig::clock	clocktime;
 
 	bool added;
 

--- a/synfig-studio/src/gui/trees/childrentreestore.cpp
+++ b/synfig-studio/src/gui/trees/childrentreestore.cpp
@@ -35,13 +35,13 @@
 
 #include <gui/trees/childrentreestore.h>
 
-#include <ETL/clock>
 #include <glibmm/main.h>
 #include <gtkmm/button.h>
 #include <gui/localization.h>
+#include <synfig/clock.h>
 #include <synfig/general.h>
 
-class Profiler : private etl::clock
+class Profiler : private synfig::clock
 {
 	const std::string name;
 public:
@@ -244,7 +244,7 @@ ChildrenTreeStore::execute_changed_value_nodes()
 	if(!replaced_set_.empty())
 		rebuild_value_nodes();
 
-	etl::clock timer;
+	synfig::clock timer;
 	timer.reset();
 
 	while(!changed_set_.empty())


### PR DESCRIPTION
Moved ETL benchmark test to synfig-core due to `clock` requirement

BREAKING CHANGE: both ETL and synfig API changed:
- `etl::clock` is now `synfig::clock`