### PR TITLE
refactor: make use of synfig::clamp instead of std::max(std::min())

### DIFF
--- a/synfig-core/src/modules/mod_geometry/checkerboard.cpp
+++ b/synfig-core/src/modules/mod_geometry/checkerboard.cpp
@@ -159,7 +159,7 @@ public:
 
 					ColorReal a = std::min(px, py);
 					if ((p[0] < 0.5) != (p[1] < 0.5)) a = -a;
-					a = std::max(ColorReal(0), std::min(ColorReal(1), a + ColorReal(0.5)));
+					a = synfig::clamp(a + ColorReal(0.5), ColorReal(0), ColorReal(1));
 
 					c.set_a(color.get_a()*a);
 					apen.put_value(c, amount);

--- a/synfig-core/src/modules/mod_yuv420p/trgt_yuv.cpp
+++ b/synfig-core/src/modules/mod_yuv420p/trgt_yuv.cpp
@@ -136,7 +136,7 @@ yuv::end_frame()
 			Color& c(surface[y][x]);
 			c=c.clamped();
 			float f(c.get_y());
-			int i(std::max(std::min(round_to_int(c.get_y()*Y_RANGE),Y_RANGE),0)+Y_FLOOR);
+			int i(synfig::clamp(round_to_int(c.get_y()*Y_RANGE),0, Y_RANGE)+Y_FLOOR);
 
 			if(dithering)
 			{
@@ -178,7 +178,7 @@ yuv::end_frame()
 		{
 			const Color& c(sm_surface[y][x]);
 			const float f(c.get_u());
-			const int i(std::max(std::min(round_to_int((f+0.5f)*UV_RANGE),UV_RANGE),0)+UV_FLOOR);
+			const int i(synfig::clamp(round_to_int((f+0.5f)*UV_RANGE), 0, UV_RANGE)+UV_FLOOR);
 
 			if(dithering)
 			{
@@ -204,7 +204,7 @@ yuv::end_frame()
 		{
 			const Color& c(sm_surface[y][x]);
 			const float f(c.get_v());
-			const int i(std::max(std::min(round_to_int((f+0.5f)*UV_RANGE),UV_RANGE),0)+UV_FLOOR);
+			const int i(synfig::clamp(round_to_int((f+0.5f)*UV_RANGE), 0, UV_RANGE)+UV_FLOOR);
 
 			if(dithering)
 			{

--- a/synfig-core/src/synfig/color/colorblendingfunctions.h
+++ b/synfig-core/src/synfig/color/colorblendingfunctions.h
@@ -32,6 +32,7 @@
 #define COLOR_EPSILON	(0.000001f)
 
 #include <synfig/color.h>
+#include <synfig/real.h>
 #include <algorithm>
 
 namespace synfig {
@@ -177,7 +178,7 @@ C blendfunc_ADD_COMPOSITE(C &a,C &b,float amount)
 {
 	float ba(b.get_a());
 	float aa(a.get_a()*amount);
-	const float alpha(std::max(0.f, std::min(1.f, ba + aa)));
+	const float alpha(synfig::clamp(ba + aa, 0.f, 1.f));
 	const float k = fabs(alpha) > 1e-8 ? 1.0/alpha : 0.0;
 	aa *= k; ba *= k;
 

--- a/synfig-core/src/synfig/distance.cpp
+++ b/synfig-core/src/synfig/distance.cpp
@@ -115,7 +115,7 @@ Distance::operator=(const synfig::String& str)
 synfig::String
 Distance::get_string(int digits)const
 {
-	digits=std::min(9, std::max(0,digits));
+	digits=synfig::clamp(digits,0,9);
 	String fmt(strprintf("%%.%01df",digits));
 	String str(strprintf(fmt.c_str(),value_));
 	return strprintf("%s%s",str.c_str(),system_name(system_).c_str());

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -307,7 +307,7 @@ CompiledGradient::set(const Gradient &gradient, bool repeat, bool zigzag) {
 	Gradient::CPointList cpoints;
 	cpoints.reserve(zigzag ? gradient.size()*2 : gradient.size());
 	for(Gradient::const_iterator i = gradient.begin(); i != gradient.end(); ++i) {
-		Real pos = std::max(0.0, std::min(1.0, i->pos));
+		Real pos = synfig::clamp(i->pos, 0., 1.);
 		cpoints.insert( std::upper_bound(cpoints.begin(), cpoints.end(), pos), *i )->pos = pos;
 	}
 

--- a/synfig-core/src/synfig/layers/layer_bitmap.cpp
+++ b/synfig-core/src/synfig/layers/layer_bitmap.cpp
@@ -318,8 +318,8 @@ synfig::Layer_Bitmap::get_color(Context context, const Point &pos)const
 				case 0:	// Nearest Neighbor
 				default:
 					{
-						int x(std::min(w-1,std::max(0,round_to_int(surface_pos[0]))));
-						int y(std::min(h-1,std::max(0,round_to_int(surface_pos[1]))));
+						int x(synfig::clamp(round_to_int(surface_pos[0]), 0, w-1));
+						int y(synfig::clamp(round_to_int(surface_pos[1]), 0, h-1));
 						ret= surface[y][x];
 					}
 				break;

--- a/synfig-core/src/synfig/rendering/software/function/blur.cpp
+++ b/synfig-core/src/synfig/rendering/software/function/blur.cpp
@@ -551,7 +551,7 @@ software::Blur::IIRCoefficients
 software::Blur::get_iir_coefficients(Real radius)
 {
 	const Real precision(1e-8);
-	radius = max(iir_min_radius + precision, min(iir_max_radius - precision, fabs(radius)));
+	radius = synfig::clamp(fabs(radius), iir_min_radius + precision, iir_max_radius - precision);
 
 	Real x = (radius - iir_min_radius)/iir_radius_step;
 	//int index = floor(x);

--- a/synfig-core/src/synfig/rendering/software/function/resample.cpp
+++ b/synfig-core/src/synfig/rendering/software/function/resample.cpp
@@ -450,8 +450,8 @@ namespace {
 
 					int sw = src_bounds.get_width();
 					int sh = src_bounds.get_height();
-					int w = std::min( sw, std::max(1, (int)ceil((Real)sw * bounds.resolution[0])) );
-					int h = std::min( sh, std::max(1, (int)ceil((Real)sh * bounds.resolution[1])) );
+					int w = synfig::clamp((int)ceil((Real)sw * bounds.resolution[0]), 1, sw);
+					int h = synfig::clamp((int)ceil((Real)sh * bounds.resolution[1]), 1, sh);
 
 					if (w < sw || h < sh) {
 						synfig::Surface new_src(w, h);

--- a/synfig-core/src/synfig/rendering/software/task/taskblendsw.cpp
+++ b/synfig-core/src/synfig/rendering/software/task/taskblendsw.cpp
@@ -145,10 +145,10 @@ public:
 					{
 						// mark unfilled regions
 						fill[0] = fill[1] = fill[2] = fill[3] = ra;
-						fill[0].maxx = fill[2].minx = fill[3].minx = std::max(ra.minx, std::min(ra.maxx, rb.minx));
-						fill[1].minx = fill[2].maxx = fill[3].maxx = std::max(ra.minx, std::min(ra.maxx, rb.maxx));
-						fill[2].maxy = std::max(ra.miny, std::min(ra.maxy, rb.miny));
-						fill[3].miny = std::max(ra.miny, std::min(ra.maxy, rb.maxy));
+						fill[0].maxx = fill[2].minx = fill[3].minx = synfig::clamp(rb.minx, ra.minx, ra.maxx);
+						fill[1].minx = fill[2].maxx = fill[3].maxx = synfig::clamp(rb.maxx, ra.minx, ra.maxx);
+						fill[2].maxy = synfig::clamp(rb.miny, ra.miny, ra.maxy);
+						fill[3].miny = synfig::clamp(rb.maxy, ra.miny, ra.maxy);
 					}
 				}
 			}

--- a/synfig-core/src/synfig/rendering/software/task/taskpixelgammasw.cpp
+++ b/synfig-core/src/synfig/rendering/software/task/taskpixelgammasw.cpp
@@ -107,13 +107,13 @@ private:
 	static inline ColorReal clamp(const ColorReal &x)
 	{
 		const ColorReal max = ColorReal(1.0)/real_low_precision<ColorReal>();
-		return std::max(-max, std::min(max, x));
+		return synfig::clamp(x, -max, max);
 	}
 
 	static inline ColorReal clamp_positive(const ColorReal &x)
 	{
 		const ColorReal max = ColorReal(1.0)/real_low_precision<ColorReal>();
-		return std::max(real_low_precision<ColorReal>(), std::min(max, x));
+		return synfig::clamp(x, real_low_precision<ColorReal>(), max);
 	}
 
 	static inline void func_none(ColorReal&, const ColorReal&, const ColorReal&) { }

--- a/synfig-core/src/synfig/threadpool.cpp
+++ b/synfig-core/src/synfig/threadpool.cpp
@@ -81,7 +81,7 @@ ThreadPool::Group::process(int begin, int end) {
 
 void
 ThreadPool::Group::enqueue(const Slot &slot, Real weight) {
-	weight = std::max(real_precision<Real>(), std::min(1.0/real_precision<Real>(), weight));
+	weight = synfig::clamp(weight, real_precision<Real>(), 1.0/real_precision<Real>());
 	tasks.push_back(Entry(weight, slot));
 	sum_weight += weight;
 }
@@ -258,7 +258,7 @@ ThreadPool::thread_loop(int
 
 void
 ThreadPool::wakeup() {
-	int to_wakeup = std::max(0, std::min((int)queue_size, max_running_threads - (int)running_threads));
+	int to_wakeup = synfig::clamp(max_running_threads - (int)running_threads, 0, (int)queue_size);
 	int to_create = std::max(0, to_wakeup - (int)ready_threads);
 	to_wakeup     = std::max(0, to_wakeup - to_create);
 	while(to_create-- > 0)

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -208,7 +208,7 @@ synfig::find_closest_point(const ValueBase &bline, const Point &pos, Real radius
 				 + (curve[3] - curve[2]).mag();
 		
 		// want to make the distance between lines happy
-		Real step = std::max(minstep, std::min(maxstep, len/(2*radius))); 
+		Real step = synfig::clamp(len/(2*radius), minstep, maxstep);
 		float time = 0;
 		Real c = find_closest(curve, pos, step, &closest, &time);
 		if(c < closest) {

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
@@ -130,7 +130,7 @@ ValueNode_BLineCalcTangent::operator()(Time t, Real amount)const
 	if (amount > 1) amount = 1;
 	amount *= count;
 
-	int i0 = std::max(0, std::min(size-1, (int)floor(amount)));
+	int i0 = synfig::clamp((int)floor(amount), 0, size-1);
 	int i1 = (i0 + 1) % size;
 	Real part = amount - i0;
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
@@ -117,7 +117,7 @@ ValueNode_BLineCalcVertex::operator()(Time t)const
 	if (amount > 1) amount = 1;
 	amount *= count;
 
-	int i0 = std::max(0, std::min(size-1, (int)floor(amount)));
+	int i0 = synfig::clamp((int)floor(amount), 0, size-1);
 	int i1 = (i0 + 1) % size;
 	Real part = amount - i0;
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
@@ -118,7 +118,7 @@ ValueNode_BLineCalcWidth::operator()(Time t, Real amount)const
 	if (amount > 1) amount = 1;
 	amount *= count;
 
-	int i0 = std::max(0, std::min(size-1, (int)floor(amount)));
+	int i0 = synfig::clamp((int)floor(amount), 0, size-1);
 	int i1 = (i0 + 1) % size;
 	Real part = amount - i0;
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_modulo.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_modulo.cpp
@@ -219,21 +219,21 @@ ValueNode_Modulo::get_inverse(const Time& t, const ValueBase& target_value) cons
 	if (type == type_angle) {
 		int int_target = etl::round_to_int(Angle::deg(target_value.get(Angle())).get()) / scalar_value;
 		Angle::deg ret = Angle::deg(int_target / scalar_value);
-		return std::min(Angle::deg(max_value), std::max(Angle::deg(-max_value), ret));
+		return synfig::clamp(ret, Angle::deg(-max_value), Angle::deg(max_value));
 	}
 	if (type == type_integer) {
 		int ret = target_value.get(int()) / scalar_value;
-		return std::min(max_value, std::max(-max_value, ret));
+		return synfig::clamp(ret, -max_value, max_value);
 	}
 	if (type == type_real) {
 		int int_target = etl::round_to_int(target_value.get(Real()));
 		Real ret = int_target / scalar_value;
-		return std::min(Real(max_value), std::max(Real(-max_value), ret));
+		return synfig::clamp(ret, Real(-max_value), Real(max_value));
 	}
 	if (type == type_time) {
 		int int_target = etl::round_to_int(target_value.get(Time()));
 		Time ret = int_target / scalar_value;
-		return std::min(Time(max_value), std::max(Time(-max_value), ret));
+		return synfig::clamp(ret, Time(-max_value), Time(-max_value));
 	}
 	throw std::runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Invalid value type")));
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
@@ -163,13 +163,13 @@ synfig::ValueNode_Range::operator()(Time t)const
 	}
 	else
 	if (type == type_integer)
-		return std::max((*min_)(t).get(int()),  std::min((*max_)(t).get(int()),  (*link_)(t).get(int())));
+		return synfig::clamp((*link_)(t).get(int()), (*min_)(t).get(int()), (*max_)(t).get(int()));
 	else
 	if (type == type_real)
-		return std::max((*min_)(t).get(Real()), std::min((*max_)(t).get(Real()), (*link_)(t).get(Real())));
+		return synfig::clamp((*link_)(t).get(Real()), (*min_)(t).get(Real()), (*max_)(t).get(Real()));
 	else
 	if (type == type_time)
-		return std::max((*min_)(t).get(Time()), std::min((*max_)(t).get(Time()), (*link_)(t).get(Time())));
+		return synfig::clamp((*link_)(t).get(Time()), (*min_)(t).get(Time()), (*max_)(t).get(Time()));
 
 	assert(0);
 	return ValueBase();
@@ -209,14 +209,14 @@ synfig::ValueNode_Range::get_inverse(const Time& t, const synfig::Vector &target
 	{
 		int max_value((*max_)(t).get(int()));
 		int min_value((*min_)(t).get(int()));
-		return std::max(min_value, std::min(max_value, int(target_value.mag())));
+		return synfig::clamp(int(target_value.mag()), min_value, max_value);
 	}
 	else
 	if (type == type_real)
 	{
 		Real max_value((*max_)(t).get(Real()));
 		Real min_value((*min_)(t).get(Real()));
-		return std::max(min_value, std::min(max_value, target_value.mag()));
+		return synfig::clamp(target_value.mag(), min_value, max_value);
 	}
 	else
 	if (type == type_angle)
@@ -224,14 +224,14 @@ synfig::ValueNode_Range::get_inverse(const Time& t, const synfig::Vector &target
 		Angle max_value((*max_)(t).get(Angle()));
 		Angle min_value((*min_)(t).get(Angle()));
 		Angle target_angle(Angle::tan(target_value[1],target_value[0]));
-		return target_angle>max_value?max_value:target_angle<min_value?min_value:target_angle;
+		return synfig::clamp(target_angle, min_value, max_value);
 	}
 	else
 	if (type == type_time)
 	{
 		Real max_value((*max_)(t).get(Time()));
 		Real min_value((*min_)(t).get(Time()));
-		return std::max(min_value, std::min(max_value, target_value.mag()));
+		return synfig::clamp(target_value.mag(), min_value, max_value);
 	}
 
 	return target_value;

--- a/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.cpp
@@ -115,7 +115,7 @@ synfig::ValueNode_Repeat_Gradient::operator()(Time t)const
 		return ret;
 
 	const Gradient gradient((*gradient_)(t).get(Gradient()));
-	const float width(std::max(0.0, std::min(1.0,(*width_)(t).get(Real()))));
+	const float width(synfig::clamp((*width_)(t).get(Real()), 0.0, 1.0));
 	const bool specify_start((*specify_start_)(t).get(bool()));
 	const bool specify_end((*specify_end_)(t).get(bool()));
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_stripes.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_stripes.cpp
@@ -113,7 +113,7 @@ synfig::ValueNode_Stripes::operator()(Time t)const
 
 	const Color color1((*color1_)(t).get(Color()));
 	const Color color2((*color2_)(t).get(Color()));
-	const float width(std::max(0.0,std::min(1.0,(*width_)(t).get(Real()))));
+	const float width(synfig::clamp((*width_)(t).get(Real()), 0., 1.));
 
 	const float stripe_width_a(width/total);
 	const float stripe_width_b((1.0-width)/total);

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -2796,7 +2796,7 @@ CanvasView::on_play_timeout()
 				jack_transport_locate(jack_client, nframes);
 			}
 		}
-		time = std::max(lower, std::min(upper, time));
+		time = synfig::clamp(time, lower, upper);
 		#endif
 	} else {
 		time = time_model()->round_time(playing_time + playing_timer());

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
@@ -411,7 +411,7 @@ CellRenderer_TimeTrack::render_vfunc(
 			ValueNode_DynamicList::ListEntry::ActivepointList::const_iterator j = i; ++j;
 
 			int x = time_plot_data.get_pixel_t_coord(i->time);
-			x = std::max(0, std::min(cell_area.get_width(), x));
+			x = synfig::clamp(x, 0, cell_area.get_width());
 
 			bool status_at_time = !list_entry.status_at_time(
 				j == activepoint_list.end() ? Time::end() : (i->time + j->time)*0.5 );

--- a/synfig-studio/src/gui/helpers.h
+++ b/synfig-studio/src/gui/helpers.h
@@ -206,7 +206,7 @@ public:
 	void finish() {
 		assert(adjustment);
 		if (!adjustment) return;
-		double value = std::max(lower, std::min(upper - page_size, this->value));
+		double value = synfig::clamp(this->value, lower, upper - page_size);
 		if ( !is_equal(lower,          adjustment->get_lower())
 		  || !is_equal(upper,          adjustment->get_upper())
 		  || !is_equal(step_increment, adjustment->get_step_increment())

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -1213,8 +1213,8 @@ Widget_Preview::is_time_equal_to_current_frame(const synfig::Time &time)
 		t1 = t1.round(fps);
 	}
 
-	t0 = std::max(starttime, std::min(endtime, t0));
-	t1 = std::max(starttime, std::min(endtime, t1));
+	t0 = synfig::clamp(t0, starttime, endtime);
+	t1 = synfig::clamp(t1, starttime, endtime);
 
 	return t0.is_equal(t1);
 }

--- a/synfig-studio/src/gui/timemodel.cpp
+++ b/synfig-studio/src/gui/timemodel.cpp
@@ -165,8 +165,8 @@ bool
 TimeModel::set_time_silent(Time time, bool *is_play_time_changed)
 {
 	time = round_time(time);
-	Time t = std::max(lower, std::min(upper, time));
-	Time pt = std::max(play_bounds_lower, std::min(play_bounds_upper, t));
+	Time t = synfig::clamp(time, lower, upper);
+	Time pt = synfig::clamp(t, play_bounds_lower, play_bounds_upper);
 
 	if (this->play_time != pt) {
 		this->play_time = pt;
@@ -212,13 +212,13 @@ TimeModel::set_visible_bounds_silent(Time lower, Time upper)
 	Time duration = std::max(Time(fps ? 1.0/fps : 0.0), upper - lower);
 
 	// this->lower bound have priority when this->upper < this->lower
-	lower = std::max(this->lower, std::min(this->upper, lower));
-	upper = std::max(lower, std::min(this->upper, upper));
+	lower = synfig::clamp(lower, this->lower, this->upper);
+	upper = synfig::clamp(upper, lower, this->upper);
 
 	if (duration > Time() && this->lower < this->upper) {
 		Time t = lower + duration;
 		if (t > upper)
-			upper = std::max(lower, std::min(this->upper, t));
+			upper = synfig::clamp(t, lower, this->upper);
 		t = upper - duration;
 		if (t < lower)
 			lower = std::max(this->lower, t);
@@ -234,15 +234,15 @@ TimeModel::set_visible_bounds_silent(Time lower, Time upper)
 bool
 TimeModel::set_play_bounds_silent(Time lower, Time upper, bool enabled, bool repeat) {
 	// this->lower bound have priority when this->upper < this->lower
-	lower = std::max(this->lower, std::min(this->upper, round_time(lower)));
-	upper = std::max(lower, std::min(this->upper, round_time(upper)));
+	lower = synfig::clamp(round_time(lower), this->lower, this->upper);
+	upper = synfig::clamp(round_time(upper), lower, this->upper);
 
 	// try to keep minimum two frame range
 	if (fps && this->lower < this->upper) {
 		Time step = Time(2.0/fps);
 		Time t = round_time(lower + step);
 		if (t > upper)
-			upper = std::max(lower, std::min(this->upper, t));
+			upper = synfig::clamp(t, lower, this->upper);
 		t = round_time(upper - step);
 		if (t < lower)
 			lower = std::max(this->lower, t);
@@ -331,5 +331,5 @@ TimeModel::get_page_increment() const
 {
 	Time s = get_step_increment();
 	Time p = get_page_size();
-	return std::max(s, std::min(p*0.8, p - s));
+	return synfig::clamp(p - s, s, p*0.8);
 }

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -342,7 +342,7 @@ Widget_Keyframe_List::on_event(GdkEvent *event)
 
 	// The time where the event x is
 	Time t = time_plot_data.get_t_from_pixel_coord(x);
-	t = std::max(lower, std::min(upper, t));
+	t = synfig::clamp(t, lower, upper);
 
 	// here the guts of the event
 	switch(event->type) {

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -937,8 +937,8 @@ const Cairo::RefPtr<Cairo::SurfacePattern>&
 WorkArea::get_background_pattern() const
 {
 	if (!background_pattern) {
-		int w = std::max(1, std::min(1000, (int)round(background_size[0])));
-		int h = std::max(1, std::min(1000, (int)round(background_size[1])));
+		int w = synfig::clamp(round_to_int(background_size[0]), 1, 1000);
+		int h = synfig::clamp(round_to_int(background_size[1]), 1, 1000);
 	    Cairo::RefPtr<Cairo::ImageSurface> surface = Cairo::ImageSurface::create(Cairo::FORMAT_RGB24, w*2, h*2);
 	    Cairo::RefPtr<Cairo::Context> context = Cairo::Context::create(surface);
 	    context->set_source_rgb(background_first_color.get_r(), background_first_color.get_g(), background_first_color.get_b());
@@ -2226,7 +2226,7 @@ studio::WorkArea::reset_cursor()
 void
 studio::WorkArea::set_zoom(float z)
 {
-	z=std::max(1.0f/128.0f,std::min(128.0f,z));
+	z=synfig::clamp(z,1.0f/128.0f,128.0f);
 	zoomdial->set_zoom(z);
 	if(z==zoom)
 		return;


### PR DESCRIPTION
It's more readable this way.
In C++17, we can replace it with `std::clamp()`.