### PR TITLE
fix: layers parameter 'filename' does not accept backslash as directory separator

### DIFF
--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
@@ -730,7 +730,8 @@ Layer_Freetype::set_shape_param(const String & param, const ValueBase &value)
 */
 	IMPORT_VALUE_PLUS(param_family,
 		{
-			synfig::String family=param_family.get(synfig::String());
+			synfig::String family = FileSystem::fix_slashes(value.get(synfig::String()));
+			param_family.set(family);
 			int style=param_style.get(int());
 			int weight=param_weight.get(int());
 			new_font(family,style,weight);

--- a/synfig-core/src/modules/lyr_std/import.cpp
+++ b/synfig-core/src/modules/lyr_std/import.cpp
@@ -105,7 +105,7 @@ Import::set_param(const String & param, const ValueBase &value)
 		{
 			importer.reset();
 			rendering_surface.reset();
-			param_filename.set(value.get(String()));
+			param_filename.set(FileSystem::fix_slashes(value.get(String())));
 			return true;
 		}
 
@@ -115,7 +115,7 @@ Import::set_param(const String & param, const ValueBase &value)
 			return false;
 		}
 
-		String filename = value.get(String());
+		String filename = FileSystem::fix_slashes(value.get(String()));
 		String fixed_filename = filename;
 
 		// TODO: find source of this sreening of unicode characters

--- a/synfig-core/src/modules/mod_svg/layer_svg.cpp
+++ b/synfig-core/src/modules/mod_svg/layer_svg.cpp
@@ -72,7 +72,7 @@ svg_layer::set_param(const String & param, const ValueBase &value)
 	if(param=="filename"){
 		Canvas::Handle canvas;
 		//if ext of filename == "svg" then
-		filename = value.get(String());
+		filename = FileSystem::fix_slashes(value.get(String()));
 		canvas=open_svg(CanvasFileNaming::make_full_filename(get_canvas()->get_file_name(), filename),errors,warnings);
 		//else other parsers maybe
 		if(canvas)

--- a/synfig-core/src/synfig/filesystem.cpp
+++ b/synfig-core/src/synfig/filesystem.cpp
@@ -191,8 +191,16 @@ bool FileSystem::copy_recursive(Handle from_file_system, const String &from_file
 String FileSystem::fix_slashes(const String &filename)
 {
 	String fixed = etl::cleanup_path(filename);
-	if (fixed == ".") fixed = "";
-	for(size_t i = 0; i < fixed.size(); ++i)
+	if (fixed == ".")
+		return String();
+
+	String::size_type i = 0;
+	// For MS Windows shared folder paths like \\host\folder\file,
+	// we keep \\ for now
+	if (fixed.size() > 2 && fixed.substr(0, 2) == "\\\\")
+		i = 2;
+	// All other backslashes \ are replaced with slashes /
+	for(; i < fixed.size(); ++i)
 		if (fixed[i] == '\\') fixed[i] = '/';
 	return fixed;
 }

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -1056,7 +1056,7 @@ bool Layer::monitor(const std::string& path) { // append file monitor (returns t
 	RefPtr<Gio::File> file = Gio::File::create_for_path(path);
 	file_monitor = file->monitor_file(); // defaults to Gio::FileMonitorFlags::FILE_MONITOR_NONE
 	monitor_connection = file_monitor->signal_changed().connect(sigc::mem_fun(*this, &Layer::on_file_changed));
-	monitored_path = path;
+	monitored_path = FileSystem::fix_slashes(path);
 	synfig::info("File monitor attached to file: (" + path + ")");
 
 	return true;

--- a/synfig-core/src/synfig/layers/layer_sound.cpp
+++ b/synfig-core/src/synfig/layers/layer_sound.cpp
@@ -79,7 +79,11 @@ Layer_Sound::Layer_Sound():
 bool
 Layer_Sound::set_param(const String &param, const ValueBase &value)
 {
-	IMPORT_VALUE(param_filename);
+	IMPORT_VALUE_PLUS(param_filename,
+		{
+			param_filename = FileSystem::fix_slashes(value.get(""));
+		}
+		);
 	IMPORT_VALUE(param_delay);
 	IMPORT_VALUE(param_volume);
 


### PR DESCRIPTION
Maybe we should fix them on canvas loading.
Probably it would be good to uniform them on saving too as well
on choosing via Widget_Filename too.

Fix #2723