### PR TITLE
fix(FreeType): Duplicating Text Layer resets Font Family parameter

### DIFF
--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
@@ -467,6 +467,8 @@ Layer_Freetype::on_canvas_set()
 	int style=param_style.get(int());
 	int weight=param_weight.get(int());
 	new_font(family,style,weight);
+
+	sync(true);
 }
 
 void

--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.h
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.h
@@ -147,7 +147,7 @@ private:
 	synfig::Point contour_to_world(const synfig::Point& p) const;
 
 	enum SyncFlags {
-		SYNC_FONT,
+		SYNC_FONT = 1,
 		SYNC_TEXT,
 		SYNC_DIRECTION,
 		SYNC_COMPRESS,


### PR DESCRIPTION
if font is relative filepath, force sync when canvas changes

Fix #2724