### PR TITLE
fix: Synfig hangs when importing palette

### DIFF
--- a/synfig-core/src/synfig/filesystemnative.cpp
+++ b/synfig-core/src/synfig/filesystemnative.cpp
@@ -70,6 +70,14 @@ std::istream::pos_type FileSystemNative::ReadStream::seekpos(std::istream::pos_t
 	return ftell(file_);
 }
 
+int FileSystemNative::ReadStream::pbackfail(int ch)
+{
+	if (fseek(file_, -1, SEEK_CUR)) {
+		return EOF;
+	}
+	return FileSystem::ReadStream::underflow();
+}
+
 // WriteStream
 
 FileSystemNative::WriteStream::WriteStream(FileSystem::Handle file_system, FILE *file):

--- a/synfig-core/src/synfig/filesystemnative.h
+++ b/synfig-core/src/synfig/filesystemnative.h
@@ -55,6 +55,7 @@ namespace synfig
 			FILE *file_;
 			ReadStream(FileSystem::Handle file_system, FILE *file);
 			size_t internal_read(void *buffer, size_t size) override;
+			int pbackfail(int ch) override;
 			std::istream::pos_type seekpos(std::istream::pos_type pos, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
 		public:
 			virtual ~ReadStream();


### PR DESCRIPTION
The issue was that the `unget()` method calls the `pbackfail()`
method, which is not implemented, because of this the error
flag is set and the program goes into an infinite loop.

Fix #2720