### PR TITLE
fix: Interface background became white after clicking OK in Preferences dialog

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -559,6 +559,7 @@ CanvasView::CanvasView(etl::loose_handle<Instance> instance,etl::handle<CanvasIn
 {
 	// Make this toolbar small for space efficiency
 	get_style_context()->add_class("synfigstudio-efficient-workspace");
+	set_name("canvasview");
 
 	canvas_options = CanvasOptions::create(*App::main_window, this);
 

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -89,3 +89,11 @@
 .indentation{
 	margin-left : 6px;
 }
+
+/*
+ * Let WorkArea/Canvas background be the
+ * default system background
+ */
+#canvasview {
+	background: @theme_unfocused_bg_color;
+}

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -1967,7 +1967,7 @@ WorkArea::refresh(const Cairo::RefPtr<Cairo::Context> &/*cr*/)
 
 	assert(get_canvas());
 
-	//!Check if the window we want draw is ready
+	// Check if the window we want draw is ready
 	Glib::RefPtr<Gdk::Window> draw_area_window = drawing_area->get_window();
 	if (!draw_area_window) return false;
 


### PR DESCRIPTION
The canvas area is actually a Gtk::DrawingArea, and its default background
color is white (on light themes).
However, at start, it's not properly draw, and only the central area is
drawn by Synfig software (via workarea renderers). When Work Area itself
gains focus, it shows its white background defined by Gtk theme.

Fix #2636