### PR TITLE
fix(mod_libavcodec): fixed build with FFMPEG 5.0

### DIFF
--- a/synfig-core/src/modules/mod_libavcodec/trgt_av.cpp
+++ b/synfig-core/src/modules/mod_libavcodec/trgt_av.cpp
@@ -41,6 +41,7 @@
 extern "C"
 {
 #ifdef HAVE_LIBAVFORMAT_AVFORMAT_H
+#	include <libavcodec/avcodec.h>
 #	include <libavformat/avformat.h>
 #elif defined(HAVE_AVFORMAT_H)
 #	include <avformat.h>
@@ -234,12 +235,14 @@ public:
 		close();
 
 		if (!av_registered) {
+#if LIBAVCODEC_VERSION_MAJOR < 59 // FFMPEG < 5.0
 			av_register_all();
+#endif
 			av_registered = true;
 		}
 
 		// guess format
-		AVOutputFormat *format = av_guess_format(nullptr, filename.c_str(), nullptr);
+		const AVOutputFormat *format = av_guess_format(nullptr, filename.c_str(), nullptr);
 		if (!format) {
 			synfig::warning("Target_LibAVCodec: unable to guess the output format, defaulting to MPEG");
 			format = av_guess_format("mpeg", nullptr, nullptr);
@@ -254,6 +257,7 @@ public:
 		context = avformat_alloc_context();
 		assert(context);
 		context->oformat = format;
+#if LIBAVCODEC_VERSION_MAJOR < 59 // FFMPEG < 5.0
 		if (filename.size() + 1 > sizeof(context->filename)) {
 			synfig::error(
 				"Target_LibAVCodec: filename too long, max length is %d, filename is '%s'",
@@ -263,6 +267,14 @@ public:
 			return false;
 		}
 		memcpy(context->filename, filename.c_str(), filename.size() + 1);
+#else
+		context->url = av_strndup(filename.c_str(), filename.size());
+		if (!context->url) {
+			synfig::error("Target_LibAVCodec: cannot allocate space for filename");
+			close();
+			return false;
+		}
+#endif
 
 		packet = av_packet_alloc();
 		assert(packet);


### PR DESCRIPTION
fix #2709

[0001-fix-mod_libavcodec-fixed-build-with-FFMPEG-5.0.patch.zip](https://github.com/synfig/synfig/files/9058055/0001-fix-mod_libavcodec-fixed-build-with-FFMPEG-5.0.patch.zip)

