### PR TITLE
fix: mod_libavcodec didn't compile with MinGW

### DIFF
--- a/synfig-core/src/modules/mod_libavcodec/trgt_av.cpp
+++ b/synfig-core/src/modules/mod_libavcodec/trgt_av.cpp
@@ -235,14 +235,18 @@ public:
 		close();
 
 		if (!av_registered) {
-#if LIBAVCODEC_VERSION_MAJOR < 59 // FFMPEG < 5.0
+#if LIBAVCODEC_VERSION_MAJOR < 58 // FFMPEG < 4.0
 			av_register_all();
 #endif
 			av_registered = true;
 		}
 
 		// guess format
-		const AVOutputFormat *format = av_guess_format(nullptr, filename.c_str(), nullptr);
+#if LIBAVCODEC_VERSION_MAJOR < 59 // FFMPEG < 5.0
+		AVOutputFormat* format = av_guess_format(nullptr, filename.c_str(), nullptr);
+#else
+		const AVOutputFormat* format = av_guess_format(nullptr, filename.c_str(), nullptr);
+#endif
 		if (!format) {
 			synfig::warning("Target_LibAVCodec: unable to guess the output format, defaulting to MPEG");
 			format = av_guess_format("mpeg", nullptr, nullptr);
@@ -257,7 +261,7 @@ public:
 		context = avformat_alloc_context();
 		assert(context);
 		context->oformat = format;
-#if LIBAVCODEC_VERSION_MAJOR < 59 // FFMPEG < 5.0
+#if LIBAVCODEC_VERSION_MAJOR < 58 // FFMPEG < 4.0
 		if (filename.size() + 1 > sizeof(context->filename)) {
 			synfig::error(
 				"Target_LibAVCodec: filename too long, max length is %d, filename is '%s'",


### PR DESCRIPTION
```
error: invalid conversion from 'const AVOutputFormat*' to 'AVOutputFormat*' [-fpermissive]
  259 |                 context->oformat = format;
```

`context->oformat` is `AVOutputFormat*` before FFMPEG 5.0. It builds fine with gcc on Linux, so I missed that.