### PR TITLE
test: define ‘operator<<’ for operands std::string and std::nullptr_t

### DIFF
--- a/synfig-core/test/test_base.h
+++ b/synfig-core/test/test_base.h
@@ -52,6 +52,12 @@ std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 	return os;
 }
 
+std::ostream& operator<<(std::ostream& os, std::nullptr_t)
+{
+	os << "null";
+	return os;
+}
+
 #define ERROR_MESSAGE_TWO_VALUES(a, b) \
 	std::ostringstream oss; \
 	oss.precision(8); \

--- a/synfig-studio/test/test_base.h
+++ b/synfig-studio/test/test_base.h
@@ -52,6 +52,12 @@ std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 	return os;
 }
 
+std::ostream& operator<<(std::ostream& os, std::nullptr_t)
+{
+	os << "null";
+	return os;
+}
+
 #define ERROR_MESSAGE_TWO_VALUES(a, b) \
 	std::ostringstream oss; \
 	oss.precision(8); \


### PR DESCRIPTION
fix for some compilers not accepting ASSERT_EQUAL(nullptr, something)