### PR TITLE
Color Wheel History Pollution Fix

### DIFF
--- a/synfig-studio/src/gui/trees/historytreestore.cpp
+++ b/synfig-studio/src/gui/trees/historytreestore.cpp
@@ -56,6 +56,8 @@ using namespace studio;
 
 /* === M E T H O D S ======================================================= */
 
+bool HistoryTreeStore::block_new_history = false;
+
 static HistoryTreeStore::Model& ModelHack()
 {
 	static HistoryTreeStore::Model* model(nullptr);
@@ -209,6 +211,7 @@ HistoryTreeStore::on_redo_stack_cleared()
 void
 HistoryTreeStore::on_new_action(etl::handle<synfigapp::Action::Undoable> action)
 {
+ if (!block_new_history){ /*if change isn't due to rapid repeated actions show history normally*/
 	Gtk::TreeRow row;
 
 	row=*insert(next_action_iter);
@@ -218,7 +221,7 @@ HistoryTreeStore::on_new_action(etl::handle<synfigapp::Action::Undoable> action)
 	next_action_iter = row;
 	++next_action_iter;
 
-	signal_undo_tree_changed()();
+	signal_undo_tree_changed()();}
 }
 
 void

--- a/synfig-studio/src/gui/trees/historytreestore.h
+++ b/synfig-studio/src/gui/trees/historytreestore.h
@@ -87,6 +87,8 @@ public:
 
 	const Model model;
 
+	static bool block_new_history;
+
 	/*
  -- ** -- P R I V A T E   D A T A ---------------------------------------------
 	*/

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -53,10 +53,6 @@
 
 #include <synfigapp/actions/layerremove.h>
 #include <synfigapp/instance.h>
-#include <gui/trees/historytreestore.h>
-
-#include <thread>
-#include <chrono>
 
 #endif
 
@@ -129,7 +125,6 @@ LayerTree::LayerTree()
 {
 	layer_tree_view().signal_key_press_event().connect(sigc::mem_fun(*this, &LayerTree::on_key_press_event));
 
-
 	create_layer_tree();
 	create_param_tree();
 
@@ -142,18 +137,9 @@ LayerTree::LayerTree()
 	//param_tree_view().get_selection()->set_mode(Gtk::SELECTION_MULTIPLE);
 	layer_tree_view().show();
 	param_tree_view().show();
-	//gets the selection object at first
-	selected_param_object = param_tree_view().get_selection(); //hbd
-	// getting the selected row
-	iter = selected_param_object->get_selected();
-	row = *iter;
 	param_tree_view().set_has_tooltip();
 	layer_tree_view().set_has_tooltip();
 
-	param_tree_view().signal_motion_notify_event().connect(sigc::mem_fun(*this, &LayerTree::on_motion_notify_event), false);
-	param_tree_view().signal_button_press_event().connect(sigc::mem_fun(*this, &LayerTree::on_button_press_or_release_event), false);
-	param_tree_view().signal_button_release_event().connect(sigc::mem_fun(*this, &LayerTree::on_button_press_or_release_event), false);
-	selected_param_object->signal_changed().connect(sigc::mem_fun(*this, &LayerTree::change_selection_param), false);
 
 	disable_single_click_for_param_editing = false;
 }
@@ -237,98 +223,6 @@ LayerTree::create_layer_tree()
 	layer_tree_view().signal_event().connect(sigc::mem_fun(*this, &studio::LayerTree::on_layer_tree_event));
 	layer_tree_view().signal_query_tooltip().connect(sigc::mem_fun(*this, &studio::LayerTree::on_layer_tree_view_query_tooltip));
 	layer_tree_view().show();
-}
-
-//To Do:move to header
-int first_cord_x ;
-int second_cord_x ;
-float value_float ;
-bool just_finished = false;
-
-bool
-LayerTree::on_motion_notify_event(GdkEventMotion* event)
-{
-
-	if(HistoryTreeStore::block_new_history)
-	{
-
-	second_cord_x= event->x;
-
-	if(iter){ //to make sure there is already a treeview i.e. not empty
-	/*if(row == row_event){*/ //supposedly this is so that this feature only works if you have the needed row selected however something is off
-
-	synfig::ValueBase value_base_mod = row[param_model.value]; //getting the valuebase selected and storing it
-
-	if(value_base_mod.get_type() == type_real){ //this feature so far is only for types real
-
-	//change mouse cursor to indicate the process
-	const char * cursor_name = "move";
-	param_tree_view().get_window()->set_cursor(Gdk::Cursor::create(get_display(), cursor_name));
-
-
-	Value<float> val(value_base_mod); // value object -val- constructed using valuebase as argument
-	value_float = val.get(); //the float which gets data and then sets also
-
-
-	//whether to add or subtract //with the new conditions
-	if(second_cord_x > first_cord_x)
-	value_float += 0.1 ;
-	else if(second_cord_x < first_cord_x)
-	value_float -= 0.1 ;
-
-	//setting the new value
-	value_base_mod.set<float>(value_float);
-	row[param_model.value] = value_base_mod ;
-
-
-	std::this_thread::sleep_for (std::chrono::milliseconds(10));
-	first_cord_x= second_cord_x;
-	value_base = value_base_mod;
-	just_finished = true;
-	}}}
-
-
-	return false;
-}
-
-bool
-LayerTree::on_button_press_or_release_event(GdkEventButton* event)
-{
-	if(event->type == GDK_BUTTON_PRESS ){
-
-		HistoryTreeStore::block_new_history = true ;
-		first_cord_x = event->x;
-	}
-
-
-	if(event->type == GDK_BUTTON_RELEASE)
-	{
-		//change value without history recording i.e while flag is false
-		if(just_finished){std::cout<<std::endl<<"increase"<<std::endl;
-			value_base.set<float>(value_float+(value_float/10000000)); row[param_model.value] = value_base;}
-
-		HistoryTreeStore::block_new_history = false;
-
-		//revert changes to keep last value while having history show it
-		if(just_finished){
-			std::cout<<std::endl<<"revert"<<std::endl;
-		value_base.set<float>(value_float-(value_float/10000000)); row[param_model.value] = value_base;
-		}
-		param_tree_view().get_window()->set_cursor(default_cursor);
-		just_finished = false;
-	}
-
-	return false;
-}
-
-void
-LayerTree::change_selection_param()
-{
-	//gets the selection object at first
-	selected_param_object = param_tree_view().get_selection(); //hbd
-	// getting the selected row
-	iter = selected_param_object->get_selected();
-	row = *iter;
 }
 
 void

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -137,9 +137,9 @@ LayerTree::LayerTree()
 	//param_tree_view().get_selection()->set_mode(Gtk::SELECTION_MULTIPLE);
 	layer_tree_view().show();
 	param_tree_view().show();
+
 	param_tree_view().set_has_tooltip();
 	layer_tree_view().set_has_tooltip();
-
 
 	disable_single_click_for_param_editing = false;
 }

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -436,7 +436,7 @@ Widget_ColorEdit::Widget_ColorEdit():
 		Gtk::Box* box_cast_2 = static_cast<Gtk::Box*>( internal_child_2[0] );
 		std::vector<Widget*> internal_child_3 = box_cast_2->get_children(); //internal_child_3[0] is the color wheel widget
 		internal_child_3[0]->signal_button_release_event().connect([&](GdkEventButton *ev){ was_released=true;on_color_changed();return false;},false);
-		internal_child_3[0]->signal_key_release_event().connect([&](GdkEventButton *ev){ was_released=true;on_color_changed();return false;},false);
+		internal_child_3[0]->signal_key_release_event().connect([&](GdkEventKey *ev){ was_released=true;on_color_changed();return false;},false);
 
 		hvsColorWidget->signal_color_changed().connect(sigc::mem_fun(*this, &studio::Widget_ColorEdit::on_color_changed));
 		//TODO: Anybody knows how to set min size for this widget? I've tried use set_size_request(..). But it doesn't works.

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -436,6 +436,7 @@ Widget_ColorEdit::Widget_ColorEdit():
 		Gtk::Box* box_cast_2 = static_cast<Gtk::Box*>( internal_child_2[0] );
 		std::vector<Widget*> internal_child_3 = box_cast_2->get_children(); //internal_child_3[0] is the color wheel widget
 		internal_child_3[0]->signal_button_release_event().connect([&](GdkEventButton *ev){ was_released=true;on_color_changed();return false;},false);
+		internal_child_3[0]->signal_key_release_event().connect([&](GdkEventButton *ev){ was_released=true;on_color_changed();return false;},false);
 
 		hvsColorWidget->signal_color_changed().connect(sigc::mem_fun(*this, &studio::Widget_ColorEdit::on_color_changed));
 		//TODO: Anybody knows how to set min size for this widget? I've tried use set_size_request(..). But it doesn't works.
@@ -506,7 +507,7 @@ Widget_ColorEdit::on_color_changed()
 	{
 		Gdk::RGBA newColor = hvsColorWidget->get_current_rgba();
 		Color synfigColor;
-		if(was_released){// if there was a button release record this final color in history panel
+		if(was_released){// if there was a button/key release record this final color in history panel
 		HistoryTreeStore::block_new_history=false;
 		Color synfigColorTemp(
 				newColor.get_red()+0.00001,//slight increase doesnt affect colors value but enough to trigger new action signal

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -47,6 +47,7 @@
 #include <gui/exception_guard.h>
 #include <gui/localization.h>
 
+#include <gui/trees/historytreestore.h>
 
 #endif
 
@@ -331,7 +332,7 @@ Widget_ColorEdit::SliderRow(int left, int top, ColorSlider* color_widget, std::s
 	grid->attach(*label,        left,   top, 1, 1);
 	grid->attach(*color_widget, left+1, top, 1, 1);
 }
-
+bool was_released=false;
 void
 Widget_ColorEdit::AttachSpinButton(int left, int top, Gtk::SpinButton *spin_button, Gtk::Grid *grid)
 {
@@ -427,6 +428,15 @@ Widget_ColorEdit::Widget_ColorEdit():
 		//I use Gtk::ColorSelection widget here.
 		hvsColorWidget = manage(new Gtk::ColorSelection());
 		setHVSColor(get_value());
+
+		//navigating to inner implementation color wheel widget
+		std::vector<Widget*> internal_child = hvsColorWidget->get_children();
+		Gtk::Box* box_cast = static_cast<Gtk::Box*>( internal_child[0] );
+		std::vector<Widget*> internal_child_2 = box_cast->get_children();
+		Gtk::Box* box_cast_2 = static_cast<Gtk::Box*>( internal_child_2[0] );
+		std::vector<Widget*> internal_child_3 = box_cast_2->get_children(); //internal_child_3[0] is the color wheel widget
+		internal_child_3[0]->signal_button_release_event().connect([&](GdkEventButton *ev){ was_released=true;on_color_changed();return false;},false);
+
 		hvsColorWidget->signal_color_changed().connect(sigc::mem_fun(*this, &studio::Widget_ColorEdit::on_color_changed));
 		//TODO: Anybody knows how to set min size for this widget? I've tried use set_size_request(..). But it doesn't works.
 		hvs_grid->attach(*(hvsColorWidget), 0, 4, 1, 1);
@@ -495,15 +505,27 @@ Widget_ColorEdit::on_color_changed()
 	if (!colorHVSChanged)
 	{
 		Gdk::RGBA newColor = hvsColorWidget->get_current_rgba();
-		Color synfigColor(
+		Color synfigColor;
+		if(was_released){// if there was a button release record this final color in history panel
+		HistoryTreeStore::block_new_history=false;
+		Color synfigColorTemp(
+				newColor.get_red()+0.00001,//slight increase doesnt affect colors value but enough to trigger new action signal
+				newColor.get_green(),
+				newColor.get_blue() );
+		synfigColor=synfigColorTemp;}
+		else{
+		HistoryTreeStore::block_new_history=true;
+		Color synfigColorTemp(
 			newColor.get_red(),
 			newColor.get_green(),
 			newColor.get_blue() );
+		synfigColor=synfigColorTemp;}
 		synfigColor = App::get_selected_canvas_gamma().apply(synfigColor);
 		set_value(synfigColor);
 		colorHVSChanged = true; //I reset the flag in setHVSColor(..)
 		on_value_changed();
 	}
+	was_released=false;
 }
 
 void


### PR DESCRIPTION
Fixes #451 

Using a flag to know when there are rapid repeated actions (as in here and in #2717 ) then if it's a rapid repeated action only showing in the history panel the very last value.

p.s. I have to go now there is still a small thing left to do for when the color wheel is set using the keys I will do it when im back.