### PR TITLE
fix: synfig studio was not saving synfigapp settings on quit

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1396,6 +1396,7 @@ App::App()
 {
 	add_main_option_entry(Gio::Application::OPTION_TYPE_BOOL, "console", 'c', N_("Opens a console that shows some Synfig Studio output"));
 	signal_handle_local_options().connect(sigc::mem_fun(*this, &App::on_handle_local_options));
+	signal_shutdown().connect(sigc::mem_fun(*this, &App::on_shutdown));
 }
 
 int App::on_handle_local_options(const Glib::RefPtr<Glib::VariantDict> &options)
@@ -1800,7 +1801,8 @@ void App::init(const synfig::String& rootpath)
 
 StateManager* App::get_state_manager() { return state_manager; }
 
-App::~App()
+void
+App::on_shutdown()
 {
 	shutdown_in_progress=true;
 
@@ -1823,8 +1825,6 @@ App::~App()
 
 	main_window->hide();
 
-	delete main_window;
-
 	delete dialog_setup;
 
 	delete dialog_gradient;
@@ -1841,6 +1841,9 @@ App::~App()
 
 	if (sound_render_done) delete sound_render_done;
 	sound_render_done = nullptr;
+	
+	process_all_events();
+	delete main_window;
 }
 
 synfig::String

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -318,6 +318,8 @@ protected:
 	void on_activate() override;
 	void on_open(const type_vec_files& files, const Glib::ustring& hint) override;
 
+	void on_shutdown();
+
 	static void init_icon_themes();
 
 	/*
@@ -326,7 +328,7 @@ protected:
 
 public:
 
-	virtual ~App();
+	virtual ~App() = default;
 
 	/*
  -- ** -- S T A T I C   P U B L I C   M E T H O D S ---------------------------


### PR DESCRIPTION
Steps to reproduce the problem:

1. Select Bline Tool
2. Change a parameter in Tool Options Panel (e.g. Opacity or Line Width)
3. Restart Synfig Studio
4. Select Bline Tool and see the change was not saved.

Reason:
Since #2497, we finally use Gtk::Application as base class for `App`.
`App` is destructed before `MainWindow` is closed (basically at start).
So, stuff done on quitting before merging #2497 was not done on the right time now.

As `signal-shutdown` is only called in primary instance of Gtk::Application,
it's the proper moment to delete and finish stuff on application exit.