### PR TITLE
Shortcut to switch tabs

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1065,12 +1065,15 @@ DEFINE_ACTION("help-about",     Gtk::StockID("synfig-about"))
 // actions: Keyframe
 DEFINE_ACTION("keyframe-properties", _("Properties"))
 
+// tab actions
+DEFINE_ACTION("switch-tab", _("switch stab") )
 
 //Layout the actions in the main menu (caret menu, right click on canvas menu) and toolbar:
 	Glib::ustring ui_info_menu =
 "	<menu action='menu-file'>"
 "		<menuitem action='new' />"
 "		<menuitem action='open' />"
+"		<menuitem action='switch-tab' />"
 "		<menu action='menu-open-recent' />"
 "		<separator name='sep-file1'/>"
 "		<menuitem action='save' />"
@@ -1332,6 +1335,7 @@ App::get_default_accel_map()
 		{"<Control>l",              "<Actions>/canvasview/toggle-grid-snap"},
 		{"<Control>n",              "<Actions>/mainwindow/new"},
 		{"<Control>o",              "<Actions>/mainwindow/open"},
+		{"<Primary>t",              "<Actions>/tab_actions/switch-tab"},
 		{"<Control>s",              "<Actions>/canvasview/save"},
 		{"<Control><Shift>s",       "<Actions>/canvasview/save-as"},
 		{"<Control>e",              "<Actions>/canvasview/save-all"},

--- a/synfig-studio/src/gui/docks/dockbook.h
+++ b/synfig-studio/src/gui/docks/dockbook.h
@@ -81,6 +81,8 @@ public:
 
 	void refresh_tab(Dockable*);
 
+	void on_switch_tab_action();
+
 protected:
 	bool tab_button_pressed(GdkEventButton* event, Dockable* dockable);
 	void on_drag_data_received(const Glib::RefPtr<Gdk::DragContext>& context, int, int, const Gtk::SelectionData& selection_data, guint, guint time);
@@ -91,12 +93,16 @@ protected:
 
 	void set_dock_area_visibility(bool visible, DockBook * source);
 
+	static bool switch_tab_action_initialized;
+	static std::vector<DockBook*> books;
+	static std::vector<Gtk::Widget*> books_widget;
+
 protected:
 	DockDropArea *dock_area;
+
 }; // END of studio::DockBook
 
 }; // END of namespace studio
-
 /* === E N D =============================================================== */
 
 #endif

--- a/synfig-studio/src/gui/docks/dockbook.h
+++ b/synfig-studio/src/gui/docks/dockbook.h
@@ -99,10 +99,10 @@ protected:
 
 protected:
 	DockDropArea *dock_area;
-
 }; // END of studio::DockBook
 
 }; // END of namespace studio
+
 /* === E N D =============================================================== */
 
 #endif


### PR DESCRIPTION
Feature Description: Ctr+t to switch tabs of the dockbook which has focus. Of course the dockbook it self doesn't directly have focus (unless the tab has focus I think if i remember correctly). so basically the dockbook that has focus is the dockbook that has an element that has focus. For example the drawing area in the main window,  the treeview in the parameter panel, anything really.

Now this was supposed to be Ctr+tab but setting the accelerator to be that gives an error 
` warning: Invalid accelerator: <Primary><tab> (for action: <Actions>/tab_actions/switch-tab)`
and also I think Ctr+tab might have been a problem if it actually were it as Ctr+tab is already used for switching focus.

Anyways, best thing about the preference dialog is that the user can set it to whichever they feel their comfortable with so the initial setting here I think is no huge deal.