### PR TITLE
fix: setting filename parameter of Layer Sound corrupts file

### DIFF
--- a/synfig-core/src/synfig/layers/layer_sound.cpp
+++ b/synfig-core/src/synfig/layers/layer_sound.cpp
@@ -81,7 +81,7 @@ Layer_Sound::set_param(const String &param, const ValueBase &value)
 {
 	IMPORT_VALUE_PLUS(param_filename,
 		{
-			param_filename = FileSystem::fix_slashes(value.get(""));
+			param_filename = FileSystem::fix_slashes(value.get(String()));
 		}
 		);
 	IMPORT_VALUE(param_delay);


### PR DESCRIPTION
Fix #2757