### PR TITLE
Add WITHOUT_MLT guard

### DIFF
--- a/synfig-core/src/synfig/soundprocessor.cpp
+++ b/synfig-core/src/synfig/soundprocessor.cpp
@@ -85,7 +85,9 @@ public:
 };
 
 bool SoundProcessor::Internal::initialized = false;
+#ifndef WITHOUT_MLT
 Mlt::Repository* SoundProcessor::Internal::repository = nullptr;
+#endif
 
 SoundProcessor::SoundProcessor()
 {


### PR DESCRIPTION
Encountered this when I rebased my vcpkg build which is without MLT until now.