### PR TITLE
ci: bump macOS version

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -2,7 +2,7 @@
 
 name: Synfig CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -24,14 +24,14 @@ jobs:
         include:
         # includes a new variable of npm with a value of 2
         # for the matrix leg matching the os and version
-        - os: macos-10.15
-          name: MacOS 10.15 Catalina (Autotools)
+        - os: macos-11
+          name: macOS 11 Big Sur (Autotools)
           toolchain: autotools
           allow_failures: false
 #        - os: macos-11.0
-        - os: macos-10.15
+        - os: macos-11
 #          name: MacOS 11.0 Big Sur (CMake+Ninja)
-          name: MacOS 10.15 Catalina (CMake+Ninja)
+          name: macOS 11 Big Sur (CMake+Ninja)
           toolchain: cmake-ninja
           allow_failures: true
         - os: ubuntu-18.04

--- a/.github/workflows/synfig-stable.yml
+++ b/.github/workflows/synfig-stable.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-10.15
-          name: MacOS 10.15 Catalina (Autotools)
+        - os: macos-11
+          name: macOS 11 Big Sur (Autotools)
           toolchain: autotools-release
           allow_failures: false
         - os: ubuntu-18.04


### PR DESCRIPTION
The macOS 10.15 Actions runner image is being deprecated

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/