### PR TITLE
fix: fixed a bug when saving a file to a Windows drive root path and then reusing the file dialog

### DIFF
--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -160,8 +160,6 @@ is_absolute_path(const std::string &path)
 #ifdef _WIN32
 	if(path.size()>=3 && path[1]==':' && is_separator(path[2]))
 		return true;
-	else if(path.size()==2 && path[1] == ':')
-		return true;
 #endif
 	if(!path.empty() && is_separator(path[0]))
 		return true;

--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -129,6 +129,12 @@ dirname(const std::string &str)
 		   return ".";
 	}
 
+#ifdef _WIN32
+	// leaving trailing separator after windows drive name
+	if (std::distance(str.begin(), iter) == 2 && str[1] == ':')
+		iter++;
+#endif
+
 	return std::string(str.begin(),iter);
 }
 

--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -132,7 +132,7 @@ dirname(const std::string &str)
 #ifdef _WIN32
 	// leave the trailing separator after windows drive name
 	if (std::distance(str.begin(), iter) == 2 && str.size() >= 3 && str[1] == ':' && is_separator(str[2]))
-		iter++;
+		++iter;
 #endif
 
 	return std::string(str.begin(),iter);

--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -160,6 +160,8 @@ is_absolute_path(const std::string &path)
 #ifdef _WIN32
 	if(path.size()>=3 && path[1]==':' && is_separator(path[2]))
 		return true;
+	else if(path.size()==2 && path[1] == ':')
+		return true;
 #endif
 	if(!path.empty() && is_separator(path[0]))
 		return true;

--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -130,8 +130,8 @@ dirname(const std::string &str)
 	}
 
 #ifdef _WIN32
-	// leaving trailing separator after windows drive name
-	if (std::distance(str.begin(), iter) == 2 && str[1] == ':')
+	// leave the trailing separator after windows drive name
+	if (std::distance(str.begin(), iter) == 2 && str.size() >= 3 && str[1] == ':' && is_separator(str[2]))
 		iter++;
 #endif
 


### PR DESCRIPTION
`is_absolute_path` returns false with directories like `E:`. The following test will fail for example:
```
std::string file = "E:/file.sifz";
std::string file_dir = dirname(file_dir) // file_dir = E:
assert(is_absolute_path(file_dir) == true);
```
I encountered this on Windows where I save a sifz file as `E:/Synfig Animation 1.sifz`, which will cause synfig to record the most recent directory to `E:` in `settings-1.4` file as
```
pref.animation_dir=E:
```
Now if I try to open a file I get an error:
![Untitled](https://user-images.githubusercontent.com/101147828/180270971-8b89f32a-7465-44d0-b736-21bc0914751f.png)

