### PR TITLE
fix: fixed broken synfig.dll debugging in MSVC build

### DIFF
--- a/synfig-core/src/modules/lyr_freetype/CMakeLists.txt
+++ b/synfig-core/src/modules/lyr_freetype/CMakeLists.txt
@@ -17,7 +17,7 @@ if (FRIBIDI_STATIC_LIBRARIES)
 	target_compile_definitions(lyr_freetype PRIVATE -DFRIBIDI_LIB_STATIC)
 endif()
 
-target_link_libraries(lyr_freetype synfig
+target_link_libraries(lyr_freetype libsynfig
 	PkgConfig::FREETYPE2
 	PkgConfig::FRIBIDI
 )

--- a/synfig-core/src/modules/lyr_std/CMakeLists.txt
+++ b/synfig-core/src/modules/lyr_std/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(lyr_std MODULE
         "${CMAKE_CURRENT_LIST_DIR}/zoom.cpp"
 )
 
-target_link_libraries(lyr_std synfig)
+target_link_libraries(lyr_std libsynfig)
 
 install (
     TARGETS lyr_std

--- a/synfig-core/src/modules/mod_bmp/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_bmp/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_bmp MODULE
         "${CMAKE_CURRENT_LIST_DIR}/trgt_bmp.cpp"
 )
 
-target_link_libraries(mod_bmp synfig)
+target_link_libraries(mod_bmp libsynfig)
 
 install (
     TARGETS mod_bmp

--- a/synfig-core/src/modules/mod_dv/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_dv/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(mod_dv MODULE
         "${CMAKE_CURRENT_LIST_DIR}/trgt_dv.cpp"
 )
 
-target_link_libraries(mod_dv synfig)
+target_link_libraries(mod_dv libsynfig)
 
 install (
     TARGETS mod_dv

--- a/synfig-core/src/modules/mod_example/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_example/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_example MODULE
         "${CMAKE_CURRENT_LIST_DIR}/simplecircle.cpp"
 )
 
-target_link_libraries(mod_example synfig)
+target_link_libraries(mod_example libsynfig)
 
 install (
     TARGETS mod_example

--- a/synfig-core/src/modules/mod_ffmpeg/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_ffmpeg/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_ffmpeg MODULE
         "${CMAKE_CURRENT_LIST_DIR}/mptr_ffmpeg.cpp"
 )
 
-target_link_libraries(mod_ffmpeg synfig)
+target_link_libraries(mod_ffmpeg libsynfig)
 
 install (
     TARGETS mod_ffmpeg

--- a/synfig-core/src/modules/mod_filter/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_filter/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(mod_filter MODULE
         "${CMAKE_CURRENT_LIST_DIR}/radialblur.cpp"
 )
 
-target_link_libraries(mod_filter synfig)
+target_link_libraries(mod_filter libsynfig)
 
 install (
     TARGETS mod_filter

--- a/synfig-core/src/modules/mod_geometry/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_geometry/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(mod_geometry MODULE
         "${CMAKE_CURRENT_LIST_DIR}/star.cpp"
 )
 
-target_link_libraries(mod_geometry synfig)
+target_link_libraries(mod_geometry libsynfig)
 
 install (
     TARGETS mod_geometry

--- a/synfig-core/src/modules/mod_gif/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_gif/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(mod_gif MODULE
         "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
 )
 
-target_link_libraries(mod_gif synfig)
+target_link_libraries(mod_gif libsynfig)
 
 install (
     TARGETS mod_gif

--- a/synfig-core/src/modules/mod_gradient/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_gradient/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(mod_gradient MODULE
         "${CMAKE_CURRENT_LIST_DIR}/spiralgradient.cpp"
 )
 
-target_link_libraries(mod_gradient synfig)
+target_link_libraries(mod_gradient libsynfig)
 
 install (
     TARGETS mod_gradient

--- a/synfig-core/src/modules/mod_imagemagick/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_imagemagick/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_imagemagick MODULE
         "${CMAKE_CURRENT_LIST_DIR}/trgt_imagemagick.cpp"
 )
 
-target_link_libraries(mod_imagemagick synfig)
+target_link_libraries(mod_imagemagick libsynfig)
 
 install (
     TARGETS mod_imagemagick

--- a/synfig-core/src/modules/mod_jpeg/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_jpeg/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_jpeg MODULE
         "${CMAKE_CURRENT_LIST_DIR}/trgt_jpeg.cpp"
 )
 
-target_link_libraries(mod_jpeg synfig PkgConfig::LIBJPEG)
+target_link_libraries(mod_jpeg libsynfig PkgConfig::LIBJPEG)
 
 install (
     TARGETS mod_jpeg

--- a/synfig-core/src/modules/mod_libavcodec/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_libavcodec/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(mod_libavcodec
         "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
 )
 
-target_link_libraries(mod_libavcodec PUBLIC synfig PkgConfig::LIBAVFORMAT)
+target_link_libraries(mod_libavcodec PUBLIC libsynfig PkgConfig::LIBAVFORMAT)
 target_compile_definitions(mod_libavcodec PRIVATE HAVE_LIBAVFORMAT_AVFORMAT_H HAVE_LIBSWSCALE_SWSCALE_H)
 
 install (

--- a/synfig-core/src/modules/mod_magickpp/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_magickpp/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_magickpp MODULE
 )
 
 target_compile_options(mod_magickpp PRIVATE ${MAGICKCORE_CFLAGS})
-target_link_libraries(mod_magickpp synfig ${MAGICKCORE_LINK_LIBRARIES} ${ImageMagick_LIBRARIES})
+target_link_libraries(mod_magickpp libsynfig ${MAGICKCORE_LINK_LIBRARIES} ${ImageMagick_LIBRARIES})
 
 install (
     TARGETS mod_magickpp

--- a/synfig-core/src/modules/mod_mng/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_mng/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(mod_mng MODULE
         "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
 )
 
-target_link_libraries(mod_mng PRIVATE synfig PkgConfig::LIBMNG)
+target_link_libraries(mod_mng PRIVATE libsynfig PkgConfig::LIBMNG)
 
 install (
     TARGETS mod_mng

--- a/synfig-core/src/modules/mod_noise/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_noise/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(mod_noise MODULE
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_random.cpp"
 )
 
-target_link_libraries(mod_noise PRIVATE synfig)
+target_link_libraries(mod_noise PRIVATE libsynfig)
 
 install (
     TARGETS mod_noise

--- a/synfig-core/src/modules/mod_openexr/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_openexr/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(mod_openexr MODULE
 )
 
 message(STATUS "OpenEXR include: ${OPENEXR_INCLUDE_DIRS}")
-target_link_libraries(mod_openexr PRIVATE synfig PkgConfig::OPENEXR)
+target_link_libraries(mod_openexr PRIVATE libsynfig PkgConfig::OPENEXR)
 
 install (
     TARGETS mod_openexr

--- a/synfig-core/src/modules/mod_particle/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_particle/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_particle MODULE
         "${CMAKE_CURRENT_LIST_DIR}/plant.cpp"
 )
 
-target_link_libraries(mod_particle synfig)
+target_link_libraries(mod_particle libsynfig)
 
 install (
     TARGETS mod_particle

--- a/synfig-core/src/modules/mod_png/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_png/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(mod_png MODULE
         "${CMAKE_CURRENT_LIST_DIR}/trgt_png.cpp"
 )
 
-target_link_libraries(mod_png synfig PkgConfig::LIBPNG)
+target_link_libraries(mod_png libsynfig PkgConfig::LIBPNG)
 
 install (
     TARGETS mod_png

--- a/synfig-core/src/modules/mod_ppm/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_ppm/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_ppm MODULE
         "${CMAKE_CURRENT_LIST_DIR}/mptr_ppm.cpp"
 )
 
-target_link_libraries(mod_ppm synfig)
+target_link_libraries(mod_ppm libsynfig)
 
 install (
     TARGETS mod_ppm

--- a/synfig-core/src/modules/mod_svg/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_svg/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mod_svg MODULE
         "${CMAKE_CURRENT_LIST_DIR}/svg_parser.cpp"
 )
 
-target_link_libraries(mod_svg PRIVATE synfig)
+target_link_libraries(mod_svg PRIVATE libsynfig)
 
 install (
     TARGETS mod_svg

--- a/synfig-core/src/modules/mod_yuv420p/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_yuv420p/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(mod_yuv420p MODULE
         "${CMAKE_CURRENT_LIST_DIR}/trgt_yuv.cpp"
 )
 
-target_link_libraries(mod_yuv420p synfig)
+target_link_libraries(mod_yuv420p libsynfig)
 
 install (
     TARGETS mod_yuv420p

--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -4,7 +4,8 @@
 
 ## Main target: libsynfig
 ## TODO: optional static linking?
-add_library(synfig SHARED "")
+add_library(libsynfig SHARED "")
+set_target_properties(libsynfig PROPERTIES PREFIX "")
 
 add_definitions(-DVERSION="${STUDIO_VERSION_MAJOR}.${STUDIO_VERSION_MINOR}.${STUDIO_VERSION_PATCH}")
 
@@ -24,9 +25,9 @@ else()
     set(LTDL_LIBRARIES ltdl)
 endif()
 
-target_include_directories(synfig PUBLIC ${LTDL_INCLUDE_DIRS})
+target_include_directories(libsynfig PUBLIC ${LTDL_INCLUDE_DIRS})
 
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/activepoint.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/bone.cpp"
@@ -81,17 +82,17 @@ target_sources(synfig
 
 ## these were added seprately in autotools build, preserving this for now
 ## TODO: either merge with main list or create new target
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/target_multi.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/target_scanline.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/target_tile.cpp"
 )
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/listimporter.cpp"
 )
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/blinepoint.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/widthpoint.cpp"
@@ -115,7 +116,7 @@ include(valuenodes/CMakeLists.txt)
 ## TODO: check if we need this for release build
 include(debug/CMakeLists.txt)
 
-target_link_libraries(synfig PUBLIC
+target_link_libraries(libsynfig PUBLIC
 	PkgConfig::SIGCPP
 	PkgConfig::GLIBMM
 	PkgConfig::GIOMM
@@ -127,7 +128,7 @@ target_link_libraries(synfig PUBLIC
 )
 
 if (MLT_FOUND)
-	target_link_libraries(synfig PUBLIC PkgConfig::MLT)
+	target_link_libraries(libsynfig PUBLIC PkgConfig::MLT)
 endif ()
 
 ## Install headers
@@ -140,18 +141,18 @@ install(
 )
 
 install(
-    TARGETS synfig
-    EXPORT synfig
+    TARGETS libsynfig
+    EXPORT libsynfig
     LIBRARY DESTINATION lib
 )
 
 export(
-    EXPORT synfig
+    EXPORT libsynfig
     FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
 )
 
 install(
-    EXPORT synfig
+    EXPORT libsynfig
     FILE "${PROJECT_NAME}-config.cmake"
     DESTINATION "lib/cmake/${PROJECT_NAME}"
 )

--- a/synfig-core/src/synfig/color/CMakeLists.txt
+++ b/synfig-core/src/synfig/color/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/color.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/colormatrix.cpp"

--- a/synfig-core/src/synfig/debug/CMakeLists.txt
+++ b/synfig-core/src/synfig/debug/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/debugsurface.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/log.cpp"

--- a/synfig-core/src/synfig/layers/CMakeLists.txt
+++ b/synfig-core/src/synfig/layers/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/layer_bitmap.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layer_composite.cpp"

--- a/synfig-core/src/synfig/rendering/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/optimizer.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer.cpp"

--- a/synfig-core/src/synfig/rendering/common/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/surfacefile.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/surfacememoryreadwrapper.cpp"

--- a/synfig-core/src/synfig/rendering/common/optimizer/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/common/optimizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/optimizerblendassociative.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/optimizerblendmerge.cpp"

--- a/synfig-core/src/synfig/rendering/common/task/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/common/task/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/taskblend.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/taskblur.cpp"

--- a/synfig-core/src/synfig/rendering/primitive/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/primitive/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/bend.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/contour.cpp"

--- a/synfig-core/src/synfig/rendering/software/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/software/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/rendererdraftsw.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/rendererlowressw.cpp"

--- a/synfig-core/src/synfig/rendering/software/function/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/software/function/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/blur.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/blur_iir_coefficients.cpp"

--- a/synfig-core/src/synfig/rendering/software/task/CMakeLists.txt
+++ b/synfig-core/src/synfig/rendering/software/task/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/taskblendsw.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/taskblursw.cpp"

--- a/synfig-core/src/synfig/synfig_export.h
+++ b/synfig-core/src/synfig/synfig_export.h
@@ -27,7 +27,7 @@
 
 #ifdef _MSC_VER
 // We need this export only for MSVC. Even on MinGW, it breaks linkning.
-#ifdef synfig_EXPORTS
+#ifdef libsynfig_EXPORTS
 /* We are building this library */
 #define SYNFIG_EXPORT __declspec(dllexport)
 #else

--- a/synfig-core/src/synfig/valuenodes/CMakeLists.txt
+++ b/synfig-core/src/synfig/valuenodes/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(synfig
+target_sources(libsynfig
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_add.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_and.cpp"
@@ -70,7 +70,7 @@ target_sources(synfig
 )
 
 file(GLOB VALUENODES_HEADERS "${CMAKE_CURRENT_LIST_DIR}/*.h")
-target_include_directories(synfig PRIVATE ${Boost_INCLUDE_DIRS})
+target_include_directories(libsynfig PRIVATE ${Boost_INCLUDE_DIRS})
 
 install(
     FILES ${VALUENODES_HEADERS}

--- a/synfig-core/src/tool/CMakeLists.txt
+++ b/synfig-core/src/tool/CMakeLists.txt
@@ -18,7 +18,7 @@ target_sources(synfig_bin
         "${CMAKE_CURRENT_LIST_DIR}/renderprogress.cpp"
 )
 
-target_link_libraries(synfig_bin PRIVATE synfig)
+target_link_libraries(synfig_bin PRIVATE libsynfig)
 if(TCMALLOC_LIBRARY)
     target_link_libraries(synfig_bin PRIVATE ${TCMALLOC_LIBRARY})
 endif()

--- a/synfig-core/test/CMakeLists.txt
+++ b/synfig-core/test/CMakeLists.txt
@@ -2,35 +2,35 @@
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
 add_executable(test_synfig_angle angle.cpp)
-target_link_libraries(test_synfig_angle PRIVATE synfig)
+target_link_libraries(test_synfig_angle PRIVATE libsynfig)
 add_test(NAME test_synfig_angle COMMAND test_synfig_angle)
 
 add_executable(test_synfig_benchmark benchmark.cpp)
-target_link_libraries(test_synfig_benchmark PRIVATE synfig)
+target_link_libraries(test_synfig_benchmark PRIVATE libsynfig)
 add_test(NAME test_synfig_benchmark COMMAND test_synfig_benchmark)
 
 add_executable(test_synfig_bline bline.cpp)
-target_link_libraries(test_synfig_bline PRIVATE synfig)
+target_link_libraries(test_synfig_bline PRIVATE libsynfig)
 add_test(NAME test_synfig_bline COMMAND test_synfig_bline)
 
 add_executable(test_synfig_bone bone.cpp)
-target_link_libraries(test_synfig_bone PRIVATE synfig)
+target_link_libraries(test_synfig_bone PRIVATE libsynfig)
 add_test(NAME test_synfig_bone COMMAND test_synfig_bone)
 
 add_executable(test_synfig_clock clock.cpp)
-target_link_libraries(test_synfig_clock PRIVATE synfig)
+target_link_libraries(test_synfig_clock PRIVATE libsynfig)
 add_test(NAME test_synfig_clock COMMAND test_synfig_clock)
 
 add_executable(test_synfig_keyframe keyframe.cpp)
-target_link_libraries(test_synfig_keyframe PRIVATE synfig)
+target_link_libraries(test_synfig_keyframe PRIVATE libsynfig)
 add_test(NAME test_synfig_keyframe COMMAND test_synfig_keyframe)
 
 add_executable(test_synfig_node node.cpp)
-target_link_libraries(test_synfig_node PRIVATE synfig)
+target_link_libraries(test_synfig_node PRIVATE libsynfig)
 add_test(NAME test_synfig_node COMMAND test_synfig_node)
 
 add_executable(test_synfig_string string.cpp)
-target_link_libraries(test_synfig_string PRIVATE synfig)
+target_link_libraries(test_synfig_string PRIVATE libsynfig)
 add_test(NAME test_synfig_string COMMAND test_synfig_string)
 
 set_target_properties(

--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -86,7 +86,7 @@ add_subdirectory(resources)
 target_link_libraries(synfigstudio PRIVATE
 	PkgConfig::GTKMM3
 	PkgConfig::XMLPP
-	synfig
+	libsynfig
 	synfigapp
 )
 

--- a/synfig-studio/src/synfigapp/CMakeLists.txt
+++ b/synfig-studio/src/synfigapp/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(synfigapp
         "${CMAKE_CURRENT_LIST_DIR}/value_desc.cpp"
 )
 
-target_link_libraries(synfigapp synfig)
+target_link_libraries(synfigapp libsynfig)
 
 include(actions/CMakeLists.txt)
 include(vectorizer/CMakeLists.txt)


### PR DESCRIPTION
While testing the Synfig MSVC build, I noticed that debugging of
functions located in the synfig.dll library does not work.

Visual Studio shows that this is happening because the pdb file
(with debug information) cannot be loaded. 

![Screenshot_42](https://user-images.githubusercontent.com/5604544/180916135-583a9dcf-847a-4f8e-8473-b0cf0c316ba1.png)

Attempting to load this file manually gives a strange error message:
"No matching symbol file found in this folder."

![Screenshot_43](https://user-images.githubusercontent.com/5604544/180916138-8cbc2583-82d3-4f23-b8e0-45e01daef4fa.png)

However, if we rebuild the synfig target, then everything started working.

This is happens because the synfig library (synfig.dll) and the
synfig executable (synfig.exe) have the same name and located
in the same directory (bin on Windows).

There are several solutions here:
1) Change the name of the `synfig` executable to something else like `synfig-cli`.

2) Set different output path for library pdb file:
```
set_target_properties(synfig PROPERTIES PDB_OUTPUT_DIRECTORY "lib")
```

3) Rename target in CMake from `synfig` to `libsynfig`

I prefer the last solution, but I'm not sure which one is better.

Your opinion?