### PR TITLE
feat: Added support for copying/pasting waypoints

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -340,7 +340,8 @@ really_delete_widget(Gtk::Widget *widget)
 // so schedule the real delete to happen in 50ms, giving the action a chance to run
 void
 studio::delete_widget(Gtk::Widget *widget)
-{
+{	std::cout<<std::endl<<"delted"<<std::endl;
+	App::get_selected_canvas_view()->menu_present=false;
 	Glib::signal_timeout().connect(sigc::bind(sigc::ptr_fun(&really_delete_widget), widget), 50);
 }
 

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -383,6 +383,10 @@ private:
 	bool ducks_rebuild_requested;
 	bool ducks_rebuild_queue_requested;
 
+	std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoints_copied;
+	etl::loose_handle<synfigapp::CanvasInterface> canvas_interface_copied;
+
+
 	/*
  -- ** -- P U B L I C   D A T A -----------------------------------------------
 	*/
@@ -390,6 +394,8 @@ private:
 public:
 	void queue_rebuild_ducks();
 	sigc::signal<void>& signal_deleted() { return signal_deleted_; }
+	bool menu_present = false;//remove
+	bool waypoint_copied=false;
 
 private:
 	//! This is for the IsWorking class.
@@ -642,6 +648,10 @@ public:
 	void import_sequence();
 
 	void on_waypoint_clicked_canvasview(synfigapp::ValueDesc,std::set<synfig::Waypoint,std::less<synfig::UniqueID> >, int button);
+
+	void copy_waypoints(std::set<synfig::Waypoint, std::less<synfig::UniqueID> > waypoints, etl::loose_handle<synfigapp::CanvasInterface> canvas_interface);
+
+	void paste_waypoints(synfig::Time time);
 
 	void preview_option() {on_preview_option();}
 

--- a/synfig-studio/src/gui/widgets/widget_timeslider.h
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.h
@@ -80,6 +80,7 @@ public:
 	~Widget_Timeslider();
 
 	const etl::handle<TimeModel>& get_time_model() const;
+	TimePlotData* get_time_plot_data(){return time_plot_data; }
 	void set_time_model(const etl::handle<TimeModel> &x);
 };
 

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -1172,6 +1172,29 @@ CanvasInterface::waypoint_duplicate(ValueNode::Handle value_node,synfig::Waypoin
 }
 
 void
+CanvasInterface::waypoint_paste(synfig::ValueNode::Handle value_node, synfig::Waypoint waypoint, synfig::Time time)//sent here first and seems that everything is also done here, basically the whole thing is done throuh actions
+{
+	Action::Handle 	action(Action::create("WaypointSetSmart"));
+
+	assert(action);
+	if(!action)
+		return;
+
+	waypoint.make_unique();
+	waypoint.set_time(time);//time not this
+
+	action->set_param("canvas",get_canvas());
+	action->set_param("canvas_interface",etl::loose_handle<CanvasInterface>(this));
+	action->set_param("waypoint",waypoint);
+	action->set_param("time",time);
+	action->set_param("value_node",value_node);
+
+	if(!get_instance()->perform_action(action))
+		get_ui_interface()->error(_("Action Failed."));
+}
+
+
+void
 CanvasInterface::waypoint_remove(synfigapp::ValueDesc value_desc,synfig::Waypoint waypoint)
 {
 	//ValueNode::Handle value_node();

--- a/synfig-studio/src/synfigapp/canvasinterface.h
+++ b/synfig-studio/src/synfigapp/canvasinterface.h
@@ -344,6 +344,8 @@ public:
 	void waypoint_remove(synfigapp::ValueDesc value_desc,synfig::Waypoint waypoint);
 	void waypoint_remove(synfig::ValueNode::Handle value_node,synfig::Waypoint waypoint);
 
+	void waypoint_paste(synfig::ValueNode::Handle value_node,synfig::Waypoint waypoint,synfig::Time time);
+
 	bool change_value(synfigapp::ValueDesc value_desc,synfig::ValueBase new_value,bool lock_animation = false);
 	bool change_value_at_time(synfigapp::ValueDesc value_desc,synfig::ValueBase new_value,const synfig::Time &time,bool lock_animation = false);
 


### PR DESCRIPTION
Work in progress... but the basic functionality for copying/pasting one waypoint entity should be done by today hopefully, then I will be looking to allow copying/pasting multiple waypoints, which would most likely involve using the get_selected() method of the select drag helper and then iterating through the selected waypoints so theoretically it shouldn't take much time when the functionality for one waypoint is working correctly.