### PR TITLE
refactor!: remove etl::unix_to_local()

### DIFF
--- a/ETL/ETL/_stringf.h
+++ b/ETL/ETL/_stringf.h
@@ -173,27 +173,6 @@ is_absolute_path(const std::string &path)
 }
 
 inline std::string
-unix_to_local_path(const std::string &path)
-{
-	std::string ret;
-	std::string::const_iterator iter;
-	for(iter=path.begin();iter!=path.end();iter++)
-		if (is_separator(*iter))
-			ret+=ETL_DIRECTORY_SEPARATOR;
-		else
-		switch(*iter)
-		{
-		case '~':
-			ret+='~';
-			break;
-		default:
-			ret+=*iter;
-			break;
-		}
-	return ret;
-}
-
-inline std::string
 current_working_directory() {
 	return Glib::get_current_dir();
 }

--- a/ETL/test/stringf.cpp
+++ b/ETL/test/stringf.cpp
@@ -40,23 +40,23 @@ int base_and_dir_name_test(void)
 {
 	int ret=0;
 
-	std::string str(unix_to_local_path("/usr/bin/bleh.exe"));
+	std::string str("/usr/bin/bleh.exe");
 	std::cout<<"Test Case 1 -> "<<str<<std::endl;
 	std::cout<<"basename -> "<<basename(str)<<std::endl;
 	if(basename(str)!="bleh.exe")
 		std::cerr<<"error:Bad basename"<<std::endl,ret++;
 	std::cout<<"dirname -> "<<dirname(str)<<std::endl;
-	if(dirname(str)!=unix_to_local_path("/usr/bin"))
+	if(dirname(str)!="/usr/bin")
 		std::cerr<<"error:Bad dirname"<<std::endl,ret++;
 	std::cout<<std::endl;
 
-	str=unix_to_local_path("/usr/bin/");
+	str="/usr/bin/";
 	std::cout<<"Test Case 2 -> "<<str<<std::endl;
 	std::cout<<"basename -> "<<basename(str)<<std::endl;
 	if(basename(str)!="bin")
 		std::cerr<<"error:Bad basename"<<std::endl,ret++;
 	std::cout<<"dirname -> "<<dirname(str)<<std::endl;
-	if(dirname(str)!=unix_to_local_path("/usr"))
+	if(dirname(str)!="/usr")
 		std::cerr<<"error:Bad dirname"<<std::endl,ret++;
 	std::cout<<std::endl;
 
@@ -66,7 +66,7 @@ int base_and_dir_name_test(void)
 	if(basename(str)!="bleh.exe")
 		std::cerr<<"error:Bad basename"<<std::endl,ret++;
 	std::cout<<"dirname -> "<<dirname(str)<<std::endl;
-	if(dirname(str)!=unix_to_local_path("."))
+	if(dirname(str)!=".")
 		std::cerr<<"error:Bad dirname"<<std::endl,ret++;
 	std::cout<<std::endl;
 
@@ -77,35 +77,35 @@ int relative_path_test()
 {
 	int ret=0;
 
-	std::string curr_path=unix_to_local_path("/usr/local/bin/.");
-	std::string dest_path=unix_to_local_path("/usr/share");
+	std::string curr_path="/usr/local/bin/.";
+	std::string dest_path="/usr/share";
 
 	std::cout<<"curr_path="<<curr_path<<" dest_path="<<dest_path<<std::endl;
 	std::cout<<"relative_path="<<relative_path(curr_path,dest_path)<<std::endl;
-	if(relative_path(curr_path,dest_path)!=unix_to_local_path("../../share"))
+	if(relative_path(curr_path,dest_path)!="../../share")
 		std::cerr<<"Bad relative path"<<std::endl,ret++;
 
 	std::cout<<std::endl;
 
-	curr_path=unix_to_local_path("/home/darco/projects/voria");
-	dest_path=unix_to_local_path("/home/darco/projects/voria/myfile.txt");
+	curr_path="/home/darco/projects/voria";
+	dest_path="/home/darco/projects/voria/myfile.txt";
 	std::cout<<"curr_path="<<curr_path<<" dest_path="<<dest_path<<std::endl;
 	std::cout<<"relative_path="<<relative_path(curr_path,dest_path)<<std::endl;
-	if(relative_path(curr_path,dest_path)!=unix_to_local_path("myfile.txt"))
+	if(relative_path(curr_path,dest_path)!="myfile.txt")
 		std::cerr<<"Bad relative path"<<std::endl,ret++;
 
 	std::cout<<std::endl;
 
-	curr_path=unix_to_local_path("/home/darco/projects/voria");
-	dest_path=unix_to_local_path("/home/darco/projects/voria/files/myfile.txt");
+	curr_path="/home/darco/projects/voria";
+	dest_path="/home/darco/projects/voria/files/myfile.txt";
 	std::cout<<"curr_path="<<curr_path<<" dest_path="<<dest_path<<std::endl;
 	std::cout<<"relative_path="<<relative_path(curr_path,dest_path)<<std::endl;
-	if(relative_path(curr_path,dest_path)!=unix_to_local_path("files/myfile.txt"))
+	if(relative_path(curr_path,dest_path)!="files/myfile.txt")
 		std::cerr<<"Bad relative path"<<std::endl,ret++;
 
 	std::cout<<std::endl;
 
-	curr_path=unix_to_local_path("/usr/local/../include/sys/../linux/linux.h");
+	curr_path="/usr/local/../include/sys/../linux/linux.h";
 	std::cout<<"dirty_path="<<curr_path<<std::endl;
 	std::cout<<"clean_path="<<cleanup_path(curr_path)<<std::endl;
 

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -754,7 +754,7 @@ Canvas::surefind_canvas(const String &id, String &warnings)
 		String file_name(id,0,id.find_first_of('#'));
 		String external_id(id,id.find_first_of('#')+1);
 
-		file_name=unix_to_local_path(file_name);
+		file_name=FileSystem::fix_slashes(file_name);
 
 		Canvas::Handle external_canvas;
 
@@ -843,7 +843,7 @@ Canvas::find_canvas(const String &id, String &warnings)const
 		String file_name(id,0,id.find_first_of('#'));
 		String external_id(id,id.find_first_of('#')+1);
 
-		file_name=unix_to_local_path(file_name);
+		file_name=FileSystem::fix_slashes(file_name);
 
 		Canvas::Handle external_canvas;
 


### PR DESCRIPTION
This method only changed backslashes to regular slashes

BREAKING CHANGE: ETL API changed:
- removed etl::unix_to_local();
   use synfig::FileSystem::fix_slashes() instead