### PR TITLE
fix!: mod_imagemagick didn't import anything

### DIFF
--- a/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
@@ -111,11 +111,13 @@ imagemagick_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &re
 
 	bool is_temporary_file = false;
 	std::string filename=identifier.file_system->get_real_filename(identifier.filename);
-	std::string target_filename=FileSystemTemporary::generate_system_temporary_filename("imagemagick");
+	std::string target_filename=FileSystemTemporary::generate_system_temporary_filename("imagemagick", ".png");
+
+	std::string filename_extension = etl::filename_extension(identifier.filename);
 
 	if (filename.empty()) {
 		is_temporary_file = true;
-		filename = FileSystemTemporary::generate_system_temporary_filename("imagemagick");
+		filename = FileSystemTemporary::generate_system_temporary_filename("imagemagick", filename_extension);
 
 		// try to copy file to a temp file
 		if (!FileSystem::copy(identifier.file_system, identifier.filename, identifier.file_system, filename))

--- a/synfig-core/src/synfig/filesystemtemporary.cpp
+++ b/synfig-core/src/synfig/filesystemtemporary.cpp
@@ -89,9 +89,9 @@ FileSystemTemporary::get_system_temporary_directory()
 }
 
 String
-FileSystemTemporary::generate_temporary_filename_base(const String &tag)
+FileSystemTemporary::generate_temporary_filename_base(const String &tag, const String &extension)
 {
-    return "synfig_" + tag + "_" + GUID().get_string();
+	return "synfig_" + tag + "_" + GUID().get_string() + (extension.size() && extension[0] != '.' ? "." : "") + extension;
 }
 
 bool
@@ -112,9 +112,9 @@ FileSystemTemporary::scan_temporary_directory(const String &tag, FileList &out_f
 }
 
 String
-FileSystemTemporary::generate_system_temporary_filename(const String &tag)
+FileSystemTemporary::generate_system_temporary_filename(const String &tag, const String &extension)
 {
-    return get_system_temporary_directory() + ETL_DIRECTORY_SEPARATOR + generate_temporary_filename_base(tag);
+	return get_system_temporary_directory() + ETL_DIRECTORY_SEPARATOR + generate_temporary_filename_base(tag, extension);
 }
 
 bool

--- a/synfig-core/src/synfig/filesystemtemporary.h
+++ b/synfig-core/src/synfig/filesystemtemporary.h
@@ -140,8 +140,8 @@ namespace synfig
 		bool open_temporary(const String &filename);
 
 		static String get_system_temporary_directory();
-		static String generate_temporary_filename_base(const String &tag);
-		static String generate_system_temporary_filename(const String &tag);
+		static String generate_temporary_filename_base(const String &tag, const String &extension = String());
+		static String generate_system_temporary_filename(const String &tag, const String &extension = String());
 		static String generate_indexed_temporary_filename(const FileSystem::Handle &fs, const String &filename);
 		static bool scan_temporary_directory(const String &tag, FileList &out_files, const String &dirname = String());
 	};


### PR DESCRIPTION
it uses application name "convert" to convert the desired image
into another temporary one with a well-known format (PNG).
This temporary image would then be really imported
(via another module - not very clever; what if it is not loaded?)

The problem is the temporary file is automatically named without any
extension.
In the end, Synfig can't load it, as it depends on the extension to select
the Importer.

Tested with a XPM file because XPM seems to be only loaded by imagemagick
https://filesamples.com/formats/xpm

BREAKING CHANGE: Synfig library API changed:
- Two methods of FileSystemTemporary has a new optional parameter: extension:
 - generate_system_temporary_filename
 - generate_system_temporary_filename_base