### PR TITLE
ci: disabled `mod_magickpp` in macOS builds

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -85,7 +85,7 @@ jobs:
         if: matrix.toolchain == 'cmake-ninja'
         run: |
           mkdir build-cmake && cd build-cmake
-          cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release ..
+          cmake -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release -DWITHOUT_MAGICPP=ON ..
           ninja
 
       - name: Build (Autotools+Make)


### PR DESCRIPTION
fix #2787