### PR TITLE
build: remove nonexistent files listed in synfig-core/po/POTFILES.in

### DIFF
--- a/synfig-core/po/POTFILES.in
+++ b/synfig-core/po/POTFILES.in
@@ -293,9 +293,7 @@ src/synfig/target.cpp
 src/synfig/target.h
 src/synfig/target_multi.cpp
 src/synfig/target_multi.h
-src/synfig/target_null.cpp
 src/synfig/target_null.h
-src/synfig/target_null_tile.cpp
 src/synfig/target_null_tile.h
 src/synfig/target_scanline.cpp
 src/synfig/target_scanline.h


### PR DESCRIPTION
they were removed in c67b5d3f34eb8413dc9d2fcb0f657a2f743174a0
(PR #2775)