### PR TITLE
chore: fix various typos

### DIFF
--- a/ETL/ChangeLog.old
+++ b/ETL/ChangeLog.old
@@ -22,7 +22,7 @@
 
   * Fix initialization of accumulator_type.
   * Fixed 'unused variable warnings' (cleaning output)
-  * Fixed error preventing builing on gcc 8.1
+  * Fixed error preventing building on gcc 8.1
   * A lot of warnings fixed
   * Added bootstrap.sh
 

--- a/ETL/NEWS
+++ b/ETL/NEWS
@@ -29,7 +29,7 @@
 
   * Fix initialization of accumulator_type.
   * Fixed 'unused variable warnings' (cleaning output)
-  * Fixed error preventing builing on gcc 8.1
+  * Fixed error preventing building on gcc 8.1
   * A lot of warnings fixed
   * Added bootstrap.sh
 

--- a/perf/scripts/view_comparison_graph.py
+++ b/perf/scripts/view_comparison_graph.py
@@ -10,7 +10,7 @@
 # it was faster. Make sure you have enough passes from the
 # `test_render_all_perf.py` script (default should be set to 10).  The `mean`
 # of all runs will be plotted as a bar's value.  But black line will appear
-# on the edge of the bar's tip, as to mark the varriance/error.
+# on the edge of the bar's tip, as to mark the variance/error.
 
 import sys
 import matplotlib.pyplot as plt

--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -2,7 +2,7 @@
 /*!	\file svg_parser.cpp
 **	\brief Implementation of the Svg parser
 **	\brief Based on SVG XML specification 1.1
-**	\brief See: http://www.w3.org/TR/xml11/ for deatils
+**	\brief See: http://www.w3.org/TR/xml11/ for details
 **
 **
 **	\legal

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -2,7 +2,7 @@
 /*!	\file svg_parser.h
 **	\brief Implementation of the Svg parser
 **	\brief Based on SVG XML specification 1.1
-**	\brief See: http://www.w3.org/TR/xml11/ for deatils
+**	\brief See: http://www.w3.org/TR/xml11/ for details
 **
 **	\legal
 **	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley

--- a/synfig-core/src/synfig/node.h
+++ b/synfig-core/src/synfig/node.h
@@ -230,11 +230,11 @@ public:
 
 	//! Flag this node has changed.
 	//! This way programmer can batch its changes and call it only once
-	//! It emmits signal_changed()
+	//! It emits signal_changed()
 	void changed();
 	//! Flag the child node \p x has changed.
 	//! This way programmer can batch its changes and call it only once
-	//! It emmits signal_child_changed() and signal_changed()
+	//! It emits signal_child_changed() and signal_changed()
 	void child_changed(const Node *x);
 
 	//! Gets the GUID for this Node

--- a/synfig-core/src/synfig/valuenodes/valuenode_derivative.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_derivative.h
@@ -39,7 +39,7 @@
 namespace synfig {
 
 // Class ValueNode_Derivative
-// Implementation of a derivative based on finite diferences
+// Implementation of a derivative based on finite differences
 // See: http://en.wikipedia.org/wiki/Finite_difference
 // and http://en.wikipedia.org/wiki/Finite_difference_coefficients
 

--- a/synfig-osx/launcher/utils/dumpkeymap.man
+++ b/synfig-osx/launcher/utils/dumpkeymap.man
@@ -58,7 +58,7 @@
 //	used with fixed-point font.  The third argument is the annotation
 //	itself.  The block should be terminated with the `AE' macro.  For all
 //	roff interpreters which properly implement diversions, indentation, and
-//	tab stops, all anotations within the block are automatically aligned at
+//	tab stops, all annotations within the block are automatically aligned at
 //	the same horizontal position.  This position is guaranteed to be just
 //	to the right of the widest `AN' detail line.  For broken roff
 //	interpreters, such as `rman', the string of spaces from the second

--- a/synfig-studio/AUTHORS
+++ b/synfig-studio/AUTHORS
@@ -46,7 +46,7 @@ Russian: Alexandre Prokoudine, Konstantin Dmitriev (zelgadis),
 		Artem Krosheninnikov, Oleg Gordeev, darumka
 Italian: Bottero Ermanno, nullo, mattia_b89
 German: Oliver Horn, noael, cyborgx7
-Chinesse: Yu Chen (jcome)
+Chinese: Yu Chen (jcome)
 English (United Kingdom): Robert Readman, berteh. d.j.a.y, pixelgeek, UbunTom
 Portuguese (Brazilian): Ricardo Graça, Henrique Barone, Gabriel Menor, rodolforg
 		smoreiramendes, Valessio Brito

--- a/synfig-studio/docs/bones_gui.txt
+++ b/synfig-studio/docs/bones_gui.txt
@@ -148,7 +148,7 @@ same. In this way the workflow for this creation of the skeleton will be:
 
 1) In non animation mode and with no waypoints, modify the setup skeleton
 should modify also the not setup skeleton. In this case there is not difference
-between one skeleton and the other and the interface will mdify both at
+between one skeleton and the other and the interface will modify both at
 the same time.
 
 2) Once you're in animation mode you can modify either the setup skeleton

--- a/synfig-studio/src/gui/docks/dockable.cpp
+++ b/synfig-studio/src/gui/docks/dockable.cpp
@@ -250,7 +250,7 @@ Dockable::reset_container()
 	//App::process_all_events();
 	// Update:
 	// Seems bug in other place, process_all_events() here produces
-	// a concurrent event processing and collissions
+	// a concurrent event processing and collisions
 }
 
 void

--- a/synfig-studio/src/gui/docks/dockbook.cpp
+++ b/synfig-studio/src/gui/docks/dockbook.cpp
@@ -97,7 +97,7 @@ DockBook::clear()
 	// i didn't know why this happens, possibly because clear() is called from destructor
 	// and 'this' is already deleted. Or, this function maybe never work right.
 	// So here quick-hack again. Btw, as you can see from commented code later newly created 
-	// dockbook is works fine, so this situation is reqired more detailed investigation.
+	// dockbook is works fine, so this situation is required more detailed investigation.
 	if (!GTK_IS_NOTEBOOK (this)) return; // because we always fail if 'this' is not notebook
 
 	/*Gtk::Notebook note;

--- a/synfig-studio/src/gui/duckmatic.cpp
+++ b/synfig-studio/src/gui/duckmatic.cpp
@@ -1340,7 +1340,7 @@ Duckmatic::find_duck(synfig::Point point, synfig::Real radius, Duck::Type type)
 		}
 	}
 
-	// Priorization of duck selection when are in the same place.
+	// Prioritization of duck selection when are in the same place.
 	bool found(false);
 	if(ret_vector.size())
 	{

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -689,7 +689,7 @@ StateNormal_Context::event_key_down_handler(const Smach::event& x)
 {
 	// event.modifier yet not set when ctrl (or alt or shift)
 	// key pressed event handled. So we need to check this keys manually.
-	// We may encountred some cosmetic problems with mouse-cursor image
+	// We may encounter some cosmetic problems with mouse-cursor image
 	// if user will redefine modifier keys.
 	// Anyway processing of keys Ctrl+Right, Ctrl+Left etc will works fine.
 	// see 'xmodmap' command

--- a/synfig-studio/src/synfigapp/vectorizer/centerlineskeletonizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlineskeletonizer.cpp
@@ -1708,7 +1708,7 @@ SkeletonList* studio::skeletonize(Contours &contours, const etl::handle<synfigap
 
 
   for (i = 0; i <contours_size ; ++i) {
-    /* To be enabled in case on isCancenled is implemnted
+    /* To be enabled in case on isCancenled is implemented
         if (thisVectorizer->isCanceled()) break;
     */
     res->push_back(skeletonize(contours[i], context));


### PR DESCRIPTION
Found via `codespell -q 3 -L aline,ang,ba,childs,dout,eiter,forse,objext,pard,parms,pevent,propertyst,ro,shouldbe,thru,uint,unselect,vertexes -S ./synfig-studio/po,./synfig-core/po,/synfig-core/m4,./synfig-osx/,./gtkmm-osx,./bugs,.*.eps,*.sif,./synfig-studio/plugins/lottie-exporter`