### PR TITLE
feat: Faster entry of values in the value field

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_distance.cpp
+++ b/synfig-studio/src/gui/widgets/widget_distance.cpp
@@ -59,6 +59,7 @@ Widget_Distance::Widget_Distance():
 {
 	set_adjustment(adjustment);
 	set_numeric(false);
+	signal_event_after().connect(sigc::mem_fun(*this, &Widget_Distance::after_event));
 }
 
 Widget_Distance::~Widget_Distance()
@@ -99,6 +100,14 @@ Widget_Distance::on_key_release_event(GdkEventKey* event)
 	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 }
 
+void
+Widget_Distance::after_event(GdkEvent *event)
+{
+	SYNFIG_EXCEPTION_GUARD_BEGIN()
+	if (event->type == GDK_BUTTON_RELEASE)
+		select_region(0, get_text_length()-2);
+	SYNFIG_EXCEPTION_GUARD_END()
+}
 
 void
 Widget_Distance::set_value(const synfig::Distance &data)

--- a/synfig-studio/src/gui/widgets/widget_distance.h
+++ b/synfig-studio/src/gui/widgets/widget_distance.h
@@ -55,6 +55,7 @@ protected:
 
 	bool on_key_press_event(GdkEventKey* event);
 	bool on_key_release_event(GdkEventKey* event);
+	void after_event(GdkEvent *event);
 
 public:
 	void set_value(const synfig::Distance &data);


### PR DESCRIPTION
Fixes #2191

- done for the distance widget, Aka the spin button with the pixels unit.
- now mostly what remains is to decide on what method would be best for the remaining spin buttons, I think maybe just sub-classing/deriving a class from the spin button would save having to connect signals to each and every spin button, so I think I will probably go with that, will do early in the morning tomorrow.

p.s in the original feature request it was mainly highlighting the need for this there, I'm not quite sure if it should only be done there, but since it was mentioned it was wanted to be universal behavior I'm assuming maybe apply everywhere in the main window? However, I think I will just continue this for the different tools until I get an opinion, and anyways I think only places where it is yet to be implemented is probably some of the entries below and above the zoom dial entry so it shouldnt be a problem.