### PR TITLE
feat: Added support for scrolling through text in text paragraph dialog

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3852,6 +3852,18 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 
 	}), false );
+
+	int previous_num_lines(0);
+
+	text_buffer->signal_changed().connect(sigc::track_obj([&dialog,&text_buffer,&previous_num_lines](){
+			int num_lines=text_buffer->get_line_count();
+			if(num_lines<previous_num_lines)
+				dialog.resize(dialog.get_width(), 2);//any size less than minimum causes a resize to minimum possible size
+
+			previous_num_lines=num_lines;
+
+		}, dialog));
+
 	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -70,6 +70,7 @@
 #endif
 #include <gtkmm/stock.h>
 #include <gtkmm/textview.h>
+#include <gtkmm/scrolledwindow.h>
 
 #include <gui/app.h>
 #include <gui/autorecover.h>
@@ -3826,14 +3827,17 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	Gtk::Label* label = manage(new Gtk::Label(message));
 	label->show();
-	dialog.get_content_area()->pack_start(*label);
+	dialog.get_content_area()->pack_start(*label,false,false);
 
 	Glib::RefPtr<Gtk::TextBuffer> text_buffer(Gtk::TextBuffer::create());
 	text_buffer->set_text(text);
 	Gtk::TextView text_view(text_buffer);
 	text_view.show();
+	Gtk::ScrolledWindow s_window;
+	s_window.add(text_view);
+	s_window.show();
 
-	dialog.get_content_area()->pack_start(text_view);
+	dialog.get_content_area()->pack_start(s_window);
 
 	dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
 	dialog.add_button(_("_OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
@@ -3852,17 +3856,6 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 
 	}), false );
-
-	int previous_num_lines(0);
-
-	text_buffer->signal_changed().connect(sigc::track_obj([&dialog,&text_buffer,&previous_num_lines](){
-			int num_lines=text_buffer->get_line_count();
-			if(num_lines<previous_num_lines)
-				dialog.resize(dialog.get_width(), 2);//any size less than minimum causes a resize to minimum possible size
-
-			previous_num_lines=num_lines;
-
-		}, dialog));
 
 	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3827,17 +3827,17 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	Gtk::Label* label = manage(new Gtk::Label(message));
 	label->show();
-	dialog.get_content_area()->pack_start(*label, false, false);
+	dialog.get_content_area()->pack_start(*label, Gtk::PACK_SHRINK);
 
 	Glib::RefPtr<Gtk::TextBuffer> text_buffer(Gtk::TextBuffer::create());
 	text_buffer->set_text(text);
 	Gtk::TextView text_view(text_buffer);
 	text_view.show();
-	Gtk::ScrolledWindow s_window;
-	s_window.add(text_view);
-	s_window.show();
+	Gtk::ScrolledWindow scrolled_window;
+	scrolled_window.add(text_view);
+	scrolled_window.show();
 
-	dialog.get_content_area()->pack_start(s_window);
+	dialog.get_content_area()->pack_start(scrolled_window);
 
 	dialog.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL)->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_BUTTON);
 	dialog.add_button(_("_OK"),   Gtk::RESPONSE_OK)->set_image_from_icon_name("gtk-ok", Gtk::ICON_SIZE_BUTTON);
@@ -3857,6 +3857,7 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	}), false );
 	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
+	dialog.set_default_size(400, 300);
 	dialog.show();
 
 	if(dialog.run()!=Gtk::RESPONSE_OK)

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3827,7 +3827,7 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 
 	Gtk::Label* label = manage(new Gtk::Label(message));
 	label->show();
-	dialog.get_content_area()->pack_start(*label,false,false);
+	dialog.get_content_area()->pack_start(*label, false, false);
 
 	Glib::RefPtr<Gtk::TextBuffer> text_buffer(Gtk::TextBuffer::create());
 	text_buffer->set_text(text);
@@ -3856,7 +3856,6 @@ App::dialog_paragraph(const std::string &title, const std::string &message,std::
 		SYNFIG_EXCEPTION_GUARD_END_BOOL(true)
 
 	}), false );
-
 	//text_entry.signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
 	dialog.show();
 


### PR DESCRIPTION
before:

https://user-images.githubusercontent.com/100296264/186509747-ac2fdcf4-c8d9-4640-b8d2-006553db931c.mp4

After:

https://user-images.githubusercontent.com/100296264/186509792-8eb58113-f5e8-4531-8db7-b08615ce9d78.mp4


One thing I'm not sure about though... with the current implementation if the user manually resized the dialog to a greater vertical size, if he then deletes a line then the dialog is auto-adjusted to the size fitting to the number of lines he has, is this okay? or should it be that if it's manually resized the size of the resize is the new minimum size?

Also I just thought of this, should this auto shrink be only when we are deleting the last line?

p.s. excuse the horrendous video quality I had to compress to upload xD.