### PR TITLE
fix: params panel doesn't update after layer switch

### DIFF
--- a/synfig-studio/src/gui/trees/layerparamtreestore.cpp
+++ b/synfig-studio/src/gui/trees/layerparamtreestore.cpp
@@ -617,7 +617,7 @@ LayerParamTreeStore::on_value_node_replaced(synfig::ValueNode::Handle /*replaced
 	//    of Skeleton Layer.
 	//    'Solution' seems to be to call queue_rebuild()
 
-	//rebuild();
+	refresh();
 }
 
 void


### PR DESCRIPTION
After merging synfig/synfig#2729

I didn't notice this the first time:

https://user-images.githubusercontent.com/5604544/186569950-b23b4c5b-3f1f-42c7-b60d-07a843db12aa.mp4