### PR TITLE
build(autotools): fix MSYS2 build

### DIFF
--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -13,6 +13,12 @@ AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([nostdinc subdir-objects])
 AM_MAINTAINER_MODE
 
+dnl override platform specific check for dependent libraries
+dnl otherwise libtool linking of shared libraries will
+dnl fail on anything other than pass_all.
+# this hack is needed to link libsynfig with static libdl in MSYS2 environment
+AC_CACHE_VAL(lt_cv_deplibs_check_method, [lt_cv_deplibs_check_method=pass_all])
+
 LT_CONFIG_LTDL_DIR([libltdl])
 
 LT_INIT([dlopen, win32-dll, disable-static])


### PR DESCRIPTION
A bit of history on this fix:
MSYS team removed removed shared libdl.dll and libdl.dll.a

commit: https://github.com/msys2/MINGW-packages/commit/c27ad107f7df624604c96f45d124b761b6fc0aa9
discussion: https://github.com/msys2/MINGW-packages/issues/7548

When compiling synfig it shows the warning:
```
*** Warning: linker path does not have real file for library -ldl.
*** I have the capability to make that library automatically link in when
*** you link to this library.  But I can only do this if you have a
*** shared version of the library, which you do not appear to have
*** because I did check the linker path looking for a file starting
*** with libdl and none of the candidates passed a file format test
*** using a file magic. Last file checked: C:/msys64/mingw64/lib/libdl.a
```

This happens because
(cite from here: https://github.com/msys2/MINGW-packages/issues/7548#issuecomment-753619221):
> "it is a known problem with libtool on windows, on unix libtool uses file magic to get dependencies but this does not quite work on windows even though the tool can be build with mingw* it uses windows paths which confuses libtool so it is not normally included. The above is a workaround for cases like that, if you prefer to newer see this warning you can simply yank it into /mingw*/etc/config.site."

This leads to the impossibility of linking with libdl.dll and for this reason the
loading of modules do not work. This is why images can't be built.

AppVeyour CI build works because it uses CMake toolchain.

fix #2817

P.S. Debug build still doesn't work due to another issue.