### PR TITLE
fix: Synfig CLI does not open file if path contains non-Latin characters (Windows)

### DIFF
--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -241,7 +241,11 @@ bool SynfigCommandLineParser::parse(int argc, char* argv[])
 #ifdef GLIBMM_EXCEPTIONS_ENABLED
 	try
 	{
+#ifdef _WIN32
+		context.parse(argv);
+#else
 		context.parse(argc, argv);
+#endif
 	}
 	catch(const Glib::Error& ex)
 	{


### PR DESCRIPTION
The problem was double conversion of command line options from local codepage to UTF-8.

Arguments was already converted in main()