### PR TITLE
build(cmake): fixed build when path contains non-Latin characters (MSYS2)

### DIFF
--- a/synfig-studio/src/gui/CMakeLists.txt
+++ b/synfig-studio/src/gui/CMakeLists.txt
@@ -30,8 +30,9 @@ endif()
 ##
 
 if(WIN32)
-	configure_file(synfigstudio.rc ${CMAKE_CURRENT_BINARY_DIR}/synfigstudio.rc)
-	add_executable(synfigstudio main.cpp ${CMAKE_CURRENT_BINARY_DIR}/synfigstudio.rc)
+	set(RC_FILE ${SYNFIG_BUILD_ROOT}/share/synfig/icons/classic/synfigstudio.rc)
+	configure_file(synfigstudio.rc ${RC_FILE})
+	add_executable(synfigstudio main.cpp ${RC_FILE})
 else()
 	add_executable(synfigstudio main.cpp)
 endif()

--- a/synfig-studio/src/gui/synfigstudio.rc
+++ b/synfig-studio/src/gui/synfigstudio.rc
@@ -1,4 +1,4 @@
-APPLICATION_ICON    ICON    "${SYNFIG_BUILD_ROOT}/share/synfig/icons/classic/synfig_icon.ico" 
+APPLICATION_ICON    ICON    "synfig_icon.ico"
  
 1 VERSIONINFO 
     FILEVERSION     ${STUDIO_VERSION_MAJOR},${STUDIO_VERSION_MINOR},${STUDIO_VERSION_PATCH},0 


### PR DESCRIPTION

MSYS2/Windows only.
The problem occurred when trying to compile Windows resources using the `winres.exe` tool.

If the path to an icon in a resource contains non-Latin characters, then winres.exe cannot
compile this resource. Solved by using a relative path to the icon.