### PR TITLE
fix: "rule of two" : copy constructor and copy assignment operator

### DIFF
--- a/synfig-core/src/synfig/base_types.cpp
+++ b/synfig-core/src/synfig/base_types.cpp
@@ -148,6 +148,7 @@ public:
 		mutable Time t;
 		Real r;
 		Inner(): f(0.f), t(0.0), r(0.0) { }
+		Inner(const Inner& other) { r = other.r; }
 
 		bool operator== (const Inner &other) const { return r == other.r; }
 		Inner& operator= (const Inner &other) { return *this = other.r; }
@@ -416,6 +417,8 @@ class TypeCanvas: public Type
 #else
 		Inner(): p(nullptr) { }
 #endif
+		Inner(const Inner& other) { *this = other; }
+
 		Inner& operator= (const etl::loose_handle<Canvas> &other)
 		{
 #ifdef TRY_FIX_FOR_BUG_27
@@ -542,6 +545,7 @@ class TypeBoneValueNode: public Type
 		mutable ValueNode_BonePtr p;
 
 		Inner(): p(nullptr) { }
+		Inner(const Inner& other) { h = other.h; }
 		Inner& operator= (const etl::handle<ValueNode_Bone> &other) { h = other; return *this; }
 		Inner& operator= (const etl::loose_handle<ValueNode_Bone> &other) { h = other; return *this; }
 		Inner& operator= (const ValueNode_BonePtr &other) { h = other; return *this; }

--- a/synfig-core/src/synfig/context.h
+++ b/synfig-core/src/synfig/context.h
@@ -69,9 +69,12 @@ public:
 	//! Constructor based on other CanvasBase iterator
 	IndependentContext(const CanvasBase::const_iterator &x):CanvasBase::const_iterator(x) { }
 
-	//! Assignation operator
-	IndependentContext operator=(const CanvasBase::const_iterator &x)
-	{ return CanvasBase::const_iterator::operator=(x); }
+	//! Assignment operator
+	IndependentContext& operator=(const CanvasBase::const_iterator &x)
+	{
+		CanvasBase::const_iterator::operator=(x);
+		return *this;
+	}
 
 	//! Sets the context to the Time \time. It is done recursively.
 	void set_time(Time time, bool force = false) const;

--- a/synfig-core/src/synfig/rect.h
+++ b/synfig-core/src/synfig/rect.h
@@ -101,6 +101,14 @@ public:
 			minx(o.minx), miny(o.miny), maxx(o.maxx), maxy(o.maxy) { }
 	rect(const rect<T> &o):
 			minx(o.minx), miny(o.miny), maxx(o.maxx), maxy(o.maxy) { }
+	rect<T>& operator=(const rect<T>& o)
+	{
+		minx = o.minx;
+		maxx = o.maxx;
+		miny = o.miny;
+		maxy = o.maxy;
+		return *this;
+	}
 
 	template<typename F>
 	rect(

--- a/synfig-studio/src/gui/_smach.h
+++ b/synfig-studio/src/gui/_smach.h
@@ -142,6 +142,12 @@ public:
 
 		//! Copy constructor
 		event_def_internal(const event_def_internal &x):id(x.id),handler(x.handler) { }
+		event_def_internal& operator=(const event_def_internal& x)
+		{
+			id = x.id;
+			handler = x.handler;
+			return *this;
+		}
 
 	};
 


### PR DESCRIPTION
And copy assignment operator returns reference, not a copy.