### PR TITLE
build(vcpkg): Support building synfig using vcpkg on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ set(STUDIO_VERSION_PATCH 0)
 
 option(ENABLE_TCMALLOC "Enable use of tcmalloc library" OFF)
 
+if(VCPKG_TOOLCHAIN)
+	set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib")
+	add_definitions(-DSYNFIG_PORTABLE)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE Debug)
 endif()

--- a/autobuild/appdeps.py
+++ b/autobuild/appdeps.py
@@ -1,0 +1,135 @@
+import argparse
+import subprocess
+import shutil
+import os
+
+
+def _change_rpath(lib, rpath):
+    val = subprocess.run(args=["patchelf", "--set-rpath", rpath, lib])
+    if val.returncode != 0:
+        print(f"Error: Failed setting rpath of {lib} to {rpath}!")
+        exit(-1)
+
+
+def change_rpath(libs, rpath):
+    for lib in libs:
+        _change_rpath(lib, rpath)
+
+
+def is_executable_or_shared(file):
+    val = subprocess.run(args=["file", "-L", "--mime-type", file],
+                         capture_output=True)
+    output = val.stdout.decode("utf-8")
+
+    mime_types = [
+        "application/x-sharedlib", "application/x-executable",
+        "application/x-pie-executable"
+    ]
+    for mime_type in mime_types:
+        if mime_type in output:
+            return True
+
+    return False
+
+
+def find_deps(file, libdirs):
+    val = subprocess.run(args=["ldd", file],
+                         env={"LD_LIBRARY_PATH": ":".join(libdirs)},
+                         capture_output=True)
+
+    output = val.stdout.decode("utf-8")
+
+    deps = {}
+    for line in output.splitlines():
+        # ldd writes lines in the form of "<lib-name> => <lib-path> (<addr>)"
+        # or in the form "<lib-name> (<addr>)"
+        # we're only interested in the first form
+        parts = line.split("=>")
+        if len(parts) == 1:
+            continue
+
+        lib_name = parts[0].strip()
+        lib_path = parts[1].split(" (")[0].strip()
+        if lib_path == "not found":
+            lib_path = None
+
+        deps[lib_name] = lib_path
+
+    return deps
+
+
+def copy_deps(deps, outdir, libdirs, rpath):
+    copied_deps = []
+    for libname, libpath in deps.items():
+        reallibpath = os.path.realpath(libpath)
+        found_lib = False
+        for libdir in libdirs:
+            if os.path.commonpath([reallibpath,
+                                   libdir]) == os.path.commonpath([libdir]):
+                found_lib = True
+                break
+
+        if not found_lib:
+            continue
+
+        newlibpath = os.path.join(outdir, libname)
+        shutil.copy(reallibpath, newlibpath)
+
+        copied_deps.append(newlibpath)
+
+    return copied_deps
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=
+        "Copy dependencies of executables and shared objects, and change their rpath"
+    )
+    parser.add_argument("file_path", metavar="file", type=str)
+    parser.add_argument("-L",
+                        action="append",
+                        metavar="libdirs",
+                        dest="libdirs",
+                        type=str)
+    parser.add_argument("--outdir",
+                        metavar="outdir",
+                        dest="outdir",
+                        type=str,
+                        required=True)
+    parser.add_argument("--set-rpath", metavar="rpath", dest="rpath", type=str)
+    args = parser.parse_args()
+
+    if not os.path.exists(args.file_path):
+        print(f"Error: No such file or directory ({args.file_path})!")
+        exit(-1)
+
+    file_path = os.path.abspath(args.file_path)
+
+    libdirs = []
+    for searchdir in (args.libdirs or []):
+        if not os.path.exists(searchdir):
+            print(f"Error: No such file or directory ({searchdir})!")
+            exit(-1)
+        else:
+            libdirs.append(os.path.abspath(searchdir))
+
+    if not os.path.exists(args.outdir):
+        os.makedirs(args.outdir)
+    outdir = os.path.abspath(args.outdir)
+
+    if not is_executable_or_shared(args.file_path):
+        print("Error: File is neither a shared library nor an executable!")
+        exit(-1)
+
+    deps = find_deps(file_path, libdirs)
+
+    unresolved_deps = [key for key, value in deps.items() if value == None]
+    if len(unresolved_deps) > 0:
+        for dep in unresolved_deps:
+            print(f"Error: Could not resolve path for dependency \"{dep}\"")
+        exit(-1)
+
+    copied_deps = copy_deps(deps, outdir, libdirs, args.rpath)
+
+    if args.rpath:
+        change_rpath(copied_deps, args.rpath)

--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -114,6 +114,19 @@ public:
 
 GeneralIOMutexHolder general_io_mutex;
 
+#ifdef SYNFIG_PORTABLE
+static bool set_fontconfig_env() {
+	String rootpath = dirname(dirname(get_binary_path("")));
+	if (rootpath.empty()) return false;
+	String fonts_dir = strprintf("%s/etc/fonts", rootpath.c_str());
+	Glib::setenv("FONTCONFIG_PATH", fonts_dir);
+	Glib::setenv("FONTCONFIG_FILE", "fonts.conf");
+	return true;
+}
+
+static bool initialize_fontconfig = set_fontconfig_env();
+#endif
+
 /* === P R O C E D U R E S ================================================= */
 
 /* === M E T H O D S ======================================================= */
@@ -233,12 +246,6 @@ synfig::Main::Main(const synfig::String& rootpath,ProgressCallback *cb):
 	lib_synfig_path = lib_path   + "/synfig";
 
 	// Add initialization after this point
-
-#ifdef _MSC_VER
-	String module_location = get_binary_path("");
-	_putenv(strprintf("FONTCONFIG_PATH=%s/../../etc/fonts", module_location.c_str()).c_str());
-	_putenv("FONTCONFIG_FILE=fonts.conf");
-#endif
 
 #ifdef ENABLE_NLS
 	bindtextdomain("synfig", Glib::locale_from_utf8(locale_path).c_str() );

--- a/vcpkg-ports/adwaita-icon-theme/portfile.cmake
+++ b/vcpkg-ports/adwaita-icon-theme/portfile.cmake
@@ -11,8 +11,7 @@ vcpkg_extract_source_archive_ex(
 
 vcpkg_configure_make(
   SOURCE_PATH "${SOURCE_PATH}"
-  DETERMINE_BUILD_TRIPLET
-  USE_WRAPPERS
+  NO_DEBUG
 )
 
 vcpkg_install_make()

--- a/vcpkg-ports/at-spi2-atk/portfile.cmake
+++ b/vcpkg-ports/at-spi2-atk/portfile.cmake
@@ -1,0 +1,33 @@
+# a copy from the work of Max Khon (https://github.com/mkhon)
+# from the following PR: https://github.com/microsoft/vcpkg/pull/24934
+# TODO: remove once merged
+
+if(VCPKG_TARGET_IS_LINUX)
+    message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n    libdbus-1-dev\n\nThese can be installed on Ubuntu systems via apt-get install libdbus-1-dev")
+endif()
+
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.gnome.org
+    REPO GNOME/at-spi2-atk
+    REF AT_SPI2_ATK_2_38_0
+    SHA512 d065a22e46f5d9459e14bc81050795e8b60ba8d6650ec9edf90ec6c205e68eb4ea3cc01f096cf636b066439b85892f203bc7a1c9d41f8ca899f29777556aa6cd
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dtests=false
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()

--- a/vcpkg-ports/at-spi2-atk/vcpkg.json
+++ b/vcpkg-ports/at-spi2-atk/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "at-spi2-atk",
+  "version": "2.38.0",
+  "description": "Implementation of the ATK interfaces in terms of the libatspi2 API.",
+  "homepage": "https://www.gtk.org/",
+  "license": null,
+  "supports": "linux",
+  "dependencies": [
+    "at-spi2-core",
+    "atk",
+    "libxml2",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg-ports/at-spi2-core/portfile.cmake
+++ b/vcpkg-ports/at-spi2-core/portfile.cmake
@@ -1,0 +1,52 @@
+# a copy from the work of Max Khon (https://github.com/mkhon)
+# from the following PR: https://github.com/microsoft/vcpkg/pull/24934
+# TODO: remove once merged
+
+if(VCPKG_TARGET_IS_LINUX)
+    message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n    libdbus-1-dev\n    libxi-dev\n    libxtst-dev\n\nThese can be installed on Ubuntu systems via apt-get install libdbus-1-dev libxi-dev libxtst-dev")
+endif()
+
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.gnome.org
+    REPO GNOME/at-spi2-core
+    REF AT_SPI2_CORE_2_44_1
+    SHA512 4e98b76e019f33af698a5e2b7ae7ce17ce0ff57784b4d505fe4bad58b097080899c1ca82b443502068c5504b60886e2d4a341bba833e0279ebef352211bf3813
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dintrospection=no
+    ADDITIONAL_NATIVE_BINARIES
+        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+    ADDITIONAL_CROSS_BINARIES
+        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/atspi-2.pc"
+        "-DG_LOG_DOMAIN=\"dbind\"" ""
+    )
+endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/atspi-2.pc"
+        "-DG_LOG_DOMAIN=\"dbind\"" ""
+    )
+endif()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()

--- a/vcpkg-ports/at-spi2-core/vcpkg.json
+++ b/vcpkg-ports/at-spi2-core/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "at-spi2-core",
+  "version": "2.44.1",
+  "description": "Base DBus XML interfaces for accessibility, the accessibility registry daemon, and atspi library.",
+  "homepage": "https://www.gtk.org/",
+  "license": null,
+  "supports": "linux",
+  "dependencies": [
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg-ports/cairomm/portfile.cmake
+++ b/vcpkg-ports/cairomm/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://cairographics.org/releases/cairomm-1.14.3.tar.xz"
     FILENAME "cairomm-1.14.3.tar.xz"

--- a/vcpkg-ports/gdk-pixbuf/portfile.cmake
+++ b/vcpkg-ports/gdk-pixbuf/portfile.cmake
@@ -1,5 +1,4 @@
 # adapted from vcpkg's own gdk-pixbuf port
-
 set(GDK_PIXBUF_VERSION 2.42)
 set(GDK_PIXBUF_PATCH 8)
 
@@ -45,7 +44,7 @@ vcpkg_install_meson(ADD_BIN_TO_PATH)
 set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gdk-pixbuf-2.0.pc")
 if(EXISTS "${_file}")
     file(READ "${_file}" _contents)
-    string(REPLACE [[${bindir}]] "\${bindir}/../../tools/${PORT}" _contents "${_contents}")
+    string(REPLACE [[${bindir}]] "\${prefix}/../tools/${PORT}" _contents "${_contents}")
 
     # Essam: This is the problematic part
     # gdk_pixbuf_binarydir is erroneously set to ${libdir}/../gdk-pixbuf-2.0
@@ -57,7 +56,7 @@ endif()
 set(_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gdk-pixbuf-2.0.pc")
 if(EXISTS "${_file}")
     file(READ "${_file}" _contents)
-    string(REPLACE [[${bindir}]] "\${bindir}/../tools/${PORT}" _contents "${_contents}")
+    string(REPLACE [[${bindir}]] "\${prefix}/tools/${PORT}" _contents "${_contents}")
     # string(REPLACE [[gdk_pixbuf_binarydir=${libdir}/gdk-pixbuf-2.0/2.10.0]] "gdk_pixbuf_binarydir=\${libdir}/../gdk-pixbuf-2.0/2.10.0" _contents "${_contents}")
     file(WRITE "${_file}" "${_contents}")
 endif()
@@ -84,4 +83,3 @@ vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-

--- a/vcpkg-ports/glib/libintl.patch
+++ b/vcpkg-ports/glib/libintl.patch
@@ -1,0 +1,47 @@
+diff --git a/meson.build b/meson.build
+index f44fa2d4e..d465253af 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2090,37 +2090,10 @@ libz_dep = dependency('zlib')
+ # proxy-libintl subproject.
+ # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+ # implementations. This could be extended if issues are found in some platforms.
+-libintl_deps = []
+-libintl = dependency('intl', required: false)
+-if libintl.found()
+-  # libintl supports different threading APIs, which may not
+-  # require additional flags, but it defaults to using pthreads if
+-  # found. Meson's "threads" dependency does not allow you to
+-  # prefer pthreads. We may not be using pthreads for glib itself
+-  # either so just link the library to satisfy libintl rather than
+-  # also defining the macros with the -pthread flag.
+-  #
+-  # Meson's builtin dependency lookup as of 0.60.0 doesn't check for
+-  # pthread, so we do this manually here.
+-  if cc.has_function('ngettext', dependencies : libintl)
+-    libintl_deps += [libintl]
+-  else
+-    libintl_pthread = cc.find_library('pthread', required : false)
+-    if libintl_pthread.found() and cc.has_function('ngettext', dependencies : [libintl, libintl_pthread])
+-      libintl_deps += [libintl, libintl_pthread]
+-    else
+-      libintl = disabler()
+-    endif
+-  endif
+-endif
+-
+-if libintl.found()
+-  have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset', dependencies: libintl_deps)
+-else
+-  libintl = subproject('proxy-libintl').get_variable('intl_dep')
+-  libintl_deps = [libintl]
+-  have_bind_textdomain_codeset = true  # proxy-libintl supports it
+-endif
++libintl = dependency('Intl', method:'cmake', required : true)
++libintl_deps = [libintl]
++have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset',
++                                                   dependencies : libintl_deps)
+ 
+ glib_conf.set('HAVE_BIND_TEXTDOMAIN_CODESET', have_bind_textdomain_codeset)
+ 
+

--- a/vcpkg-ports/glib/portfile.cmake
+++ b/vcpkg-ports/glib/portfile.cmake
@@ -1,0 +1,124 @@
+set(GLIB_MAJOR_MINOR 2.73)
+set(GLIB_PATCH 3)
+
+vcpkg_download_distfile(GLIB_ARCHIVE
+    URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${GLIB_MAJOR_MINOR}.${GLIB_PATCH}.tar.xz"
+    FILENAME "glib-${GLIB_MAJOR_MINOR}.${GLIB_PATCH}.tar.xz"
+    SHA512 f965323be1d17dbc322ae329748b99365720977bd313519279a5236973532fed36a63726a3bffd2795eb5a627776cda3ebcbd3456cc2388f65ffe8afacbcc167
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${GLIB_ARCHIVE}
+    REF "${GLIB_MAJOR_MINOR}.${GLIB_PATCH}"
+    PATCHES
+        use-libiconv-on-windows.patch
+        libintl.patch
+)
+
+if (selinux IN_LIST FEATURES)
+    if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT EXISTS "/usr/include/selinux")
+        message("Selinux was not found in its typical system location. Your build may fail. You can install Selinux with \"apt-get install selinux\".")
+    endif()
+    list(APPEND OPTIONS -Dselinux=enabled)
+else()
+    list(APPEND OPTIONS -Dselinux=disabled)
+endif()
+
+if (libmount IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dlibmount=enabled)
+else()
+    list(APPEND OPTIONS -Dlibmount=disabled)
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND OPTIONS -Diconv=external)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dinstalled_tests=false
+        ${OPTIONS}
+        -Dtests=false
+        -Dxattr=false
+        -Dlibelf=disabled
+)
+
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+
+vcpkg_copy_pdbs()
+
+set(GLIB_TOOLS gdbus
+               gio
+               gio-querymodules
+               glib-compile-resources
+               glib-compile-schemas
+               gobject-query
+               gresource
+               gsettings
+               )
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    if(NOT VCPKG_TARGET_IS_OSX)
+        list(APPEND GLIB_TOOLS gapplication)
+    endif()
+    list(APPEND GLIB_TOOLS glib-gettextize gtester)
+endif()
+set(GLIB_SCRIPTS gdbus-codegen glib-genmarshal glib-mkenums gtester-report)
+
+
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "x64|arm64")
+    list(APPEND GLIB_TOOLS  gspawn-win64-helper${VCPKG_EXECUTABLE_SUFFIX}
+                            gspawn-win64-helper-console${VCPKG_EXECUTABLE_SUFFIX})
+elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    list(APPEND GLIB_TOOLS  gspawn-win32-helper${VCPKG_EXECUTABLE_SUFFIX}
+                            gspawn-win32-helper-console${VCPKG_EXECUTABLE_SUFFIX})
+endif()
+vcpkg_copy_tools(TOOL_NAMES ${GLIB_TOOLS} AUTO_CLEAN)
+foreach(script IN LISTS GLIB_SCRIPTS)
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/${script}" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/${script}")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${script}")
+endforeach()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+IF(VCPKG_TARGET_IS_WINDOWS)
+    set(SYSTEM_LIBRARIES dnsapi iphlpapi winmm lshlwapi)
+else()
+    set(SYSTEM_LIBRARIES resolv mount blkid selinux)
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gio-2.0.pc")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gio-2.0.pc" "\${bindir}" "\${prefix}/tools/${PORT}")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gio-2.0.pc")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gio-2.0.pc" "\${bindir}" "\${prefix}/../tools/${PORT}")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/glib-2.0.pc")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/glib-2.0.pc" "\${bindir}" "\${prefix}/tools/${PORT}")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/glib-2.0.pc")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/glib-2.0.pc" "\${bindir}" "\${prefix}/../tools/${PORT}")
+endif()
+vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES})
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# Fix python scripts
+set(_file "${CURRENT_PACKAGES_DIR}/tools/${PORT}/gdbus-codegen")
+file(READ "${_file}" _contents)
+string(REPLACE "elif os.path.basename(filedir) == 'bin':" "elif os.path.basename(filedir) == 'tools':" _contents "${_contents}")
+string(REPLACE "path = os.path.join(filedir, '..', 'share', 'glib-2.0')" "path = os.path.join(filedir, '../..', 'share', 'glib-2.0')" _contents "${_contents}")
+string(REPLACE "path = os.path.join(filedir, '..')" "path = os.path.join(filedir, '../../share/glib-2.0')" _contents "${_contents}")
+string(REPLACE "path = os.path.join('${CURRENT_PACKAGES_DIR}/share', 'glib-2.0')" "path = os.path.join('unuseable/share', 'glib-2.0')" _contents "${_contents}")
+
+file(WRITE "${_file}" "${_contents}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/gdb")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/glib/glib-gettextize")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/glib/glib-gettextize" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")
+endif()

--- a/vcpkg-ports/glib/use-libiconv-on-windows.patch
+++ b/vcpkg-ports/glib/use-libiconv-on-windows.patch
@@ -1,0 +1,28 @@
+diff --git a/glib/gconvert.c b/glib/gconvert.c
+index 829fe38de..e01ad8884 100644
+--- a/glib/gconvert.c
++++ b/glib/gconvert.c
+@@ -32,7 +32,8 @@
+ #include <stdlib.h>
+ 
+ #ifdef G_OS_WIN32
+-#include "win_iconv.c"
++#define USE_LIBICONV_GNU
++#include <iconv.h>
+ #endif
+ 
+ #ifdef G_PLATFORM_WIN32
+diff --git a/meson.build b/meson.build
+index d465253af..34ce69e4d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2038,7 +2038,8 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
+ if host_system == 'windows'
+   # We have a #include "win_iconv.c" in gconvert.c on Windows, so we don't need
+   # any external library for it
+-  libiconv = []
++  libiconv = [cc.find_library('iconv')]
++  found_iconv = true
+ else
+   libiconv = dependency('iconv')
+ endif

--- a/vcpkg-ports/glib/vcpkg.json
+++ b/vcpkg-ports/glib/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "glib",
+  "version": "2.73.3",
+  "description": "Portable, general-purpose utility library.",
+  "homepage": "https://developer.gnome.org/glib/",
+  "license": "LGPL-2.1-only",
+  "supports": "!uwp",
+  "dependencies": [
+    "dirent",
+    "gettext",
+    "libffi",
+    "libiconv",
+    "pcre2",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
+    "zlib"
+  ],
+  "features": {
+    "libmount": {
+      "description": "Build with libmount support.",
+      "supports": "linux",
+      "dependencies": [
+        "libmount"
+      ]
+    },
+    "selinux": {
+      "description": "Build with selinux support."
+    }
+  }
+}

--- a/vcpkg-ports/gtk3/vcpkg.json
+++ b/vcpkg-ports/gtk3/vcpkg.json
@@ -7,6 +7,10 @@
   "dependencies": [
     "atk",
     {
+      "name": "at-spi2-atk",
+      "platform": "linux"
+    },
+    {
       "name": "cairo",
       "default-features": false,
       "features": [

--- a/vcpkg-ports/hicolor-icon-theme/portfile.cmake
+++ b/vcpkg-ports/hicolor-icon-theme/portfile.cmake
@@ -11,8 +11,7 @@ vcpkg_extract_source_archive_ex(
 
 vcpkg_configure_make(
   SOURCE_PATH "${SOURCE_PATH}"
-  DETERMINE_BUILD_TRIPLET
-  USE_WRAPPERS
+  NO_DEBUG
 )
 
 vcpkg_install_make()

--- a/vcpkg-ports/imagemagick/fix_win_macros.patch
+++ b/vcpkg-ports/imagemagick/fix_win_macros.patch
@@ -1,0 +1,79 @@
+Author: Hesham Essam <hesham.essam.mail@gmail.com>
+Date:   Thu Aug 18 12:56:23 2022 +0200
+
+    Use macros _WIN32 and _WIN64 instead of WIN32 and WIN64
+
+diff --git a/Magick++/lib/Magick++/Include.h b/Magick++/lib/Magick++/Include.h
+index 5c3d8f023..ea51c84b7 100644
+--- a/Magick++/lib/Magick++/Include.h
++++ b/Magick++/lib/Magick++/Include.h
+@@ -55,7 +55,7 @@ namespace MagickCore
+ // Provide appropriate DLL imports/exports for Visual C++,
+ // Borland C++Builder and MinGW builds.
+ //
+-#if defined(WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__)
++#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__)
+ #  define MagickCplusPlusDLLSupported
+ #endif
+ #if defined(MagickCplusPlusDLLSupported)
+@@ -299,7 +299,7 @@ namespace MagickCore
+ #  endif
+ #endif
+ 
+-#if (defined(WIN32) || defined(WIN64)) && defined(_VISUALC_)
++#if (defined(_WIN32) || defined(_WIN64)) && defined(_VISUALC_)
+ #  pragma warning(disable : 4996) /* function deprecation warnings */
+ #endif
+ 
+diff --git a/MagickCore/MagickCore.h b/MagickCore/MagickCore.h
+index bcb612f3e..fd185a0e6 100644
+--- a/MagickCore/MagickCore.h
++++ b/MagickCore/MagickCore.h
+@@ -64,7 +64,7 @@ extern "C" {
+ #include <sys/types.h>
+ #include <time.h>
+ 
+-#if defined(WIN32) || defined(WIN64)
++#if defined(_WIN32) || defined(_WIN64)
+ #  define MAGICKCORE_WINDOWS_SUPPORT
+ #else
+ #  define MAGICKCORE_POSIX_SUPPORT
+diff --git a/MagickCore/studio.h b/MagickCore/studio.h
+index 5fb9a0c3b..f42cd242e 100644
+--- a/MagickCore/studio.h
++++ b/MagickCore/studio.h
+@@ -22,7 +22,7 @@
+ extern "C" {
+ #endif
+ 
+-#if defined(WIN32) || defined(WIN64)
++#if defined(_WIN32) || defined(_WIN64)
+ #  define MAGICKCORE_WINDOWS_SUPPORT
+ #else
+ #  define MAGICKCORE_POSIX_SUPPORT
+diff --git a/MagickWand/MagickWand.h b/MagickWand/MagickWand.h
+index 5018e65ce..d79b07647 100644
+--- a/MagickWand/MagickWand.h
++++ b/MagickWand/MagickWand.h
+@@ -64,7 +64,7 @@ extern "C" {
+ #include <sys/types.h>
+ #include <time.h>
+ 
+-#if defined(WIN32) || defined(WIN64)
++#if defined(_WIN32) || defined(_WIN64)
+ #  define MAGICKWAND_WINDOWS_SUPPORT
+ #else
+ #  define MAGICKWAND_POSIX_SUPPORT
+diff --git a/MagickWand/studio.h b/MagickWand/studio.h
+index 7d09f89be..1f981a0c0 100644
+--- a/MagickWand/studio.h
++++ b/MagickWand/studio.h
+@@ -22,7 +22,7 @@
+ extern "C" {
+ #endif
+ 
+-#if defined(WIN32) || defined(WIN64)
++#if defined(_WIN32) || defined(_WIN64)
+ #  define MAGICKWAND_WINDOWS_SUPPORT
+ #else
+ #  define MAGICKWAND_POSIX_SUPPORT

--- a/vcpkg-ports/imagemagick/portfile.cmake
+++ b/vcpkg-ports/imagemagick/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive_ex(
       dont_include_win32config.patch
       fix_make_dependency.patch
       fix_ssize_t_undefined.patch
+      fix_win_macros.patch
 )
 
 vcpkg_configure_make(

--- a/vcpkg-ports/librsvg/portfile.cmake
+++ b/vcpkg-ports/librsvg/portfile.cmake
@@ -12,11 +12,14 @@ vcpkg_extract_source_archive_ex(
       remove_lm_from_pkgconfig.patch
 )
 
-vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-# this is bad!
-# glib-mkenums has #!/bin/env python3
-file (COPY_FILE ${PYTHON3} "${PYTHON3_DIR}/python3.exe")
+# FIXME
+if(WIN32)
+  vcpkg_find_acquire_program(PYTHON3)
+  get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+  # this is bad!
+  # glib-mkenums has #!/bin/env python3
+  file (COPY_FILE ${PYTHON3} "${PYTHON3_DIR}/python3.exe")
+endif()
 
 vcpkg_add_to_path("${PYTHON3_DIR}")
 vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gdk-pixbuf")

--- a/vcpkg-ports/libsigcpp-2/portfile.cmake
+++ b/vcpkg-ports/libsigcpp-2/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp2.nluug.nl/windowing/gnome/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz"
     FILENAME "libsigc++-2.10.8.tar.xz"

--- a/vcpkg-ports/libxmlpp/portfile.cmake
+++ b/vcpkg-ports/libxmlpp/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/libxmlplusplus/libxmlplusplus/releases/download/2.42.1/libxml++-2.42.1.tar.xz"
     FILENAME "libxml++-2.42.1.tar.xz"

--- a/vcpkg-ports/pangomm/portfile.cmake
+++ b/vcpkg-ports/pangomm/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.2.tar.xz"
     FILENAME "pangomm-2.46.2.tar.xz"

--- a/vcpkg-triplets/x64-linux-synfig.cmake
+++ b/vcpkg-triplets/x64-linux-synfig.cmake
@@ -1,0 +1,24 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(__DYNAMIC_PORTS
+  glib
+  gdk-pixbuf
+  ffmpeg
+  glib
+  glibmm
+  gtk3
+  gtkmm3
+  pangomm
+  cairomm
+  librsvg
+)
+
+foreach(__DYNAMIC_PORT ${__DYNAMIC_PORTS})
+  if(PORT MATCHES "${__DYNAMIC_PORT}")
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+  endif()
+endforeach()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,10 +13,14 @@
     "libjpeg-turbo",
     "imagemagick",
     "openexr",
-    "pkgconf",
     "librsvg",
     "ffmpeg",
+    "jack2",
     "hicolor-icon-theme",
-    "adwaita-icon-theme"
+    "adwaita-icon-theme",
+    {
+        "name": "pkgconf",
+        "platform": "windows"
+    }
   ]
 }


### PR DESCRIPTION
This PR adds vcpkg support for linux. Changes include:
1. Adding ports for at-spi2-core and at-spi2-atk since they're required for gtk on Linux. These are the same from the PR https://github.com/microsoft/vcpkg/pull/24934, and should be removed once this PR is merged into vcpkg (not merged until now because of problems regarding CI)
2. Adding `glib` port to fix pkgconfig variable issue. I submitted these PRs to fix this, and once they're merged both the glib port and gdk-pixbuf port should be removed: https://github.com/microsoft/vcpkg/pull/26744 https://github.com/microsoft/vcpkg/pull/26743
3. Added `x64-linux-synfig` (probably a bad name) triplet file inside new folder `vcpkg-triplets`. Triplets are the recommended way for adding per port customization regarding build type.
4. Added a python script (appdeps.py) that mimics what vcpkg's `applocal.ps1` script does on Windows. i.e. it copies all dependencies of a library to enable portability.

To build, you do something like:
```
> cmake -DCMAKE_TOOLCHAIN_FILE=<vcpkg-dir>scripts/buildsystems/vcpkg.cmake -DVCPKG_INSTALLED_DIR=$(pwd)/../../synfig_vcpkg_installed -DCMAKE_BUILD_TYPE=Release -DVCPKG_OVERLAY_PORTS=$(pwd)/../vcpkg-ports  -DVCPKG_OVERLAY_TRIPLETS=$(pwd)/../vcpkg-triplets -DVCPKG_TARGET_TRIPLET="x64-linux-synfig" -DCMAKE_INSTALL_PREFIX=$HOME/synfig ..
> make -j8
> make install
```

Some dependencies require some system libraries, so they will need to be installed as needed.

Similar to windows, installation will create a portable synfig package, although it won't be truly portable in contrast to the case with Windows because of the dependencies on these system libraries.

This probably will be my last PR in my GSoC preiod. I will work on conan support afterwards.