### PR TITLE
perf: improved file opening speed in Windows

### DIFF
--- a/synfig-core/src/synfig/bone.cpp
+++ b/synfig-core/src/synfig/bone.cpp
@@ -63,8 +63,8 @@ Bone::Bone():
 	depth_(0.0),
 	parent_(nullptr)
 {
-	if (getenv("SYNFIG_DEBUG_NEW_BONES"))
-		printf("%s:%d new bone\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_NEW_BONES",
+		"%s:%d new bone\n", __FILE__, __LINE__);
 }
 
 //!Constructor by origin and tip
@@ -79,8 +79,8 @@ Bone::Bone(const Point &o, const Point &t):
 	depth_(0.0),
 	parent_(nullptr)
 {
-	if (getenv("SYNFIG_DEBUG_NEW_BONES"))
-		printf("%s:%d new bone\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_NEW_BONES",
+		"%s:%d new bone\n", __FILE__, __LINE__);
 }
 
 //!Constructor by origin, angle, length, strength, parent bone (default = no parent)
@@ -96,8 +96,8 @@ Bone::Bone(const String &n, const Point &o, const Angle &a, const Real &l, Value
 	depth_(0.0),
 	parent_(p)
 {
-	if (getenv("SYNFIG_DEBUG_NEW_BONES"))
-		printf("%s:%d new bone\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_NEW_BONES",
+		"%s:%d new bone\n", __FILE__, __LINE__);
 }
 
 const ValueNode_Bone*

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -105,8 +105,8 @@ Canvas::Canvas(const String &id):
 void
 Canvas::on_changed()
 {
-	if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
-		printf("%s:%d Canvas::on_changed()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
+		"%s:%d Canvas::on_changed()\n", __FILE__, __LINE__);
 
 	is_dirty_=true;
 	Node::on_changed();

--- a/synfig-core/src/synfig/general.h
+++ b/synfig-core/src/synfig/general.h
@@ -88,6 +88,15 @@ extern void warning(const String &str);
 extern void info(const char *format,...);
 extern void info(const String &str);
 
+//#define LOGGING_ENABLED
+#ifdef LOGGING_ENABLED
+#define DEBUG_LOG(logger, fmt, ...) if (getenv(logger)) printf(fmt __VA_OPT__(,) __VA_ARGS__);
+#define DEBUG_GETENV(name) getenv(name)
+#else
+#define DEBUG_LOG(logger, fmt, ...) void (0)
+#define DEBUG_GETENV(name) false
+#endif
+
 //! Returns absolute path to the binary
 extern String get_binary_path(const String &fallback_path);
 

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -382,8 +382,8 @@ Layer::disconnect_dynamic_param(const String& param)
 void
 Layer::on_changed()
 {
-	if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
-		printf("%s:%d Layer::on_changed()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
+		"%s:%d Layer::on_changed()\n", __FILE__, __LINE__);
 
 	clear_time_mark();
 	Node::on_changed();

--- a/synfig-core/src/synfig/layers/layer_skeleton.cpp
+++ b/synfig-core/src/synfig/layers/layer_skeleton.cpp
@@ -33,6 +33,9 @@
 #endif
 
 #include "layer_skeleton.h"
+#ifdef _DEBUG
+#include "synfig/general.h"
+#endif
 
 #include <synfig/localization.h>
 
@@ -90,8 +93,8 @@ Layer_Skeleton::Layer_Skeleton():
 #ifdef _DEBUG
 Layer_Skeleton::~Layer_Skeleton()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		printf("%s:%d ~Layer_Skeleton()\n", __FILE__, __LINE__);
+	 DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"%s:%d ~Layer_Skeleton()\n", __FILE__, __LINE__);
 }
 #endif
 

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -1852,7 +1852,7 @@ CanvasParser::parse_animated(xmlpp::Element *element,Canvas::Handle canvas)
 etl::handle<LinkableValueNode>
 CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 {
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_linkable_value_node\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_linkable_value_node\n", __FILE__, __LINE__);
 
 	// Determine the type
 	if(!element->get_attribute("type"))
@@ -1870,7 +1870,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 		return 0;
 	}
 
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d creating linkable '%s' type '%s'\n", __FILE__, __LINE__, element->get_name().c_str(), type.description.name.c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d creating linkable '%s' type '%s'\n", __FILE__, __LINE__, element->get_name().c_str(), type.description.name.c_str());
 	handle<LinkableValueNode> value_node=ValueNodeRegistry::create(element->get_name(),type);
  	//handle<ValueNode> c[value_node->link_count()]; changed because of clang complain
 	std::vector<handle<ValueNode> > c(value_node->link_count());
@@ -2075,8 +2075,8 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 	}
 
 	String version(canvas->get_version());
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d link_count() is %d\n", __FILE__, __LINE__, value_node->link_count());
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d value_node is %s\n", __FILE__, __LINE__, value_node->get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d link_count() is %d\n", __FILE__, __LINE__, value_node->link_count());
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d value_node is %s\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	for (int i = 0; i < value_node->link_count(); i++)
 	{
 		if (!c[i])
@@ -2190,7 +2190,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 		}
 	}
 
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_linkable_value_node done\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_linkable_value_node done\n", __FILE__, __LINE__);
 	return value_node;
 }
 
@@ -2549,7 +2549,7 @@ CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 handle<ValueNode>
 CanvasParser::parse_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 {
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node\n", __FILE__, __LINE__);
 	handle<ValueNode> value_node;
 	assert(element);
 
@@ -2558,12 +2558,12 @@ CanvasParser::parse_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 	if(element->get_attribute("guid"))
 	{
 		guid=GUID(element->get_attribute("guid")->get_value())^canvas->get_root()->get_guid();
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d got guid %s\n", __FILE__, __LINE__, guid.get_string().c_str());
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d and element name = '%s'\n", __FILE__, __LINE__, element->get_name().c_str());
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d got guid %s\n", __FILE__, __LINE__, guid.get_string().c_str());
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d and element name = '%s'\n", __FILE__, __LINE__, element->get_name().c_str());
 		value_node=guid_cast<ValueNode>(guid);
 		if(value_node)
 		{
-			if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node done early\n", __FILE__, __LINE__);
+			DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node done early\n", __FILE__, __LINE__);
 			if(element->get_name()!="canvas" && ValueBase::ident_type(element->get_name()) != type_nil)
 			{
 				if (element->get_name() == "bone_valuenode")
@@ -2571,7 +2571,7 @@ CanvasParser::parse_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 					ValueNode_Bone::Handle value_node_bone(ValueNode_Bone::Handle::cast_dynamic(value_node));
 					if (!value_node_bone)
 					{
-						if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d bone_valuenode isn't a ValueNode_Bone?  It's a placeholder?\n", __FILE__, __LINE__);
+						DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d bone_valuenode isn't a ValueNode_Bone?  It's a placeholder?\n", __FILE__, __LINE__);
 						return value_node;
 					}
 
@@ -2583,10 +2583,10 @@ CanvasParser::parse_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 	}
 
 	// If ValueBase::ident_type() recognizes the name, then we know it's a ValueBase
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d element name = '%s'\n", __FILE__, __LINE__, element->get_name().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d element name = '%s'\n", __FILE__, __LINE__, element->get_name().c_str());
 	if(element->get_name()!="canvas" && ValueBase::ident_type(element->get_name()) != type_nil)
 	{
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node calls parse_value\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node calls parse_value\n", __FILE__, __LINE__);
 		ValueBase data=parse_value(element,canvas);
 
 		if(!data.is_valid())
@@ -2606,25 +2606,25 @@ CanvasParser::parse_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 	else
 	if(element->get_name()=="hermite" || element->get_name()=="animated")
 	{
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node calls parse_animated\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node calls parse_animated\n", __FILE__, __LINE__);
 		value_node=parse_animated(element,canvas);
 	}
 	else
 	if(element->get_name()=="static_list")
 	{
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node calls parse_static_list\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node calls parse_static_list\n", __FILE__, __LINE__);
 		value_node=parse_static_list(element,canvas);
 	}
 	else
 	if(element->get_name()=="dynamic_list")
 	{
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node calls parse_dynamic_list\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node calls parse_dynamic_list\n", __FILE__, __LINE__);
 		value_node=parse_dynamic_list(element,canvas);
 	}
 	else
 	if(element->get_name()=="bline") // This is not a typo. The dynamic list parser will parse a bline.
 	{
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node calls parse_dynamic_list for bline\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node calls parse_dynamic_list for bline\n", __FILE__, __LINE__);
 		value_node=parse_dynamic_list(element,canvas);
 	}
 	else
@@ -2639,23 +2639,23 @@ CanvasParser::parse_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 	else
 	if(ValueNodeRegistry::book().count(element->get_name()))
 	{
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node calls parse_linkable_value_node\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node calls parse_linkable_value_node\n", __FILE__, __LINE__);
 		value_node=parse_linkable_value_node(element,canvas);
 		if (!value_node)
 		{
-			if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_linkable_value_node gave us a null valuenode\n", __FILE__, __LINE__);
+			DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_linkable_value_node gave us a null valuenode\n", __FILE__, __LINE__);
 			value_node = PlaceholderValueNode::create();
 		}
 	}
 	else
 	if(element->get_name()=="canvas")
 	{
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node calls parse_canvas\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node calls parse_canvas\n", __FILE__, __LINE__);
 		value_node=ValueNode_Const::create(parse_canvas(element,canvas,true));
 	}
 	else
 	{
-		if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node doesn't know what to call\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node doesn't know what to call\n", __FILE__, __LINE__);
 		error_unexpected_element(element,element->get_name());
 		error(element, strprintf(_("Expected a ValueNode.  Refer to '%s'"),
 								 VALUENODE_COMPATIBILITY_URL));
@@ -2695,14 +2695,14 @@ CanvasParser::parse_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 		}
 	}
 	value_node->set_guid(guid);
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_value_node done\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node done\n", __FILE__, __LINE__);
 	return value_node;
 }
 
 void
 CanvasParser::parse_canvas_defs(xmlpp::Element *element,Canvas::Handle canvas)
 {
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_canvas_defs\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_canvas_defs\n", __FILE__, __LINE__);
 	assert(element->get_name()=="defs");
 	xmlpp::Element::NodeList list = element->get_children();
 	for(xmlpp::Element::NodeList::iterator iter = list.begin(); iter != list.end(); ++iter)
@@ -2716,13 +2716,13 @@ CanvasParser::parse_canvas_defs(xmlpp::Element *element,Canvas::Handle canvas)
 		else
 			parse_value_node(child,canvas);
 	}
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_canvas_defs done\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_canvas_defs done\n", __FILE__, __LINE__);
 }
 
 std::list<ValueNode::Handle>
 CanvasParser::parse_canvas_bones(xmlpp::Element *element,Canvas::Handle canvas)
 {
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_canvas_bones\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_canvas_bones\n", __FILE__, __LINE__);
 	assert(element->get_name()=="bones");
 	xmlpp::Element::NodeList list = element->get_children();
 	std::list<ValueNode::Handle> bone_list;
@@ -2736,7 +2736,7 @@ CanvasParser::parse_canvas_bones(xmlpp::Element *element,Canvas::Handle canvas)
 			bone_list.push_back(parse_value_node(child,canvas));
 	}
 	in_bones_section = false;
-	if (getenv("SYNFIG_DEBUG_LOAD_CANVAS")) printf("%s:%d parse_canvas_bones done\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_canvas_bones done\n", __FILE__, __LINE__);
 	return bone_list;
 }
 

--- a/synfig-core/src/synfig/node.cpp
+++ b/synfig-core/src/synfig/node.cpp
@@ -236,16 +236,16 @@ Node::add_parent(Node* new_parent)
 {
 	std::lock_guard<std::mutex> lock(parent_set_mutex_);
 
-	if (getenv("SYNFIG_DEBUG_NODE_PARENT_SET"))
-		printf("%s:%d adding %p (%s) as parent of %p (%s) (%zu -> ", __FILE__, __LINE__,
+	DEBUG_LOG("SYNFIG_DEBUG_NODE_PARENT_SET",
+		"%s:%d adding %p (%s) as parent of %p (%s) (%zu -> ", __FILE__, __LINE__,
 			   new_parent, new_parent->get_string().c_str(),
 			   this, get_string().c_str(),
 			   parent_set.size());
 
 	parent_set.insert(new_parent);
 
-	if (getenv("SYNFIG_DEBUG_NODE_PARENT_SET"))
-		printf("%zu)\n", parent_set.size());
+	DEBUG_LOG("SYNFIG_DEBUG_NODE_PARENT_SET",
+		"%zu)\n", parent_set.size());
 }
 
 void
@@ -264,7 +264,7 @@ Node::remove_parent(Node* parent)
 
 	if(parent_set.count(parent) == 0)
 	{
-		if (getenv("SYNFIG_DEBUG_NODE_PARENT_SET"))
+		if (DEBUG_GETENV("SYNFIG_DEBUG_NODE_PARENT_SET"))
 			warning("%s:%d %p (%s) isn't in parent set of %p (%s)\n", __FILE__, __LINE__,
 				   parent, parent->get_string().c_str(),
 				   this, get_string().c_str());
@@ -272,16 +272,16 @@ Node::remove_parent(Node* parent)
 		return;
 	}
 
-	if (getenv("SYNFIG_DEBUG_NODE_PARENT_SET"))
-		printf("%s:%d removing %p (%s) from parent set of %p (%s) (%zu -> ", __FILE__, __LINE__,
+	DEBUG_LOG("SYNFIG_DEBUG_NODE_PARENT_SET",
+		"%s:%d removing %p (%s) from parent set of %p (%s) (%zu -> ", __FILE__, __LINE__,
 			   parent, parent->get_string().c_str(),
 			   this, get_string().c_str(),
 			   parent_set.size());
 
 	parent_set.erase(parent);
 
-	if (getenv("SYNFIG_DEBUG_NODE_PARENT_SET"))
-		printf("%zu)\n", parent_set.size());
+	DEBUG_LOG("SYNFIG_DEBUG_NODE_PARENT_SET",
+		"%zu)\n", parent_set.size());
 }
 
 void
@@ -357,7 +357,7 @@ Node::begin_delete()
 void
 Node::on_changed()
 {
-	if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
+	if (DEBUG_GETENV("SYNFIG_DEBUG_ON_CHANGED"))
 	{
 		std::lock_guard<std::mutex> lock(parent_set_mutex_);
 		printf("%s:%d Node::on_changed() for %p (%s); signalling these %zd parents:\n", __FILE__, __LINE__, this, get_string().c_str(), parent_set.size());

--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -310,7 +310,7 @@ xmlpp::Element* encode_pair(xmlpp::Element* root,types_namespace::TypePairBase &
 
 xmlpp::Element* encode_value(xmlpp::Element* root,const ValueBase &data,Canvas::ConstHandle canvas)
 {
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_value (type %s)\n", __FILE__, __LINE__, data.get_type().description.name.c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_value (type %s)\n", __FILE__, __LINE__, data.get_type().description.name.c_str());
 	Type &type(data.get_type());
 	if (type == type_real)
 	{
@@ -538,7 +538,7 @@ xmlpp::Element* encode_subtract(xmlpp::Element* root,ValueNode_Subtract::ConstHa
 
 xmlpp::Element* encode_static_list(xmlpp::Element* root,ValueNode_StaticList::ConstHandle value_node,Canvas::ConstHandle canvas=nullptr)
 {
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_static_list %s\n", __FILE__, __LINE__, value_node->get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_static_list %s\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	assert(value_node);
 
 	root->set_name(value_node->get_name());
@@ -555,12 +555,12 @@ xmlpp::Element* encode_static_list(xmlpp::Element* root,ValueNode_StaticList::Co
 			entry_node->set_attribute("use",(*iter)->get_relative_id(canvas));
 		else
 		{
-			if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode entry %s\n", __FILE__, __LINE__, (*iter)->get_string().c_str());
+			DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode entry %s\n", __FILE__, __LINE__, (*iter)->get_string().c_str());
 			encode_value_node(entry_node->add_child("value_node"),*iter,canvas);
 		}
 	}
 
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_static_list %s done\n", __FILE__, __LINE__, value_node->get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_static_list %s done\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	return root;
 }
 
@@ -662,7 +662,7 @@ xmlpp::Element* encode_dynamic_list(xmlpp::Element* root,ValueNode_DynamicList::
 // Generic linkable data node entry
 xmlpp::Element* encode_linkable_value_node(xmlpp::Element* root,LinkableValueNode::ConstHandle value_node,Canvas::ConstHandle canvas=nullptr)
 {
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_linkable_value_node %s\n", __FILE__, __LINE__, value_node->get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_linkable_value_node %s\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	assert(value_node);
 
 	String name(value_node->get_name());
@@ -699,27 +699,27 @@ xmlpp::Element* encode_linkable_value_node(xmlpp::Element* root,LinkableValueNod
 		{
 			if (name == "bone" && value_node->link_name(i) == "parent")
 			{
-				if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d saving bone's parent\n", __FILE__, __LINE__);
+				DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d saving bone's parent\n", __FILE__, __LINE__);
 			}
 			encode_value_node(root->add_child(value_node->link_name(i))->add_child("value_node"),link,canvas);
 		}
 	}
 
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_linkable_value_node %s done\n", __FILE__, __LINE__, value_node->get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_linkable_value_node %s done\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	return root;
 }
 
 xmlpp::Element* encode_value_node(xmlpp::Element* root,ValueNode::ConstHandle value_node,Canvas::ConstHandle canvas)
 {
 	assert(value_node);
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_value_node %s %s\n", __FILE__, __LINE__, value_node->get_string().c_str(), value_node->get_guid().get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_value_node %s %s\n", __FILE__, __LINE__, value_node->get_string().c_str(), value_node->get_guid().get_string().c_str());
 
 	if(value_node->rcount()>1)
 		root->set_attribute("guid",(value_node->get_guid()^canvas->get_root()->get_guid()).get_string());
 
 	if(ValueNode_Bone::ConstHandle value_node_bone = ValueNode_Bone::ConstHandle::cast_dynamic(value_node))
 	{
-		if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d shortcutting for valuenode_bone\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d shortcutting for valuenode_bone\n", __FILE__, __LINE__);
 		encode_value_node_bone_id(root, value_node_bone,canvas);
 	}
 	else
@@ -739,7 +739,7 @@ xmlpp::Element* encode_value_node(xmlpp::Element* root,ValueNode::ConstHandle va
 	// if it's a ValueNode_Const
 	else if (ValueNode_Const::ConstHandle const_value_node = ValueNode_Const::ConstHandle::cast_dynamic(value_node))
 	{
-		if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d got ValueNode_Const encoding value\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d got ValueNode_Const encoding value\n", __FILE__, __LINE__);
 		// encode its get_value()
 		encode_value(root,const_value_node->get_value(),canvas);
 	}
@@ -760,14 +760,14 @@ xmlpp::Element* encode_value_node(xmlpp::Element* root,ValueNode::ConstHandle va
 //	if(ValueNode_Bone::ConstHandle::cast_dynamic(value_node))
 //		root->set_attribute("guid",value_node->get_guid().get_string());
 
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_value_node %s done\n", __FILE__, __LINE__, value_node->get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_value_node %s done\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	return root;
 }
 
 xmlpp::Element* encode_value_node_bone(xmlpp::Element* root,ValueNode::ConstHandle value_node,Canvas::ConstHandle canvas)
 {
 	assert(value_node);
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_value_node_bone %s %s\n", __FILE__, __LINE__, value_node->get_string().c_str(), value_node->get_guid().get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_value_node_bone %s %s\n", __FILE__, __LINE__, value_node->get_string().c_str(), value_node->get_guid().get_string().c_str());
 
 	if (ValueNode_Bone::ConstHandle bone_value_node = ValueNode_Bone::ConstHandle::cast_dynamic(value_node))
 		encode_linkable_value_node(root,bone_value_node,canvas);
@@ -793,7 +793,7 @@ xmlpp::Element* encode_value_node_bone(xmlpp::Element* root,ValueNode::ConstHand
 		root->set_attribute("guid",(value_node->get_guid()^canvas->get_root()->get_guid()).get_string());
 	}
 
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_value_node %s done\n", __FILE__, __LINE__, value_node->get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_value_node %s done\n", __FILE__, __LINE__, value_node->get_string().c_str());
 	return root;
 }
 
@@ -801,13 +801,13 @@ xmlpp::Element* encode_value_node_bone_id(xmlpp::Element* root,ValueNode::ConstH
 {
 	root->set_name("bone");
 	root->set_attribute("type",type_bone_object.description.name);
-	if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d encode_value_node_bone_id %s %s\n", __FILE__, __LINE__, value_node->get_string().c_str(), value_node->get_guid().get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d encode_value_node_bone_id %s %s\n", __FILE__, __LINE__, value_node->get_string().c_str(), value_node->get_guid().get_string().c_str());
 	if(!value_node->get_id().empty())
 		root->set_attribute("id",value_node->get_id());
 
 	if(ValueNode_Bone::ConstHandle::cast_dynamic(value_node))
 	{
-		if (getenv("SYNFIG_DEBUG_SAVE_CANVAS")) printf("%s:%d bone guid case 1 guid %s\n", __FILE__, __LINE__, value_node->get_guid().get_string().c_str());
+		DEBUG_LOG("SYNFIG_DEBUG_SAVE_CANVAS", "%s:%d bone guid case 1 guid %s\n", __FILE__, __LINE__, value_node->get_guid().get_string().c_str());
 		root->set_attribute("guid",(value_node->get_guid()^canvas->get_root()->get_guid()).get_string());
 	}
 

--- a/synfig-core/src/synfig/transform.cpp
+++ b/synfig-core/src/synfig/transform.cpp
@@ -32,6 +32,7 @@
 #	include <config.h>
 #endif
 
+#include "general.h"
 #include "transform.h"
 #include <algorithm>
 
@@ -64,13 +65,13 @@ TransformStack::perform(const synfig::Vector& x)const
 {
 	synfig::Vector ret(x);
 
-	if (getenv("SYNFIG_DEBUG_TRANSFORM_STACK")) printf("   PERFORM %s: %5.2f %5.2f", get_guid().get_string().substr(0,6).c_str(), ret[0], ret[1]);
+	DEBUG_LOG("SYNFIG_DEBUG_TRANSFORM_STACK", "   PERFORM %s: %5.2f %5.2f", get_guid().get_string().substr(0,6).c_str(), ret[0], ret[1]);
 	for(const_reverse_iterator iter(rbegin());iter!=rend();++iter)
 	{
 		ret=(*iter)->perform(ret);
-		if (getenv("SYNFIG_DEBUG_TRANSFORM_STACK")) printf(" (%14s) %5.2f %5.2f", (*iter)->get_string().c_str(), ret[0], ret[1]);
+		DEBUG_LOG("SYNFIG_DEBUG_TRANSFORM_STACK", " (%14s) %5.2f %5.2f", (*iter)->get_string().c_str(), ret[0], ret[1]);
 	}
-	if (getenv("SYNFIG_DEBUG_TRANSFORM_STACK")) printf("\n");
+	DEBUG_LOG("SYNFIG_DEBUG_TRANSFORM_STACK", "\n");
 
 	return ret;
 }
@@ -80,13 +81,13 @@ TransformStack::unperform(const synfig::Vector& x)const
 {
 	synfig::Vector ret(x);
 
-	if (getenv("SYNFIG_DEBUG_TRANSFORM_STACK")) printf(" UNPERFORM %s: %5.2f %5.2f", get_guid().get_string().substr(0,6).c_str(), ret[0], ret[1]);
+	DEBUG_LOG("SYNFIG_DEBUG_TRANSFORM_STACK", " UNPERFORM %s: %5.2f %5.2f", get_guid().get_string().substr(0,6).c_str(), ret[0], ret[1]);
 	for(const_iterator iter(begin());iter!=end();++iter)
 	{
 		ret=(*iter)->unperform(ret);
-		if (getenv("SYNFIG_DEBUG_TRANSFORM_STACK")) printf(" (%14s) %5.2f %5.2f", (*iter)->get_string().c_str(), ret[0], ret[1]);
+		DEBUG_LOG("SYNFIG_DEBUG_TRANSFORM_STACK", " (%14s) %5.2f %5.2f", (*iter)->get_string().c_str(), ret[0], ret[1]);
 	}
-	if (getenv("SYNFIG_DEBUG_TRANSFORM_STACK")) printf("\n");
+	DEBUG_LOG("SYNFIG_DEBUG_TRANSFORM_STACK", "\n");
 
 	return ret;
 }

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -140,8 +140,8 @@ ValueNode::~ValueNode()
 void
 ValueNode::on_changed()
 {
-	if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
-		printf("%s:%d ValueNode::on_changed()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
+		"%s:%d ValueNode::on_changed()\n", __FILE__, __LINE__);
 
 	etl::loose_handle<Canvas> parent_canvas = get_parent_canvas();
 	if(parent_canvas)
@@ -527,8 +527,8 @@ PlaceholderValueNode::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid)c
 PlaceholderValueNode::Handle
 PlaceholderValueNode::create(Type &type)
 {
-	if (getenv("SYNFIG_DEBUG_PLACEHOLDER_VALUENODE"))
-		printf("%s:%d PlaceholderValueNode::create\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_PLACEHOLDER_VALUENODE",
+		"%s:%d PlaceholderValueNode::create\n", __FILE__, __LINE__);
 	return new PlaceholderValueNode(type);
 }
 
@@ -590,8 +590,8 @@ ValueNode::get_relative_id(etl::loose_handle<const Canvas> x)const
 etl::loose_handle<Canvas>
 ValueNode::get_parent_canvas()const
 {
-	if (getenv("SYNFIG_DEBUG_GET_PARENT_CANVAS"))
-		printf("%s:%d get_parent_canvas of %p is %p\n", __FILE__, __LINE__, this, canvas_.get());
+	DEBUG_LOG("SYNFIG_DEBUG_GET_PARENT_CANVAS",
+		"%s:%d get_parent_canvas of %p is %p\n", __FILE__, __LINE__, this, canvas_.get());
 
 	return canvas_;
 }
@@ -599,8 +599,8 @@ ValueNode::get_parent_canvas()const
 etl::loose_handle<Canvas>
 ValueNode::get_root_canvas()const
 {
-	if (getenv("SYNFIG_DEBUG_GET_PARENT_CANVAS"))
-		printf("%s:%d get_root_canvas of %p is %p\n", __FILE__, __LINE__, this, root_canvas_.get());
+	DEBUG_LOG("SYNFIG_DEBUG_GET_PARENT_CANVAS",
+		"%s:%d get_root_canvas of %p is %p\n", __FILE__, __LINE__, this, root_canvas_.get());
 
 	return root_canvas_;
 }
@@ -614,8 +614,8 @@ ValueNode::get_non_inline_ancestor_canvas()const
 	{
 		etl::loose_handle<Canvas> ret(parent->get_non_inline_ancestor());
 
-		if (getenv("SYNFIG_DEBUG_GET_PARENT_CANVAS"))
-			printf("%s:%d get_non_inline_ancestor_canvas of %p is %p\n", __FILE__, __LINE__, this, ret.get());
+		DEBUG_LOG("SYNFIG_DEBUG_GET_PARENT_CANVAS",
+			"%s:%d get_non_inline_ancestor_canvas of %p is %p\n", __FILE__, __LINE__, this, ret.get());
 
 		return ret;
 	}
@@ -626,13 +626,13 @@ ValueNode::get_non_inline_ancestor_canvas()const
 void
 ValueNode::set_parent_canvas(etl::loose_handle<Canvas> x)
 {
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d set_parent_canvas of %p to %p\n", __FILE__, __LINE__, this, x.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d set_parent_canvas of %p to %p\n", __FILE__, __LINE__, this, x.get());
 
 	canvas_=x;
 
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d now %p\n", __FILE__, __LINE__, canvas_.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d now %p\n", __FILE__, __LINE__, canvas_.get());
 
 	if(x) set_root_canvas(x);
 }
@@ -640,13 +640,13 @@ ValueNode::set_parent_canvas(etl::loose_handle<Canvas> x)
 void
 ValueNode::set_root_canvas(etl::loose_handle<Canvas> x)
 {
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d set_root_canvas of %p to %p - ", __FILE__, __LINE__, this, x.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d set_root_canvas of %p to %p - ", __FILE__, __LINE__, this, x.get());
 
 	root_canvas_=x->get_root();
 
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("now %p\n", root_canvas_.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"now %p\n", root_canvas_.get());
 }
 
 String

--- a/synfig-core/src/synfig/valuenodes/valuenode_add.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_add.cpp
@@ -143,8 +143,8 @@ synfig::ValueNode_Add::~ValueNode_Add()
 synfig::ValueBase
 synfig::ValueNode_Add::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	if(!ref_a || !ref_b)
 		throw std::runtime_error(strprintf("ValueNode_Add: %s",_("One or both of my parameters aren't set!")));

--- a/synfig-core/src/synfig/valuenodes/valuenode_and.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_and.cpp
@@ -113,8 +113,8 @@ ValueNode_And::get_link_vfunc(int i)const
 ValueBase
 ValueNode_And::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	bool link1     = (*link1_)   (t).get(bool());
 	bool link2     = (*link2_)   (t).get(bool());

--- a/synfig-core/src/synfig/valuenodes/valuenode_anglestring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_anglestring.cpp
@@ -96,8 +96,8 @@ ValueNode_AngleString::~ValueNode_AngleString()
 ValueBase
 ValueNode_AngleString::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Real angle(Angle::deg((*angle_)(t).get(Angle())).get());
 	int width((*width_)(t).get(int()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedinterface.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedinterface.cpp
@@ -398,8 +398,8 @@ public:
 
 		virtual void on_changed()
 		{
-			if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
-				printf("%s:%d _Hermite::on_changed()\n", __FILE__, __LINE__);
+			DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
+				"%s:%d _Hermite::on_changed()\n", __FILE__, __LINE__);
 
 			if(animated.waypoint_list_.size()<=1)
 				return;
@@ -729,8 +729,8 @@ public:
 
 		virtual void on_changed()
 		{
-			if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
-				printf("%s:%d _Constant::on_changed()\n", __FILE__, __LINE__);
+			DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
+				"%s:%d _Constant::on_changed()\n", __FILE__, __LINE__);
 
 			if(animated.waypoint_list_.size()<=1)
 				return;
@@ -820,8 +820,8 @@ public:
 
 		virtual void on_changed()
 		{
-			if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
-				printf("%s:%d _AnimBool::on_changed()\n", __FILE__, __LINE__);
+			DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
+				"%s:%d _AnimBool::on_changed()\n", __FILE__, __LINE__);
 
 			if(animated.waypoint_list_.size()<=1)
 				return;

--- a/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
@@ -92,8 +92,8 @@ ValueNode_Atan2::~ValueNode_Atan2()
 ValueBase
 ValueNode_Atan2::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return Angle::tan((*y_)(t).get(Real()),
 					  (*x_)(t).get(Real()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_average.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_average.cpp
@@ -38,6 +38,7 @@
 #include <synfig/valuenode_registry.h>
 
 #include "valuenode_const.h"
+#include "synfig/general.h"
 
 #include <synfig/canvas.h>
 #include <synfig/valueoperations.h>
@@ -91,8 +92,8 @@ ValueNode_Average::create(const ValueBase& value, Canvas::LooseHandle canvas)
 ValueBase
 ValueNode_Average::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 	return ValueAverage::average( ValueNode_DynamicList::operator()(t), ValueBase(), ValueBase(get_type()));
 }
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -383,8 +383,8 @@ synfig::bline_length(const ValueBase &bline, bool bline_loop, std::vector<Real> 
 ValueNode_BLine::ValueNode_BLine(Canvas::LooseHandle canvas):
 	ValueNode_DynamicList(type_bline_point, canvas)
 {
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d should have already set parent canvas for bline %p to %p (using dynamic_list constructor)\n", __FILE__, __LINE__, this, canvas.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d should have already set parent canvas for bline %p to %p (using dynamic_list constructor)\n", __FILE__, __LINE__, this, canvas.get());
 }
 
 ValueNode_BLine::~ValueNode_BLine()
@@ -548,8 +548,8 @@ ValueNode_BLine::create_list_entry(int index, Time time, Real origin)
 ValueBase
 ValueNode_BLine::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	std::vector<BLinePoint> ret_list;
 
@@ -997,8 +997,8 @@ ValueNode_BLine::get_blinepoint(std::vector<ListEntry>::const_iterator current, 
 void
 ValueNode_BLine::ref()const
 {
-	if (getenv("SYNFIG_DEBUG_BLINE_REFCOUNT"))
-		printf("%s:%d %lx   ref bline %*s -> %2d\n", __FILE__, __LINE__, uintptr_t(this), (count()*2), "", count()+1);
+	DEBUG_LOG("SYNFIG_DEBUG_BLINE_REFCOUNT",
+		"%s:%d %lx   ref bline %*s -> %2d\n", __FILE__, __LINE__, uintptr_t(this), (count()*2), "", count()+1);
 
 	LinkableValueNode::ref();
 }
@@ -1006,8 +1006,8 @@ ValueNode_BLine::ref()const
 bool
 ValueNode_BLine::unref()const
 {
-	if (getenv("SYNFIG_DEBUG_BLINE_REFCOUNT"))
-		printf("%s:%d %lx unref bline %*s%2d <-\n", __FILE__, __LINE__, uintptr_t(this), ((count()-1)*2), "", count()-1);
+	DEBUG_LOG("SYNFIG_DEBUG_BLINE_REFCOUNT",
+		"%s:%d %lx unref bline %*s%2d <-\n", __FILE__, __LINE__, uintptr_t(this), ((count()-1)*2), "", count()-1);
 
 	return LinkableValueNode::unref();
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
@@ -98,8 +98,8 @@ ValueNode_BLineCalcTangent::~ValueNode_BLineCalcTangent()
 ValueBase
 ValueNode_BLineCalcTangent::operator()(Time t, Real amount)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	const ValueBase::List bline = (*bline_)(t).get_list();
 	const ValueBase bline_value_node = (*bline_)(t);

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
@@ -96,8 +96,8 @@ ValueNode_BLineCalcVertex::~ValueNode_BLineCalcVertex()
 ValueBase
 ValueNode_BLineCalcVertex::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	const ValueBase::List bline = (*bline_)(t).get_list();
 	const ValueBase bline_value_node = (*bline_)(t);

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
@@ -97,8 +97,8 @@ ValueNode_BLineCalcWidth::~ValueNode_BLineCalcWidth()
 ValueBase
 ValueNode_BLineCalcWidth::operator()(Time t, Real amount)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	const ValueBase::List bline = (*bline_)(t).get_list();
 	const ValueBase bline_value_node = (*bline_)(t);

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.cpp
@@ -97,8 +97,8 @@ ValueNode_BLineRevTangent::~ValueNode_BLineRevTangent()
 ValueBase
 ValueNode_BLineRevTangent::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	if ((*reverse_)(t).get(bool()))
 	{

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
@@ -98,7 +98,7 @@ struct compare_bones
 void
 ValueNode_Bone::show_bone_map(Canvas::LooseHandle canvas, const char *file, int line, String text, Time t)
 {
-	if (!getenv("SYNFIG_DEBUG_BONE_MAP")) return;
+	if (!DEBUG_GETENV("SYNFIG_DEBUG_BONE_MAP")) return;
 
 	BoneMap bone_map(canvas_map[canvas]);
 
@@ -147,7 +147,7 @@ ValueNode_Bone::get_ordered_bones(etl::handle<const Canvas> canvas)
 			BoneSet ref(get_bones_referenced_by(user, false));
 			if (ref.empty())
 			{
-				if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("%s:%d %s doesn't need anybody\n", __FILE__, __LINE__,
+				DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "%s:%d %s doesn't need anybody\n", __FILE__, __LINE__,
 					   user->get_bone_name(0).c_str());
 				current_list.push_back(user);
 			}
@@ -155,7 +155,7 @@ ValueNode_Bone::get_ordered_bones(etl::handle<const Canvas> canvas)
 				for(BoneSet::iterator iter=ref.begin();iter!=ref.end();++iter)
 				{
 					ValueNode_Bone::Handle used(*iter);
-					if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("%s:%d %s is used by %s\n", __FILE__, __LINE__,
+					DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "%s:%d %s is used by %s\n", __FILE__, __LINE__,
 																				   used->get_bone_name(0).c_str(),
 																				   user->get_bone_name(0).c_str());
 					is_used_by.insert(std::make_pair(used, user));
@@ -170,12 +170,12 @@ ValueNode_Bone::get_ordered_bones(etl::handle<const Canvas> canvas)
 
 	while (current_list.size())
 	{
-		if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("%s:%d current_list has %zd members; we have %zd in is_used_by and %zd in uses\n",
+		DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "%s:%d current_list has %zd members; we have %zd in is_used_by and %zd in uses\n",
 																	   __FILE__, __LINE__, current_list.size(), is_used_by.size(), uses.size());
 		for(BoneList::iterator iter=current_list.begin();iter!=current_list.end();++iter)
 		{
 			ValueNode_Bone::Handle bone(*iter);
-			if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("%s:%d bone: %s\n", __FILE__, __LINE__, bone->get_bone_name(0).c_str());
+			DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "%s:%d bone: %s\n", __FILE__, __LINE__, bone->get_bone_name(0).c_str());
 			ret.push_back(bone);
 
 			std::multimap<ValueNode_Bone::Handle, ValueNode_Bone::Handle>::iterator begin(is_used_by.lower_bound(bone));
@@ -183,10 +183,10 @@ ValueNode_Bone::get_ordered_bones(etl::handle<const Canvas> canvas)
 			for (std::multimap<ValueNode_Bone::Handle, ValueNode_Bone::Handle>::iterator iter = begin; iter != end; iter++)
 			{
 				ValueNode_Bone::Handle user(iter->second);
-				if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("\t\t\t%s:%d user: %s\n", __FILE__, __LINE__, user->get_bone_name(0).c_str());
+				DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "\t\t\t%s:%d user: %s\n", __FILE__, __LINE__, user->get_bone_name(0).c_str());
 
 				// erase (user,bone) from uses
-				if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("%s:%d trying to erase - searching %zd\n", __FILE__, __LINE__, uses.count(user));
+				DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "%s:%d trying to erase - searching %zd\n", __FILE__, __LINE__, uses.count(user));
 				std::multimap<ValueNode_Bone::Handle, ValueNode_Bone::Handle>::iterator end2(uses.upper_bound(user));
 				bool found = false;
 				for (auto iter2 = uses.lower_bound(user); iter2 != end2; ++iter2)
@@ -195,24 +195,24 @@ ValueNode_Bone::get_ordered_bones(etl::handle<const Canvas> canvas)
 					{
 						uses.erase(iter2);
 						found = true;
-						if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("%s:%d found it\n", __FILE__, __LINE__);
+						DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "%s:%d found it\n", __FILE__, __LINE__);
 						break;
 					}
 					else
 					{
-						if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("no\n");
+						DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "no\n");
 					}
 				}
 				if (!found)
 				{
-					if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("%s:%d didn't find it?!?\n", __FILE__, __LINE__);
+					DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "%s:%d didn't find it?!?\n", __FILE__, __LINE__);
 					assert(0);
 				}
 
-				if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("%s:%d now there are %zd\n", __FILE__, __LINE__, uses.count(user));
+				DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "%s:%d now there are %zd\n", __FILE__, __LINE__, uses.count(user));
 				if (uses.count(user) == 0)
 				{
-					if (getenv("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS")) printf("\t\t\t%s:%d adding %s\n", __FILE__, __LINE__, user->get_bone_name(0).c_str());
+					DEBUG_LOG("SYNFIG_DEBUG_ORDER_BONES_FOR_SAVE_CANVAS", "\t\t\t%s:%d adding %s\n", __FILE__, __LINE__, user->get_bone_name(0).c_str());
 					new_list.push_back(user);
 				}
 			}
@@ -234,14 +234,14 @@ ValueNode_Bone::ValueNode_Bone():
 {
 	Vocab ret(get_children_vocab());
 	set_children_vocab(ret);
-	if (getenv("SYNFIG_DEBUG_ROOT_BONE"))
-		printf("%s:%d ValueNode_Bone::ValueNode_Bone() this line should only appear once guid %s\n", __FILE__, __LINE__, get_guid().get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_ROOT_BONE",
+		"%s:%d ValueNode_Bone::ValueNode_Bone() this line should only appear once guid %s\n", __FILE__, __LINE__, get_guid().get_string().c_str());
 }
 
 ValueNode_Bone::ValueNode_Bone(const ValueBase &value, etl::loose_handle<Canvas> canvas):
 	LinkableValueNode(value.get_type())
 {
-	if (getenv("SYNFIG_DEBUG_BONE_CONSTRUCTORS"))
+	if (DEBUG_GETENV("SYNFIG_DEBUG_BONE_CONSTRUCTORS"))
 	{
 		printf("\n%s:%d ------------------------------------------------------------------------\n", __FILE__, __LINE__);
 		printf("%s:%d --- ValueNode_Bone() for %s at %p---\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), this);
@@ -275,12 +275,12 @@ ValueNode_Bone::ValueNode_Bone(const ValueBase &value, etl::loose_handle<Canvas>
 		if (!parent) parent = get_root_bone();
 		set_link("parent",ValueNode_Const::create(ValueNode_Bone::Handle::cast_const(parent)));
 
-		if (getenv("SYNFIG_DEBUG_BONE_MAP"))
-			printf("%s:%d adding to canvas_map\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_MAP",
+			"%s:%d adding to canvas_map\n", __FILE__, __LINE__);
 		canvas_map[get_root_canvas()][get_guid()] = this;
 
-		if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-			printf("%s:%d set parent canvas for bone %p to %p\n", __FILE__, __LINE__, this, canvas.get());
+		DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+			"%s:%d set parent canvas for bone %p to %p\n", __FILE__, __LINE__, this, canvas.get());
 		set_parent_canvas(canvas);
 
 		show_bone_map(get_root_canvas(), __FILE__, __LINE__, strprintf("in constructor of %s at %p", GET_GUID_CSTR(get_guid()), this));
@@ -293,8 +293,8 @@ ValueNode_Bone::ValueNode_Bone(const ValueBase &value, etl::loose_handle<Canvas>
 
 void ValueNode_Bone::on_changed()
 {
-	if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
-		printf("%s:%d ValueNode_Bone::on_changed()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
+		"%s:%d ValueNode_Bone::on_changed()\n", __FILE__, __LINE__);
 
 	LinkableValueNode::on_changed();
 }
@@ -313,15 +313,15 @@ ValueNode_Bone::create(const ValueBase& x, Canvas::LooseHandle canvas)
 
 ValueNode_Bone::~ValueNode_Bone()
 {
-	if (getenv("SYNFIG_DEBUG_BONE_CONSTRUCTORS"))
+	if (DEBUG_GETENV("SYNFIG_DEBUG_BONE_CONSTRUCTORS"))
 	{
 		printf("\n%s:%d ------------------------------------------------------------------------\n", __FILE__, __LINE__);
 		printf("%s:%d --- ~ValueNode_Bone() for %s at %p---\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), this);
 		printf("%s:%d ------------------------------------------------------------------------\n\n", __FILE__, __LINE__);
 	}
 
-	if (getenv("SYNFIG_DEBUG_BONE_MAP"))
-		printf("%s:%d removing from canvas_map\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_MAP",
+		"%s:%d removing from canvas_map\n", __FILE__, __LINE__);
 	canvas_map[get_root_canvas()].erase(get_guid());
 
 	show_bone_map(get_root_canvas(), __FILE__, __LINE__, "in destructor");
@@ -359,8 +359,8 @@ ValueNode_Bone::set_root_canvas(etl::loose_handle<Canvas> canvas)
 		show_bone_map(new_canvas, __FILE__, __LINE__, strprintf("after changing canvas from %p to %p", old_canvas.get(), new_canvas.get()));
 	}
 	else
-		if (getenv("SYNFIG_DEBUG_BONE_MAP"))
-			printf("%s:%d canvases are the same\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_MAP",
+			"%s:%d canvases are the same\n", __FILE__, __LINE__);
 }
 
 //!Animated Transformation matrix.
@@ -391,7 +391,7 @@ ValueNode_Bone::get_animated_matrix(Time t, Real scalex, Real scaley, Angle angl
 			   * Matrix().set_rotate(angle)
 			   * Matrix().set_scale(scalex,scaley);
 
-	if (getenv("SYNFIG_DEBUG_ANIMATED_MATRIX_CALCULATION"))
+	if (DEBUG_GETENV("SYNFIG_DEBUG_ANIMATED_MATRIX_CALCULATION"))
 	{
 		printf("%s  *\n", Matrix().set_scale(scalex, scaley).get_string(18, "animated_matrix = ",
 																		strprintf("scale(%7.2f, %7.2f) (%s)", scalex, scaley,
@@ -431,8 +431,8 @@ ValueNode_Bone::get_parent(Time t)const
 ValueBase
 ValueNode_Bone::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 //	show_bone_map(get_root_canvas(), __FILE__, __LINE__, strprintf("in op() at %s", t.get_string().c_str()), t);
 
@@ -447,9 +447,9 @@ ValueNode_Bone::operator()(Time t)const
 	Real   bone_width			((*width_	)(t).get(Real()));
 	Real   bone_tipwidth		((*tipwidth_)(t).get(Real()));
 	Real   bone_depth			((*depth_)(t).get(Real()));
-	if (getenv("SYNFIG_DEBUG_ANIMATED_MATRIX_CALCULATION")) printf("\n***\n*** %s:%d get_animated_matrix() for %s\n***\n\n", __FILE__, __LINE__, get_bone_name(t).c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_ANIMATED_MATRIX_CALCULATION", "\n***\n*** %s:%d get_animated_matrix() for %s\n***\n\n", __FILE__, __LINE__, get_bone_name(t).c_str());
 	Matrix bone_animated_matrix	(get_animated_matrix(t, bone_scalex, 1.0, bone_angle, bone_origin, bone_parent));
-	if (getenv("SYNFIG_DEBUG_ANIMATED_MATRIX_CALCULATION")) printf("\n***\n*** %s:%d get_animated_matrix() for %s done\n***\n\n", __FILE__, __LINE__, get_bone_name(t).c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_ANIMATED_MATRIX_CALCULATION", "\n***\n*** %s:%d get_animated_matrix() for %s done\n***\n\n", __FILE__, __LINE__, get_bone_name(t).c_str());
 #endif
 
 	Bone ret;
@@ -727,34 +727,34 @@ ValueNode_Bone::is_ancestor_of(ValueNode_Bone::ConstHandle bone, Time t)const
 	ValueNode_Bone::ConstHandle ancestor(this);
 	std::set<ValueNode_Bone::ConstHandle> seen;
 
-	if (getenv("SYNFIG_DEBUG_ANCESTOR_CHECK"))
-		printf("%s:%d checking whether %s is ancestor of %s\n", __FILE__, __LINE__, GET_NODE_DESC_CSTR(ancestor,t), GET_NODE_DESC_CSTR(bone,t));
+	DEBUG_LOG("SYNFIG_DEBUG_ANCESTOR_CHECK",
+		"%s:%d checking whether %s is ancestor of %s\n", __FILE__, __LINE__, GET_NODE_DESC_CSTR(ancestor,t), GET_NODE_DESC_CSTR(bone,t));
 
 	while (bone != get_root_bone())
 	{
 		if (bone == ancestor)
 		{
-			if (getenv("SYNFIG_DEBUG_ANCESTOR_CHECK"))
-				printf("%s:%d bone reached us - so we are its ancestor - return true\n", __FILE__, __LINE__);
+			DEBUG_LOG("SYNFIG_DEBUG_ANCESTOR_CHECK",
+				"%s:%d bone reached us - so we are its ancestor - return true\n", __FILE__, __LINE__);
 			return bone;
 		}
 
 		if (seen.count(bone))
 		{
-			if (getenv("SYNFIG_DEBUG_ANCESTOR_CHECK"))
-				printf("%s:%d stuck in a loop - return true\n", __FILE__, __LINE__);
+			DEBUG_LOG("SYNFIG_DEBUG_ANCESTOR_CHECK",
+				"%s:%d stuck in a loop - return true\n", __FILE__, __LINE__);
 			return bone;
 		}
 
 		seen.insert(bone);
 		bone=GET_NODE_PARENT_NODE(bone,t);
 
-		if (getenv("SYNFIG_DEBUG_ANCESTOR_CHECK"))
-			printf("%s:%d step on to parent %s\n", __FILE__, __LINE__, GET_NODE_DESC_CSTR(bone,t));
+		DEBUG_LOG("SYNFIG_DEBUG_ANCESTOR_CHECK",
+			"%s:%d step on to parent %s\n", __FILE__, __LINE__, GET_NODE_DESC_CSTR(bone,t));
 	}
 
-	if (getenv("SYNFIG_DEBUG_ANCESTOR_CHECK"))
-		printf("%s:%d reached root - return false\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ANCESTOR_CHECK",
+		"%s:%d reached root - return false\n", __FILE__, __LINE__);
 	return nullptr;
 }
 
@@ -821,8 +821,8 @@ ValueNode_Bone::get_bones_referenced_by(ValueNode::Handle value_node, bool recur
 	{
 		// todo: while loading we might be setting up an ancestry loop by ignoring the placeholder valuenode here
 		// can we check for loops in badly formatted .sifz files somehow?
-		if (getenv("SYNFIG_DEBUG_PLACEHOLDER_VALUENODE"))
-			printf("%s:%d found a placeholder - skipping loop check\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_PLACEHOLDER_VALUENODE",
+			"%s:%d found a placeholder - skipping loop check\n", __FILE__, __LINE__);
 		return ret;
 	}
 
@@ -837,10 +837,7 @@ ValueNode_Bone::get_bones_affected_by(ValueNode::Handle value_node)
 	BoneSet ret;
 	std::set<const Node*> seen, current_nodes, new_nodes;
 	int generation = 0;
-	bool debug(false);
-
-	if (getenv("SYNFIG_DEBUG_SUITABLE_PARENTS"))
-		debug = true;
+	bool debug = DEBUG_GETENV("SYNFIG_DEBUG_SUITABLE_PARENTS");
 
 	if (debug) printf("getting bones affected by %p %s\n", value_node.get(), value_node->get_string().c_str());
 
@@ -887,10 +884,7 @@ ValueNode_Bone::BoneSet
 ValueNode_Bone::get_possible_parent_bones(ValueNode::Handle value_node)
 {
 	BoneSet ret;
-	bool debug(false);
-
-	if (getenv("SYNFIG_DEBUG_SUITABLE_PARENTS"))
-		debug = true;
+	bool debug = DEBUG_GETENV("SYNFIG_DEBUG_SUITABLE_PARENTS");
 
 	if (debug) printf("%s:%d which bones can be parents of %p (%s)\n", __FILE__, __LINE__, value_node.get(), value_node->get_string().c_str());
 
@@ -954,8 +948,8 @@ ValueNode_Bone::get_root_bone()
 void
 ValueNode_Bone::ref()const
 {
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%s:%d %s   ref valuenode_bone %*s -> %2d\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), (count()*2), "", count()+1);
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%s:%d %s   ref valuenode_bone %*s -> %2d\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), (count()*2), "", count()+1);
 
 	LinkableValueNode::ref();
 }
@@ -963,8 +957,8 @@ ValueNode_Bone::ref()const
 bool
 ValueNode_Bone::unref()const
 {
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%s:%d %s unref valuenode_bone %*s%2d <-\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), ((count()-1)*2), "", count()-1);
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%s:%d %s unref valuenode_bone %*s%2d <-\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), ((count()-1)*2), "", count()-1);
 
 	return LinkableValueNode::unref();
 }
@@ -972,25 +966,25 @@ ValueNode_Bone::unref()const
 void
 ValueNode_Bone::rref()const
 {
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%s:%d %s               rref valuenode_bone %d -> ", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), rcount());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%s:%d %s               rref valuenode_bone %d -> ", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), rcount());
 
 	LinkableValueNode::rref();
 
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%d\n", rcount());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%d\n", rcount());
 }
 
 void
 ValueNode_Bone::runref()const
 {
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%s:%d %s             runref valuenode_bone %d -> ", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), rcount());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%s:%d %s             runref valuenode_bone %d -> ", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), rcount());
 
 	LinkableValueNode::runref();
 
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%d\n", rcount());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%d\n", rcount());
 }
 #endif
 
@@ -998,14 +992,14 @@ ValueNode_Bone::runref()const
 
 ValueNode_Bone_Root::ValueNode_Bone_Root()
 {
-	if (getenv("SYNFIG_DEBUG_ROOT_BONE"))
-		printf("%s:%d ValueNode_Bone_Root::ValueNode_Bone_Root()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ROOT_BONE",
+		"%s:%d ValueNode_Bone_Root::ValueNode_Bone_Root()\n", __FILE__, __LINE__);
 }
 
 ValueNode_Bone_Root::~ValueNode_Bone_Root()
 {
-	if (getenv("SYNFIG_DEBUG_ROOT_BONE"))
-		printf("%s:%d ValueNode_Bone_Root::~ValueNode_Bone_Root()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ROOT_BONE",
+		"%s:%d ValueNode_Bone_Root::~ValueNode_Bone_Root()\n", __FILE__, __LINE__);
 }
 
 ValueBase
@@ -1020,16 +1014,16 @@ ValueNode_Bone_Root::operator()(Time /*t*/)const
 void
 ValueNode_Bone_Root::set_guid(const GUID& new_guid)
 {
-	if (getenv("SYNFIG_DEBUG_ROOT_BONE"))
-		printf("%s:%d bypass set_guid() for root bone\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ROOT_BONE",
+		"%s:%d bypass set_guid() for root bone\n", __FILE__, __LINE__);
 	LinkableValueNode::set_guid(new_guid);
 }
 
 void
 ValueNode_Bone_Root::set_root_canvas(etl::loose_handle<Canvas> canvas)
 {
-	if (getenv("SYNFIG_DEBUG_ROOT_BONE"))
-		printf("%s:%d bypass set_root_canvas() for root bone\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ROOT_BONE",
+		"%s:%d bypass set_root_canvas() for root bone\n", __FILE__, __LINE__);
 	LinkableValueNode::set_root_canvas(canvas);
 }
 
@@ -1076,8 +1070,8 @@ ValueNode_Bone_Root::check_type(Type &/*type*/)
 void
 ValueNode_Bone_Root::ref()const
 {
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%s:%d %s   ref valuenode_bone_root %*s -> %2d\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), (count()*2), "", count()+1);
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%s:%d %s   ref valuenode_bone_root %*s -> %2d\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), (count()*2), "", count()+1);
 
 	LinkableValueNode::ref();
 }
@@ -1085,8 +1079,8 @@ ValueNode_Bone_Root::ref()const
 bool
 ValueNode_Bone_Root::unref()const
 {
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%s:%d %s unref valuenode_bone_root %*s%2d <-\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), ((count()-1)*2), "", count()-1);
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%s:%d %s unref valuenode_bone_root %*s%2d <-\n", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), ((count()-1)*2), "", count()-1);
 
 	return LinkableValueNode::unref();
 }
@@ -1094,24 +1088,24 @@ ValueNode_Bone_Root::unref()const
 void
 ValueNode_Bone_Root::rref()const
 {
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%s:%d %s               rref valuenode_bone_root %d -> ", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), rcount());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%s:%d %s               rref valuenode_bone_root %d -> ", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), rcount());
 
 	LinkableValueNode::rref();
 
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%d\n", rcount());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%d\n", rcount());
 }
 
 void
 ValueNode_Bone_Root::runref()const
 {
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%s:%d %s             runref valuenode_bone_root %d -> ", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), rcount());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%s:%d %s             runref valuenode_bone_root %d -> ", __FILE__, __LINE__, GET_GUID_CSTR(get_guid()), rcount());
 
 	LinkableValueNode::runref();
 
-	if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-		printf("%d\n", rcount());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+		"%d\n", rcount());
 }
 #endif

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.cpp
@@ -84,8 +84,8 @@ ValueNode_BoneInfluence::ValueNode_BoneInfluence(const ValueNode::Handle &x, Can
 		set_link("bone_weight_list",	bone_weight_list);
 		set_link("link",				x);
 
-		if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-			printf("%s:%d set parent canvas for bone influence to %p\n", __FILE__, __LINE__, canvas.get());
+		DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+			"%s:%d set parent canvas for bone influence to %p\n", __FILE__, __LINE__, canvas.get());
 		set_parent_canvas(canvas);
 	}
 	else
@@ -117,8 +117,8 @@ ValueNode_BoneInfluence::~ValueNode_BoneInfluence()
 ValueBase
 ValueNode_BoneInfluence::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Matrix transform(get_transform(true, t));
 	Type &type(link_->get_type());
@@ -126,8 +126,8 @@ ValueNode_BoneInfluence::operator()(Time t)const
 	{
 		Vector link((*link_)(t).get(Vector()));
 
-		if (getenv("SYNFIG_DEBUG_BONE_VECTOR_TRANSFORMATION"))
-			printf("%s\n", transform.get_string(35,
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_VECTOR_TRANSFORMATION",
+			"%s\n", transform.get_string(35,
 												strprintf("transform (%7.2f %7.2f) using",
 														  link[0],
 														  link[1]),
@@ -156,8 +156,8 @@ ValueNode_BoneInfluence::operator()(Time t)const
 			link.set_vertex_setup(v);
 		}
 
-		if (getenv("SYNFIG_DEBUG_BONE_BLINEPOINT_TRANSFORMATION"))
-			printf("%s\n", transform.get_string(35,
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_BLINEPOINT_TRANSFORMATION",
+			"%s\n", transform.get_string(35,
 												strprintf("transform v(%7.2f %7.2f) using",
 														  v[0],
 														  v[1]),
@@ -241,10 +241,9 @@ ValueNode_BoneInfluence::calculate_transform(Time t)const
 		Bone bone(iter->get(BoneWeightPair()).get_bone());
 		Real weight(iter->get(BoneWeightPair()).get_weight());
 
-		if (getenv("SYNFIG_DEBUG_BONE_TRANSFORM_WEIGHTING"))
 		{
-			printf("%s  *\n", Matrix().set_scale(bone.get_local_scale()).get_string(15, "local scale").c_str());
-			printf("%s  =\n", bone.get_animated_matrix().get_string(15, "animated", strprintf("* %.2f (weight)", weight)).c_str());
+			DEBUG_LOG("SYNFIG_DEBUG_BONE_TRANSFORM_WEIGHTING", "%s  *\n", Matrix().set_scale(bone.get_local_scale()).get_string(15, "local scale").c_str());
+			DEBUG_LOG("SYNFIG_DEBUG_BONE_TRANSFORM_WEIGHTING", "%s  =\n", bone.get_animated_matrix().get_string(15, "animated", strprintf("* %.2f (weight)", weight)).c_str());
 		}
 
 		transform += ( bone.get_animated_matrix()
@@ -252,10 +251,9 @@ ValueNode_BoneInfluence::calculate_transform(Time t)const
 		total_weight += weight;
 	}
 
-	if (getenv("SYNFIG_DEBUG_BONE_TRANSFORM_WEIGHTING"))
 	{
-		printf("%s:%d transform:\n%s\n", __FILE__, __LINE__, transform.get_string().c_str());
-		printf("%s:%d total_weight: %.2f\n", __FILE__, __LINE__, total_weight);
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_TRANSFORM_WEIGHTING", "%s:%d transform:\n%s\n", __FILE__, __LINE__, transform.get_string().c_str());
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_TRANSFORM_WEIGHTING", "%s:%d total_weight: %.2f\n", __FILE__, __LINE__, total_weight);
 	}
 
 	if (std::fabs(total_weight) > epsilon)
@@ -263,8 +261,8 @@ ValueNode_BoneInfluence::calculate_transform(Time t)const
 	else
 		transform = Matrix();
 
-	if (getenv("SYNFIG_DEBUG_BONE_TRANSFORM_WEIGHTING"))
-		printf("%s:%d final transform:\n%s\n", __FILE__, __LINE__, transform.get_string().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_BONE_TRANSFORM_WEIGHTING",
+		"%s:%d final transform:\n%s\n", __FILE__, __LINE__, transform.get_string().c_str());
 
 	return transform;
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_bonelink.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bonelink.cpp
@@ -176,8 +176,8 @@ ValueNode_BoneLink::get_bone_transformation(Time t)const
 ValueBase
 ValueNode_BoneLink::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 	return ValueTransformation::transform(
 		get_bone_transformation(t), (*base_value_)(t) );
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.cpp
@@ -71,8 +71,8 @@ ValueNode_BoneWeightPair::ValueNode_BoneWeightPair(const ValueBase &value, Canva
 		set_link("bone",ValueNode_Const::create(bone_value_node, canvas));
 		set_link("weight",ValueNode_Const::create(Real(bone_weight_pair.get_weight())));
 
-		if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-			printf("%s:%d set parent canvas for bwp to %p\n", __FILE__, __LINE__, canvas.get());
+		DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+			"%s:%d set parent canvas for bwp to %p\n", __FILE__, __LINE__, canvas.get());
 		set_parent_canvas(canvas);
 
 		ValueNode_Bone::show_bone_map(canvas, __FILE__, __LINE__, "after making new boneweightpair");
@@ -103,8 +103,8 @@ ValueNode_BoneWeightPair::~ValueNode_BoneWeightPair()
 ValueBase
 ValueNode_BoneWeightPair::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	ValueNode_Bone::Handle bone_node((*bone_)(t).get(ValueNode_Bone::Handle()));
 	Bone bone((*bone_node)(t).get(Bone()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_compare.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_compare.cpp
@@ -123,8 +123,8 @@ ValueNode_Compare::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Compare::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Real lhs      = (*lhs_)     (t).get(Real());
 	Real rhs      = (*rhs_)     (t).get(Real());

--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
@@ -194,8 +194,8 @@ synfig::ValueNode_Composite::ValueNode_Composite(const ValueBase &value, Canvas:
 		throw Exception::BadType(get_type().description.local_name);
 	}
 
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d set parent canvas for composite %p to %p\n", __FILE__, __LINE__, this, canvas.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d set parent canvas for composite %p to %p\n", __FILE__, __LINE__, this, canvas.get());
 	set_parent_canvas(canvas);
 }
 
@@ -219,8 +219,8 @@ ValueNode_Composite::create_new()const
 ValueBase
 synfig::ValueNode_Composite::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Type &type(get_type());
 	if (type == type_vector)

--- a/synfig-core/src/synfig/valuenodes/valuenode_const.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_const.cpp
@@ -36,6 +36,7 @@
 #include "valuenode_bone.h"
 #include "valuenode_boneweightpair.h"
 #include "valuenode_composite.h"
+#include "synfig/general.h"
 #include <synfig/canvas.h>
 #include <synfig/localization.h>
 #include <synfig/pair.h>
@@ -64,8 +65,8 @@ ValueNode_Const::ValueNode_Const(const ValueBase &x, Canvas::LooseHandle canvas)
 	ValueNode	(x.get_type()),
 	value		(x)
 {
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d set parent canvas for const %p to %p\n", __FILE__, __LINE__, this, canvas.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d set parent canvas for const %p to %p\n", __FILE__, __LINE__, this, canvas.get());
 
 	if (x.get_type() == type_bone_valuenode)
 		add_child(x.get(ValueNode_Bone::Handle()).get());
@@ -123,8 +124,8 @@ ValueNode_Const::~ValueNode_Const()
 ValueBase
 ValueNode_Const::operator()(Time /*t*/)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return value;
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_cos.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_cos.cpp
@@ -92,8 +92,8 @@ ValueNode_Cos::~ValueNode_Cos()
 ValueBase
 ValueNode_Cos::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return
 		Angle::cos(

--- a/synfig-core/src/synfig/valuenodes/valuenode_derivative.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_derivative.cpp
@@ -190,8 +190,8 @@ ValueNode_Derivative::~ValueNode_Derivative()
 ValueBase
 ValueNode_Derivative::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Type &type(get_type());
 	if (type == type_real)

--- a/synfig-core/src/synfig/valuenodes/valuenode_dilist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dilist.cpp
@@ -130,8 +130,8 @@ ValueNode_DIList::create_list_entry(int index, Time time, Real /*origin*/)
 ValueBase
 ValueNode_DIList::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	std::vector<DashItem> ret_list;
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dotproduct.cpp
@@ -98,8 +98,8 @@ ValueNode_DotProduct::~ValueNode_DotProduct()
 ValueBase
 ValueNode_DotProduct::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Vector lhs((*lhs_)(t).get(Vector()));
 	Vector rhs((*rhs_)(t).get(Vector()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_duplicate.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_duplicate.cpp
@@ -162,8 +162,8 @@ ValueNode_Duplicate::count_steps(Time t)const
 ValueBase
 ValueNode_Duplicate::operator()(Time /*t*/)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return index;
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamic.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamic.cpp
@@ -248,8 +248,8 @@ ValueNode_Dynamic::~ValueNode_Dynamic()
 ValueBase
 ValueNode_Dynamic::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 	double t0=last_time;
 	double t1=t;
 	double step;

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
@@ -595,8 +595,8 @@ ValueNode_DynamicList::ValueNode_DynamicList(Type &container_type, Canvas::Loose
 	container_type(&container_type),
 	loop_(false)
 {
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d set parent canvas for dynamic_list %p to %p\n", __FILE__, __LINE__, this, canvas.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d set parent canvas for dynamic_list %p to %p\n", __FILE__, __LINE__, this, canvas.get());
 	set_parent_canvas(canvas);
 }
 
@@ -605,8 +605,8 @@ ValueNode_DynamicList::ValueNode_DynamicList(Type &container_type, Type &type, C
 	container_type(&container_type),
 	loop_(false)
 {
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d set parent canvas for dynamic_list %p to %p\n", __FILE__, __LINE__, this, canvas.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d set parent canvas for dynamic_list %p to %p\n", __FILE__, __LINE__, this, canvas.get());
 	set_parent_canvas(canvas);
 }
 
@@ -653,8 +653,8 @@ ValueNode_DynamicList::create(const ValueBase& value, etl::loose_handle<Canvas>)
 ValueBase
 ValueNode_DynamicList::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	std::vector<ValueBase> ret_list;
 	std::vector<ListEntry>::const_iterator iter;

--- a/synfig-core/src/synfig/valuenodes/valuenode_exp.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_exp.cpp
@@ -92,7 +92,7 @@ ValueNode_Exp::~ValueNode_Exp()
 ValueBase
 ValueNode_Exp::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
+	if (DEBUG_GETENV("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
 		printf("%s:%d operator()\n", __FILE__, __LINE__);
 
 	return (exp((*exp_)(t).get(Real())) *

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientcolor.cpp
@@ -94,8 +94,8 @@ ValueNode_GradientColor::~ValueNode_GradientColor()
 ValueBase
 ValueNode_GradientColor::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Real index((*index_)(t).get(Real()));
 	bool loop((*loop_)(t).get(bool()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_gradientrotate.cpp
@@ -98,8 +98,8 @@ synfig::ValueNode_GradientRotate::~ValueNode_GradientRotate()
 synfig::ValueBase
 synfig::ValueNode_GradientRotate::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Gradient gradient;
 	gradient=(*ref_gradient)(t).get(gradient);

--- a/synfig-core/src/synfig/valuenodes/valuenode_integer.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_integer.cpp
@@ -130,8 +130,8 @@ ValueNode_Integer::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Integer::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	int integer = (*integer_)(t).get(int());
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_intstring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_intstring.cpp
@@ -95,8 +95,8 @@ ValueNode_IntString::~ValueNode_IntString()
 ValueBase
 ValueNode_IntString::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	int integer((*int_)(t).get(int()));
 	int width((*width_)(t).get(int()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_join.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_join.cpp
@@ -102,8 +102,8 @@ ValueNode_Join::~ValueNode_Join()
 ValueBase
 ValueNode_Join::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	const std::vector<ValueBase> strings((*strings_)(t).get_list());
 	const String before((*before_)(t).get(String()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_linear.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_linear.cpp
@@ -129,8 +129,8 @@ ValueNode_Linear::~ValueNode_Linear()
 ValueBase
 ValueNode_Linear::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Type &type(get_type());
 	if (type == type_angle)

--- a/synfig-core/src/synfig/valuenodes/valuenode_log.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_log.cpp
@@ -118,8 +118,8 @@ ValueNode_Logarithm::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Logarithm::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Real link     = (*link_)    (t).get(Real());
 	Real epsilon  = (*epsilon_) (t).get(Real());

--- a/synfig-core/src/synfig/valuenodes/valuenode_modulo.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_modulo.cpp
@@ -101,8 +101,8 @@ synfig::ValueNode_Modulo::~ValueNode_Modulo()
 synfig::ValueBase
 synfig::ValueNode_Modulo::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	if(!dividend || !divisor)
 		throw std::runtime_error(strprintf("ValueNode_Modulo: %s",_("One or both of my parameters aren't set!")));

--- a/synfig-core/src/synfig/valuenodes/valuenode_not.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_not.cpp
@@ -108,8 +108,8 @@ ValueNode_Not::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Not::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	bool link      = (*link_)    (t).get(bool());
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_or.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_or.cpp
@@ -113,8 +113,8 @@ ValueNode_Or::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Or::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	bool link1     = (*link1_)   (t).get(bool());
 	bool link2     = (*link2_)   (t).get(bool());

--- a/synfig-core/src/synfig/valuenodes/valuenode_pow.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_pow.cpp
@@ -119,8 +119,8 @@ ValueNode_Pow::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Pow::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Real base     = (*base_)    (t).get(Real());
 	Real power    = (*power_)   (t).get(Real());

--- a/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
@@ -106,8 +106,8 @@ ValueNode_RadialComposite::create_new()const
 ValueBase
 synfig::ValueNode_RadialComposite::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Type &type(get_type());
 	if (type == type_vector)

--- a/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_range.cpp
@@ -128,8 +128,8 @@ synfig::ValueNode_Range::~ValueNode_Range()
 synfig::ValueBase
 synfig::ValueNode_Range::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	if(!min_ || !max_ || !link_)
 		throw std::runtime_error(strprintf("ValueNode_Range: %s",_("Some of my parameters aren't set!")));

--- a/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
@@ -129,8 +129,8 @@ ValueNode_Real::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Real::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	float real = (*real_)(t).get(float());
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_realstring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_realstring.cpp
@@ -96,8 +96,8 @@ ValueNode_RealString::~ValueNode_RealString()
 ValueBase
 ValueNode_RealString::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Real real((*real_)(t).get(Real()));
 	int width((*width_)(t).get(int()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reciprocal.cpp
@@ -121,8 +121,8 @@ ValueNode_Reciprocal::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Reciprocal::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Real link     = (*link_)    (t).get(Real());
 	Real epsilon  = (*epsilon_) (t).get(Real());

--- a/synfig-core/src/synfig/valuenodes/valuenode_reference.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reference.cpp
@@ -109,8 +109,8 @@ ValueNode_Reference::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Reference::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return (*link_)(t);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_repeat_gradient.cpp
@@ -104,8 +104,8 @@ synfig::ValueNode_Repeat_Gradient::~ValueNode_Repeat_Gradient()
 synfig::ValueBase
 synfig::ValueNode_Repeat_Gradient::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	const int count((*count_)(t).get(int()));
 	int i;

--- a/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
@@ -267,8 +267,8 @@ reverse_value(const ValueBase &value)
 ValueBase
 ValueNode_Reverse::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return reverse_value((*link_)(t));
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_scale.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_scale.cpp
@@ -119,8 +119,8 @@ synfig::ValueNode_Scale::~ValueNode_Scale()
 synfig::ValueBase
 synfig::ValueNode_Scale::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	if(!value_node || !scalar)
 		throw std::runtime_error(strprintf("ValueNode_Scale: %s",_("One or both of my parameters aren't set!")));

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalctangent.cpp
@@ -86,8 +86,8 @@ ValueNode_SegCalcTangent::~ValueNode_SegCalcTangent()
 ValueBase
 ValueNode_SegCalcTangent::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Segment segment((*segment_)(t).get(Segment()));
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_segcalcvertex.cpp
@@ -86,8 +86,8 @@ ValueNode_SegCalcVertex::~ValueNode_SegCalcVertex()
 ValueBase
 ValueNode_SegCalcVertex::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Segment segment((*segment_)(t).get(Segment()));
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_sine.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_sine.cpp
@@ -92,8 +92,8 @@ ValueNode_Sine::~ValueNode_Sine()
 ValueBase
 ValueNode_Sine::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return
 		Angle::sin(

--- a/synfig-core/src/synfig/valuenodes/valuenode_staticlist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_staticlist.cpp
@@ -206,23 +206,23 @@ ValueNode_StaticList::add(const ValueNode::Handle &value_node, int index) // lin
 {
 	if(index<0 || index>=(int)list.size())
 	{
-		if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-			printf("%s:%d vvv adding valuenode to end of static list\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+			"%s:%d vvv adding valuenode to end of static list\n", __FILE__, __LINE__);
 
 		list.push_back(value_node);
 
-		if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-			printf("%s:%d ^^^ done adding valuenode\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+			"%s:%d ^^^ done adding valuenode\n", __FILE__, __LINE__);
 	}
 	else
 	{
-		if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-			printf("%s:%d vvv inserting valuenode into static list at %d\n", __FILE__, __LINE__, index);
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+			"%s:%d vvv inserting valuenode into static list at %d\n", __FILE__, __LINE__, index);
 
 		list.insert(list.begin()+index,value_node);
 
-		if (getenv("SYNFIG_DEBUG_BONE_REFCOUNT"))
-			printf("%s:%d ^^^ done inserting valuenode\n", __FILE__, __LINE__);
+		DEBUG_LOG("SYNFIG_DEBUG_BONE_REFCOUNT",
+			"%s:%d ^^^ done inserting valuenode\n", __FILE__, __LINE__);
 	}
 
 	add_child(value_node.get());
@@ -275,18 +275,18 @@ ValueNode_StaticList::ValueNode_StaticList(Type &container_type, Canvas::LooseHa
 	container_type(&container_type),
 	loop_(false)
 {
-	if (getenv("SYNFIG_DEBUG_STATICLIST_CONSTRUCTORS"))
-		printf("%s:%d ValueNode_StaticList::ValueNode_StaticList() construct %p\n", __FILE__, __LINE__, this);
+	DEBUG_LOG("SYNFIG_DEBUG_STATICLIST_CONSTRUCTORS",
+		"%s:%d ValueNode_StaticList::ValueNode_StaticList() construct %p\n", __FILE__, __LINE__, this);
 
-	if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-		printf("%s:%d set parent canvas for static_list %p to %p\n", __FILE__, __LINE__, this, canvas.get());
+	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+		"%s:%d set parent canvas for static_list %p to %p\n", __FILE__, __LINE__, this, canvas.get());
 	set_parent_canvas(canvas);
 }
 
 ValueNode_StaticList::~ValueNode_StaticList()
 {
 #ifdef _DEBUG
-	if (getenv("SYNFIG_DEBUG_STATICLIST_CONSTRUCTORS"))
+	if (DEBUG_GETENV("SYNFIG_DEBUG_STATICLIST_CONSTRUCTORS"))
 	{
 		printf("\n%s:%d ------------------------------------------------------------------------\n", __FILE__, __LINE__);
 		printf("%s:%d ~ValueNode_StaticList()\n", __FILE__, __LINE__);
@@ -343,8 +343,8 @@ ValueNode_StaticList::create(const ValueBase& value, etl::loose_handle<Canvas>)
 ValueBase
 ValueNode_StaticList::operator()(Time t)const // line 596
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	std::vector<ValueBase> ret_list;
 	std::vector<ReplaceableListEntry>::const_iterator iter;
@@ -494,8 +494,8 @@ ValueNode_StaticList::set_member_canvas(etl::loose_handle<Canvas> canvas) // lin
 {
 	for (std::vector<ReplaceableListEntry>::iterator iter = list.begin(); iter != list.end(); iter++)
 	{
-		if (getenv("SYNFIG_DEBUG_SET_PARENT_CANVAS"))
-			printf("%s:%d set parent canvas of member (%p) to (%p)\n", __FILE__, __LINE__, iter->get(), canvas.get());
+		DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
+			"%s:%d set parent canvas of member (%p) to (%p)\n", __FILE__, __LINE__, iter->get(), canvas.get());
 		(*iter)->set_parent_canvas(canvas);
 	}
 }
@@ -516,8 +516,8 @@ ValueNode_StaticList::create_new() const
 void
 ValueNode_StaticList::ref()const
 {
-	if (getenv("SYNFIG_DEBUG_STATICLIST_REFCOUNT"))
-		printf("%s:%d %p   ref staticlist %*s -> %2d\n", __FILE__, __LINE__, this, (count()*2), "", count()+1);
+	DEBUG_LOG("SYNFIG_DEBUG_STATICLIST_REFCOUNT",
+		"%s:%d %p   ref staticlist %*s -> %2d\n", __FILE__, __LINE__, this, (count()*2), "", count()+1);
 
 	LinkableValueNode::ref();
 }
@@ -525,8 +525,8 @@ ValueNode_StaticList::ref()const
 bool
 ValueNode_StaticList::unref()const
 {
-	if (getenv("SYNFIG_DEBUG_STATICLIST_REFCOUNT"))
-		printf("%s:%d %p unref staticlist %*s%2d <-\n", __FILE__, __LINE__, this, ((count()-1)*2), "", count()-1);
+	DEBUG_LOG("SYNFIG_DEBUG_STATICLIST_REFCOUNT",
+		"%s:%d %p unref staticlist %*s%2d <-\n", __FILE__, __LINE__, this, ((count()-1)*2), "", count()-1);
 
 	return LinkableValueNode::unref();
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_step.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_step.cpp
@@ -107,8 +107,8 @@ ValueNode_Step::~ValueNode_Step()
 ValueBase
 ValueNode_Step::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Time duration    ((*duration_    )(t).get(Time()));
 	Time start_time  ((*start_time_  )(t).get(Time()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_stripes.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_stripes.cpp
@@ -101,8 +101,8 @@ synfig::ValueNode_Stripes::~ValueNode_Stripes()
 synfig::ValueBase
 synfig::ValueNode_Stripes::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	const int total((*stripes_)(t).get(int()));
 	int i;

--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
@@ -144,8 +144,8 @@ synfig::ValueNode_Subtract::~ValueNode_Subtract()
 synfig::ValueBase
 synfig::ValueNode_Subtract::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	if(!ref_a || !ref_b)
 		throw std::runtime_error(strprintf("ValueNode_Subtract: %s",_("One or both of my parameters aren't set!")));

--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
@@ -119,8 +119,8 @@ ValueNode_Switch::get_link_vfunc(int i)const
 ValueBase
 ValueNode_Switch::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return (*switch_)(t).get(bool()) ? (*link_on_)(t) : (*link_off_)(t);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_timedswap.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timedswap.cpp
@@ -132,8 +132,8 @@ synfig::ValueNode_TimedSwap::~ValueNode_TimedSwap()
 synfig::ValueBase
 synfig::ValueNode_TimedSwap::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Time swptime=(*swap_time)(t).get(Time());
 	Time swplength=(*swap_length)(t).get(Time());

--- a/synfig-core/src/synfig/valuenodes/valuenode_timeloop.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timeloop.cpp
@@ -120,8 +120,8 @@ ValueNode_TimeLoop::get_link_vfunc(int i)const
 ValueBase
 ValueNode_TimeLoop::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Time link_time  = (*link_time_) (t).get(Time());
 	Time local_time = (*local_time_)(t).get(Time());

--- a/synfig-core/src/synfig/valuenodes/valuenode_timestring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timestring.cpp
@@ -88,8 +88,8 @@ ValueNode_TimeString::~ValueNode_TimeString()
 ValueBase
 ValueNode_TimeString::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	Time time((*time_)(t).get(Time()));
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_twotone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_twotone.cpp
@@ -94,8 +94,8 @@ synfig::ValueNode_TwoTone::~ValueNode_TwoTone()
 synfig::ValueBase
 synfig::ValueNode_TwoTone::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return Gradient((*ref_a)(t).get(Color()),(*ref_b)(t).get(Color()));
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorangle.cpp
@@ -89,8 +89,8 @@ ValueNode_VectorAngle::~ValueNode_VectorAngle()
 ValueBase
 ValueNode_VectorAngle::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return (*vector_)(t).get(Vector()).angle();
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorlength.cpp
@@ -88,8 +88,8 @@ ValueNode_VectorLength::~ValueNode_VectorLength()
 ValueBase
 ValueNode_VectorLength::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return (*vector_)(t).get(Vector()).mag();
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectorx.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectorx.cpp
@@ -88,8 +88,8 @@ ValueNode_VectorX::~ValueNode_VectorX()
 ValueBase
 ValueNode_VectorX::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return (*vector_)(t).get(Vector())[0];
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_vectory.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_vectory.cpp
@@ -88,8 +88,8 @@ ValueNode_VectorY::~ValueNode_VectorY()
 ValueBase
 ValueNode_VectorY::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	return (*vector_)(t).get(Vector())[1];
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_weightedaverage.cpp
@@ -38,6 +38,7 @@
 #include <synfig/valuenode_registry.h>
 
 #include "valuenode_const.h"
+#include "synfig/general.h"
 
 #include <synfig/canvas.h>
 #include <synfig/valueoperations.h>
@@ -99,8 +100,8 @@ ValueNode_WeightedAverage::create(const ValueBase& value, Canvas::LooseHandle ca
 ValueBase
 ValueNode_WeightedAverage::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 	return ValueAverage::average_weighted(ValueNode_DynamicList::operator()(t), ValueBase(get_type()));
 }
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_wplist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_wplist.cpp
@@ -282,8 +282,8 @@ ValueNode_WPList::create_list_entry(int index, Time time, Real /*origin*/)
 ValueBase
 ValueNode_WPList::operator()(Time t)const
 {
-	if (getenv("SYNFIG_DEBUG_VALUENODE_OPERATORS"))
-		printf("%s:%d operator()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
 
 	std::vector<WidthPoint> ret_list;
 

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -696,8 +696,8 @@ CanvasView::~CanvasView()
 	delete canvas_options;
 	delete resolutiondial_;
 
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		info("CanvasView::~CanvasView(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"CanvasView::~CanvasView(): Deleted");
 
 	SYNFIG_EXCEPTION_GUARD_END()
 }

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_time.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_time.cpp
@@ -67,8 +67,8 @@ CellRenderer_Time::CellRenderer_Time():
 
 CellRenderer_Time::~CellRenderer_Time()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("CellRenderer_Time::~CellRenderer_Time(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"CellRenderer_Time::~CellRenderer_Time(): Deleted");
 }
 
 void

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -283,8 +283,8 @@ CellRenderer_ValueBase::CellRenderer_ValueBase():
 
 CellRenderer_ValueBase::~CellRenderer_ValueBase()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("CellRenderer_ValueBase::~CellRenderer_ValueBase(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"CellRenderer_ValueBase::~CellRenderer_ValueBase(): Deleted");
 }
 
 void

--- a/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
@@ -43,6 +43,8 @@
 
 #include <synfigapp/canvasinterface.h>
 #include <synfigapp/main.h>
+#include "synfig/general.h"
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -139,8 +141,8 @@ Dialog_Gradient::on_set_default_pressed()
 void
 Dialog_Gradient::on_changed()
 {
-	if (getenv("SYNFIG_DEBUG_ON_CHANGED"))
-		printf("%s:%d Dialog_Gradient::on_changed()\n", __FILE__, __LINE__);
+	DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
+		"%s:%d Dialog_Gradient::on_changed()\n", __FILE__, __LINE__);
 
 	signal_edited_(get_gradient());
 }

--- a/synfig-studio/src/gui/docks/dockdialog.cpp
+++ b/synfig-studio/src/gui/docks/dockdialog.cpp
@@ -163,8 +163,8 @@ bool DockDialog::on_key_press_event(GdkEventKey* key_event)
 bool
 DockDialog::close()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("DockDialog::close(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"DockDialog::close(): Deleted");
 
 	empty_sig.disconnect();
 	//get_dock_book().clear();

--- a/synfig-studio/src/gui/duckmatic.cpp
+++ b/synfig-studio/src/gui/duckmatic.cpp
@@ -133,8 +133,8 @@ Duckmatic::~Duckmatic()
 {
 	clear_ducks();
 
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("Duckmatic::~Duckmatic(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"Duckmatic::~Duckmatic(): Deleted");
 }
 
 void

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1008,8 +1008,8 @@ Instance::add_actions_to_menu(Gtk::Menu *menu, const synfigapp::Action::ParamLis
 void
 Instance::process_action(synfig::String name, synfigapp::Action::ParamList param_list)
 {
-	if (getenv("SYNFIG_DEBUG_ACTIONS"))
-		synfig::info("%s:%d process_action: '%s'", __FILE__, __LINE__, name.c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_ACTIONS",
+		"%s:%d process_action: '%s'", __FILE__, __LINE__, name.c_str());
 
 	assert(synfigapp::Action::book().count(name));
 

--- a/synfig-studio/src/gui/trees/historytreestore.cpp
+++ b/synfig-studio/src/gui/trees/historytreestore.cpp
@@ -78,8 +78,8 @@ HistoryTreeStore::HistoryTreeStore(etl::loose_handle<studio::Instance> instance_
 
 HistoryTreeStore::~HistoryTreeStore()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("HistoryTreeStore::~HistoryTreeStore(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"HistoryTreeStore::~HistoryTreeStore(): Deleted");
 }
 
 Glib::RefPtr<HistoryTreeStore>

--- a/synfig-studio/src/gui/trees/keyframetree.cpp
+++ b/synfig-studio/src/gui/trees/keyframetree.cpp
@@ -150,8 +150,8 @@ KeyframeTree::KeyframeTree() : editable_(false)
 KeyframeTree::~KeyframeTree()
 {
 	keyframeselected.disconnect();
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("KeyframeTree::~KeyframeTree(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"KeyframeTree::~KeyframeTree(): Deleted");
 }
 
 void

--- a/synfig-studio/src/gui/trees/keyframetreestore.cpp
+++ b/synfig-studio/src/gui/trees/keyframetreestore.cpp
@@ -128,8 +128,8 @@ KeyframeTreeStore::KeyframeTreeStore(etl::loose_handle<synfigapp::CanvasInterfac
 
 KeyframeTreeStore::~KeyframeTreeStore()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("KeyframeTreeStore::~KeyframeTreeStore(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"KeyframeTreeStore::~KeyframeTreeStore(): Deleted");
 }
 
 Glib::RefPtr<KeyframeTreeStore>

--- a/synfig-studio/src/gui/trees/layergrouptree.cpp
+++ b/synfig-studio/src/gui/trees/layergrouptree.cpp
@@ -122,8 +122,8 @@ LayerGroupTree::LayerGroupTree()
 
 LayerGroupTree::~LayerGroupTree()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("LayerGroupTree::~LayerGroupTree(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"LayerGroupTree::~LayerGroupTree(): Deleted");
 }
 
 void

--- a/synfig-studio/src/gui/trees/layergrouptreestore.cpp
+++ b/synfig-studio/src/gui/trees/layergrouptreestore.cpp
@@ -93,8 +93,8 @@ LayerGroupTreeStore::~LayerGroupTreeStore()
 {
 	//clear();
 
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("LayerGroupTreeStore::~LayerGroupTreeStore(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"LayerGroupTreeStore::~LayerGroupTreeStore(): Deleted");
 }
 
 bool

--- a/synfig-studio/src/gui/trees/layerparamtreestore.cpp
+++ b/synfig-studio/src/gui/trees/layerparamtreestore.cpp
@@ -108,8 +108,8 @@ LayerParamTreeStore::~LayerParamTreeStore()
 		changed_connection_list.pop_back();
 	}
 
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("LayerParamTreeStore::~LayerParamTreeStore(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"LayerParamTreeStore::~LayerParamTreeStore(): Deleted");
 }
 
 Glib::RefPtr<LayerParamTreeStore>

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -146,8 +146,8 @@ LayerTree::LayerTree()
 
 LayerTree::~LayerTree()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("LayerTree::~LayerTree(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"LayerTree::~LayerTree(): Deleted");
 }
 
 void

--- a/synfig-studio/src/gui/trees/layertreestore.cpp
+++ b/synfig-studio/src/gui/trees/layertreestore.cpp
@@ -119,8 +119,8 @@ LayerTreeStore::LayerTreeStore(etl::loose_handle<synfigapp::CanvasInterface> can
 
 LayerTreeStore::~LayerTreeStore()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("LayerTreeStore::~LayerTreeStore(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"LayerTreeStore::~LayerTreeStore(): Deleted");
 }
 
 int

--- a/synfig-studio/src/gui/trees/metadatatreestore.cpp
+++ b/synfig-studio/src/gui/trees/metadatatreestore.cpp
@@ -71,8 +71,8 @@ MetaDataTreeStore::MetaDataTreeStore(etl::loose_handle<synfigapp::CanvasInterfac
 
 MetaDataTreeStore::~MetaDataTreeStore()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("MetaDataTreeStore::~MetaDataTreeStore(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"MetaDataTreeStore::~MetaDataTreeStore(): Deleted");
 }
 
 Glib::RefPtr<MetaDataTreeStore>

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -332,8 +332,8 @@ WorkArea::~WorkArea()
 	set_drag_mode(DRAG_NONE);
 	while(!renderer_set_.empty())
 		erase_renderer(*renderer_set_.begin());
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		info("WorkArea::~WorkArea(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"WorkArea::~WorkArea(): Deleted");
 }
 
 void

--- a/synfig-studio/src/synfigapp/action.cpp
+++ b/synfig-studio/src/synfigapp/action.cpp
@@ -471,8 +471,8 @@ Super::perform()
 	ActionList::const_iterator iter;
 	for(iter=action_list_.begin();iter!=action_list_.end();++iter)
 	{
-		if (getenv("SYNFIG_DEBUG_ACTIONS"))
-			synfig::info("%s:%d action: '%s'", __FILE__, __LINE__, (*iter)->get_name().c_str());
+		DEBUG_LOG("SYNFIG_DEBUG_ACTIONS",
+			"%s:%d action: '%s'", __FILE__, __LINE__, (*iter)->get_name().c_str());
 
 		try
 		{
@@ -650,8 +650,8 @@ Undoable::~Undoable() {
 void
 Undoable::ref()const
 {
-	if (getenv("SYNFIG_DEBUG_ACTION_REFCOUNT"))
-		printf("%s:%d %lx   ref undoable %*s -> %2d\n", __FILE__, __LINE__, uintptr_t(this), (count()*2), "", count()+1);
+	DEBUG_LOG("SYNFIG_DEBUG_ACTION_REFCOUNT",
+		"%s:%d %lx   ref undoable %*s -> %2d\n", __FILE__, __LINE__, uintptr_t(this), (count()*2), "", count()+1);
 
 	Base::ref();
 }
@@ -659,8 +659,8 @@ Undoable::ref()const
 bool
 Undoable::unref()const
 {
-	if (getenv("SYNFIG_DEBUG_ACTION_REFCOUNT"))
-		printf("%s:%d %lx unref undoable %*s%2d <-\n", __FILE__, __LINE__, uintptr_t(this), ((count()-1)*2), "", count()-1);
+	DEBUG_LOG("SYNFIG_DEBUG_ACTION_REFCOUNT",
+		"%s:%d %lx unref undoable %*s%2d <-\n", __FILE__, __LINE__, uintptr_t(this), ((count()-1)*2), "", count()-1);
 
 	return Base::unref();
 }

--- a/synfig-studio/src/synfigapp/action_system.cpp
+++ b/synfig-studio/src/synfigapp/action_system.cpp
@@ -89,8 +89,8 @@ bool
 Action::System::perform_action(etl::handle<Action::Base> action)
 {
 	assert(action);
-	if (getenv("SYNFIG_DEBUG_ACTIONS"))
-		synfig::info("%s:%d perform_action: '%s'", __FILE__, __LINE__, action->get_name().c_str());
+	DEBUG_LOG("SYNFIG_DEBUG_ACTIONS",
+		"%s:%d perform_action: '%s'", __FILE__, __LINE__, action->get_name().c_str());
 
 	etl::handle<UIInterface> uim = get_ui_interface();
 	if (!action->is_ready()) {

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -111,8 +111,8 @@ CanvasInterface::CanvasInterface(etl::loose_handle<Instance> instance,etl::handl
 
 CanvasInterface::~CanvasInterface()
 {
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("CanvasInterface::~CanvasInterface(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"CanvasInterface::~CanvasInterface(): Deleted");
 }
 
 void

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -169,8 +169,8 @@ Instance::~Instance()
 {
 	instance_map_.erase(canvas_);
 
-	if (getenv("SYNFIG_DEBUG_DESTRUCTORS"))
-		synfig::info("Instance::~Instance(): Deleted");
+	DEBUG_LOG("SYNFIG_DEBUG_DESTRUCTORS",
+		"Instance::~Instance(): Deleted");
 }
 
 handle<CanvasInterface>


### PR DESCRIPTION
getenv is very slow on Windows, so I replaced most of the logging calls with a macro that is disabled by default.

Benchmark test (used a null target to exclude rendering impact):
```
./synfig synfig-core/examples/pirates.sif -o pirates.png -t null
```

All benchmarks made on Release builds.

Windows (MSVC) before:
```
Execution time: 28.352 s
Execution time: 28.345 s
Execution time: 28.391 s
```
Avg: 28362 ms

Windows (MSVC) after:
```
Execution time: 6.140 s
Execution time: 6.341 s
Execution time: 6.201 s
```
Avg: 6227 ms
Improvement: **4.55x faster** (455%)


Windows (MinGW) before:
```
real    0m19.757s
real    0m18.605s
real    0m18.697s
```
Avg: 19019 ms

Windows (MinGW) after:
```
real    0m6.842s
real    0m6.816s
real    0m6.772s
```
Avg: 6810 ms
Improvement: **2,79x faster** (279%)


Linux before:
```
./synfig  -o pirates.png -t null  3,72s user 0,39s system 109% cpu 3,756 total
./synfig  -o pirates.png -t null  3,83s user 0,37s system 109% cpu 3,834 total
./synfig  -o pirates.png -t null  3,71s user 0,42s system 109% cpu 3,778 total
```
Average: 3789 ms

Linux after:
```
./synfig  -o pirates.png -t null  3,62s user 0,38s system 111% cpu 3,583 total
./synfig  -o pirates.png -t null  3,50s user 0,40s system 110% cpu 3,523 total
./synfig  -o pirates.png -t null  3,52s user 0,39s system 108% cpu 3,593 total
```
Average: 3566 ms
Improvement: 0,06x (6%)

macOS before:
```
./synfig synfig-core/examples/pirates.sif -o  -  2,85s user 0,31s system 108% cpu 2,928 total
./synfig synfig-core/examples/pirates.sif -o  -  2,84s user 0,32s system 108% cpu 2,911 total
./synfig synfig-core/examples/pirates.sif -o  -  2,83s user 0,31s system 108% cpu 2,898 total
```
Average: 2912 ms

macOS after:
```
./synfig synfig-core/examples/pirates.sif -o  -  2,57s user 0,31s system 108% cpu 2,642 total
./synfig synfig-core/examples/pirates.sif -o  -  2,57s user 0,31s system 109% cpu 2,642 total
./synfig synfig-core/examples/pirates.sif -o  -  2,57s user 0,31s system 108% cpu 2,641 total
```
Average: 2642 ms
Improvement: 0,1x (10%)