### PR TITLE
fix: prevent crash or hang when have problems getting frame on importing

### DIFF
--- a/synfig-core/src/synfig/importer.cpp
+++ b/synfig-core/src/synfig/importer.cpp
@@ -170,8 +170,10 @@ Importer::get_frame(const RendDesc & /* renddesc */, const Time &time)
 		return last_surface_;
 
 	Surface surface;
-	if(!get_frame(surface, RendDesc(), time))
-		warning(strprintf("Unable to get frame from \"%s\"", identifier.filename.c_str()));
+	if(!get_frame(surface, RendDesc(), time)) {
+		warning(strprintf(_("Unable to get frame from \"%s\" [%s]"), identifier.filename.c_str(), time.get_string().c_str()));
+		return nullptr;
+	}
 
 	const char *s = getenv("SYNFIG_PACK_IMAGES");
 	if (s == nullptr || atoi(s) != 0)


### PR DESCRIPTION
Problem detected on creating PR #2491, when I wrongly assumed that could redirect stderr to stdout (FFmpeg import does not like it, as it always write to stderr the FFmpeg version info)