### PR TITLE
fix: broken opengl build (due to ETL_DIRECTORY_SEPARATOR) and typos

### DIFF
--- a/synfig-core/src/synfig/rendering/opengl/internal/shaders.cpp
+++ b/synfig-core/src/synfig/rendering/opengl/internal/shaders.cpp
@@ -178,7 +178,7 @@ String
 gl::Shaders::get_shader_path(const String &filename)
 {
 	return get_shader_path()
-		 + ETL_DIRECTORY_SEPARATOR
+		 + "/"
 		 + filename;
 }
 

--- a/synfig-core/src/synfig/rendering/opengl/task/taskcontourgl.cpp
+++ b/synfig-core/src/synfig/rendering/opengl/task/taskcontourgl.cpp
@@ -183,13 +183,13 @@ TaskContourGL::run(RunParams & /* params */) const
 	// transformation
 
 	Vector rect_size = source_rect.get_size();
-	Matrix bounds_transfromation;
-	bounds_transfromation.m00 = 2.0/rect_size[0];
-	bounds_transfromation.m11 = 2.0/rect_size[1];
-	bounds_transfromation.m20 = -1.0 - source_rect.minx*bounds_transfromation.m00;
-	bounds_transfromation.m21 = -1.0 - source_rect.miny*bounds_transfromation.m11;
+	Matrix bounds_transformation;
+	bounds_transformation.m00 = 2.0/rect_size[0];
+	bounds_transformation.m11 = 2.0/rect_size[1];
+	bounds_transformation.m20 = -1.0 - source_rect.minx*bounds_transformation.m00;
+	bounds_transformation.m21 = -1.0 - source_rect.miny*bounds_transformation.m11;
 
-	Matrix matrix = bounds_transfromation * transformation->matrix;
+	Matrix matrix = bounds_transformation * transformation->matrix;
 
 	// apply bounds
 

--- a/synfig-core/src/synfig/rendering/opengl/task/tasktransformationaffinegl.cpp
+++ b/synfig-core/src/synfig/rendering/opengl/task/tasktransformationaffinegl.cpp
@@ -70,13 +70,13 @@ public:
 		gl::Context::Lock lock(env().context);
 
 		Vector rect_size = source_rect.get_size();
-		Matrix bounds_transfromation;
-		bounds_transfromation.m00 = approximate_equal(rect_size[0], 0.0) ? 0.0 : 2.0/rect_size[0];
-		bounds_transfromation.m11 = approximate_equal(rect_size[1], 0.0) ? 0.0 : 2.0/rect_size[1];
-		bounds_transfromation.m20 = -1.0 - source_rect.minx * bounds_transfromation.m00;
-		bounds_transfromation.m21 = -1.0 - source_rect.miny * bounds_transfromation.m11;
+		Matrix bounds_transformation;
+		bounds_transformation.m00 = approximate_equal(rect_size[0], 0.0) ? 0.0 : 2.0/rect_size[0];
+		bounds_transformation.m11 = approximate_equal(rect_size[1], 0.0) ? 0.0 : 2.0/rect_size[1];
+		bounds_transformation.m20 = -1.0 - source_rect.minx * bounds_transformation.m00;
+		bounds_transformation.m21 = -1.0 - source_rect.miny * bounds_transformation.m11;
 
-		Matrix matrix = bounds_transfromation * transformation->matrix;
+		Matrix matrix = bounds_transformation * transformation->matrix;
 
 		// prepare arrays
 		Vector k(target_surface->get_width(), target_surface->get_height());
@@ -154,8 +154,8 @@ public:
 
 Task::Token TaskTransformationAffineGL::token(
 	DescReal< TaskTransformationAffineGL,
-		      TaskTransformationAffine >
-			    ("TransformationAffineGL") );
+			  TaskTransformationAffine >
+				("TransformationAffineGL") );
 
 } // end of anonimous namespace
 


### PR DESCRIPTION
Since 9c7e20221bd6d2d33db24a90090bf4b05614e58f, `ETL_DIRECTORY_SEPARATOR` is now defined in <ETL/stringf>.
As it will be 'soon' removed anyway, I just changed to `"/"`.

Fixed a couple of typos too.