### PR TITLE
ci(Github Actions): bump Ubuntu version

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -34,12 +34,12 @@ jobs:
           name: macOS 11 Big Sur (CMake+Ninja)
           toolchain: cmake-ninja
           allow_failures: true
-        - os: ubuntu-18.04
-          name: Ubuntu 18.04 Bionic (Autotools)
+        - os: ubuntu-20.04
+          name: Ubuntu 20.04 Focal (Autotools)
           allow_failures: false
           toolchain: autotools
-        - os: ubuntu-20.04
-          name: Ubuntu 20.04 Focal (CMake+Ninja)
+        - os: ubuntu-22.04
+          name: Ubuntu 22.04 Jammy (CMake+Ninja)
           toolchain: cmake-ninja
           allow_failures: false
 

--- a/.github/workflows/synfig-stable.yml
+++ b/.github/workflows/synfig-stable.yml
@@ -2,7 +2,7 @@
 
 name: Synfig (stable)
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -26,8 +26,8 @@ jobs:
           name: macOS 11 Big Sur (Autotools)
           toolchain: autotools-release
           allow_failures: false
-        - os: ubuntu-18.04
-          name: Ubuntu 18.04 Bionic (Autotools)
+        - os: ubuntu-20.04
+          name: Ubuntu 20.04 Focal (Autotools)
           allow_failures: false
           toolchain: autotools-release
 

--- a/.github/workflows/synfig-tests.yml
+++ b/.github/workflows/synfig-tests.yml
@@ -2,7 +2,7 @@
 
 name: Synfig Tests CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -24,8 +24,8 @@ jobs:
         include:
         # includes a new variable of npm with a value of 2
         # for the matrix leg matching the os and version
-        - os: ubuntu-18.04
-          name: Ubuntu 18.04 (Bionic)
+        - os: ubuntu-20.04
+          name: Ubuntu 20.04 (Focal)
           allow_failures: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -39,7 +39,7 @@ jobs:
           sudo apt install flatpak
           sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
           sudo flatpak install flathub org.freedesktop.appstream-glib -y
-          sudo flatpak run org.freedesktop.appstream-glib validate synfig-studio/org.synfig.SynfigStudio.appdata.xml.in
+          flatpak run org.freedesktop.appstream-glib validate synfig-studio/org.synfig.SynfigStudio.appdata.xml.in
 
       - name: "Lottie exporter"
         run: |


### PR DESCRIPTION
Ubuntu 18.04 is being deprecated and will be removed by 2022/12/01

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/