### PR TITLE
refactor: remove Accumulator type for etl::pen and etl::surface

### DIFF
--- a/ETL/ETL/_boxblur.h
+++ b/ETL/ETL/_boxblur.h
@@ -60,7 +60,7 @@ hbox_blur(T1 pen,int w, int h, int length, T2 outpen)
 		iter=pen.x();
 		end=pen.end_x();
 
-		typename T1::accumulator_type tot((typename T1::accumulator_type)(*iter)*(length+1));
+		typename T1::value_type tot((*iter)*(length+1));
 
 		for (x=0;x<length && iter!=end;x++,++iter) tot+=*iter;
 		iter=pen.x();
@@ -68,11 +68,11 @@ hbox_blur(T1 pen,int w, int h, int length, T2 outpen)
 		for (x=0;x<w && iter!=end;x++,++iter,outpen.inc_x())
 		{
 			tot -= (x>length) ?
-				(typename T1::accumulator_type)(iter[-length-1]) :
-				(typename T1::accumulator_type)(*pen.x());
+				iter[-length-1] :
+				*pen.x();
 			tot += ((x+length)<w) ?
-				(typename T1::accumulator_type)(iter[length]) :
-				(typename T1::accumulator_type)(end[-1]);
+				iter[length] :
+				end[-1];
 									  
 			outpen.put_value((typename T2::value_type)(tot*divisor));
 		}
@@ -95,7 +95,7 @@ vbox_blur(T1 pen,const int w, const int h, int length, T2 outpen)
 		iter=pen.y();
 		end=pen.end_y();
 
-		typename T1::accumulator_type tot((typename T1::accumulator_type)(*iter)*(length+1));
+		typename T1::value_type tot((*iter)*(length+1));
 
 		for (y=0;y<length && iter!=end;y++,++iter) tot+=*iter;
 		iter=pen.y();
@@ -103,11 +103,11 @@ vbox_blur(T1 pen,const int w, const int h, int length, T2 outpen)
 		for (y=0;y<h && iter!=end;y++,++iter,outpen.inc_y())
 		{
 			tot -= (y>length) ?
-			(typename T1::accumulator_type)(iter[-length-1]) :
-			(typename T1::accumulator_type)(*pen.y());
+				iter[-length-1] :
+				*pen.y();
 			tot += ((y+length)<h) ?
-			(typename T1::accumulator_type)(iter[length]) :
-			(typename T1::accumulator_type)(end[-1]);
+				iter[length] :
+				end[-1];
 
 			outpen.put_value((typename T2::value_type)(tot*divisor));
 		}
@@ -152,7 +152,7 @@ vbox_blur(T1 pen,int w, int h, int length,T2 outpen)
 		const typename T1::value_type bval = *iter;
 		const typename T1::value_type eval = end[-1];
 
-		typename T1::accumulator_type tot(bval*(length+1));
+		typename T1::value_type tot(bval*(length+1));
 		//beginptr = (char*)&*iter; endptr = (char*)&*end;
 
 		//printf("\nx line %d (%p,%p)\n",x,beginptr,endptr);

--- a/ETL/ETL/_gaussian.h
+++ b/ETL/ETL/_gaussian.h
@@ -49,40 +49,37 @@ namespace etl {
 
 template<typename T> void
 gaussian_blur_5x5_(T pen,int w, int h,
-typename T::accumulator_pointer SC0,
-typename T::accumulator_pointer SC1,
-typename T::accumulator_pointer SC2,
-typename T::accumulator_pointer SC3)
+typename T::pointer SC0,
+typename T::pointer SC1,
+typename T::pointer SC2,
+typename T::pointer SC3)
 {
 	int x,y;
-	typename T::accumulator_type Tmp1,Tmp2,SR0,SR1,SR2,SR3;
+	typename T::value_type Tmp1,Tmp2,SR0,SR1,SR2,SR3;
 
 	//typename T::iterator_x iter;
 
 	// Setup the row buffers
-	for(x=0;x<w;x++)SC0[x+2]=(typename T::accumulator_type)(pen.x()[x])*24;
-	memset((void *)SC1,0,(w+2)*sizeof(typename T::accumulator_type));
-	memset((void *)SC2,0,(w+2)*sizeof(typename T::accumulator_type));
-	memset((void *)SC3,0,(w+2)*sizeof(typename T::accumulator_type));
-	/*memset(SC1,0,(w+2)*sizeof(typename T::accumulator_type));
-	memset(SC2,0,(w+2)*sizeof(typename T::accumulator_type));
-	memset(SC3,0,(w+2)*sizeof(typename T::accumulator_type));*/
+	for(x=0;x<w;x++)SC0[x+2]=(pen.x()[x])*24;
+	memset((void *)SC1,0,(w+2)*sizeof(typename T::value_type));
+	memset((void *)SC2,0,(w+2)*sizeof(typename T::value_type));
+	memset((void *)SC3,0,(w+2)*sizeof(typename T::value_type));
 
 	for(y=0;y<h+2;y++,pen.inc_y())
 	{
 		int yadj;
 		if(y>=h)
-			{yadj=(h-y)-1; SR0=(typename T::accumulator_type)(pen.y()[yadj])*1.35;}
+			{yadj=(h-y)-1; SR0=(pen.y()[yadj])*1.35;}
 		else
-			{yadj=0; SR0=(typename T::accumulator_type)(pen.get_value())*1.35; }
+			{yadj=0; SR0=(pen.get_value())*1.35; }
 
-		SR1=SR2=SR3=typename T::accumulator_type();
+		SR1=SR2=SR3=typename T::value_type();
 		for(x=0;x<w+2;x++,pen.inc_x())
 		{
 			if(x>=w)
-				Tmp1=(typename T::accumulator_type)(pen[yadj][(w-x)-1]);
+				Tmp1=pen[yadj][(w-x)-1];
 			else
-				Tmp1=(typename T::accumulator_type)(*pen[yadj]);
+				Tmp1=*pen[yadj];
 
 			Tmp2=SR0+Tmp1;
 			SR0=Tmp1;
@@ -112,10 +109,10 @@ typename T::accumulator_pointer SC3)
 template<typename T> void
 gaussian_blur_5x5(T pen, int w, int h)
 {
-	typename T::accumulator_pointer SC0=new typename T::accumulator_type[w+2];
-	typename T::accumulator_pointer SC1=new typename T::accumulator_type[w+2];
-	typename T::accumulator_pointer SC2=new typename T::accumulator_type[w+2];
-	typename T::accumulator_pointer SC3=new typename T::accumulator_type[w+2];
+	typename T::pointer SC0=new typename T::value_type[w+2];
+	typename T::pointer SC1=new typename T::value_type[w+2];
+	typename T::pointer SC2=new typename T::value_type[w+2];
+	typename T::pointer SC3=new typename T::value_type[w+2];
 
 	gaussian_blur_5x5_(pen,w,h,SC0,SC1,SC2,SC3);
 
@@ -130,10 +127,10 @@ gaussian_blur_5x5(T begin, T end)
 {
 	typename T::difference_type size(end-begin);
 
-	typename T::accumulator_pointer SC0=new typename T::accumulator_type[size.x+2];
-	typename T::accumulator_pointer SC1=new typename T::accumulator_type[size.x+2];
-	typename T::accumulator_pointer SC2=new typename T::accumulator_type[size.x+2];
-	typename T::accumulator_pointer SC3=new typename T::accumulator_type[size.x+2];
+	typename T::pointer SC0=new typename T::value_type[size.x+2];
+	typename T::pointer SC1=new typename T::value_type[size.x+2];
+	typename T::pointer SC2=new typename T::value_type[size.x+2];
+	typename T::pointer SC3=new typename T::value_type[size.x+2];
 
 	gaussian_blur_5x5_(begin,size.x,size.y,SC0,SC1,SC2,SC3);
 
@@ -147,31 +144,31 @@ template<typename T> void
 gaussian_blur_3x3(T pen,int w, int h)
 {
 	int x,y;
-	typename T::accumulator_type Tmp1,Tmp2,SR0,SR1;
+	typename T::value_type Tmp1,Tmp2,SR0,SR1;
 
 //	typename T::iterator_x iter;
 
-	typename T::accumulator_pointer SC0=new typename T::accumulator_type[w+1];
-	typename T::accumulator_pointer SC1=new typename T::accumulator_type[w+1];
+	typename T::pointer SC0=new typename T::value_type[w+1];
+	typename T::pointer SC1=new typename T::value_type[w+1];
 
 	// Setup the row buffers
-	for(x=0;x<w;x++)SC0[x+1]=(typename T::accumulator_type)(pen.x()[x])*4;
-	memset((void *)SC1,0,(w+1)*sizeof(typename T::accumulator_type));
+	for(x=0;x<w;x++)SC0[x+1]=(pen.x()[x])*4;
+	memset((void *)SC1,0,(w+1)*sizeof(typename T::value_type));
 
 	for(y=0;y<h+1;y++,pen.inc_y())
 	{
 		int yadj;
 		if(y>=h)
-			{yadj=-1; SR1=SR0=(typename T::accumulator_type)(pen.y()[yadj]);}
+			{yadj=-1; SR1=SR0=pen.y()[yadj];}
 		else
-			{yadj=0; SR1=SR0=(typename T::accumulator_type)(pen.get_value()); }
+			{yadj=0; SR1=SR0=pen.get_value(); }
 
 		for(x=0;x<w+1;x++,pen.inc_x())
 		{
 			if(x>=w)
-				Tmp1=(typename T::accumulator_type)(pen[yadj][(w-x)-2]);
+				Tmp1=pen[yadj][(w-x)-2];
 			else
-				Tmp1=(typename T::accumulator_type)(*pen[yadj]);
+				Tmp1=*pen[yadj];
 
 			Tmp2=SR0+Tmp1;
 			SR0=Tmp1;
@@ -181,7 +178,7 @@ gaussian_blur_3x3(T pen,int w, int h)
 			Tmp2=SC0[x]+Tmp1;
 			SC0[x]=Tmp1;
 			if(y&&x)
-				pen[-1][-1]=(typename T::value_type)((SC1[x]+Tmp2)/16);
+				pen[-1][-1]=(SC1[x]+Tmp2)/16;
 			SC1[x]=Tmp2;
 		}
 		pen.dec_x(x);
@@ -252,10 +249,10 @@ gaussian_blur_1x3(_PEN begin, _PEN end)
 template<typename T> void
 gaussian_blur(T pen, int w, int h, int blur_x, int blur_y)
 {
-	typename T::accumulator_pointer SC0=new typename T::accumulator_type[w+2];
-	typename T::accumulator_pointer SC1=new typename T::accumulator_type[w+2];
-	typename T::accumulator_pointer SC2=new typename T::accumulator_type[w+2];
-	typename T::accumulator_pointer SC3=new typename T::accumulator_type[w+2];
+	typename T::pointer SC0=new typename T::value_type[w+2];
+	typename T::pointer SC1=new typename T::value_type[w+2];
+	typename T::pointer SC2=new typename T::value_type[w+2];
+	typename T::pointer SC3=new typename T::value_type[w+2];
 
 	blur_x--;
 	blur_y--;

--- a/ETL/ETL/_pen.h
+++ b/ETL/ETL/_pen.h
@@ -119,12 +119,12 @@ public:
 	generic_pen_row_iterator():data_(nullptr), pitch_(0) { }
 };
 
-template<typename T, typename AT=T>
+template<typename T>
 class generic_pen
 {
 public:
 	typedef T value_type;
-	typedef AT accumulator_type;
+	typedef T accumulator_type;
 	typedef value_type* pointer;
 	typedef accumulator_type* accumulator_pointer;
 	typedef const value_type* const_pointer;
@@ -155,7 +155,7 @@ private:
 	value_type value_;
 	value_type *data_ = nullptr;
 
-	typedef generic_pen<T,AT> self_type;
+	typedef generic_pen<T> self_type;
 
 	void addptr(int nbytes)
 	{
@@ -202,8 +202,8 @@ public:
 	}
 	self_type& move_to(int x, int y) { assert(data_); return move(x - x_,y - y_);}
 
-	template<typename TT, typename ATT>
-	self_type& move_to(const generic_pen<TT, ATT> &p) { assert(data_ && p.data_); return move_to(p.x_,p.y_);}
+	template<typename TT>
+	self_type& move_to(const generic_pen<TT> &p) { assert(data_ && p.data_); return move_to(p.x_,p.y_);}
 
 	void set_value(const value_type &v) { value_=v; }
 

--- a/ETL/ETL/_pen.h
+++ b/ETL/ETL/_pen.h
@@ -124,11 +124,8 @@ class generic_pen
 {
 public:
 	typedef T value_type;
-	typedef T accumulator_type;
 	typedef value_type* pointer;
-	typedef accumulator_type* accumulator_pointer;
 	typedef const value_type* const_pointer;
-	typedef const accumulator_type* const_accumulator_pointer;
 	typedef value_type& reference;
 	typedef const value_type& const_reference;
 

--- a/ETL/ETL/_surface.h
+++ b/ETL/ETL/_surface.h
@@ -205,11 +205,8 @@ class surface
 {
 public:
 	typedef T value_type;
-	typedef T accumulator_type;
 	typedef value_type* pointer;
-	typedef accumulator_type* accumulator_pointer;
 	typedef const value_type* const_pointer;
-	typedef const accumulator_type* const_accumulator_pointer;
 	typedef value_type& reference;
 	typedef generic_pen<value_type> pen;
 	typedef generic_pen<const value_type> const_pen;

--- a/ETL/ETL/_surface.h
+++ b/ETL/ETL/_surface.h
@@ -101,13 +101,12 @@ public:
 	value_type uncook(const accumulator_type& x)const { return (value_type)x; }
 };
 
-template <typename VT, typename CT, typename ST, ST reader(const void*, int, int)>
+template <typename VT, typename CT, VT reader(const void*, int, int)>
 class sampler
 {
 public:
 	typedef VT value_type;
 	typedef CT coord_type;
-	typedef ST source_type;
 	typedef coord_type float_type;
 	typedef value_type func(const void*, const coord_type, const coord_type);
 
@@ -201,19 +200,19 @@ public:
 	}
 };
 
-template <typename T, typename AT=T, class VP=value_prep<T,AT> >
+template <typename T, class VP=value_prep<T,T> >
 class surface
 {
 public:
 	typedef T value_type;
-	typedef AT accumulator_type;
+	typedef T accumulator_type;
 	typedef value_type* pointer;
 	typedef accumulator_type* accumulator_pointer;
 	typedef const value_type* const_pointer;
 	typedef const accumulator_type* const_accumulator_pointer;
 	typedef value_type& reference;
-	typedef generic_pen<value_type,accumulator_type> pen;
-	typedef generic_pen<const value_type,accumulator_type> const_pen;
+	typedef generic_pen<value_type> pen;
+	typedef generic_pen<const value_type> const_pen;
 	typedef VP value_prep_type;
 
 	typedef alpha_pen<const_pen> const_alpha_pen;
@@ -540,16 +539,16 @@ public:
 
 	template< clamping::func clamp_x = clamping::clamp,
 			  clamping::func clamp_y = clamping::clamp >
-	inline static accumulator_type reader_cook(const void *surf, int x, int y) {
+	inline static value_type reader_cook(const void *surf, int x, int y) {
 		const surface &s = *(const surface*)surf;
 		return clamp_x(x, s.get_w()) && clamp_y(y, s.get_h()) ? s.cooker_.cook(s[y][x]) : value_type();
 	}
 
-	template<typename ReaderType, ReaderType reader(const void*, int, int)>
-	class sampler: public etl::sampler<accumulator_type, float, ReaderType, reader> { };
+	template<value_type reader(const void*, int, int)>
+	class sampler: public etl::sampler<value_type, float, reader> { };
 
-	typedef sampler<accumulator_type, surface::reader_cook> sampler_cook;
-	typedef sampler<value_type, surface::reader> sampler_nocook;
+	typedef sampler<surface::reader_cook> sampler_cook;
+	typedef sampler<surface::reader> sampler_nocook;
 
 	//! Nearest sample
 	value_type nearest_sample(const float x, const float y)const

--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -156,25 +156,25 @@ inline Color zero<Color>()
 	return Color::alpha();
 }
 
-template <typename T,typename AT,class VP>
-static void GaussianBlur_2x2(etl::surface<T,AT,VP> &surface)
+template <typename T,class VP>
+static void GaussianBlur_2x2(etl::surface<T,VP>& surface)
 {
 	int x,y,w,h;
-	AT Tmp1,Tmp2,SR0;
+	T Tmp1,Tmp2,SR0;
 
 	w=surface.get_w();
 	h=surface.get_h();
 	
-	AT *SC0=new AT[w];
+	T *SC0=new T[w];
 
-	memcpy(static_cast<void*>(SC0), surface[0], w*sizeof(AT));
+	memcpy(static_cast<void*>(SC0), surface[0], w*sizeof(T));
 
 	for(y=0;y<h;y++)
 	{
 		SR0=surface[y][0];
 		for(x=0;x<w;x++)
 		{
-			Tmp1=(AT)(surface[y][x]);
+			Tmp1=surface[y][x];
 			Tmp2=SR0+Tmp1;
 			SR0=Tmp1;
 			surface[y][x]=(SC0[x]+Tmp2)/4;
@@ -184,11 +184,11 @@ static void GaussianBlur_2x2(etl::surface<T,AT,VP> &surface)
 	delete [] SC0;
 }
 
-template <typename T,typename AT,class VP>
-static void GaussianBlur_2x1(etl::surface<T,AT,VP> &surface)
+template <typename T,class VP>
+static void GaussianBlur_2x1(etl::surface<T,VP> &surface)
 {
 	int x,y,w,h;
-	AT Tmp1,Tmp2,SR0;
+	T Tmp1,Tmp2,SR0;
 
 	w = surface.get_w();
 	h = surface.get_h();
@@ -206,11 +206,11 @@ static void GaussianBlur_2x1(etl::surface<T,AT,VP> &surface)
 	}
 }
 
-template <typename T,typename AT,class VP>
-static void GaussianBlur_3x1(etl::surface<T,AT,VP> &surface)
+template <typename T,class VP>
+static void GaussianBlur_3x1(etl::surface<T,VP> &surface)
 {
 	int x,y,w,h;
-	AT Tmp1,Tmp2,SR0,SR1;
+	T Tmp1,Tmp2,SR0,SR1;
 	w = surface.get_w();
 	h = surface.get_h();
 	
@@ -232,15 +232,15 @@ static void GaussianBlur_3x1(etl::surface<T,AT,VP> &surface)
 	}
 }
 
-template <typename T,typename AT,class VP>
-static void GaussianBlur_1x2(etl::surface<T,AT,VP> &surface)
+template <typename T,class VP>
+static void GaussianBlur_1x2(etl::surface<T,VP> &surface)
 {
 	int x,y;
-	AT Tmp1,Tmp2,SR0;
+	T Tmp1,Tmp2,SR0;
 
 	for(x=0;x<surface.get_w();x++)
 	{
-		SR0 = zero<AT>();
+		SR0 = zero<T>();
 		for(y=0;y<surface.get_h();y++)
 		{
 			Tmp1=surface[y][x];
@@ -251,11 +251,11 @@ static void GaussianBlur_1x2(etl::surface<T,AT,VP> &surface)
 	}
 }
 
-template <typename T,typename AT,class VP>
-static void GaussianBlur_1x3(etl::surface<T,AT,VP> &surface)
+template <typename T,class VP>
+static void GaussianBlur_1x3(etl::surface<T,VP> &surface)
 {
 	int x,y;
-	AT Tmp1,Tmp2,SR0,SR1;
+	T Tmp1,Tmp2,SR0,SR1;
 
 	for(x=0;x<surface.get_w();x++)
 	{
@@ -556,10 +556,10 @@ bool Blur::operator()(const Surface &surface,
 			int bh = (int)(std::fabs(ph)*size[1]*GAUSSIAN_ADJUSTMENT+0.5);
 			int max=bw+bh;
 
-			ColorAccumulator *SC0=new ColorAccumulator[w+2];
-			ColorAccumulator *SC1=new ColorAccumulator[w+2];
-			ColorAccumulator *SC2=new ColorAccumulator[w+2];
-			ColorAccumulator *SC3=new ColorAccumulator[w+2];
+			Color* SC0=new Color[w+2];
+			Color* SC1=new Color[w+2];
+			Color* SC2=new Color[w+2];
+			Color* SC3=new Color[w+2];
 
 			//synfig::warning("Didn't crash yet b2");
 			//int i = 0;

--- a/synfig-core/src/synfig/color.h
+++ b/synfig-core/src/synfig/color.h
@@ -35,11 +35,6 @@
 #include <synfig/color/color.h>
 #include <synfig/color/gamma.h>
 
-
-namespace synfig {
-typedef Color ColorAccumulator;
-}
-
 #include <synfig/color/pixelformat.h>
 
 #endif // __SYNFIG_COLOR_H

--- a/synfig-core/src/synfig/rendering/software/function/packedsurface.h
+++ b/synfig-core/src/synfig/rendering/software/function/packedsurface.h
@@ -104,7 +104,7 @@ public:
 
 		template< etl::clamping::func clamp_x = etl::clamping::clamp,
 				  etl::clamping::func clamp_y = etl::clamping::clamp >
-		inline static ColorAccumulator reader_cook(const void *surf, int x, int y)
+		inline static Color reader_cook(const void *surf, int x, int y)
 		{
 			const Reader &r = *(const Reader*)surf;
 			return clamp_x(x, r.surface->width) && clamp_y(y, r.surface->height)
@@ -128,7 +128,7 @@ public:
 			{ return min <= c && c <= max; }
 	};
 
-	typedef etl::sampler<ColorAccumulator, float, ColorAccumulator, Reader::reader_cook> Sampler;
+	typedef etl::sampler<Color, float, Reader::reader_cook> Sampler;
 
 private:
 	mutable std::mutex mutex;

--- a/synfig-core/src/synfig/rendering/software/function/resample.cpp
+++ b/synfig-core/src/synfig/rendering/software/function/resample.cpp
@@ -46,7 +46,7 @@ using namespace rendering;
 
 #ifdef _MSC_VER
 // MSVC requires explicit template instantiation. Without it, it will crash with an internal compiler error :(
-template Color etl::surface<Color, ColorAccumulator, ColorPrep>::reader<etl::clamping::clamp, etl::clamping::clamp>(const void*, int, int);
+template Color etl::surface<Color, ColorPrep>::reader<etl::clamping::clamp, etl::clamping::clamp>(const void*, int, int);
 template Color software::PackedSurface::Reader::reader<etl::clamping::clamp, etl::clamping::clamp>(void const*, int, int);
 #endif
 
@@ -64,11 +64,11 @@ namespace {
 		struct MapPixelPart { int src; int dst; ColorReal k0; ColorReal k1; };
 
 		template< Color reader(const void*,int,int),
-				ColorAccumulator reader_cook(const void*,int,int) >
+				Color reader_cook(const void*,int,int) >
 		class Generic {
 		public:
-			typedef synfig::Surface::sampler<Color, reader> Sampler;
-			typedef synfig::Surface::sampler<ColorAccumulator, reader_cook> SamplerCook;
+			typedef synfig::Surface::sampler<reader> Sampler;
+			typedef synfig::Surface::sampler<reader_cook> SamplerCook;
 			typedef typename Sampler::coord_type Coord;
 			typedef typename Sampler::func SamplerFunc;
 			typedef typename SamplerCook::func SamplerCookFunc;

--- a/synfig-core/src/synfig/surface.cpp
+++ b/synfig-core/src/synfig/surface.cpp
@@ -134,7 +134,7 @@ synfig::Surface::clear()
 #ifdef HAS_VIMAGE
 	fill(Color(0.5,0.5,0.5,0.0000001));
 #else
-	etl::surface<Color, ColorAccumulator, ColorPrep>::clear();
+	etl::surface<Color, ColorPrep>::clear();
 #endif
 }
 
@@ -238,7 +238,7 @@ synfig::Surface::blit_to(alpha_pen& pen, int x, int y, int w, int h)
 		return;
 	}
 #endif
-	etl::surface<Color, ColorAccumulator, ColorPrep>::blit_to(pen,x,y,w,h);
+	etl::surface<Color, ColorPrep>::blit_to(pen,x,y,w,h);
 }
 
 

--- a/synfig-core/src/synfig/surface.h
+++ b/synfig-core/src/synfig/surface.h
@@ -51,14 +51,14 @@ class Target_Tile;
 class ColorPrep
 {
 public:
-	static ColorAccumulator cook_static(Color x)
+	static Color cook_static(Color x)
 	{
 		x.set_r(x.get_r()*x.get_a());
 		x.set_g(x.get_g()*x.get_a());
 		x.set_b(x.get_b()*x.get_a());
 		return x;
 	}
-	static Color uncook_static(ColorAccumulator x)
+	static Color uncook_static(Color x)
 	{
 		if(!x.get_a())
 			return Color::alpha();
@@ -71,9 +71,9 @@ public:
 		return x;
 	}
 
-	ColorAccumulator cook(Color x)const
+	Color cook(Color x)const
 		{ return cook_static(x); }
-	Color uncook(ColorAccumulator x)const
+	Color uncook(Color x)const
 		{ return uncook_static(x); }
 };
 
@@ -82,7 +82,7 @@ public:
 **	\brief Bitmap Surface
 **	\todo writeme
 */
-class Surface : public etl::surface<Color, ColorAccumulator, ColorPrep>
+class Surface : public etl::surface<Color, ColorPrep>
 {
 public:
 	typedef Color value_type;
@@ -91,14 +91,14 @@ public:
 	Surface() { }
 
 	Surface(const size_type::value_type &w, const size_type::value_type &h):
-		etl::surface<Color, ColorAccumulator,ColorPrep>(w,h) { }
+		etl::surface<Color, ColorPrep>(w,h) { }
 
 	Surface(const size_type &s):
-		etl::surface<Color, ColorAccumulator,ColorPrep>(s) { }
+		etl::surface<Color, ColorPrep>(s) { }
 
 	template <typename _pen>
 	Surface(const _pen &_begin, const _pen &_end):
-		etl::surface<Color, ColorAccumulator,ColorPrep>(_begin,_end) { }
+		etl::surface<Color, ColorPrep>(_begin,_end) { }
 
 	template <class _pen> void blit_to(_pen &pen)
 	{ return blit_to(pen,0,0, get_w(),get_h()); }
@@ -106,7 +106,7 @@ public:
 	template <class _pen> void
 	blit_to(_pen& DEST_PEN,	int x, int y, int w, int h)
 	{
-		etl::surface<Color, ColorAccumulator, ColorPrep>::blit_to(DEST_PEN,x,y,w,h);
+		etl::surface<Color, ColorPrep>::blit_to(DEST_PEN,x,y,w,h);
 	}
 
 	void clear();
@@ -142,16 +142,16 @@ struct _BlendFunc
 **	The default blending method is Color::BLEND_COMPOSITE.
 **	\see Color::BlendMethod
 */
-class Surface::alpha_pen : public etl::alpha_pen< etl::generic_pen<Color, ColorAccumulator>, Color::value_type, _BlendFunc<Color> >
+class Surface::alpha_pen : public etl::alpha_pen< etl::generic_pen<Color>, Color::value_type, _BlendFunc<Color> >
 {
 public:
 	alpha_pen() { }
-	alpha_pen(const etl::alpha_pen< etl::generic_pen<Color, ColorAccumulator>, Color::value_type, _BlendFunc<Color> > &x):
-		etl::alpha_pen< etl::generic_pen<Color, ColorAccumulator>, Color::value_type, _BlendFunc<Color> >(x)
+	alpha_pen(const etl::alpha_pen< etl::generic_pen<Color>, Color::value_type, _BlendFunc<Color> > &x):
+		etl::alpha_pen< etl::generic_pen<Color>, Color::value_type, _BlendFunc<Color> >(x)
 	{ }
 
-	alpha_pen(const etl::generic_pen<Color, ColorAccumulator>& pen, const Color::value_type &a = 1, const _BlendFunc<Color> &func = _BlendFunc<Color>()):
-		etl::alpha_pen< etl::generic_pen<Color, ColorAccumulator>, Color::value_type, _BlendFunc<Color> >(pen,a,func)
+	alpha_pen(const etl::generic_pen<Color>& pen, const Color::value_type &a = 1, const _BlendFunc<Color> &func = _BlendFunc<Color>()):
+		etl::alpha_pen< etl::generic_pen<Color>, Color::value_type, _BlendFunc<Color> >(pen,a,func)
 	{ }
 
 	//! Sets the blend method to that described by \a method


### PR DESCRIPTION
It is not actually used. The only non-primitive type that uses it is `synfig::Color`, but `synfig::ColorAccumulator` is a `typedef` to `Color`.

A previous work makes us free to really removed:
7832633f8fe3069e5d83be9bebe0e3258d2f1f93 (#1810, #1805)