### PR TITLE
fix: crash with a bline containing only 2 points that are too close

### DIFF
--- a/synfig-studio/src/synfigapp/wplistconverter.cpp
+++ b/synfig-studio/src/synfigapp/wplistconverter.cpp
@@ -80,7 +80,7 @@ WPListConverter::operator()(std::list<synfig::WidthPoint> &wp_out, const std::li
 	Point c(*p_iter);
 	points.push_back(c);
 	widths.push_back(*w_iter);
-	p_iter++;
+	++p_iter;
 	for(;p_iter != end; ++p_iter,++w_iter)
 		if (*p_iter != c)
 		{
@@ -101,8 +101,13 @@ WPListConverter::operator()(std::list<synfig::WidthPoint> &wp_out, const std::li
 		p1=p2;
 	}
 	// Calculate the normalized cumulative distances
-	for(i=0;i<n;i++)
-		norm_distances.push_back(distances[i]/distances[n-1]);
+	if (synfig::approximate_zero(distances[n-1])) {
+		norm_distances.push_back(0.);
+	} else {
+		int total_length = distances[n-1];
+		for(i=0;i<n;i++)
+			norm_distances.push_back(distances[i]/total_length);
+	}
 	// Prepare the output
 	work_out.resize(n);
 	// Prepare the errors


### PR DESCRIPTION
prevent crash due to NaN with a bline containing only 2 points that are too close

distance[n-1] would be zero, and make the WidthPoint position to be NaN

That problem is propagated, affects `synfig::hom_to_std()` and a crash happens

How to reproduce: with Draw Tool and a drawing tablet, quickly tap twice (or more in a row) at the same point. Synfig Studio crashes.