### PR TITLE
fix: changing interpolation of Canvas parameter changes interpolation for other waypoints

### DIFF
--- a/synfig-core/src/synfig/timepointcollect.cpp
+++ b/synfig-core/src/synfig/timepointcollect.cpp
@@ -87,7 +87,8 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		const Layer::DynamicParamList& dyn_param_list(layer->dynamic_param_list());
 		Layer::DynamicParamList::const_iterator iter;
 		int ret(0);
-		if (layer->get_name() != "group"){
+		etl::handle<Layer_PasteCanvas> p = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer);
+		if (!p){
 			for(iter=dyn_param_list.begin();iter!=dyn_param_list.end();++iter)
 				ret+=waypoint_collect(waypoint_set,time,iter->second);
 		}
@@ -95,7 +96,6 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		ValueBase canvas_value(layer->get_param("canvas"));
 		if(canvas_value.get_type()==type_canvas)
 		{
-			etl::handle<Layer_PasteCanvas> p = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer);
 			if (p)
 				ret+=waypoint_collect(waypoint_set, time + p->get_time_offset(),
 									  Canvas::Handle(canvas_value.get(Canvas::Handle())));

--- a/synfig-core/src/synfig/timepointcollect.cpp
+++ b/synfig-core/src/synfig/timepointcollect.cpp
@@ -90,6 +90,7 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		if (layer->get_name() != "group"){
 			for(iter=dyn_param_list.begin();iter!=dyn_param_list.end();++iter)
 				ret+=waypoint_collect(waypoint_set,time,iter->second);
+		}
 
 		ValueBase canvas_value(layer->get_param("canvas"));
 		if(canvas_value.get_type()==type_canvas)

--- a/synfig-core/src/synfig/timepointcollect.cpp
+++ b/synfig-core/src/synfig/timepointcollect.cpp
@@ -87,8 +87,9 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		const Layer::DynamicParamList& dyn_param_list(layer->dynamic_param_list());
 		Layer::DynamicParamList::const_iterator iter;
 		int ret(0);
-		for(iter=dyn_param_list.begin();iter!=dyn_param_list.end();++iter)
-			ret+=waypoint_collect(waypoint_set,time,iter->second);
+		if (layer->get_name() != "group"){
+			for(iter=dyn_param_list.begin();iter!=dyn_param_list.end();++iter)
+				ret+=waypoint_collect(waypoint_set,time,iter->second);
 
 		ValueBase canvas_value(layer->get_param("canvas"));
 		if(canvas_value.get_type()==type_canvas)


### PR DESCRIPTION
quick fix #2857 .
So from what I understood changing the interpolation of a canvas parameter of a group layer should change the interpolation of itself + the waypoints of the grouped layers which have the same time.
The issue as described was that changing the interpolation of a canvas parameter of a group layer changed along with it other parameters of the group layer. This PR stops that from happening (by not allowing the other waypoints of the group to be a part of the waypoint set we have), but I dont really understand this much so there are two points here :
1.  is the current behaviour the intended behaviour ?
2. does this break anything ? 

And this is just in case previous points are good

1.  is using the layers `get_name()` method to know if its a group safe ? or should I check if a layer is itself a group by another way (quickly looking around in the layer class I couldn't really find alternative ways to check if our layer is a group)

@morevnaproject could you please test it? :)