### PR TITLE
feat: Move "Default interpolation" dropdown to Preferences dialog

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -72,7 +72,6 @@
 #include <gui/preview.h>
 #include <gui/states/state_normal.h>
 #include <gui/widgets/widget_canvastimeslider.h>
-#include <gui/widgets/widget_interpolation.h>
 #include <gui/workarea.h>
 
 #include <pangomm.h>
@@ -833,18 +832,6 @@ CanvasView::create_time_bar()
 	timetrack->attach(*widget_kf_list, 0, 2, 1, 1);
 	timetrack->hide();
 
-	// Interpolation widget
-	widget_interpolation = manage(new Widget_Interpolation(Widget_Interpolation::SIDE_BOTH));
-	widget_interpolation->set_tooltip_text(_("Default Interpolation"));
-	widget_interpolation->set_popup_fixed_width(false);
-	widget_interpolation->set_hexpand(false);
-	widget_interpolation->show();
-	widget_interpolation->signal_changed().connect(sigc::mem_fun(*this, &CanvasView::on_interpolation_changed));
-
-	synfigapp::Main::signal_interpolation_changed().connect(sigc::mem_fun(*this, &CanvasView::interpolation_refresh));
-	synfigapp::Main::set_interpolation(INTERPOLATION_CLAMPED); // Clamped by default.
-	interpolation_refresh();
-
 	//Setup the Animation Mode Button and the Keyframe Lock button
 	{
 		Gtk::IconSize iconsize=Gtk::IconSize::from_name("synfig-small_icon_16x16");
@@ -975,7 +962,6 @@ CanvasView::create_time_bar()
 		controls->attach(*jackdial, left_pos++, 0, 1, 1);
 		controls->attach(*statusbar, left_pos++, 0, 1, 1);
 		controls->attach(*progressbar, left_pos++, 0, 1, 1);
-		controls->attach(*widget_interpolation, left_pos++, 0, 1, 1);
 		controls->attach(*keyframedial, left_pos++, 0, 1, 1);
 		controls->attach(*animatebutton, left_pos++, 0, 1, 1);
 
@@ -3857,14 +3843,6 @@ CanvasView::jack_sync_callback(jack_transport_state_t /* state */, jack_position
 	return 1;
 }
 #endif
-
-void
-CanvasView::interpolation_refresh()
-	{ widget_interpolation->set_value(synfigapp::Main::get_interpolation()); }
-
-void
-CanvasView::on_interpolation_changed()
-	{ synfigapp::Main::set_interpolation(Waypoint::Interpolation(widget_interpolation->get_value())); }
 
 void 
 CanvasView::toggle_show_toolbar(){

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -115,7 +115,6 @@ class CanvasViewSelectionManager;
 class CellRenderer_TimeTrack;
 class CellRenderer_ValueBase;
 class WorkArea;
-class Widget_Enum;
 class Preview;
 struct PreviewInfo;
 class ResolutionDial;
@@ -285,7 +284,6 @@ private:
 	Gtk::ComboBoxText *render_combobox;
 	Gtk::Grid *timebar;
 	Gtk::Toolbar *displaybar;
-	Widget_Enum *widget_interpolation;
 	Gtk::ToggleButton *animatebutton;
 	Gtk::ToggleButton *timetrackbutton;
 	Gtk::Grid *timetrack;
@@ -482,9 +480,6 @@ private:
 	void toggle_render_combobox();
 
 	void on_play_timeout();
-
-	void interpolation_refresh();
-	void on_interpolation_changed();
 
 	static void save_all();
 

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -47,6 +47,7 @@
 #include <gui/localization.h>
 #include <gui/resourcehelper.h>
 #include <gui/widgets/widget_enum.h>
+#include <gui/widgets/widget_interpolation.h>
 #include <gui/autorecover.h>
 #include <synfig/threadpool.h>
 
@@ -439,6 +440,14 @@ Dialog_Setup::create_editing_page(PageInfo pi)
 	toggle_animation_thumbnail_preview.set_tooltip_text(_("Turn on/off animation thumbnail preview when you hover your mouse over the timetrack panel."));
 	toggle_animation_thumbnail_preview.set_halign(Gtk::ALIGN_START);
 	toggle_animation_thumbnail_preview.set_hexpand(false);
+
+	attach_label(pi.grid, _("Default Interpolation"), ++row);
+	widget_interpolation = manage(new Widget_Interpolation(Widget_Interpolation::SIDE_BOTH));
+	widget_interpolation->set_tooltip_text(_("Default Interpolation"));
+	widget_interpolation->set_popup_fixed_width(false);
+	widget_interpolation->set_hexpand(false);
+	widget_interpolation->show();
+	pi.grid->attach(*widget_interpolation, 1, row, 1, 1);
 
 	// Editing Other section
 	attach_label_section(pi.grid, _("Other"), ++row);
@@ -870,6 +879,8 @@ Dialog_Setup::on_restore_pressed()
 		widget_enum->set_value(Distance::SYSTEM_POINTS);
 		toggle_restrict_radius_ducks.set_active(true);
 		toggle_animation_thumbnail_preview.set_active(true);
+		synfigapp::Main::set_interpolation(INTERPOLATION_CLAMPED);
+		widget_interpolation->set_value(synfigapp::Main::get_interpolation());
 		toggle_enable_experimental_features.set_active(false);
 		toggle_clear_redo_stack_on_new_action.set_active(true);
 		toggle_use_dark_theme.set_active(false);
@@ -956,6 +967,9 @@ Dialog_Setup::on_apply_pressed()
 
 	// Set the animation_thumbnail_preview flag
 	App::animation_thumbnail_preview  = toggle_animation_thumbnail_preview.get_active();
+
+	// Set the default widget interpolation
+	synfigapp::Main::set_interpolation(Waypoint::Interpolation(widget_interpolation->get_value()));
 
 	// Set the experimental features flag
 	App::enable_experimental_features = toggle_enable_experimental_features.get_active();
@@ -1241,6 +1255,9 @@ Dialog_Setup::refresh()
 
 	// Refresh the status of animation_thumbnail_preview flag
 	toggle_animation_thumbnail_preview.set_active(App::animation_thumbnail_preview);
+
+	// Refresh the default interpolation
+	widget_interpolation->set_value(synfigapp::Main::get_interpolation());
 
 	// Refresh the status of the experimental features flag
 	toggle_enable_experimental_features.set_active(App::enable_experimental_features);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -443,7 +443,6 @@ Dialog_Setup::create_editing_page(PageInfo pi)
 
 	attach_label(pi.grid, _("Default Interpolation"), ++row);
 	widget_interpolation = manage(new Widget_Interpolation(Widget_Interpolation::SIDE_BOTH));
-	widget_interpolation->set_tooltip_text(_("Default Interpolation"));
 	widget_interpolation->set_popup_fixed_width(false);
 	widget_interpolation->set_hexpand(false);
 	widget_interpolation->show();

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -445,6 +445,8 @@ Dialog_Setup::create_editing_page(PageInfo pi)
 	widget_interpolation = manage(new Widget_Interpolation(Widget_Interpolation::SIDE_BOTH));
 	widget_interpolation->set_popup_fixed_width(false);
 	widget_interpolation->set_hexpand(false);
+	synfigapp::Main::set_interpolation(INTERPOLATION_CLAMPED);// To Do maybe: store interpolation in settings instead of default clamped
+	widget_interpolation->set_value(synfigapp::Main::get_interpolation());
 	widget_interpolation->show();
 	pi.grid->attach(*widget_interpolation, 1, row, 1, 1);
 

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -128,6 +128,7 @@ class Dialog_Setup : public Dialog_Template
 	synfig::Time::Format time_format;
 
 	Widget_Enum *widget_enum;
+	Widget_Enum *widget_interpolation;
 
 	Widget_Time auto_backup_interval;
 


### PR DESCRIPTION
moved and this is how every thing looks now:
![moved to prefrences](https://user-images.githubusercontent.com/100296264/196813689-a8d64963-6688-40f8-b3c2-3cc3fa52b8ab.png)

But there is one issue (or not) I noticed. the original default interpolation button didnt save the default interpolation, instead each time synfig opens it defaults its value as "clamped". I think now that its in preferences it probably should be saved on reopen, so I will have to implement that still. 

@ice0 , @morevnaproject opinions ?