### PR TITLE
chore: fix typos

### DIFF
--- a/ChangeLog-development.md
+++ b/ChangeLog-development.md
@@ -586,7 +586,7 @@
 - [`0485671`](https://github.com/synfig/synfig/commit/048567137d1235fd4f46754adb6f126d0c1a3eb4) CMake NSIS Installer ([#1582](https://github.com/synfig/synfig/issues/1582)) [studio]
 - [`b92a370`](https://github.com/synfig/synfig/commit/b92a3708db735f18c45534066fe158c960978a35) Skeleton Tool: Fixed Skeleton Deformation layer Highlighting ([#1628](https://github.com/synfig/synfig/issues/1628)) [studio]
 - [`8d27d97`](https://github.com/synfig/synfig/commit/8d27d97bfd709cecd5f52ca77b5693fac338df43) Added button to stop rendering process ([#1585](https://github.com/synfig/synfig/issues/1585)) [studio]
-- [`f89c807`](https://github.com/synfig/synfig/commit/f89c8079d407f5863f4f3ddf76bff37f36b6fb72) Merge PR [#1622](https://github.com/synfig/synfig/issues/1622): Freetype: avoid uneeded font search [core]
+- [`f89c807`](https://github.com/synfig/synfig/commit/f89c8079d407f5863f4f3ddf76bff37f36b6fb72) Merge PR [#1622](https://github.com/synfig/synfig/issues/1622): Freetype: avoid unneeded font search [core]
 - [`161fd5b`](https://github.com/synfig/synfig/commit/161fd5b5f2f3294a6537d1e287002cf60bc84384) Canvas end-time could be set by wrong reason ([#1614](https://github.com/synfig/synfig/issues/1614)) [core]
 - [`8cece27`](https://github.com/synfig/synfig/commit/8cece276ec0891f3573a4975a1ab1d444e5b3985) Merge PR [#1617](https://github.com/synfig/synfig/issues/1617): Skeleton Tool - Skeleton Deformation Layer created as "disabled". Closes [#1615](https://github.com/synfig/synfig/issues/1615). [studio]
 - [`e02a3a8`](https://github.com/synfig/synfig/commit/e02a3a8c944fbd3731c6486de9ecd2eea73f597d) Removed old (2005) simple hack for gcc < 4.1.2 bugged warning ([#1613](https://github.com/synfig/synfig/issues/1613)) [core]
@@ -708,7 +708,7 @@
 - [`b57b280`](https://github.com/synfig/synfig/commit/b57b2809af3e52f16bc5d67b351e79fd04d9b222) "Lock Selection" parameter of Group Layer should be static by default ([#1259](https://github.com/synfig/synfig/issues/1259)) [studio]
 - [`616ba52`](https://github.com/synfig/synfig/commit/616ba526c7111bdf98d13f97c666a80c34082c0c) 1-setup-linux-native.sh can now use /etc/os-release for better OS detection ([#1263](https://github.com/synfig/synfig/issues/1263))
 - [`a12bbfb`](https://github.com/synfig/synfig/commit/a12bbfbee316953834e17d8a0acd134ad5979471) fix missing breaks in switch ([#1268](https://github.com/synfig/synfig/issues/1268)) [studio]
-- [`75029fb`](https://github.com/synfig/synfig/commit/75029fb7b942c66eaefbbd5a0fdaa4cb8f4c8624) Merge PR [#1248](https://github.com/synfig/synfig/issues/1248): Restore defaults now reset all settings [studi
+- [`75029fb`](https://github.com/synfig/synfig/commit/75029fb7b942c66eaefbbd5a0fdaa4cb8f4c8624) Merge PR [#1248](https://github.com/synfig/synfig/issues/1248): Restore defaults now reset all settings [studio]
 - [`6591875`](https://github.com/synfig/synfig/commit/6591875e830e41352d753a0f9f1b47135fbd31b9) Add FUNDING.yml
 - [`70c851e`](https://github.com/synfig/synfig/commit/70c851e9028527208109f7cb49a90576f068d616) Merge PR [#1135](https://github.com/synfig/synfig/issues/1135): New timetrack [studio]
 - [`2dbc760`](https://github.com/synfig/synfig/commit/2dbc76041d379ea1232788dd5157a2eb2d5425a7) Merge PR [#1247](https://github.com/synfig/synfig/issues/1247): [CMake] build_images target now places images in the correct folder [studio]

--- a/bugs/resolved/000010.txt
+++ b/bugs/resolved/000010.txt
@@ -1,8 +1,8 @@
-Subject: Edit the parent in animation mode without modification produces uneeded waypoints
+Subject: Edit the parent in animation mode without modification produces unneeded waypoints
 
 Create a skeleton layer, change to animation mode.
 Edit the parent paramter of any bone and select <none>.
-It creates uneeded waypoint
+It creates unneeded waypoint
 
 ------------------------------------------------------------------------
 

--- a/cmake/SynfigVcpkg.cmake
+++ b/cmake/SynfigVcpkg.cmake
@@ -11,7 +11,7 @@ endif()
 
 get_filename_component(VCPKG_TOOLCHAIN_DIR "${CMAKE_TOOLCHAIN_FILE}" DIRECTORY)
 
-# install dependecies
+# install dependencies
 # we could have required the user to pass the option X_VCPKG_APPLOCAL_DEPS_INSTALL
 # to enable installing dependencies automatically without this section, but this
 # current solution requires less work on the user side, and will give us more control

--- a/synfig-core/src/synfig/bezier.h
+++ b/synfig-core/src/synfig/bezier.h
@@ -907,7 +907,7 @@ public:
 	/** The tangent at the end point @c p2 */
 	value_type& t2() { return T2; }
 
-	/** It must be called everytime you finish updating vertices and tangents */
+	/** It must be called every time you finish updating vertices and tangents */
 	void sync()
 	{
 		bezier<V,T>::operator[](0)=P1;

--- a/synfig-core/src/synfig/node.cpp
+++ b/synfig-core/src/synfig/node.cpp
@@ -360,7 +360,7 @@ Node::on_changed()
 	if (DEBUG_GETENV("SYNFIG_DEBUG_ON_CHANGED"))
 	{
 		std::lock_guard<std::mutex> lock(parent_set_mutex_);
-		printf("%s:%d Node::on_changed() for %p (%s); signalling these %zd parents:\n", __FILE__, __LINE__, this, get_string().c_str(), parent_set.size());
+		printf("%s:%d Node::on_changed() for %p (%s); signaling these %zd parents:\n", __FILE__, __LINE__, this, get_string().c_str(), parent_set.size());
 		for (std::set<Node*>::iterator iter = parent_set.begin(); iter != parent_set.end(); ++iter) printf(" %p (%s)\n", *iter, (*iter)->get_string().c_str());
 		printf("\n");
 	}

--- a/synfig-core/src/synfig/synfig_iterations.h
+++ b/synfig-core/src/synfig/synfig_iterations.h
@@ -39,9 +39,9 @@ namespace synfig
 struct TraverseLayerStatus
 {
 	// - SETTINGS -
-	/// Should traverse into layer paramenter valuenodes of canvas type and they are inline
+	/// Should traverse into layer parameter valuenodes of canvas type and they are inline
 	bool traverse_dynamic_inline_canvas = true;
-	/// Should traverse into layer paramenter valuenodes of canvas type and they are not inline
+	/// Should traverse into layer parameter valuenodes of canvas type and they are not inline
 	bool traverse_dynamic_non_inline_canvas = false;
 	// - STATUS -
 	/// Tracks the index of each recursive iteration. The last element is the current level. Its size is, then, the real depth

--- a/synfig-osx/launcher/rootless-common.c
+++ b/synfig-osx/launcher/rootless-common.c
@@ -282,7 +282,7 @@ RootlessStopDrawing (WindowPtr pWindow, Bool flush)
     }
 
     /* FIXME: instead of just checking if we tried to flush (which
-       happens everytime we block for I/O), I used to check if
+       happens every time we block for I/O), I used to check if
        anything was actually marked in the window. But that often
        caused problems with some window managers, and it didn't really
        make any noticeable difference, so... */

--- a/synfig-studio/ChangeLog.old
+++ b/synfig-studio/ChangeLog.old
@@ -729,7 +729,7 @@
 2003-10-07 (darco) : Layers are now categorized
 2003-10-06 (darco) : Added red-blue gamma adjustment to setup dialog
 2003-10-06 (darco) : Implemented Image Import Tool. (CTRL-I)
-2003-10-06 (darco) : The Ducks in the Work Area are now more percisely placed. (Especially obvious for radiuses)
+2003-10-06 (darco) : The Ducks in the Work Area are now more precisely placed. (Especially obvious for radiuses)
 2003-10-06 (darco) : Implemented adjustable default BLine width. To adjust it, use the scroll wheel on your mouse.
 2003-10-06 (darco) : Fixed bug where changing parameters may not always refresh the work area. (AGAIN)
 2003-10-06 (darco) : Fixed dragging-layer-into-inline-canvas crash bug.

--- a/synfig-studio/NEWS
+++ b/synfig-studio/NEWS
@@ -817,7 +817,7 @@
 2003-10-07 (darco) : Layers are now categorized
 2003-10-06 (darco) : Added red-blue gamma adjustment to setup dialog
 2003-10-06 (darco) : Implemented Image Import Tool. (CTRL-I)
-2003-10-06 (darco) : The Ducks in the Work Area are now more percisely placed. (Especially obvious for radiuses)
+2003-10-06 (darco) : The Ducks in the Work Area are now more precisely placed. (Especially obvious for radiuses)
 2003-10-06 (darco) : Implemented adjustable default BLine width. To adjust it, use the scroll wheel on your mouse.
 2003-10-06 (darco) : Fixed bug where changing parameters may not always refresh the work area. (AGAIN)
 2003-10-06 (darco) : Fixed dragging-layer-into-inline-canvas crash bug.

--- a/synfig-studio/src/brushlib/brush.hpp
+++ b/synfig-studio/src/brushlib/brush.hpp
@@ -325,7 +325,7 @@ private:
       wrap = 1.0 + settings_value[BRUSH_STROKE_HOLDTIME];
       if (states[STATE_STROKE] > wrap) {
         if (wrap > 9.9 + 1.0) {
-          // "inifinity", just hold stroke somewhere >= 1.0
+          // "infinity", just hold stroke somewhere >= 1.0
           states[STATE_STROKE] = 1.0;
         } else {
           states[STATE_STROKE] = fmodf(states[STATE_STROKE], wrap);

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinecolors.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinecolors.cpp
@@ -407,9 +407,8 @@ void studio::calculateSequenceColors(const etl::handle<synfig::Layer_Bitmap> &ra
 
   if (ras && g.currConfig->m_maxThickness > 0.0) 
   {
-    // singleSequence is traversed back-to-front because new, possibly splitted
-    // sequences
-    // are inserted at back - and don't have to be re-sampled.
+    // singleSequence is traversed back-to-front because new, possibly split
+    // sequences are inserted at back - and don't have to be re-sampled.
     for (l = singleSequences.size() - 1; l >= 0; --l) 
     {
       Sequence rear;


### PR DESCRIPTION
Found via `codespell -q 3 -L aline,ang,apendices,ba,bu,childs,dout,eiter,existant,forse,objext,pard,parms,pevent,propertyst,ro,shouldbe,thru,uint,unselect,vertexes -S ./.git,./synfig-studio/po,./synfig-core/po,/synfig-core/m4,./synfig-osx/,./gtkmm-osx,./bugs,.*.eps,*.sif,./synfig-studio/plugins/lottie-exporter`