### PR TITLE
fix: added ImageMagick 7.1 library initialization

### DIFF
--- a/synfig-core/src/modules/mod_magickpp/trgt_magickpp.h
+++ b/synfig-core/src/modules/mod_magickpp/trgt_magickpp.h
@@ -78,7 +78,10 @@ public:
 		transparent(),
 		is_gif(false),
 		sequence_separator(params.sequence_separator)
-	{ }
+	{
+		// todo(ice0): fix portable build
+		Magick::InitializeMagick(nullptr);
+	}
 	virtual ~magickpp_trgt();
 
 	bool set_rend_desc(synfig::RendDesc* desc) override;


### PR DESCRIPTION
fixed hang when using `mod_magickpp` with ImageMagick 7.1 library