### PR TITLE
fix: no context menu when right-clicking on waypoint 

### DIFF
--- a/synfig-core/src/synfig/timepointcollect.cpp
+++ b/synfig-core/src/synfig/timepointcollect.cpp
@@ -58,7 +58,8 @@ using namespace synfig;
 int
 synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 						 const Time								&time,
-						 const etl::handle<Node>				&node)
+						 const etl::handle<Node>				&node,
+						 bool initial_waypoint)
 {
 	const TimePointSet& timepoint_set(node->get_times());
 
@@ -88,7 +89,7 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		Layer::DynamicParamList::const_iterator iter;
 		int ret(0);
 		etl::handle<Layer_PasteCanvas> p = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer);
-		if (!p){
+		if ((!p && initial_waypoint) || !initial_waypoint){
 			for(iter=dyn_param_list.begin();iter!=dyn_param_list.end();++iter)
 				ret+=waypoint_collect(waypoint_set,time,iter->second);
 		}
@@ -114,7 +115,7 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		Canvas::const_iterator iter;
 		int ret(0);
 		for(iter=canvas->begin();iter!=canvas->end();++iter)
-			ret+=waypoint_collect(waypoint_set,time,*iter);
+			ret+=waypoint_collect(waypoint_set,time,*iter, initial_waypoint);
 		return ret;
 	}
 

--- a/synfig-core/src/synfig/timepointcollect.cpp
+++ b/synfig-core/src/synfig/timepointcollect.cpp
@@ -89,7 +89,7 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		Layer::DynamicParamList::const_iterator iter;
 		int ret(0);
 		etl::handle<Layer_PasteCanvas> p = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer);
-        if ((!p && ignore_dynamic_parameters) || !ignore_dynamic_parameters){
+		if (!p || !ignore_dynamic_parameters){
 			for(iter=dyn_param_list.begin();iter!=dyn_param_list.end();++iter)
 				ret+=waypoint_collect(waypoint_set,time,iter->second);
 		}

--- a/synfig-core/src/synfig/timepointcollect.cpp
+++ b/synfig-core/src/synfig/timepointcollect.cpp
@@ -115,7 +115,7 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		Canvas::const_iterator iter;
 		int ret(0);
 		for(iter=canvas->begin();iter!=canvas->end();++iter)
-            ret+=waypoint_collect(waypoint_set,time,*iter, ignore_dynamic_parameters);
+			ret+=waypoint_collect(waypoint_set,time,*iter, ignore_dynamic_parameters);
 		return ret;
 	}
 

--- a/synfig-core/src/synfig/timepointcollect.cpp
+++ b/synfig-core/src/synfig/timepointcollect.cpp
@@ -59,7 +59,7 @@ int
 synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 						 const Time								&time,
 						 const etl::handle<Node>				&node,
-						 bool initial_waypoint)
+                         bool ignore_dynamic_parameters)
 {
 	const TimePointSet& timepoint_set(node->get_times());
 
@@ -89,7 +89,7 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		Layer::DynamicParamList::const_iterator iter;
 		int ret(0);
 		etl::handle<Layer_PasteCanvas> p = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer);
-		if ((!p && initial_waypoint) || !initial_waypoint){
+        if ((!p && ignore_dynamic_parameters) || !ignore_dynamic_parameters){
 			for(iter=dyn_param_list.begin();iter!=dyn_param_list.end();++iter)
 				ret+=waypoint_collect(waypoint_set,time,iter->second);
 		}
@@ -115,7 +115,7 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		Canvas::const_iterator iter;
 		int ret(0);
 		for(iter=canvas->begin();iter!=canvas->end();++iter)
-			ret+=waypoint_collect(waypoint_set,time,*iter, initial_waypoint);
+            ret+=waypoint_collect(waypoint_set,time,*iter, ignore_dynamic_parameters);
 		return ret;
 	}
 

--- a/synfig-core/src/synfig/timepointcollect.h
+++ b/synfig-core/src/synfig/timepointcollect.h
@@ -45,7 +45,7 @@
 namespace synfig {
 
 //! \writeme
-int waypoint_collect(std::set<Waypoint, std::less<UniqueID> >& waypoint_set, const Time& time, const etl::handle<Node>& node, bool initial_waypoint = false);
+int waypoint_collect(std::set<Waypoint, std::less<UniqueID> >& waypoint_set, const Time& time, const etl::handle<Node>& node, bool ignore_dynamic_parameters = false);
 
 //! Search for a specific waypoint (by its uid) in node.
 bool waypoint_search(Waypoint& waypoint, const UniqueID& uid, const etl::handle<Node>& node);

--- a/synfig-core/src/synfig/timepointcollect.h
+++ b/synfig-core/src/synfig/timepointcollect.h
@@ -45,7 +45,7 @@
 namespace synfig {
 
 //! \writeme
-int waypoint_collect(std::set<Waypoint, std::less<UniqueID> >& waypoint_set,const Time& time, const etl::handle<Node>& node);
+int waypoint_collect(std::set<Waypoint, std::less<UniqueID> >& waypoint_set, const Time& time, const etl::handle<Node>& node, bool initial_waypoint = false);
 
 //! Search for a specific waypoint (by its uid) in node.
 bool waypoint_search(Waypoint& waypoint, const UniqueID& uid, const etl::handle<Node>& node);

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -954,7 +954,7 @@ bool Widget_Timetrack::fetch_waypoints(const WaypointItem &wi, std::set<synfig::
 			node = value_desc.get_canvas();
 
 		if (node)
-			synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), node);
+			synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), node, true);
 
 		return node;
 	} catch (std::out_of_range& ex) {


### PR DESCRIPTION
Fixes #2875 , and adds on to #2858.

So the issue #2858  was fixing was that editing the canvas parameter of a group changed along with it the groups other parameters of the same time. So the fix was to not allow the canvas waypoint to change any of the groups parameters, which in fact was not general enough as if the group has a group beneath it, then in that case the canvas parameter should change the child groups parameters as well (but not its own).

Here is a video demonstration: (note: I'm changing the interpolation via the menu on right click but for some reason windows recorder doesn't record windows on top the window we are in)

https://user-images.githubusercontent.com/100296264/201393112-a217d37d-2b39-4b4f-bf59-c37c11420179.mp4




@morevnaproject, waiting for you review :) also if there is something I'm missing here please let me know.
