### PR TITLE
feat: New and updated icons for  "width interpolation"

### DIFF
--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -96,8 +96,10 @@ set(ICONS
 	action_flat_interpolation_icon
 	action_interpolate_interpolation_icon
 	action_peak_interpolation_icon
+	action_offpeak_interpolation_icon
 	action_remove_from_set_icon
 	action_rounded_interpolation_icon
+	action_innerrounded_interpolation_icon
 	action_set_layer_description_icon
 	action_squared_interpolation_icon
 	action_unexport_icon

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -79,7 +79,9 @@ EXTRA_DIST = \
 	action_flat_interpolation_icon.sif \
 	action_interpolate_interpolation_icon.sif \
 	action_peak_interpolation_icon.sif \
+	action_offpeak_interpolation_icon.sif \
 	action_rounded_interpolation_icon.sif \
+	action_innerrounded_interpolation_icon.sif \
 	action_squared_interpolation_icon.sif \
 	\
 	action_doc_icons.sif \
@@ -269,7 +271,9 @@ ICONS = \
 	action_flat_interpolation_icon.$(EXT) \
 	action_interpolate_interpolation_icon.$(EXT) \
 	action_peak_interpolation_icon.$(EXT) \
+	action_offpeak_interpolation_icon.$(EXT) \
 	action_rounded_interpolation_icon.$(EXT) \
+	action_innerrounded_interpolation_icon.$(EXT) \
 	action_squared_interpolation_icon.$(EXT) \
 	\
 	action_doc_new_icon.$(EXT) \

--- a/synfig-studio/images/action_flat_interpolation_icon.sif
+++ b/synfig-studio/images/action_flat_interpolation_icon.sif
@@ -1,13 +1,24 @@
-<?xml version="1.0"?>
-<canvas version="0.7" width="128" height="128" xres="2952.755900" yres="2952.755900" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
-  <name>Synfig Studio Set Width Point Flat Type</name>
-  <desc>Placed in the Public Domain in 2011 by Carlos L&#xF3;pez (genete)</desc>
-  <meta name="grid_show" content="0"/>
-  <meta name="grid_size" content="0,250000 0,250000"/>
-  <meta name="grid_snap" content="0"/>
-  <meta name="guide_show" content="1"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.2" width="128" height="128" xres="2952.755900" yres="2952.755900" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>action_flat_interpolation_icon.sif</name>
+  <desc>Placed in the Public Domain in 2011 by Carlos López (genete)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="1"/>
+  <meta name="grid_size" content="0.062500 0.062500"/>
+  <meta name="grid_snap" content="1"/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="0"/>
   <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
   <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
   <defs>
     <color id="color">
       <r>1.000000</r>
@@ -16,7 +27,7 @@
       <a>1.000000</a>
     </color>
     <canvas id="Item" bgcolor="0.500000 0.500000 0.500000 1.000000">
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -58,25 +69,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F8BC064CA4C25124724004DAA993E82F">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="56A6A5CE73D4CAB5D7C56AD376C6C5A7">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="C5A57C68A9653BB2723E63D13BC7D069">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="DCDD1F48DFC302B2938E33918FF8E689">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -84,7 +95,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="blur" active="true" version="0.2">
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -96,15 +107,15 @@
         </param>
         <param name="size">
           <vector>
-            <x>0.1000000015</x>
-            <y>0.1000000015</y>
+            <x>0.0342190713</x>
+            <y>0.0342190713</y>
           </vector>
         </param>
         <param name="type">
           <integer value="1"/>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -146,25 +157,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="C2801CF7B73DE6CE52D5418292D7EAF5">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="F0D3DE80AE371F5CE9D84E7467D3F1EA">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="97DFA9063AFBA8E5828BAD3AF05A1EE7">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="95214CD39CB8149E54C25B5A1E29138C">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -172,7 +183,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -207,25 +218,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F122250E50A2F89F40E5B457D9CDFCD0">
                 <x>-0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A536EBEFE7EDB06118D5B92D4368CB20">
                 <x>-0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A00B373CCF0ECC5A72027C67A157DDC5">
                 <x>0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A1B3E39FFEFB09C250978BE1C8A2E7E4">
                 <x>0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
@@ -243,7 +254,7 @@
       <meta name="onion_skin" content="0"/>
       <defs>
         <canvas id="Layer" bgcolor="0.500000 0.500000 0.500000 1.000000">
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -285,25 +296,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="EE98B59B39AA90D37C2CDFC8E7DB59B3">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="3FC3A320D181297CEF59CB6FF998710A">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="6710A64FB4C8840D87518D40D8DC94A9">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="31D08C6B5689BC801B4CCE99559DD808">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -311,7 +322,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="blur" active="true" version="0.2">
+          <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -323,15 +334,15 @@
             </param>
             <param name="size">
               <vector>
-                <x>0.2000000030</x>
-                <y>0.2000000030</y>
+                <x>0.0684381425</x>
+                <y>0.0684381425</y>
               </vector>
             </param>
             <param name="type">
               <integer value="1"/>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -373,25 +384,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="83813BD5FFF0367B45BA774B4B637CB8">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="03B26A460D24DECB9885178DA57E60AC">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="674659AA4596317F391BBF3127E2034B">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="51BA26E0328390FDF18590DB6ECE0AD7">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -399,7 +410,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -441,25 +452,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="F7134BDD94A662349C4AFE9FB6C1146A">
                     <x>-0.6999999881</x>
                     <y>0.6999999881</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="2B8E667E5D733CE779F007E1F976CD91">
                     <x>-0.6999999881</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="B78C3CA8AB2F9DCD77C8277B0C3F4648">
                     <x>0.1000000015</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="071780545B342020904F7DDC47896A7F">
                     <x>0.1000000015</x>
                     <y>0.6999999881</y>
                   </vector>
@@ -469,7 +480,7 @@
           </layer>
         </canvas>
       </defs>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Back">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Back">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -485,9 +496,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide01 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide01 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -527,126 +560,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -682,12 +598,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide01 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide01 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -727,126 +784,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -882,6 +822,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -901,17 +982,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -919,14 +997,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Left">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Left">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -942,9 +1029,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide04 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide04 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -984,126 +1093,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1139,12 +1131,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide04 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide04 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1184,126 +1317,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1339,6 +1355,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1358,17 +1515,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1376,14 +1530,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+      <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1416,11 +1579,8 @@
         <param name="invert">
           <bool value="true"/>
         </param>
-        <param name="falloff">
-          <integer value="2"/>
-        </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Right">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Right">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1436,9 +1596,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide03 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide03 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1478,126 +1660,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1633,12 +1698,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide03 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide03 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1678,126 +1884,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1833,6 +1922,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1852,14 +2082,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="SolidColor" active="true" version="0.1" group="Shading">
+            <layer type="SolidColor" active="true" exclude_from_rendering="false" version="0.1" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1880,8 +2107,8 @@
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1889,14 +2116,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Front">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Front">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1912,9 +2148,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide02 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide02 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1954,126 +2212,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2109,12 +2250,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide02 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide02 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2154,126 +2436,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2309,6 +2474,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -2328,14 +2634,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+            <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2368,14 +2671,11 @@
               <param name="invert">
                 <bool value="true"/>
               </param>
-              <param name="falloff">
-                <integer value="2"/>
-              </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -2383,16 +2683,25 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
     </canvas>
   </defs>
-  <layer type="region" active="true" version="0.1" desc="Circle058Region">
+  <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1" desc="Polygon017">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2400,7 +2709,7 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
     <param name="color">
       <color>
@@ -2411,7 +2720,7 @@
       </color>
     </param>
     <param name="origin">
-      <vector guid="967DCDC4FB0137A6CC08EEBB691D8D04">
+      <vector>
         <x>0.0000000000</x>
         <y>0.0000000000</y>
       </vector>
@@ -2426,134 +2735,41 @@
       <real value="0.0000000000"/>
     </param>
     <param name="blurtype">
-      <integer value="1"/>
+      <integer value="1" static="true"/>
     </param>
     <param name="winding_style">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
-    <param name="bline">
-      <bline type="bline_point" loop="true" guid="9248DBEB0AEF1F18714177C355FA2FBE">
+    <param name="vector_list">
+      <dynamic_list type="vector" loop="true">
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.0000000219</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="false"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000000"/>
-                </radius>
-                <theta>
-                  <angle value="-228.273254"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.2655983379"/>
-                </radius>
-                <theta>
-                  <angle value="-228.273254"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="99BB57B7BCCCEEDF328ED2A17E17A2B0">
+            <x>0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
         </entry>
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.0000000000</x>
-                <y>0.0000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="95AB21B91912C663F14F43714D3500D7">
+            <x>-0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
         </entry>
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.0000000060</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="false"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0010851829"/>
-                </radius>
-                <theta>
-                  <angle value="270.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="0F4F5E5A729A53F93379B9DCD01B35A5">
+            <x>-0.5625000000</x>
+            <y>0.0000000000</y>
+          </vector>
         </entry>
-      </bline>
+        <entry>
+          <vector guid="383BFEFFED30488C53AABCEC22203A0E">
+            <x>0.5625000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </entry>
+      </dynamic_list>
     </param>
   </layer>
-  <layer type="outline" active="true" version="0.2" desc="Circle058Contorno">
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="GroupCurva">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2561,181 +2777,1046 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
-    </param>
-    <param name="color">
-      <color>
-        <r>0.010398</r>
-        <g>0.065754</g>
-        <b>0.246800</b>
-        <a>1.000000</a>
-      </color>
+      <integer value="0" static="true"/>
     </param>
     <param name="origin">
-      <vector guid="967DCDC4FB0137A6CC08EEBB691D8D04">
+      <vector>
         <x>0.0000000000</x>
         <y>0.0000000000</y>
       </vector>
     </param>
-    <param name="invert">
-      <bool value="false"/>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
     </param>
-    <param name="antialias">
-      <bool value="true"/>
+    <param name="canvas">
+      <canvas>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="813CC98A8C3D2020507453622E1906D2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5625000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="2C943434F263D1E7DF431025A99BFA76" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="0E68DC603FC5A56EA1CCC6A613E60444" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A3C021DE419B54A92EFB85E19464F8E0" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="D22EA12CFC622A7B9DEDAAC238CF3580" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="7F865C92823CDBBC12DAE985BF4DC924" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="6EB4AA0E20134427E7387070E70F40CC" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C31C57B05E4DB5E0680F3337608DBC68" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="C32978F960E55CB5158A37B8C6B7A37B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6E8185471EBBAD729ABD74FF41355FDF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="8F37DF78C493CD74DA9092DC7038D62A" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="229F22C6BACD3CB355A7D19BF7BA2A8E" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle064">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.1250000000"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle066">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.506560</r>
+              <g>0.374113</g>
+              <b>0.599158</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.0823921239"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+      </canvas>
     </param>
-    <param name="feather">
-      <real value="0.0000000000"/>
-    </param>
-    <param name="blurtype">
-      <integer value="1"/>
-    </param>
-    <param name="winding_style">
-      <integer value="0"/>
-    </param>
-    <param name="bline">
-      <bline type="bline_point" loop="true" guid="9248DBEB0AEF1F18714177C355FA2FBE">
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.0000000219</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="false"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000000"/>
-                </radius>
-                <theta>
-                  <angle value="-228.273254"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.2655983379"/>
-                </radius>
-                <theta>
-                  <angle value="-228.273254"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.0000000000</x>
-                <y>0.0000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.0000000060</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="false"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0010851829"/>
-                </radius>
-                <theta>
-                  <angle value="270.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-      </bline>
-    </param>
-    <param name="width">
-      <real value="0.1250000000" guid="B9EE4406D903EAE110416A5006BA6A5A"/>
-    </param>
-    <param name="expand">
-      <real value="0.0000000000"/>
-    </param>
-    <param name="sharp_cusps">
-      <bool value="true"/>
-    </param>
-    <param name="round_tip[0]">
-      <bool value="true"/>
-    </param>
-    <param name="round_tip[1]">
-      <bool value="true"/>
-    </param>
-    <param name="loopyness">
+    <param name="time_dilation">
       <real value="1.0000000000"/>
     </param>
-    <param name="homogeneous_width">
-      <bool value="true"/>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
     </param>
   </layer>
-  <layer type="zoom" active="true" version="0.1">
+  <layer type="zoom" active="true" exclude_from_rendering="false" version="0.1">
     <param name="amount">
       <real value="0.5000000000"/>
     </param>

--- a/synfig-studio/images/action_innerrounded_interpolation_icon.sif
+++ b/synfig-studio/images/action_innerrounded_interpolation_icon.sif
@@ -1,0 +1,4031 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.2" width="128" height="128" xres="2952.755900" yres="2952.755900" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>action_innerrounded_interpolation_icon.sif</name>
+  <desc>Placed in the Public Domain in 2011 by Carlos López (genete)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="1"/>
+  <meta name="grid_size" content="0.062500 0.062500"/>
+  <meta name="grid_snap" content="1"/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="0"/>
+  <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
+  <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
+  <defs>
+    <color id="color">
+      <r>1.000000</r>
+      <g>0.900000</g>
+      <b>0.600000</b>
+      <a>1.000000</a>
+    </color>
+    <canvas id="Item" bgcolor="0.500000 0.500000 0.500000 1.000000">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="0.5000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.1000000015</x>
+            <y>-0.1000000015</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="F8BC064CA4C25124724004DAA993E82F">
+                <x>-0.4000000060</x>
+                <y>0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="56A6A5CE73D4CAB5D7C56AD376C6C5A7">
+                <x>-0.4000000060</x>
+                <y>-0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="C5A57C68A9653BB2723E63D13BC7D069">
+                <x>0.4000000060</x>
+                <y>-0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="DCDD1F48DFC302B2938E33918FF8E689">
+                <x>0.4000000060</x>
+                <y>0.4000000060</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="1"/>
+        </param>
+        <param name="size">
+          <vector>
+            <x>0.0342190713</x>
+            <y>0.0342190713</y>
+          </vector>
+        </param>
+        <param name="type">
+          <integer value="1"/>
+        </param>
+      </layer>
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="C2801CF7B73DE6CE52D5418292D7EAF5">
+                <x>-0.4000000060</x>
+                <y>0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="F0D3DE80AE371F5CE9D84E7467D3F1EA">
+                <x>-0.4000000060</x>
+                <y>-0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="97DFA9063AFBA8E5828BAD3AF05A1EE7">
+                <x>0.4000000060</x>
+                <y>-0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="95214CD39CB8149E54C25B5A1E29138C">
+                <x>0.4000000060</x>
+                <y>0.4000000060</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color" use=":color"/>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="F122250E50A2F89F40E5B457D9CDFCD0">
+                <x>-0.3000000119</x>
+                <y>0.3000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="A536EBEFE7EDB06118D5B92D4368CB20">
+                <x>-0.3000000119</x>
+                <y>-0.3000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="A00B373CCF0ECC5A72027C67A157DDC5">
+                <x>0.3000000119</x>
+                <y>-0.3000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="A1B3E39FFEFB09C250978BE1C8A2E7E4">
+                <x>0.3000000119</x>
+                <y>0.3000000119</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+    </canvas>
+    <canvas id="paste-canvas" bgcolor="0.500000 0.500000 0.500000 1.000000">
+      <name>Untitled0</name>
+      <meta name="grid_show" content="1"/>
+      <meta name="grid_size" content="0.250000 0.250000"/>
+      <meta name="grid_snap" content="0"/>
+      <meta name="guide_snap" content="0"/>
+      <meta name="onion_skin" content="0"/>
+      <defs>
+        <canvas id="Layer" bgcolor="0.500000 0.500000 0.500000 1.000000">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+            <param name="z_depth">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="amount">
+              <real value="0.5000000000"/>
+            </param>
+            <param name="blend_method">
+              <integer value="0"/>
+            </param>
+            <param name="color">
+              <color>
+                <r>0.000000</r>
+                <g>0.000000</g>
+                <b>0.000000</b>
+                <a>1.000000</a>
+              </color>
+            </param>
+            <param name="origin">
+              <vector>
+                <x>0.1000000015</x>
+                <y>-0.1000000015</y>
+              </vector>
+            </param>
+            <param name="invert">
+              <bool value="false"/>
+            </param>
+            <param name="antialias">
+              <bool value="true"/>
+            </param>
+            <param name="feather">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="blurtype">
+              <integer value="1"/>
+            </param>
+            <param name="winding_style">
+              <integer value="0"/>
+            </param>
+            <param name="vector_list">
+              <dynamic_list type="vector">
+                <entry>
+                  <vector guid="EE98B59B39AA90D37C2CDFC8E7DB59B3">
+                    <x>-0.8000000119</x>
+                    <y>0.8000000119</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="3FC3A320D181297CEF59CB6FF998710A">
+                    <x>-0.8000000119</x>
+                    <y>-0.2000000030</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="6710A64FB4C8840D87518D40D8DC94A9">
+                    <x>0.2000000030</x>
+                    <y>-0.2000000030</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="31D08C6B5689BC801B4CCE99559DD808">
+                    <x>0.2000000030</x>
+                    <y>0.8000000119</y>
+                  </vector>
+                </entry>
+              </dynamic_list>
+            </param>
+          </layer>
+          <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
+            <param name="z_depth">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="amount">
+              <real value="1.0000000000"/>
+            </param>
+            <param name="blend_method">
+              <integer value="1"/>
+            </param>
+            <param name="size">
+              <vector>
+                <x>0.0684381425</x>
+                <y>0.0684381425</y>
+              </vector>
+            </param>
+            <param name="type">
+              <integer value="1"/>
+            </param>
+          </layer>
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+            <param name="z_depth">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="amount">
+              <real value="1.0000000000"/>
+            </param>
+            <param name="blend_method">
+              <integer value="0"/>
+            </param>
+            <param name="color">
+              <color>
+                <r>0.000000</r>
+                <g>0.000000</g>
+                <b>0.000000</b>
+                <a>1.000000</a>
+              </color>
+            </param>
+            <param name="origin">
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </param>
+            <param name="invert">
+              <bool value="false"/>
+            </param>
+            <param name="antialias">
+              <bool value="true"/>
+            </param>
+            <param name="feather">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="blurtype">
+              <integer value="1"/>
+            </param>
+            <param name="winding_style">
+              <integer value="0"/>
+            </param>
+            <param name="vector_list">
+              <dynamic_list type="vector">
+                <entry>
+                  <vector guid="83813BD5FFF0367B45BA774B4B637CB8">
+                    <x>-0.8000000119</x>
+                    <y>0.8000000119</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="03B26A460D24DECB9885178DA57E60AC">
+                    <x>-0.8000000119</x>
+                    <y>-0.2000000030</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="674659AA4596317F391BBF3127E2034B">
+                    <x>0.2000000030</x>
+                    <y>-0.2000000030</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="51BA26E0328390FDF18590DB6ECE0AD7">
+                    <x>0.2000000030</x>
+                    <y>0.8000000119</y>
+                  </vector>
+                </entry>
+              </dynamic_list>
+            </param>
+          </layer>
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+            <param name="z_depth">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="amount">
+              <real value="1.0000000000"/>
+            </param>
+            <param name="blend_method">
+              <integer value="0"/>
+            </param>
+            <param name="color">
+              <color>
+                <r>1.000000</r>
+                <g>0.900000</g>
+                <b>0.600000</b>
+                <a>1.000000</a>
+              </color>
+            </param>
+            <param name="origin">
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </param>
+            <param name="invert">
+              <bool value="false"/>
+            </param>
+            <param name="antialias">
+              <bool value="true"/>
+            </param>
+            <param name="feather">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="blurtype">
+              <integer value="1"/>
+            </param>
+            <param name="winding_style">
+              <integer value="0"/>
+            </param>
+            <param name="vector_list">
+              <dynamic_list type="vector">
+                <entry>
+                  <vector guid="F7134BDD94A662349C4AFE9FB6C1146A">
+                    <x>-0.6999999881</x>
+                    <y>0.6999999881</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="2B8E667E5D733CE779F007E1F976CD91">
+                    <x>-0.6999999881</x>
+                    <y>-0.1000000015</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="B78C3CA8AB2F9DCD77C8277B0C3F4648">
+                    <x>0.1000000015</x>
+                    <y>-0.1000000015</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="071780545B342020904F7DDC47896A7F">
+                    <x>0.1000000015</x>
+                    <y>0.6999999881</y>
+                  </vector>
+                </entry>
+              </dynamic_list>
+            </param>
+          </layer>
+        </canvas>
+      </defs>
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Back">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
+        <param name="canvas">
+          <canvas>
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide01 Region">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.850000</r>
+                  <g>0.640000</g>
+                  <b>0.200000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
+                      <point>
+                        <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
+                          <x>-0.2500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+            </layer>
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide01 Outline">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
+                      <point>
+                        <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
+                          <x>-0.2500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+              <param name="width">
+                <real value="0.0651041665"/>
+              </param>
+              <param name="expand">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="sharp_cusps">
+                <bool value="false"/>
+              </param>
+              <param name="round_tip[0]">
+                <bool value="true"/>
+              </param>
+              <param name="round_tip[1]">
+                <bool value="true"/>
+              </param>
+              <param name="homogeneous_width">
+                <bool value="true"/>
+              </param>
+            </layer>
+          </canvas>
+        </param>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="time_offset">
+          <time value="0s"/>
+        </param>
+        <param name="children_lock">
+          <bool value="false"/>
+        </param>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
+        </param>
+      </layer>
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Left">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
+        <param name="canvas">
+          <canvas>
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide04 Region">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.850000</r>
+                  <g>0.640000</g>
+                  <b>0.200000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
+                      <point>
+                        <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
+                          <x>-0.2500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+            </layer>
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide04 Outline">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
+                      <point>
+                        <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
+                          <x>-0.2500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+              <param name="width">
+                <real value="0.0651041665"/>
+              </param>
+              <param name="expand">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="sharp_cusps">
+                <bool value="false"/>
+              </param>
+              <param name="round_tip[0]">
+                <bool value="true"/>
+              </param>
+              <param name="round_tip[1]">
+                <bool value="true"/>
+              </param>
+              <param name="homogeneous_width">
+                <bool value="true"/>
+              </param>
+            </layer>
+          </canvas>
+        </param>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="time_offset">
+          <time value="0s"/>
+        </param>
+        <param name="children_lock">
+          <bool value="false"/>
+        </param>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
+        </param>
+      </layer>
+      <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="0.8000000119"/>
+        </param>
+        <param name="blend_method">
+          <integer value="13"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="radius">
+          <real value="0.5000000000"/>
+        </param>
+        <param name="feather">
+          <real value="0.4882812491"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.3589743674</x>
+            <y>-0.1217948720</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="true"/>
+        </param>
+      </layer>
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Right">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
+        <param name="canvas">
+          <canvas>
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide03 Region">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.850000</r>
+                  <g>0.640000</g>
+                  <b>0.200000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+            </layer>
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide03 Outline">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+              <param name="width">
+                <real value="0.0651041665"/>
+              </param>
+              <param name="expand">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="sharp_cusps">
+                <bool value="false"/>
+              </param>
+              <param name="round_tip[0]">
+                <bool value="true"/>
+              </param>
+              <param name="round_tip[1]">
+                <bool value="true"/>
+              </param>
+              <param name="homogeneous_width">
+                <bool value="true"/>
+              </param>
+            </layer>
+            <layer type="SolidColor" active="true" exclude_from_rendering="false" version="0.1" group="Shading">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="0.7500000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="13"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+            </layer>
+          </canvas>
+        </param>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="time_offset">
+          <time value="0s"/>
+        </param>
+        <param name="children_lock">
+          <bool value="false"/>
+        </param>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
+        </param>
+      </layer>
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Front">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
+        <param name="canvas">
+          <canvas>
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide02 Region">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.850000</r>
+                  <g>0.640000</g>
+                  <b>0.200000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+            </layer>
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide02 Outline">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+              <param name="width">
+                <real value="0.0651041665"/>
+              </param>
+              <param name="expand">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="sharp_cusps">
+                <bool value="false"/>
+              </param>
+              <param name="round_tip[0]">
+                <bool value="true"/>
+              </param>
+              <param name="round_tip[1]">
+                <bool value="true"/>
+              </param>
+              <param name="homogeneous_width">
+                <bool value="true"/>
+              </param>
+            </layer>
+            <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="0.5500000119"/>
+              </param>
+              <param name="blend_method">
+                <integer value="13"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="radius">
+                <real value="0.7500000000"/>
+              </param>
+              <param name="feather">
+                <real value="0.4882812491"/>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>-0.7500000000</x>
+                  <y>0.2500000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="true"/>
+              </param>
+            </layer>
+          </canvas>
+        </param>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="time_offset">
+          <time value="0s"/>
+        </param>
+        <param name="children_lock">
+          <bool value="false"/>
+        </param>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
+        </param>
+      </layer>
+    </canvas>
+  </defs>
+  <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="NewSpline031 Region">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="color">
+      <color>
+        <r>0.010398</r>
+        <g>0.065754</g>
+        <b>0.246800</b>
+        <a>1.000000</a>
+      </color>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="invert">
+      <bool value="false"/>
+    </param>
+    <param name="antialias">
+      <bool value="true"/>
+    </param>
+    <param name="feather">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="blurtype">
+      <integer value="1" static="true"/>
+    </param>
+    <param name="winding_style">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="bline">
+      <bline type="bline_point" loop="true">
+        <entry>
+          <composite guid="1B49B14A0C424686E63EF346EA908206" type="bline_point">
+            <point>
+              <vector>
+                <x>-0.5625000000</x>
+                <y>-0.5625000000</y>
+              </vector>
+            </point>
+            <width>
+              <real value="1.0000000000"/>
+            </width>
+            <origin>
+              <real value="0.5000000000"/>
+            </origin>
+            <split>
+              <bool value="false"/>
+            </split>
+            <t1>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.0000000000"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t1>
+            <t2>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.0000000000"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t2>
+            <split_radius>
+              <bool value="false"/>
+            </split_radius>
+            <split_angle>
+              <bool value="false"/>
+            </split_angle>
+          </composite>
+        </entry>
+        <entry>
+          <composite guid="239265792593E718A62265744A97CC1D" type="bline_point">
+            <point>
+              <vector>
+                <x>-0.5625000000</x>
+                <y>0.1875000000</y>
+              </vector>
+            </point>
+            <width>
+              <real value="1.0000000000"/>
+            </width>
+            <origin>
+              <real value="0.5000000000"/>
+            </origin>
+            <split>
+              <bool value="false"/>
+            </split>
+            <t1>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.5625000000"/>
+                </radius>
+                <theta>
+                  <angle value="89.999992"/>
+                </theta>
+              </radial_composite>
+            </t1>
+            <t2>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.7500000000"/>
+                </radius>
+                <theta>
+                  <angle value="-89.999992"/>
+                </theta>
+              </radial_composite>
+            </t2>
+            <split_radius>
+              <bool value="true"/>
+            </split_radius>
+            <split_angle>
+              <bool value="true"/>
+            </split_angle>
+          </composite>
+        </entry>
+        <entry>
+          <composite guid="04EE25F492441831E8FC2A94979D56A0" type="bline_point">
+            <point>
+              <vector>
+                <x>-0.0000000164</x>
+                <y>-0.3750000000</y>
+              </vector>
+            </point>
+            <width>
+              <real value="1.0000000000"/>
+            </width>
+            <origin>
+              <real value="0.5000000000"/>
+            </origin>
+            <split>
+              <bool value="false"/>
+            </split>
+            <t1>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.9375000902"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t1>
+            <t2>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.9375000902"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t2>
+            <split_radius>
+              <bool value="false"/>
+            </split_radius>
+            <split_angle>
+              <bool value="false"/>
+            </split_angle>
+          </composite>
+        </entry>
+        <entry>
+          <composite guid="CD576B0726AAC06041C2D13B25208139" type="bline_point">
+            <point>
+              <vector>
+                <x>0.5625000000</x>
+                <y>0.1875000000</y>
+              </vector>
+            </point>
+            <width>
+              <real value="1.0000000000"/>
+            </width>
+            <origin>
+              <real value="0.5000000000"/>
+            </origin>
+            <split>
+              <bool value="false"/>
+            </split>
+            <t1>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.7500000000"/>
+                </radius>
+                <theta>
+                  <angle value="89.999992"/>
+                </theta>
+              </radial_composite>
+            </t1>
+            <t2>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.5625000000"/>
+                </radius>
+                <theta>
+                  <angle value="-90.000000"/>
+                </theta>
+              </radial_composite>
+            </t2>
+            <split_radius>
+              <bool value="true"/>
+            </split_radius>
+            <split_angle>
+              <bool value="true"/>
+            </split_angle>
+          </composite>
+        </entry>
+        <entry>
+          <composite guid="7E4A1BB1E897DA5F8400DF1E602F2E88" type="bline_point">
+            <point>
+              <vector>
+                <x>0.5625000000</x>
+                <y>-0.5625000000</y>
+              </vector>
+            </point>
+            <width>
+              <real value="1.0000000000"/>
+            </width>
+            <origin>
+              <real value="0.5000000000"/>
+            </origin>
+            <split>
+              <bool value="false"/>
+            </split>
+            <t1>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.0000000000"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t1>
+            <t2>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.0000000000"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t2>
+            <split_radius>
+              <bool value="false"/>
+            </split_radius>
+            <split_angle>
+              <bool value="false"/>
+            </split_angle>
+          </composite>
+        </entry>
+      </bline>
+    </param>
+  </layer>
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="GroupCurva">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
+    </param>
+    <param name="canvas">
+      <canvas>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="813CC98A8C3D2020507453622E1906D2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5625000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="2C943434F263D1E7DF431025A99BFA76" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="0E68DC603FC5A56EA1CCC6A613E60444" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A3C021DE419B54A92EFB85E19464F8E0" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="D22EA12CFC622A7B9DEDAAC238CF3580" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="7F865C92823CDBBC12DAE985BF4DC924" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="6EB4AA0E20134427E7387070E70F40CC" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C31C57B05E4DB5E0680F3337608DBC68" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="C32978F960E55CB5158A37B8C6B7A37B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6E8185471EBBAD729ABD74FF41355FDF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="8F37DF78C493CD74DA9092DC7038D62A" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="229F22C6BACD3CB355A7D19BF7BA2A8E" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle064">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.1250000000"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle066">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.506560</r>
+              <g>0.374113</g>
+              <b>0.599158</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.0823921239"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+      </canvas>
+    </param>
+    <param name="time_dilation">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
+    </param>
+  </layer>
+  <layer type="zoom" active="true" exclude_from_rendering="false" version="0.1">
+    <param name="amount">
+      <real value="0.5000000000"/>
+    </param>
+    <param name="center">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+  </layer>
+</canvas>

--- a/synfig-studio/images/action_interpolate_interpolation_icon.sif
+++ b/synfig-studio/images/action_interpolate_interpolation_icon.sif
@@ -1,13 +1,24 @@
-<?xml version="1.0"?>
-<canvas version="0.7" width="128" height="128" xres="2952.755900" yres="2952.755900" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
-  <name>Synfig Studio Set Width Point Interpolation Type</name>
-  <desc>Placed in the Public Domain in 2011 by Carlos L&#xF3;pez (genete)</desc>
-  <meta name="grid_show" content="0"/>
-  <meta name="grid_size" content="0,250000 0,250000"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.2" width="128" height="128" xres="2952.755900" yres="2952.755900" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>action_interpolate_interpolation_icon.sif</name>
+  <desc>Placed in the Public Domain in 2011 by Carlos López (genete)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="1"/>
+  <meta name="grid_size" content="0.031250 0.031250"/>
   <meta name="grid_snap" content="1"/>
-  <meta name="guide_show" content="1"/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="0"/>
   <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
   <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
   <defs>
     <color id="color">
       <r>1.000000</r>
@@ -16,7 +27,7 @@
       <a>1.000000</a>
     </color>
     <canvas id="Item" bgcolor="0.500000 0.500000 0.500000 1.000000">
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -58,25 +69,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F8BC064CA4C25124724004DAA993E82F">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="56A6A5CE73D4CAB5D7C56AD376C6C5A7">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="C5A57C68A9653BB2723E63D13BC7D069">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="DCDD1F48DFC302B2938E33918FF8E689">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -84,7 +95,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="blur" active="true" version="0.2">
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -96,15 +107,15 @@
         </param>
         <param name="size">
           <vector>
-            <x>0.1000000015</x>
-            <y>0.1000000015</y>
+            <x>0.0342190713</x>
+            <y>0.0342190713</y>
           </vector>
         </param>
         <param name="type">
           <integer value="1"/>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -146,25 +157,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="C2801CF7B73DE6CE52D5418292D7EAF5">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="F0D3DE80AE371F5CE9D84E7467D3F1EA">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="97DFA9063AFBA8E5828BAD3AF05A1EE7">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="95214CD39CB8149E54C25B5A1E29138C">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -172,7 +183,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -207,25 +218,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F122250E50A2F89F40E5B457D9CDFCD0">
                 <x>-0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A536EBEFE7EDB06118D5B92D4368CB20">
                 <x>-0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A00B373CCF0ECC5A72027C67A157DDC5">
                 <x>0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A1B3E39FFEFB09C250978BE1C8A2E7E4">
                 <x>0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
@@ -243,7 +254,7 @@
       <meta name="onion_skin" content="0"/>
       <defs>
         <canvas id="Layer" bgcolor="0.500000 0.500000 0.500000 1.000000">
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -285,25 +296,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="EE98B59B39AA90D37C2CDFC8E7DB59B3">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="3FC3A320D181297CEF59CB6FF998710A">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="6710A64FB4C8840D87518D40D8DC94A9">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="31D08C6B5689BC801B4CCE99559DD808">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -311,7 +322,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="blur" active="true" version="0.2">
+          <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -323,15 +334,15 @@
             </param>
             <param name="size">
               <vector>
-                <x>0.2000000030</x>
-                <y>0.2000000030</y>
+                <x>0.0684381425</x>
+                <y>0.0684381425</y>
               </vector>
             </param>
             <param name="type">
               <integer value="1"/>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -373,25 +384,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="83813BD5FFF0367B45BA774B4B637CB8">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="03B26A460D24DECB9885178DA57E60AC">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="674659AA4596317F391BBF3127E2034B">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="51BA26E0328390FDF18590DB6ECE0AD7">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -399,7 +410,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -441,25 +452,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="F7134BDD94A662349C4AFE9FB6C1146A">
                     <x>-0.6999999881</x>
                     <y>0.6999999881</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="2B8E667E5D733CE779F007E1F976CD91">
                     <x>-0.6999999881</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="B78C3CA8AB2F9DCD77C8277B0C3F4648">
                     <x>0.1000000015</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="071780545B342020904F7DDC47896A7F">
                     <x>0.1000000015</x>
                     <y>0.6999999881</y>
                   </vector>
@@ -469,7 +480,7 @@
           </layer>
         </canvas>
       </defs>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Back">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Back">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -485,9 +496,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide01 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide01 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -527,126 +560,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -682,12 +598,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide01 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide01 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -727,126 +784,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -882,6 +822,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -901,17 +982,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -919,14 +997,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Left">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Left">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -942,9 +1029,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide04 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide04 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -984,126 +1093,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1139,12 +1131,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide04 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide04 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1184,126 +1317,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1339,6 +1355,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1358,17 +1515,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1376,14 +1530,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+      <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1416,11 +1579,8 @@
         <param name="invert">
           <bool value="true"/>
         </param>
-        <param name="falloff">
-          <integer value="2"/>
-        </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Right">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Right">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1436,9 +1596,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide03 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide03 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1478,126 +1660,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1633,12 +1698,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide03 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide03 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1678,126 +1884,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1833,6 +1922,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1852,14 +2082,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="SolidColor" active="true" version="0.1" group="Shading">
+            <layer type="SolidColor" active="true" exclude_from_rendering="false" version="0.1" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1880,8 +2107,8 @@
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1889,14 +2116,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Front">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Front">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1912,9 +2148,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide02 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide02 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1954,126 +2212,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2109,12 +2250,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide02 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide02 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2154,126 +2436,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2309,6 +2474,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -2328,14 +2634,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+            <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2368,14 +2671,11 @@
               <param name="invert">
                 <bool value="true"/>
               </param>
-              <param name="falloff">
-                <integer value="2"/>
-              </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -2383,16 +2683,25 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
     </canvas>
   </defs>
-  <layer type="rectangle" active="true" version="0.2" desc="Rectangle004">
+  <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1" desc="Polygon017">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2400,7 +2709,7 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
     <param name="color">
       <color>
@@ -2410,28 +2719,2086 @@
         <a>1.000000</a>
       </color>
     </param>
-    <param name="point1">
+    <param name="origin">
       <vector>
-        <x>-1.0000000000</x>
-        <y>0.5000000000</y>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
       </vector>
-    </param>
-    <param name="point2">
-      <vector>
-        <x>1.0000000000</x>
-        <y>-0.5000000000</y>
-      </vector>
-    </param>
-    <param name="expand">
-      <real value="0.0000000000"/>
     </param>
     <param name="invert">
       <bool value="false"/>
     </param>
+    <param name="antialias">
+      <bool value="true"/>
+    </param>
+    <param name="feather">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="blurtype">
+      <integer value="1" static="true"/>
+    </param>
+    <param name="winding_style">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="vector_list">
+      <dynamic_list type="vector" loop="true">
+        <entry>
+          <vector guid="99BB57B7BCCCEEDF328ED2A17E17A2B0">
+            <x>0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="95AB21B91912C663F14F43714D3500D7">
+            <x>-0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="0F4F5E5A729A53F93379B9DCD01B35A5">
+            <x>-0.5625000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="383BFEFFED30488C53AABCEC22203A0E">
+            <x>0.5625000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </entry>
+      </dynamic_list>
+    </param>
   </layer>
-  <layer type="zoom" active="true" version="0.1">
+  <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1" desc="Polygon019">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
     <param name="amount">
       <real value="0.4000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="color">
+      <color>
+        <r>0.010398</r>
+        <g>0.065754</g>
+        <b>0.246800</b>
+        <a>1.000000</a>
+      </color>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="invert">
+      <bool value="false"/>
+    </param>
+    <param name="antialias">
+      <bool value="true"/>
+    </param>
+    <param name="feather">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="blurtype">
+      <integer value="1" static="true"/>
+    </param>
+    <param name="winding_style">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="vector_list">
+      <dynamic_list type="vector" loop="true">
+        <entry>
+          <vector guid="8AADE8CE0F52F73E10C37137ED2EEE98">
+            <x>0.5625000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="2C56496F12501678B16A617072FC7708">
+            <x>-0.5625000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="5E8CB6F73180194AC87134285E4A97D9">
+            <x>-0.5625000000</x>
+            <y>0.5625000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="4ABF88C88AAF84B44BBF0CD3B68E31DF">
+            <x>0.5625000000</x>
+            <y>0.5625000000</y>
+          </vector>
+        </entry>
+      </dynamic_list>
+    </param>
+  </layer>
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="GroupCurva">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
+    </param>
+    <param name="canvas">
+      <canvas>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="813CC98A8C3D2020507453622E1906D2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5625000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="2C943434F263D1E7DF431025A99BFA76" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="0E68DC603FC5A56EA1CCC6A613E60444" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A3C021DE419B54A92EFB85E19464F8E0" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="D22EA12CFC622A7B9DEDAAC238CF3580" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="7F865C92823CDBBC12DAE985BF4DC924" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="6EB4AA0E20134427E7387070E70F40CC" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C31C57B05E4DB5E0680F3337608DBC68" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="C32978F960E55CB5158A37B8C6B7A37B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6E8185471EBBAD729ABD74FF41355FDF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="8F37DF78C493CD74DA9092DC7038D62A" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="229F22C6BACD3CB355A7D19BF7BA2A8E" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="2ECD9B6E7E311613E7773BA4DFDE0579" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000232</x>
+                      <y>0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="836566D0006FE7D4684078E3585CF9DD" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000246</x>
+                      <y>0.5625000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="A1998E84CDC9935D16CFAE60E22107EF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000191</x>
+                      <y>0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="0C31733AB397629A99F8ED2765A3FB4B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000232</x>
+                      <y>0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="7DDFF3C80E6E1C482AEEC204C908362B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000150</x>
+                      <y>0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="D0770E767030ED8FA5D981434E8ACA8F" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000191</x>
+                      <y>0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="C145F8EAD21F7214503B18B616C84367" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000109</x>
+                      <y>0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6CED0554AC4183D3DF0C5BF1914ABFC3" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000150</x>
+                      <y>0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="6CD82A1D92E96A86A2895F7E3770A0D0" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000068</x>
+                      <y>0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C170D7A3ECB79B412DBE1C39B0F25C74" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000109</x>
+                      <y>0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="20C68D9C369FFB476D93FA1A81FFD581" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="8D6E702248C10A80E2A4B95D067D2925" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000068</x>
+                      <y>0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle064">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.1250000000"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle066">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.506560</r>
+              <g>0.374113</g>
+              <b>0.599158</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.0823921239"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+      </canvas>
+    </param>
+    <param name="time_dilation">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
+    </param>
+  </layer>
+  <layer type="zoom" active="true" exclude_from_rendering="false" version="0.1">
+    <param name="amount">
+      <real value="0.5000000000"/>
     </param>
     <param name="center">
       <vector>

--- a/synfig-studio/images/action_offpeak_interpolation_icon.sif
+++ b/synfig-studio/images/action_offpeak_interpolation_icon.sif
@@ -1,0 +1,3836 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.2" width="128" height="128" xres="2952.755900" yres="2952.755900" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>action_offpeak_interpolation_icon.sif</name>
+  <desc>Placed in the Public Domain in 2011 by Carlos López (genete)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="1"/>
+  <meta name="grid_size" content="0.062500 0.062500"/>
+  <meta name="grid_snap" content="1"/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="0"/>
+  <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
+  <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
+  <defs>
+    <color id="color">
+      <r>1.000000</r>
+      <g>0.900000</g>
+      <b>0.600000</b>
+      <a>1.000000</a>
+    </color>
+    <canvas id="Item" bgcolor="0.500000 0.500000 0.500000 1.000000">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="0.5000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.1000000015</x>
+            <y>-0.1000000015</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="F8BC064CA4C25124724004DAA993E82F">
+                <x>-0.4000000060</x>
+                <y>0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="56A6A5CE73D4CAB5D7C56AD376C6C5A7">
+                <x>-0.4000000060</x>
+                <y>-0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="C5A57C68A9653BB2723E63D13BC7D069">
+                <x>0.4000000060</x>
+                <y>-0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="DCDD1F48DFC302B2938E33918FF8E689">
+                <x>0.4000000060</x>
+                <y>0.4000000060</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="1"/>
+        </param>
+        <param name="size">
+          <vector>
+            <x>0.0342190713</x>
+            <y>0.0342190713</y>
+          </vector>
+        </param>
+        <param name="type">
+          <integer value="1"/>
+        </param>
+      </layer>
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="C2801CF7B73DE6CE52D5418292D7EAF5">
+                <x>-0.4000000060</x>
+                <y>0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="F0D3DE80AE371F5CE9D84E7467D3F1EA">
+                <x>-0.4000000060</x>
+                <y>-0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="97DFA9063AFBA8E5828BAD3AF05A1EE7">
+                <x>0.4000000060</x>
+                <y>-0.4000000060</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="95214CD39CB8149E54C25B5A1E29138C">
+                <x>0.4000000060</x>
+                <y>0.4000000060</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color" use=":color"/>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="F122250E50A2F89F40E5B457D9CDFCD0">
+                <x>-0.3000000119</x>
+                <y>0.3000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="A536EBEFE7EDB06118D5B92D4368CB20">
+                <x>-0.3000000119</x>
+                <y>-0.3000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="A00B373CCF0ECC5A72027C67A157DDC5">
+                <x>0.3000000119</x>
+                <y>-0.3000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="A1B3E39FFEFB09C250978BE1C8A2E7E4">
+                <x>0.3000000119</x>
+                <y>0.3000000119</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+    </canvas>
+    <canvas id="paste-canvas" bgcolor="0.500000 0.500000 0.500000 1.000000">
+      <name>Untitled0</name>
+      <meta name="grid_show" content="1"/>
+      <meta name="grid_size" content="0.250000 0.250000"/>
+      <meta name="grid_snap" content="0"/>
+      <meta name="guide_snap" content="0"/>
+      <meta name="onion_skin" content="0"/>
+      <defs>
+        <canvas id="Layer" bgcolor="0.500000 0.500000 0.500000 1.000000">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+            <param name="z_depth">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="amount">
+              <real value="0.5000000000"/>
+            </param>
+            <param name="blend_method">
+              <integer value="0"/>
+            </param>
+            <param name="color">
+              <color>
+                <r>0.000000</r>
+                <g>0.000000</g>
+                <b>0.000000</b>
+                <a>1.000000</a>
+              </color>
+            </param>
+            <param name="origin">
+              <vector>
+                <x>0.1000000015</x>
+                <y>-0.1000000015</y>
+              </vector>
+            </param>
+            <param name="invert">
+              <bool value="false"/>
+            </param>
+            <param name="antialias">
+              <bool value="true"/>
+            </param>
+            <param name="feather">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="blurtype">
+              <integer value="1"/>
+            </param>
+            <param name="winding_style">
+              <integer value="0"/>
+            </param>
+            <param name="vector_list">
+              <dynamic_list type="vector">
+                <entry>
+                  <vector guid="EE98B59B39AA90D37C2CDFC8E7DB59B3">
+                    <x>-0.8000000119</x>
+                    <y>0.8000000119</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="3FC3A320D181297CEF59CB6FF998710A">
+                    <x>-0.8000000119</x>
+                    <y>-0.2000000030</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="6710A64FB4C8840D87518D40D8DC94A9">
+                    <x>0.2000000030</x>
+                    <y>-0.2000000030</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="31D08C6B5689BC801B4CCE99559DD808">
+                    <x>0.2000000030</x>
+                    <y>0.8000000119</y>
+                  </vector>
+                </entry>
+              </dynamic_list>
+            </param>
+          </layer>
+          <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
+            <param name="z_depth">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="amount">
+              <real value="1.0000000000"/>
+            </param>
+            <param name="blend_method">
+              <integer value="1"/>
+            </param>
+            <param name="size">
+              <vector>
+                <x>0.0684381425</x>
+                <y>0.0684381425</y>
+              </vector>
+            </param>
+            <param name="type">
+              <integer value="1"/>
+            </param>
+          </layer>
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+            <param name="z_depth">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="amount">
+              <real value="1.0000000000"/>
+            </param>
+            <param name="blend_method">
+              <integer value="0"/>
+            </param>
+            <param name="color">
+              <color>
+                <r>0.000000</r>
+                <g>0.000000</g>
+                <b>0.000000</b>
+                <a>1.000000</a>
+              </color>
+            </param>
+            <param name="origin">
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </param>
+            <param name="invert">
+              <bool value="false"/>
+            </param>
+            <param name="antialias">
+              <bool value="true"/>
+            </param>
+            <param name="feather">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="blurtype">
+              <integer value="1"/>
+            </param>
+            <param name="winding_style">
+              <integer value="0"/>
+            </param>
+            <param name="vector_list">
+              <dynamic_list type="vector">
+                <entry>
+                  <vector guid="83813BD5FFF0367B45BA774B4B637CB8">
+                    <x>-0.8000000119</x>
+                    <y>0.8000000119</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="03B26A460D24DECB9885178DA57E60AC">
+                    <x>-0.8000000119</x>
+                    <y>-0.2000000030</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="674659AA4596317F391BBF3127E2034B">
+                    <x>0.2000000030</x>
+                    <y>-0.2000000030</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="51BA26E0328390FDF18590DB6ECE0AD7">
+                    <x>0.2000000030</x>
+                    <y>0.8000000119</y>
+                  </vector>
+                </entry>
+              </dynamic_list>
+            </param>
+          </layer>
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+            <param name="z_depth">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="amount">
+              <real value="1.0000000000"/>
+            </param>
+            <param name="blend_method">
+              <integer value="0"/>
+            </param>
+            <param name="color">
+              <color>
+                <r>1.000000</r>
+                <g>0.900000</g>
+                <b>0.600000</b>
+                <a>1.000000</a>
+              </color>
+            </param>
+            <param name="origin">
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </param>
+            <param name="invert">
+              <bool value="false"/>
+            </param>
+            <param name="antialias">
+              <bool value="true"/>
+            </param>
+            <param name="feather">
+              <real value="0.0000000000"/>
+            </param>
+            <param name="blurtype">
+              <integer value="1"/>
+            </param>
+            <param name="winding_style">
+              <integer value="0"/>
+            </param>
+            <param name="vector_list">
+              <dynamic_list type="vector">
+                <entry>
+                  <vector guid="F7134BDD94A662349C4AFE9FB6C1146A">
+                    <x>-0.6999999881</x>
+                    <y>0.6999999881</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="2B8E667E5D733CE779F007E1F976CD91">
+                    <x>-0.6999999881</x>
+                    <y>-0.1000000015</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="B78C3CA8AB2F9DCD77C8277B0C3F4648">
+                    <x>0.1000000015</x>
+                    <y>-0.1000000015</y>
+                  </vector>
+                </entry>
+                <entry>
+                  <vector guid="071780545B342020904F7DDC47896A7F">
+                    <x>0.1000000015</x>
+                    <y>0.6999999881</y>
+                  </vector>
+                </entry>
+              </dynamic_list>
+            </param>
+          </layer>
+        </canvas>
+      </defs>
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Back">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
+        <param name="canvas">
+          <canvas>
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide01 Region">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.850000</r>
+                  <g>0.640000</g>
+                  <b>0.200000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
+                      <point>
+                        <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
+                          <x>-0.2500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+            </layer>
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide01 Outline">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
+                      <point>
+                        <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
+                          <x>-0.2500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+              <param name="width">
+                <real value="0.0651041665"/>
+              </param>
+              <param name="expand">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="sharp_cusps">
+                <bool value="false"/>
+              </param>
+              <param name="round_tip[0]">
+                <bool value="true"/>
+              </param>
+              <param name="round_tip[1]">
+                <bool value="true"/>
+              </param>
+              <param name="homogeneous_width">
+                <bool value="true"/>
+              </param>
+            </layer>
+          </canvas>
+        </param>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="time_offset">
+          <time value="0s"/>
+        </param>
+        <param name="children_lock">
+          <bool value="false"/>
+        </param>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
+        </param>
+      </layer>
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Left">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
+        <param name="canvas">
+          <canvas>
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide04 Region">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.850000</r>
+                  <g>0.640000</g>
+                  <b>0.200000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
+                      <point>
+                        <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
+                          <x>-0.2500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+            </layer>
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide04 Outline">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
+                      <point>
+                        <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
+                          <x>-0.2500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+              <param name="width">
+                <real value="0.0651041665"/>
+              </param>
+              <param name="expand">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="sharp_cusps">
+                <bool value="false"/>
+              </param>
+              <param name="round_tip[0]">
+                <bool value="true"/>
+              </param>
+              <param name="round_tip[1]">
+                <bool value="true"/>
+              </param>
+              <param name="homogeneous_width">
+                <bool value="true"/>
+              </param>
+            </layer>
+          </canvas>
+        </param>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="time_offset">
+          <time value="0s"/>
+        </param>
+        <param name="children_lock">
+          <bool value="false"/>
+        </param>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
+        </param>
+      </layer>
+      <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="0.8000000119"/>
+        </param>
+        <param name="blend_method">
+          <integer value="13"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="radius">
+          <real value="0.5000000000"/>
+        </param>
+        <param name="feather">
+          <real value="0.4882812491"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.3589743674</x>
+            <y>-0.1217948720</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="true"/>
+        </param>
+      </layer>
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Right">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
+        <param name="canvas">
+          <canvas>
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide03 Region">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.850000</r>
+                  <g>0.640000</g>
+                  <b>0.200000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+            </layer>
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide03 Outline">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+              <param name="width">
+                <real value="0.0651041665"/>
+              </param>
+              <param name="expand">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="sharp_cusps">
+                <bool value="false"/>
+              </param>
+              <param name="round_tip[0]">
+                <bool value="true"/>
+              </param>
+              <param name="round_tip[1]">
+                <bool value="true"/>
+              </param>
+              <param name="homogeneous_width">
+                <bool value="true"/>
+              </param>
+            </layer>
+            <layer type="SolidColor" active="true" exclude_from_rendering="false" version="0.1" group="Shading">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="0.7500000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="13"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+            </layer>
+          </canvas>
+        </param>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="time_offset">
+          <time value="0s"/>
+        </param>
+        <param name="children_lock">
+          <bool value="false"/>
+        </param>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
+        </param>
+      </layer>
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Front">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
+        <param name="canvas">
+          <canvas>
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide02 Region">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.850000</r>
+                  <g>0.640000</g>
+                  <b>0.200000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+            </layer>
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide02 Outline">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="1.0000000000"/>
+              </param>
+              <param name="blend_method">
+                <integer value="0"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>0.0000000000</x>
+                  <y>0.0000000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="false"/>
+              </param>
+              <param name="antialias">
+                <bool value="true"/>
+              </param>
+              <param name="feather">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="blurtype">
+                <integer value="1"/>
+              </param>
+              <param name="winding_style">
+                <integer value="0"/>
+              </param>
+              <param name="bline">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
+                  <entry>
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                </bline>
+              </param>
+              <param name="width">
+                <real value="0.0651041665"/>
+              </param>
+              <param name="expand">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="sharp_cusps">
+                <bool value="false"/>
+              </param>
+              <param name="round_tip[0]">
+                <bool value="true"/>
+              </param>
+              <param name="round_tip[1]">
+                <bool value="true"/>
+              </param>
+              <param name="homogeneous_width">
+                <bool value="true"/>
+              </param>
+            </layer>
+            <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
+              <param name="z_depth">
+                <real value="0.0000000000"/>
+              </param>
+              <param name="amount">
+                <real value="0.5500000119"/>
+              </param>
+              <param name="blend_method">
+                <integer value="13"/>
+              </param>
+              <param name="color">
+                <color>
+                  <r>0.000000</r>
+                  <g>0.000000</g>
+                  <b>0.000000</b>
+                  <a>1.000000</a>
+                </color>
+              </param>
+              <param name="radius">
+                <real value="0.7500000000"/>
+              </param>
+              <param name="feather">
+                <real value="0.4882812491"/>
+              </param>
+              <param name="origin">
+                <vector>
+                  <x>-0.7500000000</x>
+                  <y>0.2500000000</y>
+                </vector>
+              </param>
+              <param name="invert">
+                <bool value="true"/>
+              </param>
+            </layer>
+          </canvas>
+        </param>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="time_offset">
+          <time value="0s"/>
+        </param>
+        <param name="children_lock">
+          <bool value="false"/>
+        </param>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
+        </param>
+      </layer>
+    </canvas>
+  </defs>
+  <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1" desc="Polygon017">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="color">
+      <color>
+        <r>0.010398</r>
+        <g>0.065754</g>
+        <b>0.246800</b>
+        <a>1.000000</a>
+      </color>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="invert">
+      <bool value="false"/>
+    </param>
+    <param name="antialias">
+      <bool value="true"/>
+    </param>
+    <param name="feather">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="blurtype">
+      <integer value="1" static="true"/>
+    </param>
+    <param name="winding_style">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="vector_list">
+      <dynamic_list type="vector" loop="true">
+        <entry>
+          <vector guid="99BB57B7BCCCEEDF328ED2A17E17A2B0">
+            <x>0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="95AB21B91912C663F14F43714D3500D7">
+            <x>-0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="0F4F5E5A729A53F93379B9DCD01B35A5">
+            <x>-0.5625000000</x>
+            <y>0.1250000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="3FB5C72051B1DB0EB195D9F6A1A31F86">
+            <x>0.0000000000</x>
+            <y>-0.4375000000</y>
+          </vector>
+        </entry>
+        <entry>
+          <vector guid="383BFEFFED30488C53AABCEC22203A0E">
+            <x>0.5625000000</x>
+            <y>0.1250000000</y>
+          </vector>
+        </entry>
+      </dynamic_list>
+    </param>
+  </layer>
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="GroupCurva">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
+    </param>
+    <param name="canvas">
+      <canvas>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="813CC98A8C3D2020507453622E1906D2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5625000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="2C943434F263D1E7DF431025A99BFA76" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="0E68DC603FC5A56EA1CCC6A613E60444" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A3C021DE419B54A92EFB85E19464F8E0" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="D22EA12CFC622A7B9DEDAAC238CF3580" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="7F865C92823CDBBC12DAE985BF4DC924" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="6EB4AA0E20134427E7387070E70F40CC" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C31C57B05E4DB5E0680F3337608DBC68" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="C32978F960E55CB5158A37B8C6B7A37B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6E8185471EBBAD729ABD74FF41355FDF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="8F37DF78C493CD74DA9092DC7038D62A" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="229F22C6BACD3CB355A7D19BF7BA2A8E" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle064">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.1250000000"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle066">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.506560</r>
+              <g>0.374113</g>
+              <b>0.599158</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.0823921239"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+      </canvas>
+    </param>
+    <param name="time_dilation">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
+    </param>
+  </layer>
+  <layer type="zoom" active="true" exclude_from_rendering="false" version="0.1">
+    <param name="amount">
+      <real value="0.5000000000"/>
+    </param>
+    <param name="center">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+  </layer>
+</canvas>

--- a/synfig-studio/images/action_peak_interpolation_icon.sif
+++ b/synfig-studio/images/action_peak_interpolation_icon.sif
@@ -1,13 +1,24 @@
-<?xml version="1.0"?>
-<canvas version="0.7" width="128" height="128" xres="2952.755900" yres="2952.755900" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
-  <name>Synfig Studio Set Width Point Rounded Type</name>
-  <desc>Placed in the Public Domain in 2011 by Carlos L&#xF3;pez (genete)</desc>
-  <meta name="grid_show" content="0"/>
-  <meta name="grid_size" content="0,250000 0,250000"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.2" width="128" height="128" xres="2952.755900" yres="2952.755900" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>action_peak_interpolation_icon.sif</name>
+  <desc>Placed in the Public Domain in 2011 by Carlos López (genete)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="1"/>
+  <meta name="grid_size" content="0.062500 0.062500"/>
   <meta name="grid_snap" content="1"/>
-  <meta name="guide_show" content="1"/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="0"/>
   <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
   <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
   <defs>
     <color id="color">
       <r>1.000000</r>
@@ -16,7 +27,7 @@
       <a>1.000000</a>
     </color>
     <canvas id="Item" bgcolor="0.500000 0.500000 0.500000 1.000000">
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -58,25 +69,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F8BC064CA4C25124724004DAA993E82F">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="56A6A5CE73D4CAB5D7C56AD376C6C5A7">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="C5A57C68A9653BB2723E63D13BC7D069">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="DCDD1F48DFC302B2938E33918FF8E689">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -84,7 +95,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="blur" active="true" version="0.2">
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -96,15 +107,15 @@
         </param>
         <param name="size">
           <vector>
-            <x>0.1000000015</x>
-            <y>0.1000000015</y>
+            <x>0.0342190713</x>
+            <y>0.0342190713</y>
           </vector>
         </param>
         <param name="type">
           <integer value="1"/>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -146,25 +157,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="C2801CF7B73DE6CE52D5418292D7EAF5">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="F0D3DE80AE371F5CE9D84E7467D3F1EA">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="97DFA9063AFBA8E5828BAD3AF05A1EE7">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="95214CD39CB8149E54C25B5A1E29138C">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -172,7 +183,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -207,25 +218,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F122250E50A2F89F40E5B457D9CDFCD0">
                 <x>-0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A536EBEFE7EDB06118D5B92D4368CB20">
                 <x>-0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A00B373CCF0ECC5A72027C67A157DDC5">
                 <x>0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A1B3E39FFEFB09C250978BE1C8A2E7E4">
                 <x>0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
@@ -243,7 +254,7 @@
       <meta name="onion_skin" content="0"/>
       <defs>
         <canvas id="Layer" bgcolor="0.500000 0.500000 0.500000 1.000000">
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -285,25 +296,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="EE98B59B39AA90D37C2CDFC8E7DB59B3">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="3FC3A320D181297CEF59CB6FF998710A">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="6710A64FB4C8840D87518D40D8DC94A9">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="31D08C6B5689BC801B4CCE99559DD808">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -311,7 +322,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="blur" active="true" version="0.2">
+          <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -323,15 +334,15 @@
             </param>
             <param name="size">
               <vector>
-                <x>0.2000000030</x>
-                <y>0.2000000030</y>
+                <x>0.0684381425</x>
+                <y>0.0684381425</y>
               </vector>
             </param>
             <param name="type">
               <integer value="1"/>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -373,25 +384,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="83813BD5FFF0367B45BA774B4B637CB8">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="03B26A460D24DECB9885178DA57E60AC">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="674659AA4596317F391BBF3127E2034B">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="51BA26E0328390FDF18590DB6ECE0AD7">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -399,7 +410,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -441,25 +452,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="F7134BDD94A662349C4AFE9FB6C1146A">
                     <x>-0.6999999881</x>
                     <y>0.6999999881</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="2B8E667E5D733CE779F007E1F976CD91">
                     <x>-0.6999999881</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="B78C3CA8AB2F9DCD77C8277B0C3F4648">
                     <x>0.1000000015</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="071780545B342020904F7DDC47896A7F">
                     <x>0.1000000015</x>
                     <y>0.6999999881</y>
                   </vector>
@@ -469,7 +480,7 @@
           </layer>
         </canvas>
       </defs>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Back">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Back">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -485,9 +496,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide01 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide01 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -527,126 +560,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -682,12 +598,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide01 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide01 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -727,126 +784,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -882,6 +822,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -901,17 +982,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -919,14 +997,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Left">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Left">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -942,9 +1029,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide04 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide04 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -984,126 +1093,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1139,12 +1131,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide04 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide04 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1184,126 +1317,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1339,6 +1355,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1358,17 +1515,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1376,14 +1530,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+      <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1416,11 +1579,8 @@
         <param name="invert">
           <bool value="true"/>
         </param>
-        <param name="falloff">
-          <integer value="2"/>
-        </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Right">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Right">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1436,9 +1596,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide03 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide03 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1478,126 +1660,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1633,12 +1698,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide03 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide03 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1678,126 +1884,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1833,6 +1922,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1852,14 +2082,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="SolidColor" active="true" version="0.1" group="Shading">
+            <layer type="SolidColor" active="true" exclude_from_rendering="false" version="0.1" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1880,8 +2107,8 @@
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1889,14 +2116,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Front">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Front">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1912,9 +2148,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide02 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide02 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1954,126 +2212,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2109,12 +2250,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide02 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide02 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2154,126 +2436,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2309,6 +2474,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -2328,14 +2634,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+            <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2368,14 +2671,11 @@
               <param name="invert">
                 <bool value="true"/>
               </param>
-              <param name="falloff">
-                <integer value="2"/>
-              </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -2383,16 +2683,25 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
     </canvas>
   </defs>
-  <layer type="region" active="true" version="0.1" desc="Circle058Region">
+  <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1" desc="Polygon017">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2400,7 +2709,7 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
     <param name="color">
       <color>
@@ -2411,7 +2720,7 @@
       </color>
     </param>
     <param name="origin">
-      <vector guid="967DCDC4FB0137A6CC08EEBB691D8D04">
+      <vector>
         <x>0.0000000000</x>
         <y>0.0000000000</y>
       </vector>
@@ -2426,173 +2735,47 @@
       <real value="0.0000000000"/>
     </param>
     <param name="blurtype">
-      <integer value="1"/>
+      <integer value="1" static="true"/>
     </param>
     <param name="winding_style">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
-    <param name="bline">
-      <bline type="bline_point" loop="true" guid="9248DBEB0AEF1F18714177C355FA2FBE">
+    <param name="vector_list">
+      <dynamic_list type="vector" loop="true">
         <entry>
-          <composite type="bline_point" guid="9ECDC77A73D627FF837D046271863829">
-            <point>
-              <vector>
-                <x>0.5000000000</x>
-                <y>0.0000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5250852704"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601718"/>
-                </radius>
-                <theta>
-                  <angle value="45.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601718"/>
-                </radius>
-                <theta>
-                  <angle value="135.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="99BB57B7BCCCEEDF328ED2A17E17A2B0">
+            <x>0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
         </entry>
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.0000000219</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606602182"/>
-                </radius>
-                <theta>
-                  <angle value="-225.000015"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601253"/>
-                </radius>
-                <theta>
-                  <angle value="-135.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="95AB21B91912C663F14F43714D3500D7">
+            <x>-0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
         </entry>
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.5000000000</x>
-                <y>-0.0000000437</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606602645"/>
-                </radius>
-                <theta>
-                  <angle value="-135.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606600791"/>
-                </radius>
-                <theta>
-                  <angle value="-45.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="0F4F5E5A729A53F93379B9DCD01B35A5">
+            <x>-0.5625000000</x>
+            <y>0.0000000000</y>
+          </vector>
         </entry>
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.0000000060</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601845"/>
-                </radius>
-                <theta>
-                  <angle value="-45.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601591"/>
-                </radius>
-                <theta>
-                  <angle value="404.999969"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="3FB5C72051B1DB0EB195D9F6A1A31F86">
+            <x>0.0000000246</x>
+            <y>0.5625000000</y>
+          </vector>
         </entry>
-      </bline>
+        <entry>
+          <vector guid="383BFEFFED30488C53AABCEC22203A0E">
+            <x>0.5625000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </entry>
+      </dynamic_list>
     </param>
   </layer>
-  <layer type="outline" active="true" version="0.2" desc="Circle058Contorno">
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="GroupCurva">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2600,220 +2783,1046 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
-    </param>
-    <param name="color">
-      <color>
-        <r>0.010398</r>
-        <g>0.065754</g>
-        <b>0.246800</b>
-        <a>1.000000</a>
-      </color>
+      <integer value="0" static="true"/>
     </param>
     <param name="origin">
-      <vector guid="967DCDC4FB0137A6CC08EEBB691D8D04">
+      <vector>
         <x>0.0000000000</x>
         <y>0.0000000000</y>
       </vector>
     </param>
-    <param name="invert">
-      <bool value="false"/>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
     </param>
-    <param name="antialias">
-      <bool value="true"/>
+    <param name="canvas">
+      <canvas>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="813CC98A8C3D2020507453622E1906D2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5625000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="2C943434F263D1E7DF431025A99BFA76" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="0E68DC603FC5A56EA1CCC6A613E60444" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A3C021DE419B54A92EFB85E19464F8E0" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="D22EA12CFC622A7B9DEDAAC238CF3580" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="7F865C92823CDBBC12DAE985BF4DC924" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="6EB4AA0E20134427E7387070E70F40CC" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C31C57B05E4DB5E0680F3337608DBC68" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="C32978F960E55CB5158A37B8C6B7A37B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6E8185471EBBAD729ABD74FF41355FDF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="8F37DF78C493CD74DA9092DC7038D62A" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="229F22C6BACD3CB355A7D19BF7BA2A8E" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle064">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.1250000000"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle066">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.506560</r>
+              <g>0.374113</g>
+              <b>0.599158</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.0823921239"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+      </canvas>
     </param>
-    <param name="feather">
-      <real value="0.0000000000"/>
-    </param>
-    <param name="blurtype">
-      <integer value="1"/>
-    </param>
-    <param name="winding_style">
-      <integer value="0"/>
-    </param>
-    <param name="bline">
-      <bline type="bline_point" loop="true" guid="9248DBEB0AEF1F18714177C355FA2FBE">
-        <entry>
-          <composite type="bline_point" guid="9ECDC77A73D627FF837D046271863829">
-            <point>
-              <vector>
-                <x>0.5000000000</x>
-                <y>0.0000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5250852704"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601718"/>
-                </radius>
-                <theta>
-                  <angle value="45.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601718"/>
-                </radius>
-                <theta>
-                  <angle value="135.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.0000000219</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606602182"/>
-                </radius>
-                <theta>
-                  <angle value="-225.000015"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601253"/>
-                </radius>
-                <theta>
-                  <angle value="-135.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.5000000000</x>
-                <y>-0.0000000437</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606602645"/>
-                </radius>
-                <theta>
-                  <angle value="-135.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606600791"/>
-                </radius>
-                <theta>
-                  <angle value="-45.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.0000000060</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601845"/>
-                </radius>
-                <theta>
-                  <angle value="-45.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="1.0606601591"/>
-                </radius>
-                <theta>
-                  <angle value="404.999969"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-      </bline>
-    </param>
-    <param name="width">
-      <real value="0.1250000000" guid="B9EE4406D903EAE110416A5006BA6A5A"/>
-    </param>
-    <param name="expand">
-      <real value="0.0000000000"/>
-    </param>
-    <param name="sharp_cusps">
-      <bool value="true"/>
-    </param>
-    <param name="round_tip[0]">
-      <bool value="true"/>
-    </param>
-    <param name="round_tip[1]">
-      <bool value="true"/>
-    </param>
-    <param name="loopyness">
+    <param name="time_dilation">
       <real value="1.0000000000"/>
     </param>
-    <param name="homogeneous_width">
-      <bool value="true"/>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
     </param>
   </layer>
-  <layer type="zoom" active="true" version="0.1">
+  <layer type="zoom" active="true" exclude_from_rendering="false" version="0.1">
     <param name="amount">
       <real value="0.5000000000"/>
     </param>

--- a/synfig-studio/images/action_rounded_interpolation_icon.sif
+++ b/synfig-studio/images/action_rounded_interpolation_icon.sif
@@ -1,13 +1,24 @@
-<?xml version="1.0"?>
-<canvas version="0.7" width="128" height="128" xres="2952.755900" yres="2952.755900" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
-  <name>Synfig Studio Set Width Point Rounded Type</name>
-  <desc>Placed in the Public Domain in 2011 by Carlos L&#xF3;pez (genete)</desc>
-  <meta name="grid_show" content="0"/>
-  <meta name="grid_size" content="0,250000 0,250000"/>
-  <meta name="grid_snap" content="0"/>
-  <meta name="guide_show" content="1"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.2" width="128" height="128" xres="2952.755900" yres="2952.755900" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>action_rounded_interpolation_icon.sif</name>
+  <desc>Placed in the Public Domain in 2011 by Carlos López (genete)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="1"/>
+  <meta name="grid_size" content="0.062500 0.062500"/>
+  <meta name="grid_snap" content="1"/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="0"/>
   <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
   <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
   <defs>
     <color id="color">
       <r>1.000000</r>
@@ -16,7 +27,7 @@
       <a>1.000000</a>
     </color>
     <canvas id="Item" bgcolor="0.500000 0.500000 0.500000 1.000000">
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -58,25 +69,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F8BC064CA4C25124724004DAA993E82F">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="56A6A5CE73D4CAB5D7C56AD376C6C5A7">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="C5A57C68A9653BB2723E63D13BC7D069">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="DCDD1F48DFC302B2938E33918FF8E689">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -84,7 +95,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="blur" active="true" version="0.2">
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -96,15 +107,15 @@
         </param>
         <param name="size">
           <vector>
-            <x>0.1000000015</x>
-            <y>0.1000000015</y>
+            <x>0.0342190713</x>
+            <y>0.0342190713</y>
           </vector>
         </param>
         <param name="type">
           <integer value="1"/>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -146,25 +157,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="C2801CF7B73DE6CE52D5418292D7EAF5">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="F0D3DE80AE371F5CE9D84E7467D3F1EA">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="97DFA9063AFBA8E5828BAD3AF05A1EE7">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="95214CD39CB8149E54C25B5A1E29138C">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -172,7 +183,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -207,25 +218,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F122250E50A2F89F40E5B457D9CDFCD0">
                 <x>-0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A536EBEFE7EDB06118D5B92D4368CB20">
                 <x>-0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A00B373CCF0ECC5A72027C67A157DDC5">
                 <x>0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A1B3E39FFEFB09C250978BE1C8A2E7E4">
                 <x>0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
@@ -243,7 +254,7 @@
       <meta name="onion_skin" content="0"/>
       <defs>
         <canvas id="Layer" bgcolor="0.500000 0.500000 0.500000 1.000000">
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -285,25 +296,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="EE98B59B39AA90D37C2CDFC8E7DB59B3">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="3FC3A320D181297CEF59CB6FF998710A">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="6710A64FB4C8840D87518D40D8DC94A9">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="31D08C6B5689BC801B4CCE99559DD808">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -311,7 +322,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="blur" active="true" version="0.2">
+          <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -323,15 +334,15 @@
             </param>
             <param name="size">
               <vector>
-                <x>0.2000000030</x>
-                <y>0.2000000030</y>
+                <x>0.0684381425</x>
+                <y>0.0684381425</y>
               </vector>
             </param>
             <param name="type">
               <integer value="1"/>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -373,25 +384,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="83813BD5FFF0367B45BA774B4B637CB8">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="03B26A460D24DECB9885178DA57E60AC">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="674659AA4596317F391BBF3127E2034B">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="51BA26E0328390FDF18590DB6ECE0AD7">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -399,7 +410,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -441,25 +452,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="F7134BDD94A662349C4AFE9FB6C1146A">
                     <x>-0.6999999881</x>
                     <y>0.6999999881</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="2B8E667E5D733CE779F007E1F976CD91">
                     <x>-0.6999999881</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="B78C3CA8AB2F9DCD77C8277B0C3F4648">
                     <x>0.1000000015</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="071780545B342020904F7DDC47896A7F">
                     <x>0.1000000015</x>
                     <y>0.6999999881</y>
                   </vector>
@@ -469,7 +480,7 @@
           </layer>
         </canvas>
       </defs>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Back">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Back">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -485,9 +496,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide01 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide01 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -527,126 +560,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -682,12 +598,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide01 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide01 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -727,126 +784,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -882,6 +822,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -901,17 +982,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -919,14 +997,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Left">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Left">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -942,9 +1029,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide04 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide04 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -984,126 +1093,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1139,12 +1131,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide04 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide04 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1184,126 +1317,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1339,6 +1355,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1358,17 +1515,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1376,14 +1530,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+      <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1416,11 +1579,8 @@
         <param name="invert">
           <bool value="true"/>
         </param>
-        <param name="falloff">
-          <integer value="2"/>
-        </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Right">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Right">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1436,9 +1596,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide03 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide03 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1478,126 +1660,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1633,12 +1698,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide03 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide03 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1678,126 +1884,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1833,6 +1922,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1852,14 +2082,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="SolidColor" active="true" version="0.1" group="Shading">
+            <layer type="SolidColor" active="true" exclude_from_rendering="false" version="0.1" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1880,8 +2107,8 @@
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1889,14 +2116,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Front">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Front">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1912,9 +2148,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide02 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide02 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1954,126 +2212,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2109,12 +2250,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide02 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide02 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2154,126 +2436,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2309,6 +2474,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -2328,14 +2634,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+            <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2368,14 +2671,11 @@
               <param name="invert">
                 <bool value="true"/>
               </param>
-              <param name="falloff">
-                <integer value="2"/>
-              </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -2383,16 +2683,25 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
     </canvas>
   </defs>
-  <layer type="region" active="true" version="0.1" desc="Circle058Region">
+  <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="NewSpline031 Region">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2400,7 +2709,7 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
     <param name="color">
       <color>
@@ -2411,7 +2720,7 @@
       </color>
     </param>
     <param name="origin">
-      <vector guid="967DCDC4FB0137A6CC08EEBB691D8D04">
+      <vector>
         <x>0.0000000000</x>
         <y>0.0000000000</y>
       </vector>
@@ -2426,18 +2735,63 @@
       <real value="0.0000000000"/>
     </param>
     <param name="blurtype">
-      <integer value="1"/>
+      <integer value="1" static="true"/>
     </param>
     <param name="winding_style">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
     <param name="bline">
-      <bline type="bline_point" loop="true" guid="9248DBEB0AEF1F18714177C355FA2FBE">
+      <bline type="bline_point" loop="true">
         <entry>
-          <composite type="bline_point" guid="013337FA0148CBA0E1A75A9231301BC6">
+          <composite guid="1B49B14A0C424686E63EF346EA908206" type="bline_point">
             <point>
               <vector>
-                <x>0.5000000000</x>
+                <x>-0.5625000000</x>
+                <y>-0.5625000000</y>
+              </vector>
+            </point>
+            <width>
+              <real value="1.0000000000"/>
+            </width>
+            <origin>
+              <real value="0.5000000000"/>
+            </origin>
+            <split>
+              <bool value="false"/>
+            </split>
+            <t1>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.0000000000"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t1>
+            <t2>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.0000000000"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t2>
+            <split_radius>
+              <bool value="false"/>
+            </split_radius>
+            <split_angle>
+              <bool value="false"/>
+            </split_angle>
+          </composite>
+        </entry>
+        <entry>
+          <composite guid="239265792593E718A62265744A97CC1D" type="bline_point">
+            <point>
+              <vector>
+                <x>-0.5625000000</x>
                 <y>0.0000000000</y>
               </vector>
             </point>
@@ -2445,7 +2799,7 @@
               <real value="1.0000000000"/>
             </width>
             <origin>
-              <real value="0.5062233210"/>
+              <real value="0.5000000000"/>
             </origin>
             <split>
               <bool value="false"/>
@@ -2453,70 +2807,37 @@
             <t1>
               <radial_composite type="vector">
                 <radius>
-                  <real value="0.7500000000"/>
+                  <real value="0.9375000000"/>
                 </radius>
                 <theta>
-                  <angle value="90.000000"/>
+                  <angle value="89.999992"/>
                 </theta>
               </radial_composite>
             </t1>
             <t2>
               <radial_composite type="vector">
                 <radius>
-                  <real value="0.7500000000"/>
+                  <real value="0.9375000000"/>
                 </radius>
                 <theta>
-                  <angle value="90.000000"/>
+                  <angle value="89.999992"/>
                 </theta>
               </radial_composite>
             </t2>
+            <split_radius>
+              <bool value="false"/>
+            </split_radius>
+            <split_angle>
+              <bool value="false"/>
+            </split_angle>
           </composite>
         </entry>
         <entry>
-          <composite type="bline_point">
+          <composite guid="04EE25F492441831E8FC2A94979D56A0" type="bline_point">
             <point>
               <vector>
-                <x>-0.0000000219</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000657"/>
-                </radius>
-                <theta>
-                  <angle value="-180.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000656"/>
-                </radius>
-                <theta>
-                  <angle value="-179.999985"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.5000000000</x>
-                <y>-0.0000000437</y>
+                <x>0.0000000246</x>
+                <y>0.5625000000</y>
               </vector>
             </point>
             <width>
@@ -2531,68 +2852,125 @@
             <t1>
               <radial_composite type="vector">
                 <radius>
-                  <real value="0.8284270763"/>
+                  <real value="0.9375000902"/>
                 </radius>
                 <theta>
-                  <angle value="-89.999992"/>
+                  <angle value="0.000000"/>
                 </theta>
               </radial_composite>
             </t1>
             <t2>
               <radial_composite type="vector">
                 <radius>
-                  <real value="0.8284270763"/>
-                </radius>
-                <theta>
-                  <angle value="-89.999992"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.0000000060</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.8284270763"/>
-                </radius>
-                <theta>
-                  <angle value="0.000001"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7499999820"/>
+                  <real value="0.9375000902"/>
                 </radius>
                 <theta>
                   <angle value="0.000000"/>
                 </theta>
               </radial_composite>
             </t2>
+            <split_radius>
+              <bool value="false"/>
+            </split_radius>
+            <split_angle>
+              <bool value="false"/>
+            </split_angle>
+          </composite>
+        </entry>
+        <entry>
+          <composite guid="CD576B0726AAC06041C2D13B25208139" type="bline_point">
+            <point>
+              <vector>
+                <x>0.5625000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </point>
+            <width>
+              <real value="1.0000000000"/>
+            </width>
+            <origin>
+              <real value="0.5000000000"/>
+            </origin>
+            <split>
+              <bool value="false"/>
+            </split>
+            <t1>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.9375000000"/>
+                </radius>
+                <theta>
+                  <angle value="-89.999992"/>
+                </theta>
+              </radial_composite>
+            </t1>
+            <t2>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.1875000000"/>
+                </radius>
+                <theta>
+                  <angle value="-89.999992"/>
+                </theta>
+              </radial_composite>
+            </t2>
+            <split_radius>
+              <bool value="false"/>
+            </split_radius>
+            <split_angle>
+              <bool value="false"/>
+            </split_angle>
+          </composite>
+        </entry>
+        <entry>
+          <composite guid="7E4A1BB1E897DA5F8400DF1E602F2E88" type="bline_point">
+            <point>
+              <vector>
+                <x>0.5625000000</x>
+                <y>-0.5625000000</y>
+              </vector>
+            </point>
+            <width>
+              <real value="1.0000000000"/>
+            </width>
+            <origin>
+              <real value="0.5000000000"/>
+            </origin>
+            <split>
+              <bool value="false"/>
+            </split>
+            <t1>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.0000000000"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t1>
+            <t2>
+              <radial_composite type="vector">
+                <radius>
+                  <real value="0.0000000000"/>
+                </radius>
+                <theta>
+                  <angle value="0.000000"/>
+                </theta>
+              </radial_composite>
+            </t2>
+            <split_radius>
+              <bool value="false"/>
+            </split_radius>
+            <split_angle>
+              <bool value="false"/>
+            </split_angle>
           </composite>
         </entry>
       </bline>
     </param>
   </layer>
-  <layer type="outline" active="true" version="0.2" desc="Circle058Contorno">
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="GroupCurva">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2600,220 +2978,1046 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
-    </param>
-    <param name="color">
-      <color>
-        <r>0.010398</r>
-        <g>0.065754</g>
-        <b>0.246800</b>
-        <a>1.000000</a>
-      </color>
+      <integer value="0" static="true"/>
     </param>
     <param name="origin">
-      <vector guid="967DCDC4FB0137A6CC08EEBB691D8D04">
+      <vector>
         <x>0.0000000000</x>
         <y>0.0000000000</y>
       </vector>
     </param>
-    <param name="invert">
-      <bool value="false"/>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
     </param>
-    <param name="antialias">
-      <bool value="true"/>
+    <param name="canvas">
+      <canvas>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="813CC98A8C3D2020507453622E1906D2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5625000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="2C943434F263D1E7DF431025A99BFA76" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="0E68DC603FC5A56EA1CCC6A613E60444" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A3C021DE419B54A92EFB85E19464F8E0" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="D22EA12CFC622A7B9DEDAAC238CF3580" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="7F865C92823CDBBC12DAE985BF4DC924" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="6EB4AA0E20134427E7387070E70F40CC" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C31C57B05E4DB5E0680F3337608DBC68" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="C32978F960E55CB5158A37B8C6B7A37B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6E8185471EBBAD729ABD74FF41355FDF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="8F37DF78C493CD74DA9092DC7038D62A" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="229F22C6BACD3CB355A7D19BF7BA2A8E" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle064">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.1250000000"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle066">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.506560</r>
+              <g>0.374113</g>
+              <b>0.599158</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.0823921239"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+      </canvas>
     </param>
-    <param name="feather">
-      <real value="0.0000000000"/>
-    </param>
-    <param name="blurtype">
-      <integer value="1"/>
-    </param>
-    <param name="winding_style">
-      <integer value="0"/>
-    </param>
-    <param name="bline">
-      <bline type="bline_point" loop="true" guid="9248DBEB0AEF1F18714177C355FA2FBE">
-        <entry>
-          <composite type="bline_point" guid="013337FA0148CBA0E1A75A9231301BC6">
-            <point>
-              <vector>
-                <x>0.5000000000</x>
-                <y>0.0000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5062233210"/>
-            </origin>
-            <split>
-              <bool value="false"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="90.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.0000000219</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000657"/>
-                </radius>
-                <theta>
-                  <angle value="-180.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000656"/>
-                </radius>
-                <theta>
-                  <angle value="-179.999985"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.5000000000</x>
-                <y>-0.0000000437</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="false"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.8284270763"/>
-                </radius>
-                <theta>
-                  <angle value="-89.999992"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.8284270763"/>
-                </radius>
-                <theta>
-                  <angle value="-89.999992"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.0000000060</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.8284270763"/>
-                </radius>
-                <theta>
-                  <angle value="0.000001"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7499999820"/>
-                </radius>
-                <theta>
-                  <angle value="0.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-      </bline>
-    </param>
-    <param name="width">
-      <real value="0.1250000000" guid="B9EE4406D903EAE110416A5006BA6A5A"/>
-    </param>
-    <param name="expand">
-      <real value="0.0000000000"/>
-    </param>
-    <param name="sharp_cusps">
-      <bool value="true"/>
-    </param>
-    <param name="round_tip[0]">
-      <bool value="true"/>
-    </param>
-    <param name="round_tip[1]">
-      <bool value="true"/>
-    </param>
-    <param name="loopyness">
+    <param name="time_dilation">
       <real value="1.0000000000"/>
     </param>
-    <param name="homogeneous_width">
-      <bool value="true"/>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
     </param>
   </layer>
-  <layer type="zoom" active="true" version="0.1">
+  <layer type="zoom" active="true" exclude_from_rendering="false" version="0.1">
     <param name="amount">
       <real value="0.5000000000"/>
     </param>

--- a/synfig-studio/images/action_squared_interpolation_icon.sif
+++ b/synfig-studio/images/action_squared_interpolation_icon.sif
@@ -1,13 +1,24 @@
-<?xml version="1.0"?>
-<canvas version="0.7" width="128" height="128" xres="2952.755900" yres="2952.755900" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
-  <name>Synfig Studio Set Width Point Square Type</name>
-  <desc>Placed in the Public Domain in 2011 by Carlos L&#xF3;pez (genete)</desc>
-  <meta name="grid_show" content="0"/>
-  <meta name="grid_size" content="0,250000 0,250000"/>
-  <meta name="grid_snap" content="0"/>
-  <meta name="guide_show" content="1"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.2" width="128" height="128" xres="2952.755900" yres="2952.755900" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>action_squared_interpolation_icon.sif</name>
+  <desc>Placed in the Public Domain in 2011 by Carlos López (genete)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="1"/>
+  <meta name="grid_size" content="0.062500 0.062500"/>
+  <meta name="grid_snap" content="1"/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="0"/>
   <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
   <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
   <defs>
     <color id="color">
       <r>1.000000</r>
@@ -16,7 +27,7 @@
       <a>1.000000</a>
     </color>
     <canvas id="Item" bgcolor="0.500000 0.500000 0.500000 1.000000">
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -58,25 +69,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F8BC064CA4C25124724004DAA993E82F">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="56A6A5CE73D4CAB5D7C56AD376C6C5A7">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="C5A57C68A9653BB2723E63D13BC7D069">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="DCDD1F48DFC302B2938E33918FF8E689">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -84,7 +95,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="blur" active="true" version="0.2">
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -96,15 +107,15 @@
         </param>
         <param name="size">
           <vector>
-            <x>0.1000000015</x>
-            <y>0.1000000015</y>
+            <x>0.0342190713</x>
+            <y>0.0342190713</y>
           </vector>
         </param>
         <param name="type">
           <integer value="1"/>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -146,25 +157,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="C2801CF7B73DE6CE52D5418292D7EAF5">
                 <x>-0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="F0D3DE80AE371F5CE9D84E7467D3F1EA">
                 <x>-0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="97DFA9063AFBA8E5828BAD3AF05A1EE7">
                 <x>0.4000000060</x>
                 <y>-0.4000000060</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="95214CD39CB8149E54C25B5A1E29138C">
                 <x>0.4000000060</x>
                 <y>0.4000000060</y>
               </vector>
@@ -172,7 +183,7 @@
           </dynamic_list>
         </param>
       </layer>
-      <layer type="polygon" active="true" version="0.1">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -207,25 +218,25 @@
         <param name="vector_list">
           <dynamic_list type="vector">
             <entry>
-              <vector>
+              <vector guid="F122250E50A2F89F40E5B457D9CDFCD0">
                 <x>-0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A536EBEFE7EDB06118D5B92D4368CB20">
                 <x>-0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A00B373CCF0ECC5A72027C67A157DDC5">
                 <x>0.3000000119</x>
                 <y>-0.3000000119</y>
               </vector>
             </entry>
             <entry>
-              <vector>
+              <vector guid="A1B3E39FFEFB09C250978BE1C8A2E7E4">
                 <x>0.3000000119</x>
                 <y>0.3000000119</y>
               </vector>
@@ -243,7 +254,7 @@
       <meta name="onion_skin" content="0"/>
       <defs>
         <canvas id="Layer" bgcolor="0.500000 0.500000 0.500000 1.000000">
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -285,25 +296,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="EE98B59B39AA90D37C2CDFC8E7DB59B3">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="3FC3A320D181297CEF59CB6FF998710A">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="6710A64FB4C8840D87518D40D8DC94A9">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="31D08C6B5689BC801B4CCE99559DD808">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -311,7 +322,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="blur" active="true" version="0.2">
+          <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -323,15 +334,15 @@
             </param>
             <param name="size">
               <vector>
-                <x>0.2000000030</x>
-                <y>0.2000000030</y>
+                <x>0.0684381425</x>
+                <y>0.0684381425</y>
               </vector>
             </param>
             <param name="type">
               <integer value="1"/>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -373,25 +384,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="83813BD5FFF0367B45BA774B4B637CB8">
                     <x>-0.8000000119</x>
                     <y>0.8000000119</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="03B26A460D24DECB9885178DA57E60AC">
                     <x>-0.8000000119</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="674659AA4596317F391BBF3127E2034B">
                     <x>0.2000000030</x>
                     <y>-0.2000000030</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="51BA26E0328390FDF18590DB6ECE0AD7">
                     <x>0.2000000030</x>
                     <y>0.8000000119</y>
                   </vector>
@@ -399,7 +410,7 @@
               </dynamic_list>
             </param>
           </layer>
-          <layer type="polygon" active="true" version="0.1">
+          <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
             <param name="z_depth">
               <real value="0.0000000000"/>
             </param>
@@ -441,25 +452,25 @@
             <param name="vector_list">
               <dynamic_list type="vector">
                 <entry>
-                  <vector>
+                  <vector guid="F7134BDD94A662349C4AFE9FB6C1146A">
                     <x>-0.6999999881</x>
                     <y>0.6999999881</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="2B8E667E5D733CE779F007E1F976CD91">
                     <x>-0.6999999881</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="B78C3CA8AB2F9DCD77C8277B0C3F4648">
                     <x>0.1000000015</x>
                     <y>-0.1000000015</y>
                   </vector>
                 </entry>
                 <entry>
-                  <vector>
+                  <vector guid="071780545B342020904F7DDC47896A7F">
                     <x>0.1000000015</x>
                     <y>0.6999999881</y>
                   </vector>
@@ -469,7 +480,7 @@
           </layer>
         </canvas>
       </defs>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Back">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Back">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -485,9 +496,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide01 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide01 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -527,126 +560,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -682,12 +598,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide01 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide01 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -727,126 +784,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="800FFDCAE3DC6A233B55317FC60D7097">
+                <bline guid="800FFDCAE3DC6A233B55317FC60D7097" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
-                          <x>0.7500000000</x>
-                          <y>-0.3782051206</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="D4679AD387AEF9EC5B776F1C17E315B0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -882,6 +822,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="F0D3D74715FB985A6039E3A650C243F7" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="66F32A49B11B0D19B196A9ADE579C953" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="C0E69248BBC71642DF7864260009D6C6" type="bline_point">
+                      <point>
+                        <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
+                          <x>0.7500000000</x>
+                          <y>-0.3782051206</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -901,17 +982,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -919,14 +997,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Left">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Left">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -942,9 +1029,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide04 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide04 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -984,126 +1093,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1139,12 +1131,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide04 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide04 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1184,126 +1317,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="C467144BA4A6CBE4F9960DF5AB8277F6">
+                <bline guid="C467144BA4A6CBE4F9960DF5AB8277F6" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
-                          <x>-0.2500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
-                          <x>-0.7500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="9670CC4F827101D5A5F175F17493C3E0" type="bline_point">
                       <point>
                         <vector guid="9DF5E6A05B93C32913EDC80ECDB2446A">
                           <x>-0.2500000000</x>
@@ -1339,6 +1355,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="756A120E7595153D38CBA3AA6871595C" type="bline_point">
+                      <point>
+                        <vector guid="A3D1A583B2C6FC7B8E15A05C8CECBF35">
+                          <x>-0.2500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="6BC88EDFDA1BA22DB3254409FA85EF8F" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="ECFD001903AB960D93BD9B699FF64C7F" type="bline_point">
+                      <point>
+                        <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
+                          <x>-0.7500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1358,17 +1515,14 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1376,14 +1530,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+      <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1416,11 +1579,8 @@
         <param name="invert">
           <bool value="true"/>
         </param>
-        <param name="falloff">
-          <integer value="2"/>
-        </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Right">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Right">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1436,9 +1596,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide03 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide03 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1478,126 +1660,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1633,12 +1698,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide03 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide03 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1678,126 +1884,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="F4D9B98A6DD4EF193B93F9D120357511">
+                <bline guid="F4D9B98A6DD4EF193B93F9D120357511" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
-                          <x>0.7500000000</x>
-                          <y>0.6217948794</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="CCA68E2AAC92CD2D31DBC32CC0DF0A3B" type="bline_point">
                       <point>
                         <vector guid="1C00406C6C5BCEBD97431AA812B067C5">
                           <x>0.7500000000</x>
@@ -1833,6 +1922,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="CF075C073D3B0B373B98F9A21EED9444" type="bline_point">
+                      <point>
+                        <vector guid="F5E7D10E1E407BD9EA4EC4B1557101E8">
+                          <x>0.7500000000</x>
+                          <y>0.6217948794</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="914E63AA0E756767010AE9952A8FCF45" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="9DD5B2539ED1263DF44E534822E42AF7" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -1852,14 +2082,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="SolidColor" active="true" version="0.1" group="Shading">
+            <layer type="SolidColor" active="true" exclude_from_rendering="false" version="0.1" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1880,8 +2107,8 @@
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -1889,14 +2116,23 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
-      <layer type="PasteCanvas" active="true" version="0.1" desc="Front">
+      <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="Front">
         <param name="z_depth">
           <real value="0.0000000000"/>
         </param>
@@ -1912,9 +2148,31 @@
             <y>0.0000000000</y>
           </vector>
         </param>
+        <param name="transformation">
+          <composite type="transformation">
+            <offset>
+              <vector>
+                <x>0.0000000000</x>
+                <y>0.0000000000</y>
+              </vector>
+            </offset>
+            <angle>
+              <angle value="0.000000"/>
+            </angle>
+            <skew_angle>
+              <angle value="0.000000"/>
+            </skew_angle>
+            <scale>
+              <vector>
+                <x>1.0000000000</x>
+                <y>1.0000000000</y>
+              </vector>
+            </scale>
+          </composite>
+        </param>
         <param name="canvas">
           <canvas>
-            <layer type="region" active="true" version="0.1" desc="BoxSide02 Region">
+            <layer type="region" active="true" exclude_from_rendering="false" version="0.1" desc="BoxSide02 Region">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -1954,126 +2212,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2109,12 +2250,153 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
               </param>
             </layer>
-            <layer type="outline" active="true" version="0.2" desc="BoxSide02 Outline">
+            <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="BoxSide02 Outline">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2154,126 +2436,9 @@
                 <integer value="0"/>
               </param>
               <param name="bline">
-                <bline type="bline_point" loop="true" guid="260EA51C9613F1F9D7A0B4B78E86B3BB">
+                <bline guid="260EA51C9613F1F9D7A0B4B78E86B3BB" type="bline_point" loop="true">
                   <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
-                          <x>-0.7500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
-                          <x>0.2500000000</x>
-                          <y>0.2500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
-                      <point>
-                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
-                          <x>0.2500000000</x>
-                          <y>-0.7500000000</y>
-                        </vector>
-                      </point>
-                      <width>
-                        <real value="1.0000000000"/>
-                      </width>
-                      <origin>
-                        <real value="0.5000000000"/>
-                      </origin>
-                      <split>
-                        <bool value="false"/>
-                      </split>
-                      <t1>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="-180.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t1>
-                      <t2>
-                        <radial_composite type="vector">
-                          <radius>
-                            <real value="0.0000000000"/>
-                          </radius>
-                          <theta>
-                            <angle value="0.000000"/>
-                          </theta>
-                        </radial_composite>
-                      </t2>
-                    </composite>
-                  </entry>
-                  <entry>
-                    <composite type="bline_point">
+                    <composite guid="179F6785543C59CD3649D34525EC6693" type="bline_point">
                       <point>
                         <vector guid="A9FE474A3B8562B92B3E74DF5F555267">
                           <x>-0.7500000000</x>
@@ -2309,6 +2474,147 @@
                           </theta>
                         </radial_composite>
                       </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="EFDF76F4C4F1A211C5C38CA31DFC7EE4" type="bline_point">
+                      <point>
+                        <vector guid="64505142FFC04B2450BB112F796DDE2E">
+                          <x>-0.7500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="DDD9D10D5FC60A37691B7106DA6D85DB" type="bline_point">
+                      <point>
+                        <vector guid="5AF3F811D810DDA5CFBD71153758D864">
+                          <x>0.2500000000</x>
+                          <y>0.2500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
+                    </composite>
+                  </entry>
+                  <entry>
+                    <composite guid="4DDF09F8809BAC44A2763E1A96662319" type="bline_point">
+                      <point>
+                        <vector guid="2AFFC5845055FE6EA613B9B14FEC5D48">
+                          <x>0.2500000000</x>
+                          <y>-0.7500000000</y>
+                        </vector>
+                      </point>
+                      <width>
+                        <real value="1.0000000000"/>
+                      </width>
+                      <origin>
+                        <real value="0.5000000000"/>
+                      </origin>
+                      <split>
+                        <bool value="false"/>
+                      </split>
+                      <t1>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="-180.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t1>
+                      <t2>
+                        <radial_composite type="vector">
+                          <radius>
+                            <real value="0.0000000000"/>
+                          </radius>
+                          <theta>
+                            <angle value="0.000000"/>
+                          </theta>
+                        </radial_composite>
+                      </t2>
+                      <split_radius>
+                        <bool value="false"/>
+                      </split_radius>
+                      <split_angle>
+                        <bool value="false"/>
+                      </split_angle>
                     </composite>
                   </entry>
                 </bline>
@@ -2328,14 +2634,11 @@
               <param name="round_tip[1]">
                 <bool value="true"/>
               </param>
-              <param name="loopyness">
-                <real value="1.0000000000"/>
-              </param>
               <param name="homogeneous_width">
                 <bool value="true"/>
               </param>
             </layer>
-            <layer type="circle" active="true" version="0.1" desc="Shading" group="Shading">
+            <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Shading" group="Shading">
               <param name="z_depth">
                 <real value="0.0000000000"/>
               </param>
@@ -2368,14 +2671,11 @@
               <param name="invert">
                 <bool value="true"/>
               </param>
-              <param name="falloff">
-                <integer value="2"/>
-              </param>
             </layer>
           </canvas>
         </param>
-        <param name="zoom">
-          <real value="0.0000000000"/>
+        <param name="time_dilation">
+          <real value="1.0000000000"/>
         </param>
         <param name="time_offset">
           <time value="0s"/>
@@ -2383,16 +2683,25 @@
         <param name="children_lock">
           <bool value="false"/>
         </param>
-        <param name="focus">
-          <vector>
-            <x>0.0000000000</x>
-            <y>0.0000000000</y>
-          </vector>
+        <param name="outline_grow">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range">
+          <bool value="false" static="true"/>
+        </param>
+        <param name="z_range_position">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="z_range_blur">
+          <real value="0.0000000000"/>
         </param>
       </layer>
     </canvas>
   </defs>
-  <layer type="region" active="true" version="0.1" desc="Circle058Region">
+  <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1" desc="Polygon017">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2400,7 +2709,7 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
     <param name="color">
       <color>
@@ -2411,7 +2720,7 @@
       </color>
     </param>
     <param name="origin">
-      <vector guid="967DCDC4FB0137A6CC08EEBB691D8D04">
+      <vector>
         <x>0.0000000000</x>
         <y>0.0000000000</y>
       </vector>
@@ -2426,173 +2735,41 @@
       <real value="0.0000000000"/>
     </param>
     <param name="blurtype">
-      <integer value="1"/>
+      <integer value="1" static="true"/>
     </param>
     <param name="winding_style">
-      <integer value="0"/>
+      <integer value="0" static="true"/>
     </param>
-    <param name="bline">
-      <bline type="bline_point" loop="true" guid="9248DBEB0AEF1F18714177C355FA2FBE">
+    <param name="vector_list">
+      <dynamic_list type="vector" loop="true">
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.4999999702</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000656"/>
-                </radius>
-                <theta>
-                  <angle value="-180.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000656"/>
-                </radius>
-                <theta>
-                  <angle value="0.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="99BB57B7BCCCEEDF328ED2A17E17A2B0">
+            <x>0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
         </entry>
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.5000000000</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-180.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="95AB21B91912C663F14F43714D3500D7">
+            <x>-0.5625000000</x>
+            <y>-0.5625000000</y>
+          </vector>
         </entry>
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.5000000000</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.3756182194"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="0.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="0F4F5E5A729A53F93379B9DCD01B35A5">
+            <x>-0.5625000000</x>
+            <y>0.5625000000</y>
+          </vector>
         </entry>
         <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.5000000000</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000000"/>
-                </radius>
-                <theta>
-                  <angle value="179.999985"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
+          <vector guid="383BFEFFED30488C53AABCEC22203A0E">
+            <x>0.5625000000</x>
+            <y>0.5625000000</y>
+          </vector>
         </entry>
-      </bline>
+      </dynamic_list>
     </param>
   </layer>
-  <layer type="outline" active="true" version="0.2" desc="Circle058Contorno">
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="GroupCurva">
     <param name="z_depth">
       <real value="0.0000000000"/>
     </param>
@@ -2600,220 +2777,1046 @@
       <real value="1.0000000000"/>
     </param>
     <param name="blend_method">
-      <integer value="0"/>
-    </param>
-    <param name="color">
-      <color>
-        <r>0.010398</r>
-        <g>0.065754</g>
-        <b>0.246800</b>
-        <a>1.000000</a>
-      </color>
+      <integer value="0" static="true"/>
     </param>
     <param name="origin">
-      <vector guid="967DCDC4FB0137A6CC08EEBB691D8D04">
+      <vector>
         <x>0.0000000000</x>
         <y>0.0000000000</y>
       </vector>
     </param>
-    <param name="invert">
-      <bool value="false"/>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
     </param>
-    <param name="antialias">
-      <bool value="true"/>
+    <param name="canvas">
+      <canvas>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="813CC98A8C3D2020507453622E1906D2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5625000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="2C943434F263D1E7DF431025A99BFA76" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="0E68DC603FC5A56EA1CCC6A613E60444" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.5312500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A3C021DE419B54A92EFB85E19464F8E0" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="D22EA12CFC622A7B9DEDAAC238CF3580" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.4375000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="7F865C92823CDBBC12DAE985BF4DC924" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="6EB4AA0E20134427E7387070E70F40CC" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.3437500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C31C57B05E4DB5E0680F3337608DBC68" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="C32978F960E55CB5158A37B8C6B7A37B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-0.0000000000</x>
+                      <y>-0.2500000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6E8185471EBBAD729ABD74FF41355FDF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="NewSpline028 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point">
+              <entry>
+                <composite guid="8F37DF78C493CD74DA9092DC7038D62A" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="229F22C6BACD3CB355A7D19BF7BA2A8E" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>-0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.0937500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="false"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="false"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle064">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.1250000000"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle066">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.506560</r>
+              <g>0.374113</g>
+              <b>0.599158</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="radius">
+            <real value="0.0823921239"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+        </layer>
+      </canvas>
     </param>
-    <param name="feather">
-      <real value="0.0000000000"/>
-    </param>
-    <param name="blurtype">
-      <integer value="1"/>
-    </param>
-    <param name="winding_style">
-      <integer value="0"/>
-    </param>
-    <param name="bline">
-      <bline type="bline_point" loop="true" guid="9248DBEB0AEF1F18714177C355FA2FBE">
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.4999999702</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000656"/>
-                </radius>
-                <theta>
-                  <angle value="-180.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000656"/>
-                </radius>
-                <theta>
-                  <angle value="0.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.5000000000</x>
-                <y>0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-180.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>-0.5000000000</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.3756182194"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.7500000000"/>
-                </radius>
-                <theta>
-                  <angle value="0.000000"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-        <entry>
-          <composite type="bline_point">
-            <point>
-              <vector>
-                <x>0.5000000000</x>
-                <y>-0.5000000000</y>
-              </vector>
-            </point>
-            <width>
-              <real value="1.0000000000"/>
-            </width>
-            <origin>
-              <real value="0.5000000000"/>
-            </origin>
-            <split>
-              <bool value="true"/>
-            </split>
-            <t1>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000000"/>
-                </radius>
-                <theta>
-                  <angle value="-90.000000"/>
-                </theta>
-              </radial_composite>
-            </t1>
-            <t2>
-              <radial_composite type="vector">
-                <radius>
-                  <real value="0.0000000000"/>
-                </radius>
-                <theta>
-                  <angle value="179.999985"/>
-                </theta>
-              </radial_composite>
-            </t2>
-          </composite>
-        </entry>
-      </bline>
-    </param>
-    <param name="width">
-      <real value="0.1250000000" guid="B9EE4406D903EAE110416A5006BA6A5A"/>
-    </param>
-    <param name="expand">
-      <real value="0.0000000000"/>
-    </param>
-    <param name="sharp_cusps">
-      <bool value="true"/>
-    </param>
-    <param name="round_tip[0]">
-      <bool value="true"/>
-    </param>
-    <param name="round_tip[1]">
-      <bool value="true"/>
-    </param>
-    <param name="loopyness">
+    <param name="time_dilation">
       <real value="1.0000000000"/>
     </param>
-    <param name="homogeneous_width">
-      <bool value="true"/>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
     </param>
   </layer>
-  <layer type="zoom" active="true" version="0.1">
+  <layer type="zoom" active="true" exclude_from_rendering="false" version="0.1">
     <param name="amount">
       <real value="0.5000000000"/>
     </param>

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -231,7 +231,9 @@ IconController::init_icons(const synfig::String& path_to_icons)
 	INIT_STOCK_ICON(flat_interpolation, "action_flat_interpolation_icon." IMAGE_EXT, _("Set Interpolation to Flat"));
 	INIT_STOCK_ICON(interpolate_interpolation, "action_interpolate_interpolation_icon." IMAGE_EXT, _("Set Interpolation to Interpolate"));
 	INIT_STOCK_ICON(peak_interpolation, "action_peak_interpolation_icon." IMAGE_EXT, _("Set Interpolation to Peak"));
+	INIT_STOCK_ICON(offpeak_interpolation, "action_offpeak_interpolation_icon." IMAGE_EXT, _("Set Interpolation to Off-Peak"));
 	INIT_STOCK_ICON(rounded_interpolation, "action_rounded_interpolation_icon." IMAGE_EXT, _("Set Interpolation to Rounded"));
+	INIT_STOCK_ICON(innerrounded_interpolation, "action_innerrounded_interpolation_icon." IMAGE_EXT, _("Set Interpolation to Inner Rounded"));
 	INIT_STOCK_ICON(squared_interpolation, "action_squared_interpolation_icon." IMAGE_EXT, _("Set Interpolation to Squared"));
 
 	INIT_STOCK_ICON(toggle_duck_position, "duck_position_icon." IMAGE_EXT, _("Toggle position handles"));

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1341,8 +1341,8 @@ Instance::make_param_menu(Gtk::Menu *menu,synfig::Canvas::Handle canvas, synfiga
 		ADD_IMAGE_MENU_ITEM(TYPE_SQUARED, "action_squared_interpolation_icon", _("Cusp Before: Squared"))
 		ADD_IMAGE_MENU_ITEM(TYPE_PEAK, "action_peak_interpolation_icon", _("Cusp Before: Peak"))
 		ADD_IMAGE_MENU_ITEM(TYPE_FLAT, "action_flat_interpolation_icon", _("Cusp Before: Flat"))
-		ADD_IMAGE_MENU_ITEM(TYPE_INNER_ROUNDED, "action_rounded_interpolation_icon", _("Cusp Before: Inner Rounded"))
-		ADD_IMAGE_MENU_ITEM(TYPE_INNER_PEAK, "action_peak_interpolation_icon", _("Cusp Before: Off-Peak"))
+		ADD_IMAGE_MENU_ITEM(TYPE_INNER_ROUNDED, "action_innerrounded_interpolation_icon", _("Cusp Before: Inner Rounded"))
+		ADD_IMAGE_MENU_ITEM(TYPE_INNER_PEAK, "action_offpeak_interpolation_icon", _("Cusp Before: Off-Peak"))
 
 		///////
 		item = Gtk::manage(new Gtk::SeparatorMenuItem());
@@ -1358,8 +1358,8 @@ Instance::make_param_menu(Gtk::Menu *menu,synfig::Canvas::Handle canvas, synfiga
 		ADD_IMAGE_MENU_ITEM(TYPE_SQUARED, "action_squared_interpolation_icon", _("Cusp After: Squared"))
 		ADD_IMAGE_MENU_ITEM(TYPE_PEAK, "action_peak_interpolation_icon", _("Cusp After: Peak"))
 		ADD_IMAGE_MENU_ITEM(TYPE_FLAT, "action_flat_interpolation_icon", _("Cusp After: Flat"))
-		ADD_IMAGE_MENU_ITEM(TYPE_INNER_ROUNDED, "action_rounded_interpolation_icon", _("Cusp After: Inner Rounded"))
-		ADD_IMAGE_MENU_ITEM(TYPE_INNER_PEAK, "action_peak_interpolation_icon", _("Cusp After: Off-Peak"))
+		ADD_IMAGE_MENU_ITEM(TYPE_INNER_ROUNDED, "action_innerrounded_interpolation_icon", _("Cusp After: Inner Rounded"))
+		ADD_IMAGE_MENU_ITEM(TYPE_INNER_PEAK, "action_offpeak_interpolation_icon", _("Cusp After: Off-Peak"))
 
 		///////
 		item = Gtk::manage(new Gtk::SeparatorMenuItem());


### PR DESCRIPTION
Hi,

While designing a ["modern iconset" for Synfig](https://forums.synfig.org/t/modern-iconset-light-and-dark/13560), I realized the "width interpolation" icons were so simple, they didn't clearly represent what they actually do and there were 2 ones missing: "off-peek" and "inner rounded" interpolation.
This PR tries to update and fulfill those gaps:

![interpolation_v01](https://user-images.githubusercontent.com/5942369/202029366-e8c423a2-a328-4215-8f04-48f551cef651.jpg)

I not only added the icons in .sif format but changed the files needed to make it all work (tested under macOS).

I hope you like it.


![PabloInterpolation](https://user-images.githubusercontent.com/5604544/203804538-55b9b328-0692-4e3f-a008-b7314c93ffd9.png)
