### PR TITLE
feat: added hotkey for duplicate layer button

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1365,7 +1365,7 @@ App::get_default_accel_map()
 		{"<Control>parenleft" ,     "<Actions>/canvasview/decrease-low-res-pixel-size"},
 		{"<Control>parenright" ,    "<Actions>/canvasview/increase-low-res-pixel-size"},
 		{"<Primary>g",              "<Actions>/action_group_layer_action_manager/action-LayerEncapsulate"},
-        {"<Primary>u",              "<Actions>/action_group_layer_action_manager/action-LayerDuplicate"},
+		{"<Primary>u",              "<Actions>/action_group_layer_action_manager/action-LayerDuplicate"},
 		{"<Control><Mod1>parenleft",  "<Actions>/action_group_layer_action_manager/amount-dec"},
 		{"<Control><Mod1>parenright", "<Actions>/action_group_layer_action_manager/amount-inc"},
 		{"equal",                   "<Actions>/canvasview/canvas-zoom-in"},

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1365,6 +1365,7 @@ App::get_default_accel_map()
 		{"<Control>parenleft" ,     "<Actions>/canvasview/decrease-low-res-pixel-size"},
 		{"<Control>parenright" ,    "<Actions>/canvasview/increase-low-res-pixel-size"},
 		{"<Primary>g",              "<Actions>/action_group_layer_action_manager/action-LayerEncapsulate"},
+        {"<Primary>u",              "<Actions>/action_group_layer_action_manager/action-LayerDuplicate"},
 		{"<Control><Mod1>parenleft",  "<Actions>/action_group_layer_action_manager/amount-dec"},
 		{"<Control><Mod1>parenright", "<Actions>/action_group_layer_action_manager/amount-inc"},
 		{"equal",                   "<Actions>/canvasview/canvas-zoom-in"},


### PR DESCRIPTION
fixes #2891 
ctrl + d and ctrl + shift + d, are both already being used for unselect all layer and ducks. I semi-arbitrarily chose ctrl+u as its what comes after the d in duplicate, and anyway the user can change it. But if there is a better initial key pair please let me know :).