### PR TITLE
chore: added /build-cmake/ folder to .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ compile
 /_debug/
 /_production/
 /_release/
+/build-cmake/
 /build.conf
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
Adds `/build-cmake/` folder to **.gitignore** file as it is needed under macOS when compiling with Cmake