### PR TITLE
refactor(UI): rename Eyedrop Tool to Eyedropper Tool

### DIFF
--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -131,7 +131,7 @@ IconController::init_icons(const synfig::String& path_to_icons)
 	INIT_STOCK_ICON(polygon, "tool_polyline_icon." IMAGE_EXT, _("Polygon Tool"));
 	INIT_STOCK_ICON(bline, "tool_spline_icon." IMAGE_EXT, _("Spline Tool"));
 	INIT_STOCK_ICON(bone,"tool_skeleton_icon." IMAGE_EXT,_("Skeleton Tool"));
-	INIT_STOCK_ICON(eyedrop, "tool_eyedrop_icon." IMAGE_EXT, _("Eyedrop Tool"));
+	INIT_STOCK_ICON(eyedrop, "tool_eyedrop_icon." IMAGE_EXT, _("Eyedropper Tool"));
 	INIT_STOCK_ICON(fill, "tool_fill_icon." IMAGE_EXT, _("Fill Tool"));
 	INIT_STOCK_ICON(draw, "tool_draw_icon." IMAGE_EXT, _("Draw Tool"));
 	INIT_STOCK_ICON(lasso, "tool_cutout_icon." IMAGE_EXT, _("Cutout Tool"));

--- a/synfig-studio/src/gui/resources/ui/studio_menubar.xml
+++ b/synfig-studio/src/gui/resources/ui/studio_menubar.xml
@@ -473,7 +473,7 @@
                     <attribute name="accel">U</attribute>
                 </item>
                 <item>
-                    <attribute name="label" translatable="yes">_Eyedrop Tool</attribute>
+                    <attribute name="label" translatable="yes">_Eyedropper Tool</attribute>
                     <attribute name="action">app.state-eyedrop</attribute>
                     <attribute name="icon">tool_eyedrop_icon</attribute>
                     <attribute name="accel">D</attribute>

--- a/synfig-studio/src/gui/states/state_eyedrop.cpp
+++ b/synfig-studio/src/gui/states/state_eyedrop.cpp
@@ -116,7 +116,7 @@ StateEyedrop_Context::StateEyedrop_Context(CanvasView *canvasView):
 	canvas_view->get_work_area()->set_cursor(Gdk::Cursor::create(Gdk::CROSSHAIR));
 
 	// Toolbox widgets
-	title_label.set_label(_("Eyedrop Tool"));
+	title_label.set_label(_("Eyedropper Tool"));
 	Pango::AttrList list;
 	Pango::AttrInt attr = Pango::Attribute::create_attr_weight(Pango::WEIGHT_BOLD);
 	list.insert(attr);
@@ -156,7 +156,7 @@ StateEyedrop_Context::refresh_tool_options()
 {
 	App::dialog_tool_options->clear();
 	App::dialog_tool_options->set_widget(options_grid);
-	App::dialog_tool_options->set_local_name(_("Eyedrop Tool"));
+	App::dialog_tool_options->set_local_name(_("Eyedropper Tool"));
 	App::dialog_tool_options->set_name("eyedrop");
 }
 


### PR DESCRIPTION
Fixes #2900 
should the eye-drop state be renamed as well?