### PR TITLE
ci: bump GitHub actions

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -46,7 +46,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare ccache timestamp
         id: ccache_timestamp
@@ -54,7 +54,7 @@ jobs:
 
       - name: Download ccache archive
         id: ccache-archive
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .ccache
           key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ steps.ccache_timestamp.outputs.timestamp }}

--- a/.github/workflows/synfig-stable.yml
+++ b/.github/workflows/synfig-stable.yml
@@ -34,7 +34,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare ccache timestamp
         id: ccache_timestamp
@@ -42,7 +42,7 @@ jobs:
 
       - name: Download ccache archive
         id: ccache-archive
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: .ccache
           key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ steps.ccache_timestamp.outputs.timestamp }}

--- a/.github/workflows/synfig-tests.yml
+++ b/.github/workflows/synfig-tests.yml
@@ -31,7 +31,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: "Synfig Studio (Check appdata.xml)"
         run: |


### PR DESCRIPTION
The old actions are deprecated and will stop working soon.

> [Ubuntu 20.04 Focal (CMake+Ninja)](https://github.com/synfig/synfig/actions/runs/3548808344/jobs/5961404035)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2