### PR TITLE
feat: eyedropper tool now takes fill color instead of outline color by default

### DIFF
--- a/synfig-studio/src/gui/states/state_eyedrop.cpp
+++ b/synfig-studio/src/gui/states/state_eyedrop.cpp
@@ -128,9 +128,9 @@ StateEyedrop_Context::StateEyedrop_Context(CanvasView *canvasView):
 	// Toolbox layout
 	options_grid.attach(title_label,
 		0, 0, 2, 1);
-	options_grid.attach(*manage(new Gtk::Label(_("Click to assign Outline Color"), Gtk::ALIGN_START)),
+	options_grid.attach(*manage(new Gtk::Label(_("Click to assign Fill Color"), Gtk::ALIGN_START)),
 		0, 1, 2, 1);
-	options_grid.attach(*manage(new Gtk::Label(_("Ctrl + Click to assign Fill Color"), Gtk::ALIGN_START)),
+	options_grid.attach(*manage(new Gtk::Label(_("Ctrl + Click to assign Outline Color"), Gtk::ALIGN_START)),
 		0, 2, 2, 1);
 
 	options_grid.set_border_width(GAP*2);

--- a/synfig-studio/src/gui/states/state_eyedrop.cpp
+++ b/synfig-studio/src/gui/states/state_eyedrop.cpp
@@ -195,10 +195,10 @@ StateEyedrop_Context::event_workarea_mouse_button_down_handler(const Smach::even
 	{
 		Color color(canvas_view->get_canvas()->get_context(canvas_view->get_context_params()).get_color(event.pos));
 		if((event.modifier&GDK_CONTROL_MASK) == GDK_CONTROL_MASK) {
-		    synfigapp::Main::set_fill_color(color);
+			synfigapp::Main::set_outline_color(color);
 		}
 		else {
-		    synfigapp::Main::set_outline_color(color);
+			synfigapp::Main::set_fill_color(color);
 		}
 		studio::App::dialog_color->set_color(color);
 		return Smach::RESULT_ACCEPT;


### PR DESCRIPTION
Fixes #2899 
not sure if this is a "refactor" or a "feature". Anyways, pretty straightforward reordereding of condition statement.