### PR TITLE
ci: added conventional commits style check for PR titles

### DIFF
--- a/.github/workflows/conventional-commits-style.yml
+++ b/.github/workflows/conventional-commits-style.yml
@@ -1,0 +1,34 @@
+name: Style
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  pull_request:
+    types: [opened, edited]
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  install-and-lint-pr-title:
+    runs-on: ubuntu-latest
+    name: Conventional commits style check
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install conventional commits linter
+        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
+
+      - name: Configure commitlint
+        run: |
+          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
+
+      - name: Lint current pull request title
+        run: jq --raw-output ".pull_request.title" "$GITHUB_EVENT_PATH" | npx commitlint --verbose
+
+# The code below is saved for future references.
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+#          gh pr view $pr_number --json=title --jq '.title' | npx commitlint --verbose


### PR DESCRIPTION
The main feature of these PR is the ability to automatically start the check after editing the title of the PR, so no need to restart this check manually.

This is made possible by the GitHub Actions event system.

In this case, we use the `PR edited` event.
```
  pull_request:
    types: [opened, edited]
```

P.S.
PR title is extracted from GitHub Actions JSON file located at ${GITHUB_EVENT_PATH}

https://docs.github.com/en/actions/learn-github-actions/environment-variables
> GITHUB_EVENT_PATH
> The path to the file on the runner that contains the full event webhook payload. 
> For example, /github/workflow/event.json.