### PR TITLE
ci: added `synchronize` to the list of processed events

### DIFF
--- a/.github/workflows/conventional-commits-style.yml
+++ b/.github/workflows/conventional-commits-style.yml
@@ -2,8 +2,9 @@ name: Style
 
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
+  # Event list: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
     branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
`synchronize` event is fired when you add commits to PR.

At first I thought that there is no reason to add this event, because this change does not change PR title.
But it resets PR statuses, so this check needs to be run again.