### PR TITLE
fix: support FontConfig older than version 2.11.91

### DIFF
--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
@@ -571,7 +571,11 @@ static std::string fontconfig_get_filename(const std::string& font_fam, int styl
 		case SYNFIG_TO_FC(THIN);
 		case SYNFIG_TO_FC(ULTRALIGHT);
 		case SYNFIG_TO_FC(LIGHT);
+#if FC_VERSION >= 21191
 		case SYNFIG_TO_FC(SEMILIGHT);
+#else
+		case TEXT_WEIGHT_SEMILIGHT : fc_weight = FC_WEIGHT_LIGHT ; break;
+#endif
 		case SYNFIG_TO_FC(BOOK);
 		case SYNFIG_TO_FC(MEDIUM);
 		case SYNFIG_TO_FC(SEMIBOLD);


### PR DESCRIPTION
FC_WEIGHT_SEMILIGHT and FC_WEIGHT_DEMILIGHT were added in https://cgit.freedesktop.org/fontconfig/commit/fontconfig/fontconfig.h?id=be6506ca04ccce10868a8cd51d89e586284d149b

Release Notes:
https://github.com/freedesktop/fontconfig/blob/2.11.91/README

(Debian 9 uses 2.11.1)