### PR TITLE
fix(ffmpeg): logic for detection of image-only videos was inverted

### DIFF
--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -151,7 +151,7 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 	bool with_sound = false;
 	const std::string extension = etl::filename_extension(filename);
 	const std::vector<const char*> image_only_extensions{".gif", ".mng"};
-	const bool does_file_format_support_audio = std::find(image_only_extensions.begin(), image_only_extensions.end(), extension) != image_only_extensions.end();
+	const bool does_file_format_support_audio = std::find(image_only_extensions.begin(), image_only_extensions.end(), extension) == image_only_extensions.end();
 
 	if (!does_file_format_support_audio) {
 		with_sound = false;


### PR DESCRIPTION
error introduced by me in #2915 (c91ce50797be72fa56b59f4aa36c986ef504e7b4)