### PR TITLE
revert: "fix: after exporting audio via ffmpeg, SoundProcessor wasn't …

### DIFF
--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -174,8 +174,6 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 		if (!fs->is_exists(sound_filename)) {
 			with_sound = false;
 		}
-
-		SoundProcessor::subsys_stop();
 	}
 
 	String ffmpeg_binary_path;


### PR DESCRIPTION
…stopped (#2914)"

This reverts commit 7a13496534706c71a309273bc16126e68e28e85b.

It isn't needed and it makes Synfig crash on rendering via FFmpeg.
My mistake, sorry.

We should revert this PR or insert a reference counter in the SoundProcessor subsystem.