### PR TITLE
refactor: remove useless initialization in blur

### DIFF
--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -951,13 +951,6 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			float *SC2=new float[w+2];
 			float *SC3=new float[w+2];
 
-			memset(SC0,0,(w+2)*sizeof(float));
-			memset(SC0,0,(w+2)*sizeof(float));
-			memset(SC0,0,(w+2)*sizeof(float));
-			memset(SC0,0,(w+2)*sizeof(float));
-
-			//int i = 0;
-
 			while(bw&&bh)
 			{
 				if (!blurcall.amount_complete(max-(bw+bh),max)) {

--- a/synfig-core/src/synfig/blur/gaussian.h
+++ b/synfig-core/src/synfig/blur/gaussian.h
@@ -62,6 +62,7 @@ typename T::pointer SC3)
 	typename T::value_type Tmp1,Tmp2,SR0,SR1,SR2,SR3;
 
 	// Setup the row buffers
+	SC0[0] = SC0[1] = typename T::value_type();
 	for(x=0;x<w;x++)SC0[x+2]=(pen.x()[x])*24;
 	memset((void *)SC1,0,(w+2)*sizeof(typename T::value_type));
 	memset((void *)SC2,0,(w+2)*sizeof(typename T::value_type));


### PR DESCRIPTION
the gaussian_blur_5x5_() method already initializes it

And it was wrong anyway; it initializes the same array 4 times, and left the other 3 uninitialized.