### PR TITLE
feat: Support for animated webp with transparency

### DIFF
--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -128,6 +128,13 @@ AC_ARG_WITH(ffmpeg,
 ])
 AM_CONDITIONAL(WITH_FFMPEG, test $with_ffmpeg = yes)
 
+AC_ARG_WITH(webp,
+	AS_HELP_STRING(--without-webp, [do not support WEBP]),[
+],[
+	with_webp="yes"
+])
+AM_CONDITIONAL(WITH_WEBP, test $with_webp = yes)
+
 
 AC_ARG_WITH(vimage,
 	AS_HELP_STRING(--with-vimage, [support Apple vImage]),[
@@ -497,7 +504,7 @@ AC_CHECK_HEADERS([signal.h termios.h process.h io.h fcntl.h])
 
 # -- F U N C T I O N S ----------------------------------------
 
-AC_CHECK_FUNCS([fork]) # used by mod_dv, mod_ffmpeg, mod_imagemagick and synfig-osx launcher
+AC_CHECK_FUNCS([fork]) # used by mod_dv, mod_ffmpeg, mod_webp, mod_imagemagick and synfig-osx launcher
 AC_CHECK_FUNCS([pipe])
 AC_CHECK_FUNCS([waitpid])
 
@@ -560,6 +567,7 @@ src/modules/mod_png/Makefile
 src/modules/mod_ppm/Makefile
 src/modules/mod_yuv420p/Makefile
 src/modules/mod_svg/Makefile
+src/modules/mod_webp/Makefile
 src/modules/mod_example/Makefile
 src/tool/Makefile
 src/modules/synfig_modules.cfg
@@ -598,6 +606,7 @@ vImage ---------------------------> $with_vimage
 ImageMagick ----------------------> $with_imagemagick
 Magick++ -------------------------> $with_magickpp
 FFMPEG ---------------------------> $with_ffmpeg
+WEBP -----------------------------> $with_webp
 OpenGL ---------------------------> $with_opengl
 OpenCL ---------------------------> $with_opencl
 libdv ----------------------------> $with_libdv

--- a/synfig-core/src/modules/CMakeLists.txt
+++ b/synfig-core/src/modules/CMakeLists.txt
@@ -26,6 +26,7 @@ set(MODS_ENABLED
     mod_dv
     mod_example
     mod_ffmpeg
+    mod_webp
     mod_filter
     mod_geometry
     mod_gif

--- a/synfig-core/src/modules/Makefile.am
+++ b/synfig-core/src/modules/Makefile.am
@@ -4,53 +4,54 @@ MAINTAINERCLEANFILES = \
 	Makefile.in
 
 SUBDIRS = \
-	mod_particle \
-	mod_filter \
-	mod_yuv420p \
-	mod_gif \
-	mod_gradient \
-	mod_geometry \
-	mod_noise \
-	mod_libavcodec \
-	mod_jpeg \
-	mod_openexr \
-	mod_bmp \
-	mod_ppm \
-	mod_png \
-	mod_dv \
+	mod_particle    \
+	mod_filter      \
+	mod_yuv420p     \
+	mod_gif         \
+	mod_gradient    \
+	mod_geometry    \
+	mod_noise       \
+	mod_libavcodec  \
+	mod_jpeg        \
+	mod_openexr     \
+	mod_bmp         \
+	mod_ppm         \
+	mod_png         \
+	mod_dv          \
 	mod_imagemagick \
-	mod_ffmpeg \
-	lyr_freetype \
-	lyr_std \
-	mod_mng \
-	mod_svg \
-	mod_magickpp \
+	mod_ffmpeg      \
+	mod_webp        \
+	lyr_freetype    \
+	lyr_std         \
+	mod_mng         \
+	mod_svg         \
+	mod_magickpp    \
 	mod_example
 
 EXTRA_DIST = \
-	untemplate.nsh \
-	template.nsh \
-	mod_example/simplecircle.h \
-	mod_example/simplecircle.cpp \
-	mod_example/main.cpp \
-	mod_example/Makefile.am \
-	mod_example/metaballs.cpp \
-	mod_example/metaballs.h \
-	mod_mng/trgt_mng.h \
-	mod_mng/unmod_mng.nsh \
-	mod_mng/main.cpp \
-	mod_mng/Makefile.am \
-	mod_mng/mod_mng.nsh \
-	mod_mng/trgt_mng.cpp \
-	mptr_mplayer/main.cpp \
-	mptr_mplayer/mptr_mplayer.h \
-	mptr_mplayer/Makefile.am \
-	mptr_mplayer/mptr_mplayer.cpp \
-	mod_magickpp/trgt_magickpp.h \
+	untemplate.nsh                  \
+	template.nsh                    \
+	mod_example/simplecircle.h      \
+	mod_example/simplecircle.cpp    \
+	mod_example/main.cpp            \
+	mod_example/Makefile.am         \
+	mod_example/metaballs.cpp       \
+	mod_example/metaballs.h         \
+	mod_mng/trgt_mng.h              \
+	mod_mng/unmod_mng.nsh           \
+	mod_mng/main.cpp                \
+	mod_mng/Makefile.am             \
+	mod_mng/mod_mng.nsh             \
+	mod_mng/trgt_mng.cpp            \
+	mptr_mplayer/main.cpp           \
+	mptr_mplayer/mptr_mplayer.h     \
+	mptr_mplayer/Makefile.am        \
+	mptr_mplayer/mptr_mplayer.cpp   \
+	mod_magickpp/trgt_magickpp.h    \
 	mod_magickpp/unmod_magickpp.nsh \
-	mod_magickpp/main.cpp \
-	mod_magickpp/Makefile.am \
-	mod_magickpp/mod_magickpp.nsh \
+	mod_magickpp/main.cpp           \
+	mod_magickpp/Makefile.am        \
+	mod_magickpp/mod_magickpp.nsh   \
 	mod_magickpp/trgt_magickpp.cpp
 
 sysconf_DATA = synfig_modules.cfg

--- a/synfig-core/src/modules/mod_webp/CMakeLists.txt
+++ b/synfig-core/src/modules/mod_webp/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(mod_ffmpeg MODULE
+        "${CMAKE_CURRENT_LIST_DIR}/main.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/trgt_webp.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/mptr_webp.cpp"
+)
+
+target_link_libraries(mod_webp libsynfig)
+
+install (
+    TARGETS mod_webp
+    DESTINATION lib/synfig/modules
+)

--- a/synfig-core/src/modules/mod_webp/Makefile.am
+++ b/synfig-core/src/modules/mod_webp/Makefile.am
@@ -1,0 +1,39 @@
+MAINTAINERCLEANFILES = \
+	Makefile.in
+
+AM_CPPFLAGS = \
+	-I$(top_builddir) \
+	-I$(top_srcdir)/src
+
+
+moduledir = @MODULE_DIR@
+
+if WITH_WEBP
+
+module_LTLIBRARIES = libmod_webp.la
+
+libmod_webp_la_SOURCES =  \
+	main.cpp          \
+	mptr_webp.cpp     \
+	mptr_webp.h       \
+	trgt_webp.cpp     \
+	trgt_webp.h
+
+libmod_webp_la_LDFLAGS =  \
+	-module           \
+	-no-undefined     \
+	-avoid-version
+
+libmod_webp_la_CXXFLAGS = \
+	@SYNFIG_CFLAGS@
+
+libmod_webp_la_LIBADD =           \
+	../../synfig/libsynfig.la \
+	@SYNFIG_LIBS@
+
+endif
+
+
+EXTRA_DIST = \
+	mod_webp.nsh \
+	unmod_webp.nsh

--- a/synfig-core/src/modules/mod_webp/main.cpp
+++ b/synfig-core/src/modules/mod_webp/main.cpp
@@ -1,0 +1,64 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file mod_webp/main.cpp
+**	\brief Entry Point for WEBP (via FFMPEG) module (mod_webp)
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	Copyright (c) 2022 BobSynfig
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+**
+** ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#define SYNFIG_MODULE
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include <synfig/localization.h>
+#include <synfig/general.h>
+
+#include <synfig/module.h>
+#include "mptr_webp.h"
+#include "trgt_webp.h"
+#endif
+
+/* === E N T R Y P O I N T ================================================= */
+
+MODULE_DESC_BEGIN(mod_webp)
+	MODULE_NAME("WEBP (via FFMPEG) Module")
+	MODULE_DESCRIPTION("Provides output targets for format WEBP (via FFMPEG)")
+	MODULE_AUTHOR("BobSynfig")
+	MODULE_VERSION("1.0")
+	MODULE_COPYRIGHT(SYNFIG_COPYRIGHT)
+MODULE_DESC_END
+
+MODULE_INVENTORY_BEGIN(mod_webp)
+	BEGIN_TARGETS
+		TARGET(webp_trgt)
+		TARGET_EXT(webp_trgt, "webp")
+	END_TARGETS
+	BEGIN_IMPORTERS
+		IMPORTER_EXT(webp_mptr, "webp")
+	END_IMPORTERS
+MODULE_INVENTORY_END

--- a/synfig-core/src/modules/mod_webp/mod_webp.nsh
+++ b/synfig-core/src/modules/mod_webp/mod_webp.nsh
@@ -1,0 +1,21 @@
+; The stuff to install
+Section "mod_webp" Sec_mod_webp
+
+;  SectionIn RO
+  
+  ; Set output path to the installation directory.
+  SetOutPath "$INSTDIR\lib\synfig\modules"
+  
+  ; Put file there
+  File /oname=mod_webp.dll "src\modules\mod_webp\.libs\libmod_webp.dll"
+
+
+  FileOpen $0 $INSTDIR\etc\synfig_modules.cfg a
+  FileSeek $0 0 END
+  FileWrite $0 "mod_webp"
+  FileWriteByte $0 "13"
+  FileWriteByte $0 "10"
+  FileClose $0
+
+SectionEnd
+

--- a/synfig-core/src/modules/mod_webp/mptr_webp.cpp
+++ b/synfig-core/src/modules/mod_webp/mptr_webp.cpp
@@ -1,0 +1,198 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file mptr_webp.cpp
+**	\brief WEBP (via FFMPEG) Importer Module
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	Copyright (c) 2007 Chris Moore
+ **	Copyright (c) 2022 BobSynfig
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+**
+** ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include "mptr_webp.h"
+
+#include <ETL/stringf>
+
+#include <synfig/general.h>
+#include <synfig/localization.h>
+
+#if HAVE_IO_H
+ #include <io.h>
+#endif
+#if HAVE_PROCESS_H
+ #include <process.h>
+#endif
+#if HAVE_FCNTL_H
+ #include <fcntl.h>
+#endif
+#include <iostream>
+#endif
+
+/* === M A C R O S ========================================================= */
+
+using namespace synfig;
+using namespace etl;
+
+/* === G L O B A L S ======================================================= */
+
+SYNFIG_IMPORTER_INIT       ( webp_mptr );
+SYNFIG_IMPORTER_SET_NAME   ( webp_mptr, "webp" );
+SYNFIG_IMPORTER_SET_EXT    ( webp_mptr, "webp" ); // not working look at the main.cpp for list opf available extensions
+SYNFIG_IMPORTER_SET_VERSION( webp_mptr, "0.1"  );
+SYNFIG_IMPORTER_SET_SUPPORTS_FILE_SYSTEM_WRAPPER(webp_mptr, false);
+
+/* === M E T H O D S ======================================================= */
+
+bool webp_mptr::is_animated()
+{
+	return true;
+}
+
+bool
+webp_mptr::seek_to(const Time& time)
+{
+	//if(frame<cur_frame || !file)
+	//{
+		pipe = nullptr;
+
+		// FIXME: 24 fps is hardcoded now, but in fact we have to get it from canvas
+		//float position = (frame+1)/24; // webp didn't work with 0 frame
+		//float position = 1000/24; // webp didn't work with 0 frame
+		const std::string position = time.get_string(Time::FORMAT_NORMAL);
+
+		OS::RunArgs args;
+		args.push_back( { "-ss",      position                              });
+		args.push_back( {"-i",        filesystem::Path(identifier.filename) });
+		args.push_back( { "-vframes", "1"                                   });
+		args.push_back(   "-an"                                              );
+		args.push_back( { "-f",       "image2pipe"                          });
+		args.push_back( { "-vcodec",  "ppm"                                 });
+		args.push_back(   "-"                                                );
+
+#ifdef _WIN32
+		String binary_path = synfig::get_binary_path("");
+		if (binary_path != "")
+			binary_path = etl::dirname(binary_path)+ETL_DIRECTORY_SEPARATOR;
+		binary_path += "ffmpeg.exe";
+#else
+		String binary_path = "ffmpeg";
+#endif
+		pipe = OS::run_async(binary_path, args, OS::RUN_MODE_READ);
+
+		if (!pipe)
+		{
+			synfig::error( _("Unable to open pipe to ffmpeg") );
+			return false;
+		}
+		cur_frame = -1;
+	//}
+
+	//while(cur_frame<frame-1)
+	//{
+	//	cerr<<"Seeking to..."<<frame<<'('<<cur_frame<<')'<<endl;
+	//	if(!grab_frame())
+	//		return false;
+	//}
+	return true;
+}
+
+bool
+webp_mptr::grab_frame(void)
+{
+	if (!pipe)
+	{
+		synfig::error(_("unable to open %s"), identifier.filename.c_str());
+		return false;
+	}
+	int   w, h ;
+	float divisor;
+	char  cookie[2];
+	cookie[0] = pipe->getc();
+
+	if (pipe->eof()) return false;
+
+	cookie[1] = pipe->getc();
+
+	if ( cookie[0] != 'P' || cookie[1] != '6' )
+	{
+		synfig::error( _("stream not in PPM format \"%c%c\""), cookie[0], cookie[1] );
+		return false;
+	}
+
+	pipe->getc();
+	pipe->scanf( "%d %d\n",&w, &h  );
+	pipe->scanf( "%f",     &divisor);
+	pipe->getc();
+
+	if ( pipe->eof() ) return false;
+
+	frame.set_wh(w, h);
+	const ColorReal k = 1/255.0;
+	for ( int y = 0; y < frame.get_h(); ++y )
+		for ( int x = 0; x < frame.get_w(); ++x )
+		{
+			if (pipe->eof())
+				return false;
+			ColorReal r = k*(unsigned char)pipe->getc();
+			ColorReal g = k*(unsigned char)pipe->getc();
+			ColorReal b = k*(unsigned char)pipe->getc();
+			frame[y][x] = Color(r, g, b);
+		}
+	cur_frame++;
+	return true;
+}
+
+webp_mptr::webp_mptr(const synfig::FileSystem::Identifier &identifier):
+	synfig::Importer(identifier)
+{
+#ifdef HAVE_TERMIOS_H
+	tcgetattr (0, &oldtty);
+#endif
+	pipe      = nullptr;
+	fps       = 23.98;
+	cur_frame = -1;
+}
+
+webp_mptr::~webp_mptr()
+{
+	pipe = nullptr;
+#ifdef HAVE_TERMIOS_H
+	tcsetattr(0,TCSANOW,&oldtty);
+#endif
+}
+
+bool
+webp_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &/*renddesc*/, Time time, synfig::ProgressCallback *)
+{
+	synfig::warning("time: %f", (float)time);
+	if ( !seek_to(time) ) return false;
+	if ( !grab_frame()  ) return false;
+
+	surface = frame;
+	return true;
+}

--- a/synfig-core/src/modules/mod_webp/mptr_webp.h
+++ b/synfig-core/src/modules/mod_webp/mptr_webp.h
@@ -1,0 +1,77 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file mptr_webp.h
+**	\brief Header for WEBP (via FFMPEG) Importer (webp_mptr)
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+ *	Copyright (c) 2022 BobSynfig
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+**
+** ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef __SYNFIG_MPTR_WEBP_H
+#define __SYNFIG_MPTR_WEBP_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <synfig/importer.h>
+#include <synfig/os.h>
+#include <synfig/surface.h>
+
+#ifdef HAVE_TERMIOS_H
+#include <termios.h>
+#endif
+
+/* === M A C R O S ========================================================= */
+
+/* === T Y P E D E F S ===================================================== */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+class webp_mptr : public synfig::Importer
+{
+	SYNFIG_IMPORTER_MODULE_EXT
+private:
+	synfig::OS::RunPipe::Handle pipe;
+	int                         cur_frame;
+	synfig::Surface             frame;
+	float                       fps;
+#ifdef HAVE_TERMIOS_H
+	struct termios oldtty;
+#endif
+
+	bool seek_to   (const synfig::Time& time);
+	bool grab_frame(void);
+
+public:
+	webp_mptr(const synfig::FileSystem::Identifier &identifier);
+	~webp_mptr();
+
+	virtual bool is_animated();
+
+	virtual bool get_frame(      synfig::Surface          &surface,
+	                       const synfig::RendDesc         &renddesc,
+	                             synfig::Time              time,
+	                             synfig::ProgressCallback *callback);
+};
+
+/* === E N D =============================================================== */
+
+#endif

--- a/synfig-core/src/modules/mod_webp/trgt_webp.cpp
+++ b/synfig-core/src/modules/mod_webp/trgt_webp.cpp
@@ -1,0 +1,300 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file trgt_webp.cpp
+ **	\brief WEBP (via FFMPEG) Target Module
+ **
+ **	\legal
+ **	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+ **	Copyright (c) 2007 Chris Moore
+ **	Copyright (c) 2010 Diego Barrios Romero
+ **	Copyright (c) 2022 BobSynfig
+ **
+ **	This file is part of Synfig.
+ **
+ **	Synfig is free software: you can redistribute it and/or modify
+ **	it under the terms of the GNU General Public License as published by
+ **	the Free Software Foundation, either version 2 of the License, or
+ **	(at your option) any later version.
+ **
+ **	Synfig is distributed in the hope that it will be useful,
+ **	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **	GNU General Public License for more details.
+ **
+ **	You should have received a copy of the GNU General Public License
+ **	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+ **	\endlegal
+ **
+ ** ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include "trgt_webp.h"
+
+#include <ETL/stringf>
+
+#include <synfig/filesystemnative.h>
+#include <synfig/general.h>
+#include <synfig/localization.h>
+
+#endif
+
+/* === M A C R O S ========================================================= */
+
+using namespace synfig;
+
+/* === G L O B A L S ======================================================= */
+
+SYNFIG_TARGET_INIT       (webp_trgt);
+SYNFIG_TARGET_SET_NAME   (webp_trgt, "libwebp");
+SYNFIG_TARGET_SET_EXT    (webp_trgt, "webp"   );
+SYNFIG_TARGET_SET_VERSION(webp_trgt, "0.1"    );
+
+/* === M E T H O D S ======================================================= */
+
+bool
+webp_trgt::does_video_codec_support_alpha_channel( const synfig::String &video_codec ) const
+{
+/* TO BE CHANGED !*/
+	const std::vector<const char*> valid_codecs = {
+		"libwebp_anim" //vp8
+	};
+	return std::find( valid_codecs.begin()
+	                , valid_codecs.end()
+	                , video_codec
+	                ) != valid_codecs.end();
+
+}
+
+webp_trgt::webp_trgt( const char *Filename, const synfig::TargetParam &params ):
+	imagecount (0),
+	multi_image(false   ),
+	pipe       (nullptr ),
+	filename   (Filename),
+	bitrate    (),
+	loop       (params.loop    ), //true
+	lossless   (params.lossless), //true
+	quality    (params.quality ), //75.0
+	comp_lvl   (params.comp_lvl), // 6
+	preset     (params.preset  )  //"default"
+{
+	// Set default video codec if it wasn't given.
+	if (params.video_codec == "none")
+		video_codec = "libwebp_anim";
+	else
+		video_codec = params.video_codec;
+
+	if (does_video_codec_support_alpha_channel( video_codec ))
+		set_alpha_mode( TARGET_ALPHA_MODE_KEEP);
+	else
+		set_alpha_mode( TARGET_ALPHA_MODE_FILL );
+}
+
+webp_trgt::~webp_trgt()
+{
+	if (pipe) pipe->close();
+	pipe = nullptr;
+}
+
+bool
+webp_trgt::set_rend_desc(RendDesc *given_desc)
+{
+	//given_desc->set_pixel_format(PF_RGB);
+
+	// Make sure that the width and height
+	// are multiples of 8
+	//given_desc->set_w((given_desc->get_w()+4)/8*8);
+	//given_desc->set_h((given_desc->get_h()+4)/8*8);
+
+	// Make sure our width is divisible by two
+	//given_desc->set_w(given_desc->get_w()*2/2);
+	//given_desc->set_h(given_desc->get_h()*2/2);
+
+	//Max 16383 x 16383
+
+	desc = *given_desc;
+
+	return true;
+}
+
+bool
+webp_trgt::init( ProgressCallback* cb = nullptr )
+{
+
+	String ffmpeg_binary_path;
+#ifdef _WIN32
+	// Windows always have ffmpeg
+	ffmpeg_binary_path = etl::dirname(synfig::get_binary_path(".")) + "/ffmpeg.exe";
+	if (!FileSystemNative::instance()->is_file(ffmpeg_binary_path)) {
+		synfig::error("Expected FFmpeg binary not found: %s", ffmpeg_binary_path.c_str());
+		ffmpeg_binary_path.clear();
+	}
+#else
+	// Some Linux OS may have `avconv` instead of `ffmpeg`, so let's check both
+	const std::vector<std::string> binary_choices = {"ffmpeg", "avconv"};
+
+	for (const auto& bin_name : binary_choices) {
+		OS::RunArgs args;
+		args.push_back(bin_name);
+		OS::RunPipe::Handle pipe = OS::run_async("which", args, OS::RUN_MODE_READ);
+
+		if (!pipe) {
+			synfig::error(_("%s: Internal error: couldn't run 'which' async"), "trgt_webp");
+			continue;
+		}
+
+		std::string result = pipe->read_contents();
+		int         status = pipe->close();
+
+		synfig::info("which %s -> [%i] %s", args.get_string().c_str(), status, result.c_str());
+		if ( status == 0 ) {
+			ffmpeg_binary_path = bin_name; // we can use `result` value here, but in this case we need to remove trailing `\n`
+			break;
+		}
+	}
+#endif
+
+	if ( ffmpeg_binary_path.empty() ) {
+		if (cb) cb->error(_("Error: No FFmpeg binary found.\n\nPlease install \"ffmpeg\" or \"avconv\" (libav-tools package)."));
+		return false;
+	}
+
+	imagecount = desc.get_frame_start();
+	if ( desc.get_frame_end() - desc.get_frame_start() > 0 )
+		multi_image = true;
+
+	const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
+
+	OS::RunArgs vargs;
+/*
+	vargs.push_back( "-analyzeduration");    vargs.push_back( "2147483647" );
+	vargs.push_back( "-probesize"      );    vargs.push_back( "2147483647" );
+*/
+	//Overwrite output files
+	vargs.push_back( "-y" );
+
+	//Use Pipe as input stream
+	vargs.push_back({"-f",                 "image2pipe"                   });
+	vargs.push_back({"-vcodec",            use_alpha ? "pam" : "ppm"      });
+
+	vargs.push_back({"-i",                 "pipe:"                        });
+	vargs.push_back({"-metadata",
+	                 strprintf( "title=\"%s\"",
+	                            get_canvas()->get_name().c_str())         });
+	vargs.push_back({"-vcodec",            video_codec                    });
+	vargs.push_back({"-loop",              loop     ? "0" : "1"           });
+	vargs.push_back({"-lossless",          lossless ? "1" : "0"           });
+	vargs.push_back({"-compression_level", strprintf( "%i", comp_lvl )    });
+	//vargs.push_back({"-vsync",             "0"                          }); Not with rate!
+	vargs.push_back({"-preset",            preset                         });
+	vargs.push_back({"-pix_fmt",           use_alpha?"yuva420p":"yuv420p" }); //Needed for transparency
+	vargs.push_back( "-an" );
+
+	{//Duration + Quality + Frame rate
+		// this should avoid conflicts with locale settings
+		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
+		//Quality
+		vargs.push_back( {"-q:v", strprintf( "%.1f", quality ) });
+		//Duration
+		vargs.push_back( {"-t",
+		                  desc.get_duration().get_string(Time::Format::FORMAT_VIDEO)});
+		//Frame rate
+		vargs.push_back( {"-r",
+		                  strprintf( "%.3f", desc.get_frame_rate() ) });
+	}
+
+	// We need "--" to separate filename from arguments
+	//(for the case when filename starts with "-")
+	if ( filename.substr(0, 1) == "-" ) vargs.push_back("--");
+
+	vargs.push_back( filesystem::Path(filename) );
+
+	pipe = OS::run_async(ffmpeg_binary_path, vargs, OS::RUN_MODE_WRITE);
+
+	if ( !pipe || !pipe->is_writable() )
+	{
+		synfig::error( _("Unable to open pipe to ffmpeg (no file)") );
+		if (pipe) {
+			pipe->close();
+			pipe = nullptr;
+		}
+		return false;
+	}
+
+	synfig::info( _("Running async command: %s")
+	            , pipe->get_command().c_str()  );
+
+	return true;
+}
+
+void
+webp_trgt::end_frame()
+{
+	pipe->flush();
+	imagecount++;
+}
+
+bool
+webp_trgt::start_frame(synfig::ProgressCallback */*callback*/)
+{
+	std::size_t w = desc.get_w();
+	std::size_t h = desc.get_h();
+
+	if ( !pipe || !pipe->is_writable() )
+		return false;
+
+	const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
+
+	if (!use_alpha) {
+		pipe->printf( "P6\n"                 );
+		pipe->printf( "%zu %zu\n",      w, h );
+		pipe->printf( "%d\n",            255 );
+	} else {
+		pipe->printf( "P7\n"                 );
+		pipe->printf( "WIDTH %zu\n",       w );
+		pipe->printf( "HEIGHT %zu\n",      h );
+		pipe->printf( "DEPTH 4\n"            );
+		pipe->printf( "MAXVAL %d\n",     255 );
+		pipe->printf( "TUPLTYPE RGB_ALPHA\n" );
+		pipe->printf( "ENDHDR\n"             );
+	}
+
+	buffer.resize(w * (use_alpha ? 4 : 3));
+	color_buffer.resize(w);
+
+	return true;
+}
+
+Color *
+webp_trgt::start_scanline(int /*scanline*/)
+{
+	return color_buffer.data();
+}
+
+bool
+webp_trgt::end_scanline()
+{
+	if (!pipe) return false;
+
+	const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
+
+	PixelFormat format = use_alpha ? PF_RGB|PF_A : PF_RGB;
+
+	color_to_pixelformat( buffer.data()
+	                    , color_buffer.data()
+	                    , format
+	                    , 0
+	                    , desc.get_w()
+	                    );
+
+	if ( !pipe->write( buffer.data(), 1, buffer.size() ) )
+		return false;
+
+	return true;
+}

--- a/synfig-core/src/modules/mod_webp/trgt_webp.h
+++ b/synfig-core/src/modules/mod_webp/trgt_webp.h
@@ -1,0 +1,91 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file trgt_webp.h
+**	\brief Header for WEBP (via FFMPEG) Exporter (webp_trgt)
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	Copyright (c) 2010 Diego Barrios Romero
+**	Copyright (c) 2022 BobSynfig
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+**
+** ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef __SYNFIG_TRGT_WEBP_H
+#define __SYNFIG_TRGT_WEBP_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <synfig/os.h>
+#include <synfig/string.h>
+#include <synfig/target_scanline.h>
+
+/* === M A C R O S ========================================================= */
+
+/* === T Y P E D E F S ===================================================== */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+class TargetParam;
+
+class webp_trgt : public synfig::Target_Scanline
+{
+	SYNFIG_TARGET_MODULE_EXT
+
+private:
+	int                         imagecount;
+	bool                        multi_image;
+	synfig::OS::RunPipe::Handle pipe;
+	synfig::String              filename;
+	std::vector<unsigned char>  buffer;
+	std::vector<synfig::Color>  color_buffer;
+	std::string                 video_codec; //Not used
+	int                         bitrate;     //Not used
+
+	bool                        loop;
+	bool                        no_audio;
+	bool                        lossless;
+	float                       quality;     //qscale 0.0-100.0
+	int                         comp_lvl;    //0-6
+	synfig::String              preset;
+
+	bool does_video_codec_support_alpha_channel(const synfig::String& video_codec) const;
+
+public:
+
+	webp_trgt(const char                *filename,
+	          const synfig::TargetParam& params);
+	virtual ~webp_trgt();
+
+	bool set_rend_desc(synfig::RendDesc* desc)     override;
+
+	//! Initialization tasks of webp target.
+	//! @returns true if the initialization has no errors
+	bool init       (synfig::ProgressCallback* cb) override;
+
+	bool start_frame(synfig::ProgressCallback* cb) override;
+	void end_frame  ()                             override;
+
+	synfig::Color* start_scanline(int scanline)    override;
+	bool           end_scanline()                  override;
+};
+
+/* === E N D =============================================================== */
+
+#endif

--- a/synfig-core/src/modules/mod_webp/unmod_webp.nsh
+++ b/synfig-core/src/modules/mod_webp/unmod_webp.nsh
@@ -1,0 +1,8 @@
+Section "un.mod_webp"
+	Delete "$INSTDIR\lib\synfig\modules\mod_webp.dll"
+	RMDir "$INSTDIR\lib\synfig\modules"
+	RMDir "$INSTDIR\lib\synfig"
+	RMDir "$INSTDIR\lib"
+	RMDir "$INSTDIR"
+SectionEnd
+

--- a/synfig-core/src/modules/synfig_modules.cfg.in
+++ b/synfig-core/src/modules/synfig_modules.cfg.in
@@ -12,6 +12,7 @@ mod_mng
 mod_noise
 mod_filter
 mod_ffmpeg
+mod_webp
 mod_bmp
 mod_dv
 mod_png

--- a/synfig-core/src/synfig/targetparam.h
+++ b/synfig-core/src/synfig/targetparam.h
@@ -4,6 +4,7 @@
 **
 **	\legal
 **	Copyright (c) 2010 Diego Barrios Romero
+**	Copyright (c) 2022 BobSynfig
 **
 **	This file is part of Synfig.
 **
@@ -41,26 +42,53 @@ struct TargetParam
 		HR = 0, //Horizontal 
 		VR = 1  //Vertical
 	};
-	
+
 	//! Constructor
 	/*! Not valid default values, if they are not modified before
 	 *  passing them to the target module, it would override them with
 	 *  its own valid default settings.
 	 */
-	TargetParam (const std::string& Video_codec = "none", int Bitrate = -1):
-		video_codec(Video_codec), bitrate(Bitrate), sequence_separator("."), offset_x(0), offset_y(0),rows(0),columns(0),append(true),dir(HR)
+	TargetParam( const std::string& Video_codec = "none"
+	           , int                Bitrate     = -1
+	           ):
+		video_codec       (Video_codec),
+		bitrate           (Bitrate),
+
+		sequence_separator("."),
+		offset_x          (0),
+		offset_y          (0),
+		rows              (0),
+		columns           (0),
+		append            (true),
+		dir               (HR),
+
+		//<!-- Added for Webp support
+		comp_lvl          ( 4  ),
+		loop              (true),
+		lossless          (true),
+		quality           (75.0),
+		preset            ("default")
+		//-->  Added for Webp support
 	{ }
 
 	std::string video_codec;
-	int bitrate;
+	int         bitrate;
 	std::string sequence_separator;
 	//TODO: It is a spike. Need to separate this class.
-	int offset_x;
-	int offset_y;
-	int rows;
-	int columns;
-	bool append;
-	Direction dir;
+	int         offset_x;
+	int         offset_y;
+	int         rows;
+	int         columns;
+	bool        append;
+	Direction   dir;
+
+	//<!-- Added for Webp support
+	int         comp_lvl;
+	bool        loop;
+	bool        lossless;
+	float       quality;
+	std::string preset;
+	//-->  Added for Webp support
 };
 
 }; // END of namespace synfig

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1487,7 +1487,7 @@ void App::init(const synfig::String& rootpath)
 	String path_to_plugins = ResourceHelper::get_plugin_path();
 
 	String path_to_user_plugins = synfigapp::Main::get_user_app_directory() + "/plugins";
-	
+
 	ui_interface_=new GlobalUIInterface();
 
 	// don't call thread_init() if threads are already initialized
@@ -1496,7 +1496,7 @@ void App::init(const synfig::String& rootpath)
 	//	Glib::thread_init();
 
 	distance_system=Distance::SYSTEM_PIXELS;
-	
+
 #ifdef _WIN32
 	// Do not show "No disc in drive" errors
 	// - https://github.com/synfig/synfig/issues/489
@@ -1873,7 +1873,7 @@ App::on_shutdown()
 
 	if (sound_render_done) delete sound_render_done;
 	sound_render_done = nullptr;
-	
+
 	process_all_events();
 	delete main_window;
 }
@@ -2398,7 +2398,7 @@ App::quit()
 	if (shutdown_in_progress) return;
 
 	get_ui_interface()->task(_("Quit Request"));
-	
+
 	if(Busy::count)
 	{
 		dialog_message_1b(
@@ -2503,6 +2503,7 @@ App::dialog_open_file_ext(const std::string &title, std::vector<std::string> &fi
 	filter_supported->add_mime_type("image/svg+xml");
 	filter_supported->add_mime_type("application/x-krita");
 	filter_supported->add_mime_type("image/openraster");
+	filter_supported->add_mime_type("image/webp");
 	filter_supported->add_pattern("*.png");
 	filter_supported->add_pattern("*.jpeg");
 	filter_supported->add_pattern("*.jpg");
@@ -2511,6 +2512,7 @@ App::dialog_open_file_ext(const std::string &title, std::vector<std::string> &fi
 	filter_supported->add_pattern("*.lst");
 	filter_supported->add_pattern("*.kra");
 	filter_supported->add_pattern("*.ora");
+	filter_supported->add_pattern("*.webp");
 	// 0.3 Audio files
 	filter_supported->add_mime_type("audio/x-vorbis+ogg");
 	filter_supported->add_mime_type("audio/mpeg");
@@ -2537,17 +2539,19 @@ App::dialog_open_file_ext(const std::string &title, std::vector<std::string> &fi
 
 	// 2.1 Image files
 	Glib::RefPtr<Gtk::FileFilter> filter_image = Gtk::FileFilter::create();
-	filter_image->set_name(_("Images (*.png, *.jpeg, *.bmp, *.svg)"));
+	filter_image->set_name(_("Images (*.png, *.jpeg, *.bmp, *.svg, *.webp)"));
 	filter_image->add_mime_type("image/png");
 	filter_image->add_mime_type("image/jpeg");
 	filter_image->add_mime_type("image/jpg");
 	filter_image->add_mime_type("image/bmp");
 	filter_image->add_mime_type("image/svg+xml");
+	filter_image->add_mime_type("image/webp");
 	filter_image->add_pattern("*.png");
 	filter_image->add_pattern("*.jpeg");
 	filter_image->add_pattern("*.jpg");
 	filter_image->add_pattern("*.bmp");
 	filter_image->add_pattern("*.svg");
+	filter_image->add_pattern("*.webp");
 
 	// 2.2 Image sequence/list files
 	Glib::RefPtr<Gtk::FileFilter> filter_image_list = Gtk::FileFilter::create();
@@ -2621,7 +2625,7 @@ App::dialog_open_file(const std::string &title, std::string &filename, std::stri
 {
 	std::vector<std::string> filenames;
 	if (!filename.empty())
-        filenames.push_back(filename);
+		filenames.push_back(filename);
 	if(dialog_open_file_ext(title, filenames, preference, false)) {
 		filename = filenames.front();
 		return true;
@@ -2739,18 +2743,20 @@ App::dialog_open_file_image(const std::string &title, std::string &filename, std
 
 	// show only images
 	Glib::RefPtr<Gtk::FileFilter> filter_image = Gtk::FileFilter::create();
-	filter_image->set_name(_("Images and sequence files (*.png, *.jpg, *.jpeg, *.bmp, *.svg, *.lst)"));
+	filter_image->set_name(_("Images and sequence files (*.png, *.jpg, *.jpeg, *.bmp, *.svg, *.lst, *.webp"));
 	filter_image->add_mime_type("image/png");
 	filter_image->add_mime_type("image/jpeg");
 	filter_image->add_mime_type("image/jpg");
 	filter_image->add_mime_type("image/bmp");
 	filter_image->add_mime_type("image/svg+xml");
+	filter_image->add_mime_type("image/webp");
 	filter_image->add_pattern("*.png");
 	filter_image->add_pattern("*.jpeg");
 	filter_image->add_pattern("*.jpg");
 	filter_image->add_pattern("*.bmp");
 	filter_image->add_pattern("*.svg");
 	filter_image->add_pattern("*.lst");
+	filter_image->add_pattern("*.webp");
 	dialog->add_filter(filter_image);
 
 	// Any files
@@ -2863,7 +2869,7 @@ App::dialog_open_file_image_sequence(const std::string &title, std::set<synfig::
 	filter_any->set_name(_("Any files"));
 	filter_any->add_pattern("*");
 	dialog->add_filter(filter_any);
-	
+
 	dialog->set_extra_widget(*scale_imported_box());
 
 	std::string filename = filenames.empty() ? std::string() : *filenames.begin();
@@ -4359,7 +4365,7 @@ App::set_selected_instance(etl::loose_handle<Instance> instance)
 {
 	if (selected_instance == instance)
 		return;
-	
+
 	if (get_selected_canvas_view() && get_selected_canvas_view()->get_instance() != instance) {
 		if (instance) {
 			instance->focus( instance->get_canvas() );
@@ -4377,7 +4383,7 @@ App::set_selected_canvas_view(etl::loose_handle<CanvasView> canvas_view)
 {
 	if (selected_canvas_view == canvas_view)
 		return;
-	
+
 	etl::loose_handle<CanvasView> prev = selected_canvas_view;
 	etl::loose_handle<Instance> prev_instance = selected_instance;
 
@@ -4448,19 +4454,19 @@ studio::App::scale_imported_box()
 	Gtk::Box *box = manage(new Gtk::Box);
 	Gtk::Label *label_resize = manage(new Gtk::Label(_("Scale to fit Canvas")));
 	Gtk::Switch *toggle_resize = manage(new Gtk::Switch);
-	
+
 	label_resize->set_margin_end(5);
 	toggle_resize->set_valign(Gtk::ALIGN_CENTER);
 	toggle_resize->set_active(App::resize_imported_images);
-	
+
 	toggle_resize->property_active().signal_changed().connect(
 		sigc::mem_fun(*App::dialog_setup, &studio::Dialog_Setup::on_resize_imported_changed));
-	
+
 	box->pack_start(*label_resize, false, false);
 	box->pack_end(*toggle_resize, false, false);
 	box->set_tooltip_text(_("Check this to scale imported images to Canvas size"));
 	box->show_all();
-	
+
 	return box;
 }
 

--- a/synfig-studio/src/gui/dialogs/CMakeLists.txt
+++ b/synfig-studio/src/gui/dialogs/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(synfigstudio
         "${CMAKE_CURRENT_LIST_DIR}/dialog_soundselect.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dialog_targetparam.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dialog_ffmpegparam.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/dialog_webpparam.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dialog_spritesheetparam.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dialog_waypoint.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/dialog_workspaces.cpp"

--- a/synfig-studio/src/gui/dialogs/Makefile_insert
+++ b/synfig-studio/src/gui/dialogs/Makefile_insert
@@ -12,6 +12,7 @@ DIALOGS_HH = \
 	dialogs/dialog_soundselect.h \
 	dialogs/dialog_targetparam.h \
 	dialogs/dialog_ffmpegparam.h \
+	dialogs/dialog_webpparam.h \
 	dialogs/dialog_spritesheetparam.h \
 	dialogs/dialog_waypoint.h \
 	dialogs/dialog_workspaces.h \
@@ -32,6 +33,7 @@ DIALOGS_CC = \
 	dialogs/dialog_soundselect.cpp \
 	dialogs/dialog_targetparam.cpp \
 	dialogs/dialog_ffmpegparam.cpp \
+	dialogs/dialog_webpparam.cpp \
 	dialogs/dialog_spritesheetparam.cpp \
 	dialogs/dialog_waypoint.cpp \
 	dialogs/dialog_workspaces.cpp \

--- a/synfig-studio/src/gui/dialogs/dialog_webpparam.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_webpparam.cpp
@@ -1,0 +1,280 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file dialogs/dialog_webpparam.cpp
+**	\brief Implementation for the WebpParam Dialog
+**
+**	\legal
+**	Copyright (c) 2010 Carlos López González
+**	Copyright (c) 2015 Denis Zdorovtsov
+**	Copyright (c) 2022 BobSynfig
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+//https://developers.google.com/speed/webp/docs/cwebp
+//http://underpop.online.fr/f/ffmpeg/help/libwebp.htm.gz
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include <gui/dialogs/dialog_webpparam.h>
+#include <gui/localization.h>
+
+#endif
+
+/* === U S I N G =========================================================== */
+
+using namespace studio;
+
+/* === M A C R O S ========================================================= */
+
+/* === G L O B A L S ======================================================= */
+
+// Presets   name/id,  description
+static const std::map<const char*, const char*> preset_types = {
+	{"none",    _("Do not use a preset."                            )},
+	{"default", _("Use the encoder default."                        )},
+	{"picture", _("Digital picture, like portrait, inner shot"      )},
+	{"photo",   _("Outdoor photograph, with natural lighting"       )},
+	{"drawing", _("Hand or line drawing, with high-contrast details")},
+	{"icon",    _("Small-sized colorful images"                     )},
+	{"text",    _("Text-like"                                       )}
+};
+
+// Codec     name/id,  description
+static const std::map<const char*, const char*> codec_types = {
+	{"libwebp_anim",  _("Better for transparent animations"         )},
+	{"libwebp",       _("Standard"                                  )}
+};
+
+/* === P R O C E D U R E S ================================================= */
+
+/* === M E T H O D S ======================================================= */
+
+Dialog_WebpParam::Dialog_WebpParam(Gtk::Window &parent):
+	Dialog_TargetParam(parent, _("Webp Parameters"))
+{
+	this->set_resizable(false);
+
+	//<!-- Video codec
+	rb_wanim = Gtk::manage( new Gtk::RadioButton( "libwebp_anim" ) );
+	rb_wanim->set_active();
+	rb_wanim->signal_toggled().connect(
+	        sigc::mem_fun( *this, &Dialog_WebpParam::on_webp_wanim_toggled )
+	        );
+
+	rb_webp  = Gtk::manage( new Gtk::RadioButton( "libwebp"      ) );
+	rb_webp->join_group(*rb_wanim);
+	rb_webp->signal_toggled().connect(
+	        sigc::mem_fun( *this, &Dialog_WebpParam::on_webp_wanim_toggled )
+	        );
+
+	webp_desc = Gtk::manage( new Gtk::Entry() );
+	webp_desc->set_placeholder_text( _("Codec description") );
+	webp_desc->set_sensitive(false);
+
+	on_webp_wanim_toggled(); //Initialize
+	//->  Video codec
+
+	rb_lossless = Gtk::manage( new Gtk::RadioButton( _("Lossless") ) );
+	rb_lossless->set_active();
+	rb_lossless->signal_toggled().connect(
+	        sigc::mem_fun( *this, &Dialog_WebpParam::on_lossy_lossless_toggled )
+	        );
+
+	rb_lossy    = Gtk::manage( new Gtk::RadioButton( _("Lossy"   ) ) );
+	rb_lossy->join_group(*rb_lossless);
+	rb_lossy->signal_toggled().connect(
+	        sigc::mem_fun( *this, &Dialog_WebpParam::on_lossy_lossless_toggled )
+	        );
+
+	//Checkbox
+	cb_loop     = Gtk::manage( new Gtk::CheckButton( _("Loop animation"), true) );
+
+	//Quality
+	l_quality   = Gtk::manage( new Gtk::Label( _("Quality (0-100):") ) );
+	l_quality->set_halign( Gtk::ALIGN_START  );
+	l_quality->set_valign( Gtk::ALIGN_CENTER );
+
+	sb_quality  = Gtk::manage( new Gtk::SpinButton( Gtk::Adjustment::create( 75.0, 0.0,100.0 ) ) );
+	sb_quality->set_alignment(1.0);
+
+	//Compression Level
+	l_comp_lvl  = Gtk::manage( new Gtk::Label( _("Compression Level (0-6):" ) ) );
+	l_comp_lvl->set_halign( Gtk::ALIGN_START  );
+	l_comp_lvl->set_valign( Gtk::ALIGN_CENTER );
+
+	sb_comp_lvl = Gtk::manage( new Gtk::SpinButton(Gtk::Adjustment::create(4, 0, 6)) );
+	sb_comp_lvl->set_alignment(1.0);
+
+	//Preset
+	l_preset    = Gtk::manage( new Gtk::Label( _("Preset:") ) );
+	l_preset->set_halign( Gtk::ALIGN_START  );
+	l_preset->set_valign( Gtk::ALIGN_CENTER );
+
+	preset_desc = Gtk::manage( new Gtk::Entry() );
+	preset_desc->set_placeholder_text( _("Preset Description") );
+	preset_desc->set_sensitive(false);
+
+	cbt_preset  = Gtk::manage( new Gtk::ComboBoxText() );
+	// Appends the preset id and display to the Combo Box
+	for (const auto& item : preset_types)
+		cbt_preset->append( item.first, item.first ); //Not a mistake!
+
+	cbt_preset->signal_changed().connect(
+	        sigc::mem_fun( *this, &Dialog_WebpParam::on_preset_change )
+	        );
+
+	separator1 = Gtk::manage( new Gtk::Separator() );
+	separator2 = Gtk::manage( new Gtk::Separator() );
+	separator3 = Gtk::manage( new Gtk::Separator() );
+
+	//Grid
+	grid       = Gtk::manage( new Gtk::Grid() );
+
+	//It is easier to use a row index instead of modify row in grid in case
+	//of change of layout
+	int row = 0;
+	//                           X,    Y,  W,  H
+	grid->attach( *rb_wanim,     0,  row,  2,  1 );
+	grid->attach( *rb_webp,      2,  row,  2,  1 );
+	row++;
+	grid->attach( *webp_desc,    0,  row,  5,  1 );
+	row++;
+
+	grid->attach( *separator1,   0,  row,  5,  1 );
+	row++;
+
+	grid->attach( *rb_lossless,  0,  row,  2,  1 );
+	grid->attach( *rb_lossy,     2,  row,  2,  1 );
+	row++;
+
+	grid->attach( *l_quality,    0,  row,  2,  1 );
+	grid->attach( *sb_quality,   3,  row,  2,  1 );
+	row++;
+
+	grid->attach( *l_comp_lvl,   0,  row,  2,  1 );
+	grid->attach( *sb_comp_lvl,  3,  row,  2,  1 );
+	row++;
+
+	grid->attach( *separator2,   0,  row,  5,  1 );
+	row++;
+
+	grid->attach( *l_preset,     0,  row,  5,  1 );
+	row++;
+
+	grid->attach( *cbt_preset,   0,  row,  5,  1 );
+	row++;
+
+	grid->attach( *preset_desc,  0,  row,  5,  1 );
+	row++;
+
+	grid->attach( *separator3,   0,  row,  5,  1 );
+	row++;
+
+	grid->attach( *cb_loop,      0,  row,  5,  1 );
+	row++;
+
+	grid->set_row_spacing   (4);
+	grid->set_column_spacing(2);
+	grid->set_border_width  (8);
+	grid->show_all();
+
+	get_content_area()->pack_start( *grid, true, true, 0 );
+	get_content_area()->show_all();
+}
+
+Dialog_WebpParam::~Dialog_WebpParam()
+{
+}
+
+void
+Dialog_WebpParam::init()
+{
+	// By default, set the active text to the preset
+	cbt_preset->set_active_id( get_tparam().preset );
+	for (const auto& item : preset_types) {
+		if ( cbt_preset->get_active_id() == item.first  ) {
+			cbt_preset ->set_active_id( item.first  );
+			preset_desc->set_text     ( item.second );
+			break;
+		}
+	}
+
+	sb_comp_lvl->set_value (   int( get_tparam().comp_lvl ));
+	cb_loop    ->set_active(  bool( get_tparam().loop     ));
+	rb_lossless->set_active(  bool( get_tparam().lossless ));
+	rb_lossy   ->set_active(  bool(!get_tparam().lossless ));
+	sb_quality ->set_value ( float( get_tparam().quality  ));
+
+	//By default video_codec could be something else, like mpeg4
+	bool is_anim = !("libwebp" == get_tparam().video_codec);
+	rb_wanim   ->set_active(  is_anim );
+	rb_webp    ->set_active( !is_anim );
+
+
+}
+
+void
+Dialog_WebpParam::write_tparam( synfig::TargetParam & tparam_ )
+{
+	tparam_.comp_lvl = sb_comp_lvl->get_value();
+	tparam_.lossless = rb_lossless->get_active();
+	tparam_.loop     = cb_loop    ->get_active();
+	tparam_.preset   = cbt_preset ->get_active_id();
+	tparam_.quality  = sb_quality ->get_value();
+
+	tparam_.video_codec = rb_wanim->get_active()
+	                    ? "libwebp_anim"
+	                    : "libwebp";
+}
+
+void
+Dialog_WebpParam::on_preset_change()
+{
+	for (const auto& item : preset_types) {
+		if ( cbt_preset->get_active_id() == item.first ) {
+			cbt_preset ->set_active_id( item.first  );
+			preset_desc->set_text     ( item.second );
+			break;
+		}
+	}
+}
+
+void
+Dialog_WebpParam::on_webp_wanim_toggled()
+{
+	std::string current_codec = rb_wanim->get_active()
+	                          ? "libwebp_anim"
+	                          : "libwebp";
+
+	for (const auto& item : codec_types) {
+		if ( current_codec == item.first ) {
+			webp_desc->set_text( item.second );
+			break;
+		}
+	}
+}
+
+void
+Dialog_WebpParam::on_lossy_lossless_toggled()
+{
+}

--- a/synfig-studio/src/gui/dialogs/dialog_webpparam.h
+++ b/synfig-studio/src/gui/dialogs/dialog_webpparam.h
@@ -1,0 +1,94 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file dialogs/dialog_webpparam.h
+**	\brief FFmpegParam Dialog header
+**
+**	\legal
+**	Copyright (c) 2010 Carlos López González
+**	Copyright (c) 2015 Denis Zdorovtsov
+**	Copyright (c) 2022 BobSynfig
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef __SYNFIG_STUDIO_DIALOG_WEBPPARAM_H
+#define __SYNFIG_STUDIO_DIALOG_WEBPPARAM_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <gtkmm/checkbutton.h>
+#include <gtkmm/comboboxtext.h>
+#include <gtkmm/grid.h>
+#include <gtkmm/radiobutton.h>
+#include <gtkmm/spinbutton.h>
+#include <gtkmm/separator.h>
+
+#include <gui/dialogs/dialog_targetparam.h>
+
+/* === M A C R O S ========================================================= */
+
+/* === T Y P E D E F S ===================================================== */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace studio {
+
+class Dialog_WebpParam : public Dialog_TargetParam
+{
+public:
+	Dialog_WebpParam(Gtk::Window &parent);
+	~Dialog_WebpParam();
+
+protected:
+	virtual void init();
+	virtual void write_tparam(synfig::TargetParam & tparam);
+
+private:
+	Gtk::Grid         *grid;
+
+	Gtk::Label        *l_quality;
+	Gtk::Label        *l_comp_lvl;
+	Gtk::Label        *l_preset;
+
+	Gtk::Separator    *separator1;
+	Gtk::Separator    *separator2;
+	Gtk::Separator    *separator3;
+	Gtk::Entry        *preset_desc;
+
+	Gtk::RadioButton  *rb_wanim;
+	Gtk::RadioButton  *rb_webp;
+	Gtk::RadioButton  *rb_lossless;
+	Gtk::RadioButton  *rb_lossy;
+	Gtk::Entry        *webp_desc;
+
+	Gtk::CheckButton  *cb_loop;     //loop
+	Gtk::SpinButton   *sb_quality;  //quality  qscale float  (0-100 def 75)
+	Gtk::SpinButton   *sb_comp_lvl; //compression level int  (0-6   def  4)
+	Gtk::ComboBoxText *cbt_preset;  //
+
+	void on_preset_change();
+	void on_lossy_lossless_toggled();
+	void on_webp_wanim_toggled();
+};
+
+}; // END of namespace studio
+
+/* === E N D =============================================================== */
+
+#endif //__SYNFIG_STUDIO_DIALOG_WEBPPARAM_H

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -51,6 +51,7 @@
 #include <gui/app.h>
 #include <gui/asyncrenderer.h>
 #include <gui/dialogs/dialog_ffmpegparam.h>
+#include <gui/dialogs/dialog_webpparam.h>
 #include <gui/dialogs/dialog_spritesheetparam.h>
 #include <gui/docks/dockmanager.h>
 #include <gui/docks/dock_info.h>
@@ -247,7 +248,7 @@ RenderSettings::set_entry_filename()
 
 	if (!is_absolute_path(filename))
 		filename = Glib::get_home_dir() + ETL_DIRECTORY_SEPARATOR + filename;
-	
+
 	try
 	{
 		if(!comboboxtext_target.get_active_row_number())
@@ -265,16 +266,29 @@ RenderSettings::set_entry_filename()
 void
 RenderSettings::on_comboboxtext_target_changed()
 {
-	std::map<std::string,std::string> ext = {{"bmp",".bmp"}, {"dv",".dv"},
-					{"ffmpeg",".avi"},{"gif",".gif"},{"imagemagick",".png"}, {"jpeg",".jpg"},
-					{"magick++",".gif"},{"mng",".mng"},{"openexr",".exr"},{"png",".png"},
-					{"png-spritesheet",".png"},{"ppm",".ppm"}, {"yuv420p",".yuv"}, {"libav",".avi"}};
+	std::map<std::string,std::string> ext = {
+		{"bmp",            ".bmp"},
+		{"dv",             ".dv" },
+		{"ffmpeg",         ".avi"},
+		{"gif",            ".gif"},
+		{"imagemagick",    ".png"},
+		{"jpeg",           ".jpg"},
+		{"magick++",       ".gif"},
+		{"mng",            ".mng"},
+		{"openexr",        ".exr"},
+		{"png",            ".png"},
+		{"png-spritesheet",".png"},
+		{"ppm",            ".ppm"},
+		{"yuv420p",        ".yuv"},
+		{"libav",          ".avi"},
+		{"libwebp",        ".webp"}
+	};
 	int i = comboboxtext_target.get_active_row_number();
 	if (i < 0 || i >= (int)target_names.size()) return;
 	if (target_name == target_names[i]) return;
 	auto itr = ext.find(target_names[i]); 
-    // check if target_name is there in map
-    if(itr != ext.end())
+	// check if target_name is there in map
+	if(itr != ext.end())
 	{
 		String filename = entry_filename.get_text();
 		String newfilename = filename.substr(0,filename.find_last_of('.'))+itr->second;
@@ -294,7 +308,13 @@ RenderSettings::set_target(synfig::String name)
 {
 	target_name=name;
 	//TODO: Replace this condition
-	tparam_button->set_sensitive(!(target_name.compare("ffmpeg") && target_name.compare("png-spritesheet")));
+	tparam_button->set_sensitive(
+		!(
+			target_name.compare("ffmpeg"         ) &&
+			target_name.compare("png-spritesheet") &&
+			target_name.compare("libwebp"        )
+		)
+	);
 }
 
 void
@@ -312,12 +332,10 @@ RenderSettings::on_targetparam_pressed()
 {
 	Dialog_TargetParam * dialogtp;
 	//TODO: Replace this conditions too
-	if (!target_name.compare("ffmpeg"))
-		dialogtp = new Dialog_FFmpegParam (*this);
-	else if (!target_name.compare("png-spritesheet"))
-		dialogtp = new Dialog_SpriteSheetParam (*this);
-	else
-		return;
+	if      (!target_name.compare("ffmpeg"         )) dialogtp = new Dialog_FFmpegParam      (*this);
+	else if (!target_name.compare("png-spritesheet")) dialogtp = new Dialog_SpriteSheetParam (*this);
+	else if (!target_name.compare("libwebp"        )) dialogtp = new Dialog_WebpParam        (*this);
+	else return;
 
 	RendDesc rend_desc(widget_rend_desc.get_rend_desc());
 	dialogtp->set_desc(rend_desc);
@@ -332,18 +350,18 @@ RenderSettings::on_render_pressed()
 {
 	String filename=entry_filename.get_text();
 	tparam.sequence_separator = App::sequence_separator;
-	
+
 	if(!check_target_destination())
 	{
 		present();
 		entry_filename.grab_focus();
 		return;
 	}
-	
+
 	hide();
-		
+
 	render_passes.clear();
-		
+
 	if(toggle_extract_alpha.get_active())
 	{
 		String filename_alpha(filename_sans_extension(filename)+"-alpha"+filename_extension(filename));
@@ -410,26 +428,34 @@ RenderSettings::check_target_destination()
 		canvas_interface_->get_ui_interface()->error(_("A filename is required for this target"));
 		return false;
 	}
-	
+
 	String extension(filename_extension(filename));
 	bool ext_multi_file = false; //output target is an image sequence
 	int n_frames_overwrite = 0;
-	
+
 	//Retrieve current render settings
 	RendDesc rend_desc(widget_rend_desc.get_rend_desc());
-	
-	if(!toggle_single_frame.get_active() && (calculated_target_name != "png-spritesheet")
-			&& (rend_desc.get_frame_end() - rend_desc.get_frame_start()) > 0)
+
+	if (!toggle_single_frame.get_active() &&
+	   ( calculated_target_name != "png-spritesheet") &&
+	   ( rend_desc.get_frame_end() - rend_desc.get_frame_start()) > 0)
 	{
 		//Check format which could have an image sequence as output
 		//If format is selected in comboboxtext_target
-		std::map<std::string,std::string> ext_multi = {{"bmp",".bmp"},
-					{"imagemagick",".png"}, {"jpeg",".jpg"},{"mng",".mng"},
-					{"openexr",".exr"},{"png",".png"},{"ppm",".ppm"}};
-	
+		std::map<std::string,std::string> ext_multi = {
+			{"bmp",         ".bmp" },
+			{"imagemagick", ".png" },
+			{"jpeg",        ".jpg" },
+			{"mng",         ".mng" },
+			{"openexr",     ".exr" },
+			{"png",         ".png" },
+			{"ppm",         ".ppm" },
+			{"libwebp",     ".webp"}
+		};
+
 		std::map<std::string,std::string>::iterator ext_multi_it;
 		ext_multi_it = ext_multi.find(calculated_target_name);
-	
+
 		//calculated_target_name is a candidate with known output target (not Auto)
 		if(ext_multi_it != ext_multi.end())
 		{
@@ -439,18 +465,19 @@ RenderSettings::check_target_destination()
 		//otherwise Auto is selected
 		else
 		{
-			std::list<std::string> ext_multi_auto = {{".bmp"}, {".png"},
-					{".jpg"},{".exr"},{".ppm"}};
-	
+			std::list<std::string> ext_multi_auto = {
+				{".bmp"}, {".png"},{".jpg"},{".exr"},{".ppm"},{".webp"}
+			};
+
 			ext_multi_file = (find(ext_multi_auto.begin(), ext_multi_auto.end(),
 					filename_extension(filename)) != ext_multi_auto.end());
 		}
 
 		//Image sequence: filename + sequence_separator + time
-		if(ext_multi_file)
-			for(int n_frame = rend_desc.get_frame_start();
-					n_frame <= rend_desc.get_frame_end();
-					n_frame++)
+		if (ext_multi_file)
+			for (int n_frame  = rend_desc.get_frame_start();
+			         n_frame <= rend_desc.get_frame_end();
+			         n_frame++ )
 			{
 				if(Glib::file_test(filename_sans_extension(filename) +
 					tparam.sequence_separator +
@@ -462,13 +489,13 @@ RenderSettings::check_target_destination()
 
 	String message;
 	String details;
-	
+
 	if(n_frames_overwrite == 0)
 	{
 		message = strprintf(_("A file named \"%s\" already exists. "
 							"Do you want to replace it?"),
 							basename(filename).c_str());
-	
+
 		details = strprintf(_("The file already exists in \"%s\". "
 							"Replacing it will overwrite its contents."),
 							dirname(filename).c_str());
@@ -478,7 +505,7 @@ RenderSettings::check_target_destination()
 		message = strprintf(_("%d files with the same name already exist. "
 							"Do you want to replace them?"),
 							n_frames_overwrite);
-	
+
 		details = strprintf(_("The files already exist in \"%s\". "
 							"Replacing them will overwrite their contents."),
 							dirname(filename).c_str());
@@ -493,7 +520,7 @@ RenderSettings::check_target_destination()
 		_("Use Another Name…"),
 		_("Replace")))
 		return false;
-	
+
 	return true;
 }
 
@@ -506,7 +533,7 @@ RenderSettings::submit_next_render_pass()
 
 		App::dock_info_->set_n_passes_pending(render_passes.size()); //! Decrease until 0
 		App::dock_info_->set_render_progress(0.0); //For this pass
-		
+
 		TargetAlphaMode pass_alpha_mode = pass_info.first;
 		String pass_filename = pass_info.second;
 
@@ -564,7 +591,7 @@ RenderSettings::on_finished(std::string error_message)
 	canvas_interface_->get_ui_interface()->amount_complete(0,10000);
 
 	bool really_finished = (render_passes.size() == 0); //Must be checked BEFORE submit_next_render_pass();
-	
+
 	submit_next_render_pass();
 
 	if (really_finished) { // Because of multi-pass render


### PR DESCRIPTION
Feature request: Animated .webp support https://github.com/synfig/synfig/issues/2272

Renders Animated webp via FFMPEG (libwep_anim & libwebp).
Transparency is supported by libwep_anim (default), replaced by gray background with libwebp.
Configuration of lossless/lossy, compression level, quality and preset.

Preliminary support for import (single image only, like for png)

Let's hope my obsession for indentation and vertical alignment will not hurt the eyes of @rodolforg  ;)