### PR TITLE
fix: smooth move tool is now initialized with the saved value in settings.

### DIFF
--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -274,7 +274,7 @@ StateSmoothMove_Context::~StateSmoothMove_Context()
 
 
 
-DuckDrag_SmoothMove::DuckDrag_SmoothMove():radius(1.0f)
+DuckDrag_SmoothMove::DuckDrag_SmoothMove():radius(synfigapp::Main::get_selected_input_device()->settings().get_value("smooth_move.radius", 1.0))
 {
 }
 


### PR DESCRIPTION
fixes #2940

The radius was being saved and loaded correctly in class  `StateSmoothMove_Context`. And it seems that this class is responsible for setting the radius of the `DuckDrag_SmoothMove` class as when the spin buttons `signal_value_changed()` fires it updates `DuckDrag_SmoothMove`s radius. However the problem was when the `DuckDrag_SmoothMove` class is constructed its radius is initialized with 1 and not with the value saved in the settings.