### PR TITLE
refactor: move workspace methods from App to MainWindow

### DIFF
--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -353,13 +353,7 @@ public:
 	static const std::map<const char*, const char*>& get_default_accel_map();
 	static void load_recent_files();
 	static void load_language_settings();
-	static void set_workspace_default();
-	static void set_workspace_compositing();
-	static void set_workspace_animating();
-	static void set_workspace_from_template(const std::string &tpl);
-	static void set_workspace_from_name(const std::string &name);
 	static void load_custom_workspaces();
-	static void save_custom_workspace();
 	static void edit_custom_workspace_list();
 	static void apply_gtk_settings();
 
@@ -370,8 +364,6 @@ public:
 	static void set_icon_theme(const std::string &theme_name);
 
 	static const std::list<std::string>& get_recent_files();
-
-	static const std::vector<std::string> get_workspaces();
 
 	static const etl::handle<synfigapp::UIInterface>& get_ui_interface();
 

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -118,8 +118,6 @@ class Module;
 
 class StateManager;
 
-class WorkspaceHandler;
-
 class App : public Gtk::Application, private IconController
 {
 	class Preferences;
@@ -179,8 +177,6 @@ private:
 	static int jack_locks_;
 
 //	static std::list< etl::handle< Module > > module_list_;
-
-	static WorkspaceHandler *workspaces;
 
 	static std::string icon_theme_name;
 
@@ -250,8 +246,6 @@ public:
 
 	static Dock_Info* dock_info_; //For Render ProgressBar
 
-	static WorkspaceHandler * get_workspace_handler() {return workspaces;}
-
 	/*
  -- ** -- S I G N A L S -------------------------------------------------------
 	*/
@@ -280,8 +274,6 @@ public:
 	static sigc::signal<void> &signal_present_all();
 
 	static sigc::signal<void> &signal_recent_files_changed();
-
-	static sigc::signal<void> &signal_custom_workspaces_changed();
 
 	static sigc::signal<
 		void,
@@ -353,8 +345,6 @@ public:
 	static const std::map<const char*, const char*>& get_default_accel_map();
 	static void load_recent_files();
 	static void load_language_settings();
-	static void load_custom_workspaces();
-	static void edit_custom_workspace_list();
 	static void apply_gtk_settings();
 
 	// Get the currently used icon theme name

--- a/synfig-studio/src/gui/dialogs/dialog_workspaces.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_workspaces.cpp
@@ -30,8 +30,8 @@
 
 #include <gui/dialogs/dialog_workspaces.h>
 
-#include <gui/app.h>
 #include <gui/localization.h>
+#include <gui/mainwindow.h>
 #include <gui/resourcehelper.h>
 #include <gui/workspacehandler.h>
 
@@ -116,7 +116,7 @@ Dialog_Workspaces::Dialog_Workspaces(Gtk::Dialog::BaseObjectType* cobject, const
 //		row[ws_cols.col_name] = "ui";
 //		workspace_model->append()->set_value(0, Glib::ustring("ui"));
 
-		App::signal_custom_workspaces_changed().connect(sigc::mem_fun(*this, &Dialog_Workspaces::rebuild_list));
+		MainWindow::signal_custom_workspaces_changed().connect(sigc::mem_fun(*this, &Dialog_Workspaces::rebuild_list));
 
 		rebuild_list();
 	}
@@ -164,7 +164,7 @@ void Dialog_Workspaces::on_delete_clicked()
 		names.push_back(name);
 	}
 	for (const std::string & name : names) {
-		App::get_workspace_handler()->remove_workspace(name);
+		MainWindow::get_workspace_handler()->remove_workspace(name);
 	}
 }
 
@@ -210,23 +210,26 @@ void Dialog_Workspaces::on_rename_clicked()
 	if (old_name == name)
 		return;
 
-	if (App::get_workspace_handler()->has_workspace(name)) {
+	if (MainWindow::get_workspace_handler()->has_workspace(name)) {
 		Gtk::MessageDialog error_dlg(dialog, _("There is already a workspace with this name."), false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK);
 		error_dlg.run();
 		return;
 	}
 
 	std::string tpl;
-	App::get_workspace_handler()->get_workspace(old_name, tpl);
-	App::get_workspace_handler()->remove_workspace(old_name);
-	App::get_workspace_handler()->add_workspace(name, tpl);
+	MainWindow::get_workspace_handler()->get_workspace(old_name, tpl);
+	MainWindow::get_workspace_handler()->remove_workspace(old_name);
+	MainWindow::get_workspace_handler()->add_workspace(name, tpl);
 }
 
 void Dialog_Workspaces::rebuild_list()
 {
 	workspace_model->clear();
 
-	WorkspaceHandler *workspaces = App::get_workspace_handler();
+	WorkspaceHandler* workspaces = MainWindow::get_workspace_handler();
+	if (!workspaces)
+		return;
+
 	std::vector<std::string> names;
 	workspaces->get_name_list(names);
 	for (const std::string & name : names)

--- a/synfig-studio/src/gui/mainwindow.cpp
+++ b/synfig-studio/src/gui/mainwindow.cpp
@@ -35,6 +35,7 @@
 #include <gui/mainwindow.h>
 
 #include <gtkmm/box.h>
+#include <gtkmm/messagedialog.h>
 #include <gtkmm/stock.h>
 #include <gtkmm/textview.h>
 
@@ -50,6 +51,7 @@
 #include <gui/localization.h>
 #include <gui/widgets/widget_time.h>
 #include <gui/widgets/widget_vector.h>
+#include <gui/workspacehandler.h>
 
 #include <synfigapp/main.h>
 
@@ -181,16 +183,16 @@ MainWindow::init_menus()
 	
 	// pre defined workspace (window ui layout)
 	action_group->add( Gtk::Action::create("workspace-compositing", _("Compositing")),
-		sigc::ptr_fun(App::set_workspace_compositing)
+		sigc::ptr_fun(MainWindow::set_workspace_compositing)
 	);
 	action_group->add( Gtk::Action::create("workspace-animating", _("Animating")),
-		sigc::ptr_fun(App::set_workspace_animating)
+		sigc::ptr_fun(MainWindow::set_workspace_animating)
 	);
 	action_group->add( Gtk::Action::create("workspace-default", _("Default")),
-		sigc::ptr_fun(App::set_workspace_default)
+		sigc::ptr_fun(MainWindow::set_workspace_default)
 	);
 	action_group->add( Gtk::Action::create("save-workspace", Gtk::StockID("synfig-save_as"), _("Save workspace...")),
-		sigc::ptr_fun(App::save_custom_workspace)
+		sigc::mem_fun(*this, &MainWindow::save_custom_workspace)
 	);
 
 	action_group->add( Gtk::Action::create("edit-workspacelist", _("Edit workspaces...")),
@@ -299,6 +301,15 @@ void MainWindow::add_custom_workspace_menu_item_handlers()
 void MainWindow::remove_custom_workspace_menu_item_handlers()
 {
 	App::ui_manager()->remove_ui(save_workspace_merge_id);
+}
+
+const std::vector<std::string>
+MainWindow::get_workspaces()
+{
+	std::vector<std::string> list;
+	if (App::get_workspace_handler())
+		App::get_workspace_handler()->get_name_list(list);
+	return list;
 }
 
 bool
@@ -455,11 +466,160 @@ MainWindow::on_recent_files_changed()
 }
 
 void
+MainWindow::set_workspace_default()
+{
+	std::string tpl =
+	"[mainwindow|%0X|%0Y|%100x|%90y|"
+		"[hor|%75x"
+			"|[vert|%70y"
+				"|[hor|%10x"
+					"|[book|toolbox]"
+					"|[mainnotebook]"
+				"]"
+				"|[hor|%25x"
+					"|[book|params|keyframes]"
+					"|[book|timetrack|curves|children|meta_data|soundwave]"
+				"]"
+			"]"
+			"|[vert|%20y"
+				"|[book|canvases|pal_edit|navigator|info]"
+				"|[vert|%25y"
+					"|[book|tool_options|history]"
+										"|[book|layers|groups]"
+				"]"
+			"]"
+		"]"
+	"]";
+
+	set_workspace_from_template(tpl);
+}
+
+void
+MainWindow::set_workspace_compositing()
+{
+	std::string tpl =
+	"[mainwindow|%0X|%0Y|%100x|%90y|"
+		"[hor|%1x"
+			"|[vert|%1y|[book|toolbox]|[book|tool_options]]"
+			"|[hor|%60x|[mainnotebook]"
+				"|[hor|%50x|[book|params]"
+					"|[vert|%30y|[book|history|groups]|[book|layers|canvases]]"
+			"]"
+		"]"
+	"]";
+
+	set_workspace_from_template(tpl);
+}
+
+void
+MainWindow::set_workspace_animating()
+{
+	std::string tpl =
+	"[mainwindow|%0X|%0Y|%100x|%90y|"
+		"[hor|%70x"
+			"|[vert|%1y"
+				"|[hor|%1x|[book|toolbox]|[mainnotebook]]"
+				"|[hor|%25x|[book|params|children]|[book|timetrack|curves|soundwave|]]"
+			"]"
+			"|[vert|%30y"
+				"|[book|keyframes|history|groups]|[book|layers|canvases]]"
+			"]"
+		"]"
+	"]";
+
+	set_workspace_from_template(tpl);
+}
+
+void
+MainWindow::set_workspace_from_template(const std::string& tpl)
+{
+	Glib::RefPtr<Gdk::Display> display(Gdk::Display::get_default());
+	Glib::RefPtr<const Gdk::Screen> screen(display->get_default_screen());
+	Gdk::Rectangle rect;
+	// A proper way to obtain the primary monitor is to use the
+	// Gdk::Screen::get_primary_monitor () const member. But as it
+	// was introduced in gtkmm 2.20 I assume that the monitor 0 is the
+	// primary one.
+	screen->get_monitor_geometry(0,rect);
+	float dx = (float)rect.get_x();
+	float dy = (float)rect.get_y();
+	float sx = (float)rect.get_width();
+	float sy = (float)rect.get_height();
+
+	std::string layout = DockManager::layout_from_template(tpl, dx, dy, sx, sy);
+	App::dock_manager->load_layout_from_string(layout);
+	App::dock_manager->show_all_dock_dialogs();
+}
+
+void
+MainWindow::set_workspace_from_name(const std::string& name)
+{
+	if (!App::get_workspace_handler())
+		return;
+	std::string tpl;
+	bool ok = App::get_workspace_handler()->get_workspace(name, tpl);
+	if (!ok)
+		return;
+	set_workspace_from_template(tpl);
+}
+
+void
+MainWindow::save_custom_workspace()
+{
+	if (!App::dock_manager || !App::get_workspace_handler()) {
+		Gtk::MessageDialog dialog(*this, _("Internal error: Dock Manager or Workspace Handler not set"), false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_NONE, true);
+		return;
+	}
+
+	Gtk::MessageDialog dialog(*this, _("Type a name for this custom workspace:"), false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE);
+
+	dialog.add_button(_("Cancel"), Gtk::RESPONSE_CANCEL);
+	Gtk::Button * ok_button = dialog.add_button(_("Ok"), Gtk::RESPONSE_OK);
+	ok_button->set_sensitive(false);
+
+	Gtk::Entry * name_entry = Gtk::manage(new Gtk::Entry());
+	name_entry->set_margin_start(16);
+	name_entry->set_margin_end(16);
+	name_entry->signal_changed().connect(sigc::track_obj([&](){
+		std::string name = synfig::trim(name_entry->get_text());
+		bool has_equal_sign = name.find('=') != std::string::npos;
+		ok_button->set_sensitive(!name.empty() && !has_equal_sign);
+		if (ok_button->is_sensitive())
+			ok_button->grab_default();
+	}, dialog));
+	name_entry->signal_activate().connect(sigc::mem_fun(*ok_button, &Gtk::Button::clicked));
+
+	dialog.get_content_area()->set_spacing(12);
+	dialog.get_content_area()->add(*name_entry);
+
+	ok_button->set_can_default(true);
+
+	dialog.show_all();
+
+	int response = dialog.run();
+	if (response != Gtk::RESPONSE_OK)
+		return;
+
+	std::string name = synfig::trim(name_entry->get_text());
+
+	std::string tpl = App::dock_manager->save_layout_to_string();
+	WorkspaceHandler* workspaces = App::get_workspace_handler();
+	if (!workspaces->has_workspace(name))
+		workspaces->add_workspace(name, tpl);
+	else {
+		Gtk::MessageDialog confirm_dlg(dialog, _("Do you want to overwrite this workspace?"), false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_OK_CANCEL);
+		if (confirm_dlg.run() != Gtk::RESPONSE_OK)
+			return;
+		workspaces->set_workspace(name, tpl);
+	}
+}
+
+void
 MainWindow::on_custom_workspaces_changed()
 {
 	Glib::RefPtr<Gtk::ActionGroup> action_group = Gtk::ActionGroup::create("mainwindow-customworkspaces");
 
-	std::vector<std::string> workspaces = App::get_workspaces();
+	std::vector<std::string> workspaces = get_workspaces();
 
 	std::string menu_items;
 	unsigned int num_custom_workspaces = 0;
@@ -477,7 +637,7 @@ MainWindow::on_custom_workspaces_changed()
 		menu_items += "<menuitem action='" + action_name +"' />";
 
 		action_group->add( Gtk::Action::create(action_name, quoted),
-			sigc::bind(sigc::ptr_fun(&App::set_workspace_from_name), workspaces[num_custom_workspaces])
+			sigc::bind(sigc::ptr_fun(&MainWindow::set_workspace_from_name), workspaces[num_custom_workspaces])
 		);
 	}
 	if (num_custom_workspaces > 0)

--- a/synfig-studio/src/gui/mainwindow.h
+++ b/synfig-studio/src/gui/mainwindow.h
@@ -43,6 +43,7 @@
 namespace studio {
 	class Dockable;
 	class DockBook;
+	class WorkspaceHandler;
 
 	class MainWindow: public Gtk::ApplicationWindow
 	{
@@ -71,9 +72,11 @@ namespace studio {
 		void add_custom_workspace_menu_item_handlers();
 		void remove_custom_workspace_menu_item_handlers();
 
+		static std::unique_ptr<studio::WorkspaceHandler> workspaces;
 		static const std::vector<std::string> get_workspaces();
 
 		void save_custom_workspace();
+		static void edit_custom_workspace_list();
 
 	protected:
 		virtual bool on_key_press_event(GdkEventKey *key_event);
@@ -93,6 +96,11 @@ namespace studio {
 		static void set_workspace_animating();
 		static void set_workspace_from_template(const std::string &tpl);
 		static void set_workspace_from_name(const std::string &name);
+		static void load_custom_workspaces();
+		static void save_custom_workspaces();
+		static WorkspaceHandler* get_workspace_handler() { return workspaces.get(); }
+
+		static sigc::signal<void>& signal_custom_workspaces_changed();
 
 		static void make_short_filenames(
 			const std::vector<synfig::String> &fullnames,

--- a/synfig-studio/src/gui/mainwindow.h
+++ b/synfig-studio/src/gui/mainwindow.h
@@ -71,6 +71,10 @@ namespace studio {
 		void add_custom_workspace_menu_item_handlers();
 		void remove_custom_workspace_menu_item_handlers();
 
+		static const std::vector<std::string> get_workspaces();
+
+		void save_custom_workspace();
+
 	protected:
 		virtual bool on_key_press_event(GdkEventKey *key_event);
 
@@ -83,6 +87,12 @@ namespace studio {
 
 		DockBook& main_dock_book() { return *main_dock_book_; }
 		const DockBook& main_dock_book() const { return *main_dock_book_; }
+
+		static void set_workspace_default();
+		static void set_workspace_compositing();
+		static void set_workspace_animating();
+		static void set_workspace_from_template(const std::string &tpl);
+		static void set_workspace_from_name(const std::string &name);
 
 		static void make_short_filenames(
 			const std::vector<synfig::String> &fullnames,


### PR DESCRIPTION
Workspace layout only matters/applies to `MainWindow`, no need to bloat `App` class with this stuff.