### PR TITLE
fix: change convert.exe syntax to avoid clash in Windows

### DIFF
--- a/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
@@ -106,9 +106,9 @@ imagemagick_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &re
 
 	args.push_back(strprintf("png32:%s", target_filename.c_str()));
 
-	bool success = OS::run_sync("convert", args);
+	bool success = OS::run_sync("magick", args);
 	if (!success) {
-		synfig::error(_("Unable to open convert [ImageMagick]"));
+		synfig::error(_("Unable to open magick [ImageMagick]"));
 		return false;
 	}
 

--- a/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
@@ -99,6 +99,7 @@ imagemagick_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &re
 	}
 
 	OS::RunArgs args;
+	args.push_back("convert");
 	args.push_back(filesystem::Path(filename));
 
 	if (filename_extension == ".psd" || filename_extension == ".xcf")

--- a/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
@@ -126,6 +126,7 @@ imagemagick_trgt::start_frame(synfig::ProgressCallback *cb)
 		newfilename = filename;
 
 	OS::RunArgs args;
+	args.push_back({"convert"});
 	args.push_back({"-depth", "8"});
 	args.push_back({"-size", strprintf("%dx%d", desc.get_w(), desc.get_h())});
 	args.push_back(pixel_size(pf) == 4 ? "rgba:-[0]" : "rgb:-[0]");

--- a/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
@@ -113,7 +113,7 @@ imagemagick_trgt::end_frame()
 bool
 imagemagick_trgt::start_frame(synfig::ProgressCallback *cb)
 {
-	const char *msg=_("Unable to open pipe to imagemagick's convert utility");
+	const char *msg=_("Unable to open pipe to imagemagick's magick utility");
 
 	std::string newfilename;
 
@@ -132,7 +132,7 @@ imagemagick_trgt::start_frame(synfig::ProgressCallback *cb)
 	args.push_back({"-density", strprintf("%dx%d", round_to_int(desc.get_x_res()/39.3700787402), round_to_int(desc.get_y_res()/39.3700787402))});
 	args.push_back(filesystem::Path(newfilename));
 
-	pipe = OS::run_async("convert", args, OS::RUN_MODE_WRITE);
+	pipe = OS::run_async("magick", args, OS::RUN_MODE_WRITE);
 
 	if (!pipe) {
 		if(cb)cb->error(N_(msg));


### PR DESCRIPTION
On Windows (I built with CMake) for some weird reason calling ImageMagick's convert calls Windows/System32/convert.exe . It's odd because my Path env var seems to list the mingw64 directory first, but a solution is using the 'magick' syntax, where you just call 'magick' to convert as per https://imagemagick.org/script/command-line-tools.php

The problem is widely known as per https://stackoverflow.com/questions/3060205/error-invalid-parameter-fom-imagemagick-convert-on-windows , I was getting the same 'Invalid Parameter' error

The patch uses 'magick convert' (legacy syntax), instead of 'magick' for compatibility with ImageMagick 6, since many distros don't have official packages for ImageMagick 7, despite the release being over 5 years old:
*  https://packages.debian.org/search?searchon=sourcenames&keywords=imagemagick
*  https://packages.fedoraproject.org/pkgs/ImageMagick/ImageMagick/
*  https://packages.ubuntu.com/search?keywords=imagemagick

The reason is that v7's syntax is not fully compatible with v6 but it our syntax seems safe

TL;DR:
Instead of using ImageMagick with 'convert' use 'magick convert' since Win has another 'convert' program