### PR TITLE
refactor: replaced deprecated `signal_pressed()`  with `signal_clicked()`

### DIFF
--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -736,7 +736,7 @@ StateDraw_Context::StateDraw_Context(CanvasView* canvas_view):
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
 
-	fill_last_stroke_button.signal_pressed().connect(
+	fill_last_stroke_button.signal_clicked().connect(
 		sigc::mem_fun(*this, &StateDraw_Context::fill_last_stroke));
 	pressure_width_checkbutton.signal_toggled().connect(
 		sigc::mem_fun(*this, &StateDraw_Context::UpdateUsePressure));

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -663,7 +663,7 @@ StateLasso_Context::StateLasso_Context(CanvasView* canvas_view):
 	options_grid.set_margin_bottom(0);
 	options_grid.show_all();
 
-	fill_last_stroke_button.signal_pressed().connect(
+	fill_last_stroke_button.signal_clicked().connect(
 		sigc::mem_fun(*this, &StateLasso_Context::fill_last_stroke));
 	pressure_width_checkbutton.signal_toggled().connect(
 		sigc::mem_fun(*this, &StateLasso_Context::UpdateUsePressure));


### PR DESCRIPTION
Documentation recommended `signal_button_press_event()` but `signal_clicked()` also does the job and even has a similar prototype.
https://docs.gtk.org/gtk3/signal.Button.pressed.html

p.s. I'm not sure though but it seems like these buttons aren't even used. Should they just be removed ?... I saw a button with the same name made in the refresh toobar method.