### PR TITLE
fix: build on Ubuntu 16.04

### DIFF
--- a/synfig-core/src/synfig/node.h
+++ b/synfig-core/src/synfig/node.h
@@ -264,8 +264,8 @@ public:
 
 	//! Callback function for a foreach method.
 	//! If it returns true, the foreach iteration is halted.
-	using ForeachFunc = sigc::slot<bool(Node*)>;
-	using ConstForeachFunc = sigc::slot<bool(const Node*)>;
+	using ForeachFunc = sigc::slot1<bool, Node*>;
+	using ConstForeachFunc = sigc::slot1<bool, const Node*>;
 
 	//! Call function func for each of the parents of the current Node
 	//! Do not add or remove any parent node while doing this foreach call
@@ -302,7 +302,7 @@ public:
 	//! Return the first parent of a given type with an additional match condition
 	//! The CompareFunc should return true when match is satisfied
 	//! Example: node->find_first_parent_of_type<MyType>([](MyType::Handle v) -> bool { return v.prop == 1;});
-	template<typename T> etl::handle<T> find_first_parent_of_type(const sigc::slot<bool(const etl::handle<T>&)> &CompareFunc) const {
+	template<typename T> etl::handle<T> find_first_parent_of_type(sigc::slot1<bool, const etl::handle<T>&> CompareFunc) const {
 		T* parent = nullptr;
 		foreach_parent([&parent, CompareFunc](const Node* node) -> bool {
 			if (auto item = dynamic_cast<T*>(const_cast<Node*>(node)))

--- a/synfig-core/src/synfig/soundprocessor.cpp
+++ b/synfig-core/src/synfig/soundprocessor.cpp
@@ -292,7 +292,8 @@ bool SoundProcessor::subsys_init() {
 bool SoundProcessor::subsys_stop()
 {
 #ifndef WITHOUT_MLT
-	delete Internal::repository;
+	// delete leads to crash on Ubuntu 16.04
+	//delete Internal::repository;
 	Mlt::Factory::close();
 #endif
 	return true;

--- a/synfig-studio/src/gui/dials/jackdial.h
+++ b/synfig-studio/src/gui/dials/jackdial.h
@@ -55,7 +55,7 @@ class JackDial : public Gtk::Box
 public:
 	JackDial();
 	void set_state(bool enabled);
-	Glib::SignalProxy<void> signal_toggle_jack() { return toggle_jack_button->signal_toggled(); }
+	Glib::SignalProxy0<void> signal_toggle_jack() { return toggle_jack_button->signal_toggled(); }
 
 	sigc::signal<void>& signal_offset_changed()      { return offset_widget->signal_value_changed(); }
 

--- a/synfig-studio/src/gui/dials/keyframedial.h
+++ b/synfig-studio/src/gui/dials/keyframedial.h
@@ -55,8 +55,8 @@ public:
 
 	KeyFrameDial();
 	void on_mode_changed(synfigapp::EditMode mode); // Updates button icons/state
-	Glib::SignalProxy<void> signal_toggle_keyframe_past() { return toggle_keyframe_past->signal_toggled(); }
-	Glib::SignalProxy<void> signal_toggle_keyframe_future() { return toggle_keyframe_future->signal_toggled(); }
+	Glib::SignalProxy0<void> signal_toggle_keyframe_past() { return toggle_keyframe_past->signal_toggled(); }
+	Glib::SignalProxy0<void> signal_toggle_keyframe_future() { return toggle_keyframe_future->signal_toggled(); }
 
 }; // END of class KeyFrameDial
 


### PR DESCRIPTION
Fix #2964

Details about crash on Ubuntu 16.04:

```
gdb --args /root/projects/build/output/Debug/bin/synfig about_icon.sif -o root/projects/build/output/Debug/share/synfig/icons/classic/128x128/about_icon.png --time 0f
```

```
Thread 1 "synfig" received signal SIGSEGV, Segmentation fault.
0x00007f9a608883f0 in ?? ()
(gdb) bt
#0  0x00007f9a608883f0 in ?? ()
#1  0x00007f9a63db3719 in mlt_property_close () from /usr/lib/x86_64-linux-gnu/libmlt.so.6
#2  0x00007f9a63db5860 in mlt_properties_close () from /usr/lib/x86_64-linux-gnu/libmlt.so.6
#3  0x00007f9a63dc6811 in mlt_factory_close () from /usr/lib/x86_64-linux-gnu/libmlt.so.6
#4  0x00007f9a67f38e73 in synfig::SoundProcessor::subsys_stop () at /root/projects/synfig/synfig-core/src/synfig/soundprocessor.cpp:296
#5  0x00007f9a67e7207b in synfig::Main::~Main (this=0x7ffe962eec80, __in_chrg=<optimized out>) at /root/projects/synfig/synfig-core/src/synfig/main.cpp:434
#6  0x0000000000440467 in main (argc=6, argv=0x7ffe962ef638) at /root/projects/synfig/synfig-core/src/tool/main.cpp:272
```

This looks like a double-free issue.

I checked MLT example, and commented-out delete.
https://github.com/mltframework/mlt/blob/master/src/examples/play.cpp