### PR TITLE
refactor: rename CanvasView::toggle_show_toolbar() to set_show_toolbars()

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3731,12 +3731,8 @@ CanvasView::on_interpolation_changed()
 	{ synfigapp::Main::set_interpolation(Waypoint::Interpolation(widget_interpolation->get_value())); }
 
 void 
-CanvasView::toggle_show_toolbar(){
-	if (App::enable_mainwin_toolbar) {
-		top_toolbar->show();
-		right_toolbar->show();
-	} else {
-		top_toolbar->hide();
-		right_toolbar->hide();
-	}
+CanvasView::set_show_toolbars(bool show)
+{
+	top_toolbar->set_visible(show);
+	right_toolbar->set_visible(show);
 };

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -652,8 +652,8 @@ public:
 	//! Toggle between none/last visible handles
 	//! \Sa             DuckMatic::set_type_mask_state(), DuckMatic::get_type_mask_state()
 	void toggle_duck_mask_all();
-	// Toggle displaybar according to App::enable_mainwin_toolbar
-	void toggle_show_toolbar();
+	/** show or hide both toolbars */
+	void set_show_toolbars(bool show);
 
 	/*
  -- ** -- S I G N A L   T E R M I N A L S -------------------------------------

--- a/synfig-studio/src/gui/mainwindow.cpp
+++ b/synfig-studio/src/gui/mainwindow.cpp
@@ -287,10 +287,10 @@ MainWindow::toggle_show_toolbar()
 {
 	App::enable_mainwin_toolbar = !App::enable_mainwin_toolbar;
 	
-	for(std::list<etl::handle<Instance> >::iterator iter1 = App::instance_list.begin(); iter1 != App::instance_list.end(); iter1++){
-			const Instance::CanvasViewList &views = (*iter1)->canvas_view_list();
-			for(Instance::CanvasViewList::const_iterator iter2 = views.begin(); iter2 != views.end(); ++iter2)
-				(*iter2)->toggle_show_toolbar();
+	for (const auto& instance : App::instance_list) {
+		const Instance::CanvasViewList& views = instance->canvas_view_list();
+		for (auto& canvas_view : views)
+			canvas_view->set_show_toolbars(App::enable_mainwin_toolbar);
 	}
 }
 


### PR DESCRIPTION
As it doesn't toggle the visibility itself, so it was a misleading name