### PR TITLE
refactor: use camelcase for MotionBlur and SolidColor layer names

### DIFF
--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -132,7 +132,7 @@ Layer::subsys_init()
 				  class::get_register_version())
 
 	INCLUDE_LAYER(Layer_SolidColor);
-		LAYER_ALIAS(Layer_SolidColor,	"solid_color");
+		LAYER_ALIAS(Layer_SolidColor,	"SolidColor"); // old name, previous to version 1.5.2
 	INCLUDE_LAYER(Layer_FilterGroup);
 	INCLUDE_LAYER(Layer_Group);
 		LAYER_ALIAS(Layer_Group,		"paste_canvas");
@@ -141,7 +141,7 @@ Layer::subsys_init()
 	INCLUDE_LAYER(Layer_Polygon);
 		LAYER_ALIAS(Layer_Polygon,		"Polygon");
 	INCLUDE_LAYER(Layer_MotionBlur);
-		LAYER_ALIAS(Layer_MotionBlur,	"motion_blur");
+		LAYER_ALIAS(Layer_MotionBlur,	"MotionBlur"); // old name, previous to version 1.5.2
 	INCLUDE_LAYER(Layer_Duplicate);
 	INCLUDE_LAYER(Layer_Skeleton);
 	INCLUDE_LAYER(Layer_SkeletonDeformation);

--- a/synfig-core/src/synfig/layers/layer_motionblur.cpp
+++ b/synfig-core/src/synfig/layers/layer_motionblur.cpp
@@ -54,7 +54,7 @@ using namespace synfig;
 /* === G L O B A L S ======================================================= */
 
 SYNFIG_LAYER_INIT(Layer_MotionBlur);
-SYNFIG_LAYER_SET_NAME(Layer_MotionBlur,"MotionBlur"); // todo: use motion_blur
+SYNFIG_LAYER_SET_NAME(Layer_MotionBlur,"motion_blur");
 SYNFIG_LAYER_SET_LOCAL_NAME(Layer_MotionBlur,N_("Motion Blur"));
 SYNFIG_LAYER_SET_CATEGORY(Layer_MotionBlur,N_("Blurs"));
 SYNFIG_LAYER_SET_VERSION(Layer_MotionBlur,"0.1");

--- a/synfig-core/src/synfig/layers/layer_solidcolor.cpp
+++ b/synfig-core/src/synfig/layers/layer_solidcolor.cpp
@@ -54,7 +54,7 @@ using namespace synfig;
 /* === G L O B A L S ======================================================= */
 
 SYNFIG_LAYER_INIT(Layer_SolidColor);
-SYNFIG_LAYER_SET_NAME(Layer_SolidColor,"SolidColor"); // todo: use solid_color
+SYNFIG_LAYER_SET_NAME(Layer_SolidColor,"solid_color");
 SYNFIG_LAYER_SET_LOCAL_NAME(Layer_SolidColor,N_("Solid Color"));
 SYNFIG_LAYER_SET_CATEGORY(Layer_SolidColor,N_("Geometry"));
 SYNFIG_LAYER_SET_VERSION(Layer_SolidColor,"0.1");

--- a/synfig-core/src/synfig/rendering/software/rendererdraftsw.cpp
+++ b/synfig-core/src/synfig/rendering/software/rendererdraftsw.cpp
@@ -67,7 +67,7 @@ RendererDraftSW::RendererDraftSW()
 	// register optimizers
 	register_optimizer(new OptimizerDraftContour(2.0, true));
 	register_optimizer(new OptimizerDraftBlur());
-	register_optimizer(new OptimizerDraftLayerSkip("MotionBlur"));
+	register_optimizer(new OptimizerDraftLayerSkip("motion_blur"));
 	register_optimizer(new OptimizerDraftLayerSkip("radial_blur"));
 	register_optimizer(new OptimizerDraftLayerSkip("curve_warp"));
 	register_optimizer(new OptimizerDraftLayerSkip("inside_out"));

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3968,7 +3968,7 @@ App::new_instance()
 	if (App::default_background_layer_type == "solid_color")
 	{
 		//Create a SolidColor layer
-		synfig::Layer::Handle layer(instance->find_canvas_interface(canvas)->add_layer_to("SolidColor",
+		synfig::Layer::Handle layer(instance->find_canvas_interface(canvas)->add_layer_to("solid_color",
 			                        canvas,
 			                        0)); //target_depth
 
@@ -4032,7 +4032,7 @@ App::new_instance()
 		instance->find_canvas_view(canvas)->add_layer("skeleton");
 
 	if (getenv("SYNFIG_AUTO_ADD_MOTIONBLUR_LAYER"))
-		instance->find_canvas_view(canvas)->add_layer("MotionBlur");
+		instance->find_canvas_view(canvas)->add_layer("motion_blur");
 
 	if (getenv("SYNFIG_ENABLE_NEW_CANVAS_EDIT_PROPERTIES"))
 		instance->find_canvas_view(canvas)->canvas_properties.present();

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -407,7 +407,7 @@ studio::layer_icon_name(const synfig::String &layer)
 	// Blur Layers
 	if(layer=="blur")
 		return "layer_blur_blur_icon";
-	else if(layer=="MotionBlur") // in the future should be "motion_blur"
+	else if(layer=="motion_blur")
 		return "layer_blur_motion_icon";
 	else if(layer=="radial_blur")
 		return "layer_blur_radial_icon";
@@ -464,7 +464,7 @@ studio::layer_icon_name(const synfig::String &layer)
 		return "layer_geometry_rectangle_icon";
 	else if(layer=="region")
 		return "layer_geometry_region_icon";
-	else if(layer=="solid_color" || layer=="SolidColor")
+	else if(layer=="solid_color")
 		return "layer_geometry_solidcolor_icon";
 	else if(layer=="star")
 		return "layer_geometry_star_icon";


### PR DESCRIPTION
Following the layer naming convention elsewhere.

studio::layer_icon_name() does not need to compare to the layer name aliases because every call actually uses the Layer::get_name(), i.e. the official name, not their aliases.