### PR TITLE
refactor: replaced deprecated `hvseparator` include directive by `separator`

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -45,7 +45,7 @@
 #include <glibmm/uriutils.h>
 
 #include <gtkmm/eventbox.h>
-#include <gtkmm/hvseparator.h>
+#include <gtkmm/separator.h>
 #include <gtkmm/imagemenuitem.h>
 #include <gtkmm/label.h>
 #include <gtkmm/messagedialog.h>


### PR DESCRIPTION
`#include <gtkmm/hvseparator.h>` was an old directive which included 
- horizontal and vertical separators (both deprecated and not used in synfig)
-  `#include <gtkmm/separator.h>`