### PR TITLE
fix: crash occurs under Wayland when using tablet

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3403,6 +3403,10 @@ CanvasView::on_input_device_changed(GdkDevice* device)
 
 	InputDevice::Handle input_device;
 	input_device = synfigapp::Main::select_input_device(gdk_device_get_name(device));
+
+	if (!input_device) {
+		return;
+	}
 	App::dock_toolbox->change_state(input_device->get_state(), true);
 	process_event_key(EVENT_INPUT_DEVICE_CHANGED);
 }

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -1083,7 +1083,7 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 	// Handle input stuff
 	if (event->any.type==GDK_MOTION_NOTIFY)
 	{
-		GdkDevice *device = event->motion.device;
+		GdkDevice *device = gdk_event_get_source_device(event);
 		modifier = Gdk::ModifierType(event->motion.state);
 
 		// Calculate the position of the
@@ -1148,7 +1148,7 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 		event->any.type==GDK_3BUTTON_PRESS ||
 		event->any.type==GDK_BUTTON_RELEASE )
 	{
-		GdkDevice *device = event->button.device;
+		GdkDevice *device = gdk_event_get_source_device(event);
 		modifier = Gdk::ModifierType(event->button.state);
 		drawing_area->grab_focus();
 

--- a/synfig-studio/src/synfigapp/main.cpp
+++ b/synfig-studio/src/synfigapp/main.cpp
@@ -365,9 +365,13 @@ synfigapp::Main::add_input_device(const synfig::String id, InputDevice::Type typ
 InputDevice::Handle
 synfigapp::Main::find_input_device(const synfig::String id)
 {
+	static const char MASTER_POINTER_FOR[] = "Master pointer for ";
+	static const size_t MASTER_POINTER_FOR_LENGTH = sizeof (MASTER_POINTER_FOR) - 1;
+	const size_t offset = id.rfind(MASTER_POINTER_FOR, 0) == 0 ? MASTER_POINTER_FOR_LENGTH : 0;
+
 	std::list<InputDevice::Handle>::iterator iter;
 	for(iter=input_devices_.begin();iter!=input_devices_.end();++iter)
-		if((*iter)->get_id()==id)
+		if(id.compare(offset, std::string::npos, (*iter)->get_id()) == 0)
 			return *iter;
 	return 0;
 }

--- a/synfig-studio/src/synfigapp/main.cpp
+++ b/synfig-studio/src/synfigapp/main.cpp
@@ -373,7 +373,7 @@ synfigapp::Main::find_input_device(const synfig::String id)
 	for(iter=input_devices_.begin();iter!=input_devices_.end();++iter)
 		if(id.compare(offset, std::string::npos, (*iter)->get_id()) == 0)
 			return *iter;
-	return 0;
+	return nullptr;
 }
 
 InputDevice::Handle
@@ -381,9 +381,9 @@ synfigapp::Main::select_input_device(const synfig::String id)
 {
 	InputDevice::Handle input_device(find_input_device(id));
 	if(!input_device)
-		return 0;
+		return nullptr;
 	if(!select_input_device(input_device))
-		return 0;
+		return nullptr;
 	return input_device;
 }
 

--- a/synfig-studio/src/synfigapp/main.cpp
+++ b/synfig-studio/src/synfigapp/main.cpp
@@ -365,13 +365,9 @@ synfigapp::Main::add_input_device(const synfig::String id, InputDevice::Type typ
 InputDevice::Handle
 synfigapp::Main::find_input_device(const synfig::String id)
 {
-	static const char MASTER_POINTER_FOR[] = "Master pointer for ";
-	static const size_t MASTER_POINTER_FOR_LENGTH = sizeof (MASTER_POINTER_FOR) - 1;
-	const size_t offset = id.rfind(MASTER_POINTER_FOR, 0) == 0 ? MASTER_POINTER_FOR_LENGTH : 0;
-
 	std::list<InputDevice::Handle>::iterator iter;
 	for(iter=input_devices_.begin();iter!=input_devices_.end();++iter)
-		if(id.compare(offset, std::string::npos, (*iter)->get_id()) == 0)
+		if((*iter)->get_id()==id)
 			return *iter;
 	return nullptr;
 }


### PR DESCRIPTION
GTK gives Synfig a GdkEvent containing a GdkDevice with the ID "Master pointer for ..." when using a tablet device. The device is not found, causing a crash elsewhere.