### PR TITLE
refactor: prefer class Handle (and alike) rather etl::handle<> (and alike)

### DIFF
--- a/synfig-core/src/modules/lyr_std/timeloop.cpp
+++ b/synfig-core/src/modules/lyr_std/timeloop.cpp
@@ -216,7 +216,7 @@ Layer_TimeLoop::reset_version()
 	if (dpl.count("start_time") == 0 && dpl.count("end_time") == 0)
 		return;
 
-	etl::rhandle<ValueNode> start_time_value_node, end_time_value_node;
+	ValueNode::RHandle start_time_value_node, end_time_value_node;
 	LinkableValueNode* duration_value_node;
 
 	if (dpl.count("start_time"))

--- a/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
@@ -808,7 +808,7 @@ Advanced_Outline::get_param_vocab()const
 }
 
 bool
-Advanced_Outline::connect_dynamic_param(const String& param, etl::loose_handle<ValueNode> x)
+Advanced_Outline::connect_dynamic_param(const String& param, ValueNode::LooseHandle x)
 {
 	if(param=="bline")
 	{
@@ -845,7 +845,7 @@ Advanced_Outline::connect_dynamic_param(const String& param, etl::loose_handle<V
 }
 
 bool
-Advanced_Outline::connect_bline_to_wplist(etl::loose_handle<ValueNode> x)
+Advanced_Outline::connect_bline_to_wplist(ValueNode::LooseHandle x)
 {
 	// connect_dynamic_param() makes sure x is a list of blinepoints.
 	ValueNode::LooseHandle vnode;

--- a/synfig-core/src/modules/mod_geometry/advanced_outline.h
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.h
@@ -84,10 +84,10 @@ public:
 	virtual Vocab get_param_vocab()const;
 
 	//! Connects the parameter to another Value Node. Implementation for this layer
-	virtual bool connect_dynamic_param(const synfig::String& param, etl::loose_handle<synfig::ValueNode> x );
+	virtual bool connect_dynamic_param(const synfig::String& param, synfig::ValueNode::LooseHandle x );
 
 private:
-	bool connect_bline_to_wplist(etl::loose_handle<synfig::ValueNode> x);
+	bool connect_bline_to_wplist(synfig::ValueNode::LooseHandle x);
 	
 protected:
 	virtual void sync_vfunc();

--- a/synfig-core/src/synfig/base_types.cpp
+++ b/synfig-core/src/synfig/base_types.cpp
@@ -408,8 +408,8 @@ class TypeCanvas: public Type
 #ifdef TRY_FIX_FOR_BUG_27
 		bool fake_handle;
 #endif
-		etl::handle<Canvas> h;
-		etl::loose_handle<Canvas> lh;
+		Canvas::Handle h;
+		Canvas::LooseHandle lh;
 		mutable CanvasPtr p;
 #ifdef TRY_FIX_FOR_BUG_27
 		Inner(): fake_handle(false), p(nullptr) { }
@@ -419,7 +419,7 @@ class TypeCanvas: public Type
 #endif
 		Inner(const Inner& other) { *this = other; }
 
-		Inner& operator= (const etl::loose_handle<Canvas> &other)
+		Inner& operator= (const Canvas::LooseHandle &other)
 		{
 #ifdef TRY_FIX_FOR_BUG_27
 			if (fake_handle) h->ref();
@@ -432,17 +432,17 @@ class TypeCanvas: public Type
 #endif
 			return *this;
 		}
-		Inner& operator= (const etl::handle<Canvas> &other)
-			{ return *this = etl::loose_handle<Canvas>(other); }
+		Inner& operator= (const Canvas::Handle &other)
+			{ return *this = Canvas::LooseHandle(other); }
 		Inner& operator= (const CanvasPtr &other)
-			{ return *this = etl::loose_handle<Canvas>(other); }
+			{ return *this = Canvas::LooseHandle(other); }
 		Inner& operator= (const Inner &other)
 			{ return *this = other.lh; }
 		bool operator== (const Inner &other) const
 			{ return lh == other.lh; }
 
-		operator const etl::loose_handle<Canvas>&() const { return lh; }
-		operator const etl::handle<Canvas>&() const { return h; }
+		operator const Canvas::LooseHandle&() const { return lh; }
+		operator const Canvas::Handle&() const { return h; }
 		operator const CanvasPtr &() const { return p = &*lh; }
 	};
 	static String to_string(const Inner &x) { return strprintf("Canvas (%s)", x.lh ? x.lh->get_id().c_str() : "NULL"); }
@@ -451,16 +451,16 @@ class TypeCanvas: public Type
 		Type::initialize_vfunc(description);
 		description.name = "canvas";
 		description.local_name = N_("canvas");
-		register_all<Inner, etl::loose_handle<Canvas>, to_string>();
-		register_alias< Inner, etl::handle<Canvas> >();
+		register_all<Inner, Canvas::LooseHandle, to_string>();
+		register_alias< Inner, Canvas::Handle >();
 		register_alias<Inner, Canvas*>();
 	}
 public:
 	static TypeCanvas instance;
 };
 TypeCanvas TypeCanvas::instance;
-SYNFIG_IMPLEMENT_TYPE_ALIAS(etl::loose_handle<Canvas>, TypeCanvas)
-SYNFIG_IMPLEMENT_TYPE_ALIAS(etl::handle<Canvas>, TypeCanvas)
+SYNFIG_IMPLEMENT_TYPE_ALIAS(Canvas::LooseHandle, TypeCanvas)
+SYNFIG_IMPLEMENT_TYPE_ALIAS(Canvas::Handle, TypeCanvas)
 SYNFIG_IMPLEMENT_TYPE_ALIAS(Canvas*, TypeCanvas)
 
 

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -1509,7 +1509,7 @@ Canvas::show_structure(int i) const
 // the container is a ValueNode_{Static,Dynamic}List
 // the content is the entry
 void
-Canvas::invoke_signal_value_node_child_removed(etl::handle<ValueNode> container, etl::handle<ValueNode> content)
+Canvas::invoke_signal_value_node_child_removed(ValueNode::Handle container, ValueNode::Handle content)
 {
 	signal_value_node_child_removed()(container, content);
 	Canvas::Handle canvas(this);

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -1473,7 +1473,7 @@ Canvas::show_externals(String file, int line, String text) const
 	for (iter = externals_.begin(); iter != externals_.end(); iter++)
 	{
 		synfig::String first(iter->first);
-		etl::loose_handle<Canvas> second(iter->second);
+		Canvas::LooseHandle second(iter->second);
 		printf("  |    %40s : %lx (%d)\n", first.c_str(), uintptr_t(&*second), second->count());
 	}
 	printf("  `-----\n\n");

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -163,7 +163,7 @@ Canvas::byindex(int index) const
 }
 
 Canvas::iterator
-Canvas::find_index(const etl::handle<Layer> &layer, int &index)
+Canvas::find_index(const Layer::Handle &layer, int &index)
 {
 	index = -1;
 	int idx = 0;
@@ -173,7 +173,7 @@ Canvas::find_index(const etl::handle<Layer> &layer, int &index)
 }
 
 Canvas::const_iterator
-Canvas::find_index(const etl::handle<Layer> &layer, int &index) const
+Canvas::find_index(const Layer::Handle &layer, int &index) const
 {
 	index = -1;
 	int idx = 0;
@@ -395,7 +395,7 @@ Canvas::keyframe_list()const
 	return keyframe_list_;
 }
 
-etl::handle<Layer>
+Layer::Handle
 Canvas::find_layer(const ContextParams &context_params, const Point &pos)
 {
 	return get_context(context_params).hit_check(pos);
@@ -521,7 +521,7 @@ Canvas::get_non_inline_ancestor()const
 }
 
 int
-Canvas::get_depth(etl::handle<Layer> layer)const
+Canvas::get_depth(Layer::Handle layer)const
 {
 	const_iterator iter;
 	int i(0);
@@ -904,7 +904,7 @@ Canvas::create()
 }
 
 void
-Canvas::push_back(etl::handle<Layer> x)
+Canvas::push_back(Layer::Handle x)
 {
 //	int i(x->count());
 	insert(end(),x);
@@ -912,7 +912,7 @@ Canvas::push_back(etl::handle<Layer> x)
 }
 
 void
-Canvas::push_front(etl::handle<Layer> x)
+Canvas::push_front(Layer::Handle x)
 {
 //	int i(x->count());
 	insert(begin(),x);
@@ -920,7 +920,7 @@ Canvas::push_front(etl::handle<Layer> x)
 }
 
 void
-Canvas::insert(iterator iter,etl::handle<Layer> x)
+Canvas::insert(iterator iter,Layer::Handle x)
 {
 //	int i(x->count());
 	CanvasBase::insert(iter,x);
@@ -945,7 +945,7 @@ Canvas::insert(iterator iter,etl::handle<Layer> x)
 }
 
 void
-Canvas::push_back_simple(etl::handle<Layer> x)
+Canvas::push_back_simple(Layer::Handle x)
 {
 	CanvasBase::insert(end(),x);
 	changed();
@@ -1053,7 +1053,7 @@ Canvas::set_inline(LooseHandle parent)
 	is_inline_=true;
 
 	// Have the parent inherit all of the group stuff
-	std::map<String,std::set<etl::handle<Layer> > >::const_iterator iter;
+	std::map<String,std::set<Layer::Handle> >::const_iterator iter;
 	for(iter=group_db_.begin();iter!=group_db_.end();++iter)
 		parent->group_db_[iter->first].insert(iter->second.begin(),iter->second.end());
 	rend_desc()=parent->rend_desc();
@@ -1298,14 +1298,14 @@ Canvas::get_times_vfunc(Node::time_set &set) const
 	}
 }
 
-std::set<etl::handle<Layer> >
+std::set<Layer::Handle>
 Canvas::get_layers_in_group(const String&group)
 {
 	if(is_inline() && parent_)
 		return parent_->get_layers_in_group(group);
 
 	if(group_db_.count(group)==0)
-		return std::set<etl::handle<Layer> >();
+		return std::set<Layer::Handle>();
 	return group_db_.find(group)->second;
 }
 
@@ -1316,7 +1316,7 @@ Canvas::get_groups()const
 		return parent_->get_groups();
 
 	std::set<String> ret;
-	std::map<String,std::set<etl::handle<Layer> > >::const_iterator iter;
+	std::map<String,std::set<Layer::Handle> >::const_iterator iter;
 	for(iter=group_db_.begin();iter!=group_db_.end();++iter)
 		ret.insert(iter->first);
 	return ret;
@@ -1332,7 +1332,7 @@ Canvas::get_group_count()const
 }
 
 void
-Canvas::add_group_pair(String group, etl::handle<Layer> layer)
+Canvas::add_group_pair(String group, Layer::Handle layer)
 {
 	group_db_[group].insert(layer);
 	if(group_db_[group].size()==1)
@@ -1347,7 +1347,7 @@ Canvas::add_group_pair(String group, etl::handle<Layer> layer)
 }
 
 void
-Canvas::remove_group_pair(String group, etl::handle<Layer> layer)
+Canvas::remove_group_pair(String group, Layer::Handle layer)
 {
 	group_db_[group].erase(layer);
 
@@ -1366,7 +1366,7 @@ Canvas::remove_group_pair(String group, etl::handle<Layer> layer)
 }
 
 void
-Canvas::add_connections(etl::loose_handle<Layer> layer)
+Canvas::add_connections(Layer::LooseHandle layer)
 {
 	LooseHandle correct_canvas(this);
 	//while(correct_canvas->is_inline())correct_canvas=correct_canvas->parent();
@@ -1389,7 +1389,7 @@ Canvas::add_connections(etl::loose_handle<Layer> layer)
 }
 
 void
-Canvas::disconnect_connections(etl::loose_handle<Layer> layer)
+Canvas::disconnect_connections(Layer::LooseHandle layer)
 {
 	for(sigc::connection& connection : connections_[layer])
 		connection.disconnect();
@@ -1412,11 +1412,11 @@ Canvas::rename_group(const String&old_name,const String&new_name)
 	{
 		size_t pos = 0;
 		while ((pos = new_name.find(GROUP_NEST_CHAR, pos)) != std::string::npos) {
-			std::map<String,std::set<etl::handle<Layer> > >::iterator iter;
+			std::map<String,std::set<Layer::Handle> >::iterator iter;
 			String name(new_name, 0, pos);
 			iter=group_db_.find(name);
 			if (iter == group_db_.end()) {
-				group_db_[name] = std::set<etl::handle<Layer> >();
+				group_db_[name] = std::set<Layer::Handle>();
 				signal_group_added()(name);
 			}
 			pos++;
@@ -1427,7 +1427,7 @@ Canvas::rename_group(const String&old_name,const String&new_name)
 	{
 		const std::string old_name_prefix = old_name + GROUP_NEST_CHAR;
 
-		std::map<String,std::set<etl::handle<Layer> > >::iterator iter;
+		std::map<String,std::set<Layer::Handle> >::iterator iter;
 
 		iter=group_db_.find(old_name);
 		if(iter!=group_db_.end()) {
@@ -1440,8 +1440,8 @@ Canvas::rename_group(const String&old_name,const String&new_name)
 		}
 	}
 
-	std::set<etl::handle<Layer> > layers(get_layers_in_group(old_name));
-	std::set<etl::handle<Layer> >::iterator iter;
+	std::set<Layer::Handle> layers(get_layers_in_group(old_name));
+	std::set<Layer::Handle>::iterator iter;
 
 	for(iter=layers.begin();iter!=layers.end();++iter)
 	{
@@ -1451,7 +1451,7 @@ Canvas::rename_group(const String&old_name,const String&new_name)
 	// if empty group, rename it
 	if (layers.size() == 0) {
 		group_db_.erase(group_db_.find(old_name));
-		group_db_[new_name] = std::set<etl::handle<Layer> >();
+		group_db_[new_name] = std::set<Layer::Handle>();
 		signal_group_removed()(old_name);
 		signal_group_added()(new_name);
 	}

--- a/synfig-core/src/synfig/canvas.h
+++ b/synfig-core/src/synfig/canvas.h
@@ -278,8 +278,8 @@ private:
 	//! Group Changed
 	sigc::signal<void,String> signal_group_changed_;
 
-	sigc::signal<void,String,etl::handle<synfig::Layer> > signal_group_pair_added_;
-	sigc::signal<void,String,etl::handle<synfig::Layer> > signal_group_pair_removed_;
+	sigc::signal<void,String,etl::handle<Layer>> signal_group_pair_added_;
+	sigc::signal<void,String,etl::handle<Layer>> signal_group_pair_removed_;
 
 	//!	RendDesc Changed
 	sigc::signal<void> signal_rend_desc_changed_;
@@ -315,8 +315,8 @@ private:
 
 public:
 
-	sigc::signal<void,String,etl::handle<synfig::Layer> >& signal_group_pair_added() { return signal_group_pair_added_; }
-	sigc::signal<void,String,etl::handle<synfig::Layer> >& signal_group_pair_removed() { return signal_group_pair_removed_; }
+	sigc::signal<void,String,etl::handle<Layer>>& signal_group_pair_added() { return signal_group_pair_added_; }
+	sigc::signal<void,String,etl::handle<Layer>>& signal_group_pair_removed() { return signal_group_pair_removed_; }
 
 	//!	Group Added
 	sigc::signal<void,String>& signal_group_added() { return signal_group_added_; }

--- a/synfig-core/src/synfig/canvas.h
+++ b/synfig-core/src/synfig/canvas.h
@@ -301,13 +301,13 @@ private:
 
 
 	//!	ValueBasenode Changed
-	sigc::signal<void, etl::handle<ValueNode> > signal_value_node_changed_;
+	sigc::signal<void, ValueNode::Handle> signal_value_node_changed_;
 	//!	ValueBasenode Renamed
-	sigc::signal<void, etl::handle<ValueNode> > signal_value_node_renamed_;
+	sigc::signal<void, ValueNode::Handle> signal_value_node_renamed_;
 	//!	Child Value Node Added. Used in Dynamic List Value Nodes
-	sigc::signal<void, etl::handle<ValueNode>, etl::handle<ValueNode> > signal_value_node_child_added_;
+	sigc::signal<void, ValueNode::Handle, ValueNode::Handle> signal_value_node_child_added_;
 	//!	Child Value Node Removed. Used in Dynamic List Value Nodes
-	sigc::signal<void, etl::handle<ValueNode>, etl::handle<ValueNode> > signal_value_node_child_removed_;
+	sigc::signal<void, ValueNode::Handle, ValueNode::Handle> signal_value_node_child_removed_;
 
 	/*
  -- ** -- S I G N A L   I N T E R F A C E -------------------------------------
@@ -343,20 +343,20 @@ public:
 	sigc::signal<void>& signal_meta_data_changed(const String& key) { return signal_map_meta_data_changed_[key]; }
 
 	//! Value Node Changed
-	sigc::signal<void, etl::handle<ValueNode> >& signal_value_node_changed() { return signal_value_node_changed_; }
+	sigc::signal<void, ValueNode::Handle>& signal_value_node_changed() { return signal_value_node_changed_; }
 	//! Value Node Renamed
-	sigc::signal<void, etl::handle<ValueNode> >& signal_value_node_renamed() { return signal_value_node_renamed_; }
+	sigc::signal<void, ValueNode::Handle>& signal_value_node_renamed() { return signal_value_node_renamed_; }
 
 	//! Dirty
 	sigc::signal<void>& signal_dirty() { return signal_changed();	}
 
 	//! Child Value Node Added
-	sigc::signal<void, etl::handle<ValueNode>, etl::handle<ValueNode> >& signal_value_node_child_added() { return signal_value_node_child_added_; }
+	sigc::signal<void, ValueNode::Handle, ValueNode::Handle>& signal_value_node_child_added() { return signal_value_node_child_added_; }
 
 	//! Child Value Node Removed
-	sigc::signal<void, etl::handle<ValueNode>, etl::handle<ValueNode> >& signal_value_node_child_removed() { return signal_value_node_child_removed_; }
+	sigc::signal<void, ValueNode::Handle, ValueNode::Handle>& signal_value_node_child_removed() { return signal_value_node_child_removed_; }
 
-	void invoke_signal_value_node_child_removed(etl::handle<ValueNode>, etl::handle<ValueNode>);
+	void invoke_signal_value_node_child_removed(ValueNode::Handle, ValueNode::Handle);
 
 	/*
  --	** -- C O N S T R U C T O R S ---------------------------------------------

--- a/synfig-core/src/synfig/context.cpp
+++ b/synfig-core/src/synfig/context.cpp
@@ -232,7 +232,7 @@ Context::get_full_bounding_rect()const
 */
 
 
-etl::handle<Layer>
+Layer::Handle
 Context::hit_check(const Point &pos)const
 {
 	Context context(*this);

--- a/synfig-core/src/synfig/context.h
+++ b/synfig-core/src/synfig/context.h
@@ -174,7 +174,7 @@ public:
 	Rect get_full_bounding_rect()const;
 
 	//! Returns the first context's layer's handle that intesects the given \point */
-	etl::handle<Layer> hit_check(const Point &point)const;
+	Layer::Handle hit_check(const Point &point)const;
 
 	//! Returns \c true if layer is active with this context_params
 	static inline bool active(const ContextParams &context_params, const Layer &layer) {

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -312,7 +312,7 @@ Layer::dynamic_param_changed(const String &param)
 }
 
 bool
-Layer::connect_dynamic_param(const String& param, etl::loose_handle<ValueNode> value_node)
+Layer::connect_dynamic_param(const String& param, ValueNode::LooseHandle value_node)
 {
 	if (!value_node) return disconnect_dynamic_param(param);
 

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -206,7 +206,7 @@ synfig::Layer::~Layer()
 }
 
 void
-synfig::Layer::set_canvas(etl::loose_handle<Canvas> x)
+synfig::Layer::set_canvas(Canvas::LooseHandle x)
 {
 	if(canvas_!=x)
 	{
@@ -220,7 +220,7 @@ synfig::Layer::set_canvas(etl::loose_handle<Canvas> x)
 						*this,
 						&Layer::set_canvas
 					),
-					etl::loose_handle<synfig::Canvas>(0)
+					Canvas::LooseHandle(0)
 				)
 			);
 		}
@@ -247,7 +247,7 @@ synfig::Layer::on_dynamic_param_changed(const String & /* param */)
 	{ }
 
 
-etl::loose_handle<synfig::Canvas>
+Canvas::LooseHandle
 synfig::Layer::get_canvas()const
 {
 	return canvas_;

--- a/synfig-core/src/synfig/layers/layer_duplicate.cpp
+++ b/synfig-core/src/synfig/layers/layer_duplicate.cpp
@@ -155,7 +155,7 @@ Layer_Duplicate::get_duplicate_param()const
 	const DynamicParamList &dpl = dynamic_param_list();
 	DynamicParamList::const_iterator iter = dpl.find("index");
 	if (iter == dpl.end()) return nullptr;
-	etl::rhandle<ValueNode> param(iter->second);
+	ValueNode::RHandle param(iter->second);
 	return ValueNode_Duplicate::Handle::cast_dynamic(param);
 }
 

--- a/synfig-core/src/synfig/layers/layer_pastecanvas.cpp
+++ b/synfig-core/src/synfig/layers/layer_pastecanvas.cpp
@@ -223,7 +223,7 @@ Layer_PasteCanvas::childs_changed()
 }
 
 void
-Layer_PasteCanvas::set_sub_canvas(etl::handle<synfig::Canvas> x)
+Layer_PasteCanvas::set_sub_canvas(Canvas::Handle x)
 {
 	if (sub_canvas)
 		remove_child(sub_canvas.get());

--- a/synfig-core/src/synfig/layers/layer_pastecanvas.h
+++ b/synfig-core/src/synfig/layers/layer_pastecanvas.h
@@ -63,8 +63,8 @@ private:
 	ValueBase param_origin;
 	//! Parameter: (Transformation) Position, rotation and scale of the paste canvas layer
 	ValueBase param_transformation;
-	//! Parameter: (etl::loose_handle<synfig::Canvas>) The canvas parameter
-	etl::loose_handle<synfig::Canvas> sub_canvas;
+	//! Parameter: (Canvas::LooseHandle) The canvas parameter
+	Canvas::LooseHandle sub_canvas;
 	//! Parameter: (Real) Time dilation of the paste canvas layer
 	ValueBase param_time_dilation;
 	//! Parameter: (Time) Time offset of the paste canvas layer
@@ -141,10 +141,10 @@ public:
 
 	//! Gets the canvas parameter. It is called sub_canvas to avoid confusion
 	//! with the get_canvas from the Layer class.
-	etl::handle<synfig::Canvas> get_sub_canvas()const { return sub_canvas; }
+	Canvas::Handle get_sub_canvas()const { return sub_canvas; }
 	//! Sets the canvas parameter.
 	//! \see get_sub_canvas()
-	void set_sub_canvas(etl::handle<synfig::Canvas> x);
+	void set_sub_canvas(Canvas::Handle x);
 	//! Gets time dilation parameter
 	Real get_time_dilation()const { return param_time_dilation.get(Real()); }
 	//! Gets time offset parameter

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -1863,8 +1863,8 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 
 	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d creating linkable '%s' type '%s'\n", __FILE__, __LINE__, element->get_name().c_str(), type.description.name.c_str());
 	handle<LinkableValueNode> value_node=ValueNodeRegistry::create(element->get_name(),type);
- 	//handle<ValueNode> c[value_node->link_count()]; changed because of clang complain
-	std::vector<handle<ValueNode> > c(value_node->link_count());
+	//ValueNode::Handle c[value_node->link_count()]; changed because of clang complain
+	std::vector<ValueNode::Handle> c(value_node->link_count());
 
 	if(!value_node)
 	{
@@ -2537,11 +2537,11 @@ CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 	return value_node;
 }
 
-handle<ValueNode>
+ValueNode::Handle
 CanvasParser::parse_value_node(xmlpp::Element *element,Canvas::Handle canvas)
 {
 	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d parse_value_node\n", __FILE__, __LINE__);
-	handle<ValueNode> value_node;
+	ValueNode::Handle value_node;
 	assert(element);
 
 	GUID guid;
@@ -2860,7 +2860,7 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 				else
 				try
 				{
-					handle<ValueNode> value_node=canvas->surefind_value_node(str);
+					ValueNode::Handle value_node=canvas->surefind_value_node(str);
 					if(PlaceholderValueNode::Handle::cast_dynamic(value_node))
 						throw Exception::IDNotFound("parse_layer()");
 
@@ -2925,7 +2925,7 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 			}
 
 			ValueBase data;
-			handle<ValueNode> value_node;
+			ValueNode::Handle value_node;
 
 			// If we recognize the element name as a
 			// ValueBase, then treat is at one

--- a/synfig-core/src/synfig/loadcanvas.h
+++ b/synfig-core/src/synfig/loadcanvas.h
@@ -177,7 +177,7 @@ private:
 	//! Generic Value Base Parsing Function
 	ValueBase parse_value(xmlpp::Element *node,Canvas::Handle canvas);
 	//! Generic Value Node Parsing Function
-	etl::handle<ValueNode> parse_value_node(xmlpp::Element *node,Canvas::Handle canvas);
+	ValueNode::Handle parse_value_node(xmlpp::Element *node,Canvas::Handle canvas);
 
 	//! Real Value Base Parsing Function
 	Real parse_real(xmlpp::Element *node);

--- a/synfig-core/src/synfig/target.cpp
+++ b/synfig-core/src/synfig/target.cpp
@@ -99,7 +99,7 @@ Target::Target():
 }
 
 void
-synfig::Target::set_canvas(etl::handle<Canvas> c)
+synfig::Target::set_canvas(Canvas::Handle c)
 {
 	canvas=c;
 	RendDesc desc=canvas->rend_desc();

--- a/synfig-core/src/synfig/target.h
+++ b/synfig-core/src/synfig/target.h
@@ -170,7 +170,7 @@ public:
 	/*!
 	 ** \sa set_canvas()
 	 */
-	etl::handle<Canvas> canvas;
+	Canvas::Handle canvas;
 
 	//! Render quality used for the render process of the target.
 	int quality_;
@@ -206,9 +206,9 @@ public:
 	//! Sets how to handle alpha
 	void set_alpha_mode(TargetAlphaMode x=TARGET_ALPHA_MODE_KEEP) { alpha_mode=x; }
 	//! Sets the target canvas. Must be defined by derived targets
-	virtual void set_canvas(etl::handle<Canvas> c);
+	virtual void set_canvas(Canvas::Handle c);
 	//! Gets the target canvas.
-	const etl::handle<Canvas> &get_canvas()const { return canvas; }
+	const Canvas::Handle &get_canvas()const { return canvas; }
 	//! Gets the target particular render description
 	RendDesc &rend_desc() { return desc; }
 	//! Gets the target particular render description

--- a/synfig-core/src/synfig/target_multi.cpp
+++ b/synfig-core/src/synfig/target_multi.cpp
@@ -65,7 +65,7 @@ Target_Multi::~Target_Multi()
 }
 
 void
-Target_Multi::set_canvas(etl::handle<Canvas> c)
+Target_Multi::set_canvas(Canvas::Handle c)
 {
 	canvas=c;
 	RendDesc desc=canvas->rend_desc();

--- a/synfig-core/src/synfig/target_multi.h
+++ b/synfig-core/src/synfig/target_multi.h
@@ -59,7 +59,7 @@ public:
 	Color * start_scanline(int scanline) override;
 	bool end_scanline() override;
 
-	void set_canvas(etl::handle<Canvas> c) override;
+	void set_canvas(Canvas::Handle c) override;
 	bool set_rend_desc(RendDesc* d) override;
 	bool init(ProgressCallback* cb = nullptr) override;
 }; // END of class Target_Multi

--- a/synfig-core/src/synfig/target_tile.cpp
+++ b/synfig-core/src/synfig/target_tile.cpp
@@ -227,7 +227,7 @@ synfig::Target_Tile::render_frame_(Canvas::Handle canvas, ContextParams context_
 
 bool
 synfig::Target_Tile::async_render_tile(
-	etl::handle<Canvas> canvas,
+	Canvas::Handle canvas,
 	ContextParams context_params,
 	RectInt rect,
 	RendDesc tile_desc,

--- a/synfig-core/src/synfig/target_tile.h
+++ b/synfig-core/src/synfig/target_tile.h
@@ -85,7 +85,7 @@ public:
 	virtual bool render(ProgressCallback* cb = nullptr);
 
 	virtual bool async_render_tile(
-		etl::handle<Canvas> canvas,
+		Canvas::Handle canvas,
 		ContextParams context_params,
 		RectInt rect,
 		RendDesc tile_desc,
@@ -140,7 +140,7 @@ public:
 
 private:
 	//! Renders the context to the surface
-	bool render_frame_(etl::handle<Canvas> canvas, ContextParams context_params, ProgressCallback *cb);
+	bool render_frame_(Canvas::Handle canvas, ContextParams context_params, ProgressCallback *cb);
 
 }; // END of class Target_Tile
 

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -142,7 +142,7 @@ ValueNode::on_changed()
 	DEBUG_LOG("SYNFIG_DEBUG_ON_CHANGED",
 		"%s:%d ValueNode::on_changed()\n", __FILE__, __LINE__);
 
-	etl::loose_handle<Canvas> parent_canvas = get_parent_canvas();
+	Canvas::LooseHandle parent_canvas = get_parent_canvas();
 	if(parent_canvas)
 		do						// signal to all the ancestor canvases
 			parent_canvas->signal_value_node_changed()(this);
@@ -586,7 +586,7 @@ ValueNode::get_relative_id(etl::loose_handle<const Canvas> x)const
 	return canvas_->_get_relative_id(x)+':'+get_id();
 }
 
-etl::loose_handle<Canvas>
+Canvas::LooseHandle
 ValueNode::get_parent_canvas()const
 {
 	DEBUG_LOG("SYNFIG_DEBUG_GET_PARENT_CANVAS",
@@ -595,7 +595,7 @@ ValueNode::get_parent_canvas()const
 	return canvas_;
 }
 
-etl::loose_handle<Canvas>
+Canvas::LooseHandle
 ValueNode::get_root_canvas()const
 {
 	DEBUG_LOG("SYNFIG_DEBUG_GET_PARENT_CANVAS",
@@ -604,14 +604,14 @@ ValueNode::get_root_canvas()const
 	return root_canvas_;
 }
 
-etl::loose_handle<Canvas>
+Canvas::LooseHandle
 ValueNode::get_non_inline_ancestor_canvas()const
 {
-	etl::loose_handle<Canvas> parent(get_parent_canvas());
+	Canvas::LooseHandle parent(get_parent_canvas());
 
 	if (parent)
 	{
-		etl::loose_handle<Canvas> ret(parent->get_non_inline_ancestor());
+		Canvas::LooseHandle ret(parent->get_non_inline_ancestor());
 
 		DEBUG_LOG("SYNFIG_DEBUG_GET_PARENT_CANVAS",
 			"%s:%d get_non_inline_ancestor_canvas of %p is %p\n", __FILE__, __LINE__, this, ret.get());
@@ -623,7 +623,7 @@ ValueNode::get_non_inline_ancestor_canvas()const
 }
 
 void
-ValueNode::set_parent_canvas(etl::loose_handle<Canvas> x)
+ValueNode::set_parent_canvas(Canvas::LooseHandle x)
 {
 	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
 		"%s:%d set_parent_canvas of %p to %p\n", __FILE__, __LINE__, this, x.get());
@@ -637,7 +637,7 @@ ValueNode::set_parent_canvas(etl::loose_handle<Canvas> x)
 }
 
 void
-ValueNode::set_root_canvas(etl::loose_handle<Canvas> x)
+ValueNode::set_root_canvas(Canvas::LooseHandle x)
 {
 	DEBUG_LOG("SYNFIG_DEBUG_SET_PARENT_CANVAS",
 		"%s:%d set_root_canvas of %p to %p - ", __FILE__, __LINE__, this, x.get());
@@ -800,7 +800,7 @@ LinkableValueNode::init_children_vocab()
 }
 
 void
-LinkableValueNode::set_root_canvas(etl::loose_handle<Canvas> x)
+LinkableValueNode::set_root_canvas(Canvas::LooseHandle x)
 {
 	ValueNode::set_root_canvas(x);
 	for(int i = 0; i < link_count(); ++i)

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -154,7 +154,7 @@ ValueNode::on_changed()
 }
 
 int
-ValueNode::replace(etl::handle<ValueNode> x)
+ValueNode::replace(ValueNode::Handle x)
 {
 	if(x.get()==this)
 		return 0;

--- a/synfig-core/src/synfig/valuenode.h
+++ b/synfig-core/src/synfig/valuenode.h
@@ -255,7 +255,7 @@ public:
 	//! Notice that it is called twice and the second time it uses
 	//! a replaceable handle to the Node
 	//! \see etl::rhandle
-	int replace(etl::handle<ValueNode> x);
+	int replace(ValueNode::Handle x);
 	
 	//! Get the default interpolation for Value Nodes
 	virtual Interpolation get_interpolation()const { return INTERPOLATION_UNDEFINED; }

--- a/synfig-core/src/synfig/valuenodes/valuenode_anglestring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_anglestring.cpp
@@ -81,7 +81,7 @@ ValueNode_AngleString::create_new()const
 }
 
 ValueNode_AngleString*
-ValueNode_AngleString::create(const ValueBase& x, etl::loose_handle<Canvas>)
+ValueNode_AngleString::create(const ValueBase& x, Canvas::LooseHandle)
 {
 	return new ValueNode_AngleString(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.cpp
@@ -353,7 +353,7 @@ ValueNode_AnimatedFile::create_new() const
 	{ return new ValueNode_AnimatedFile(get_type()); }
 
 ValueNode_AnimatedFile*
-ValueNode_AnimatedFile::create(const ValueBase& x, etl::loose_handle<Canvas>)
+ValueNode_AnimatedFile::create(const ValueBase& x, Canvas::LooseHandle)
 	{ return new ValueNode_AnimatedFile(x.get_type()); }
 
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedfile.h
@@ -61,7 +61,7 @@ public:
 	typedef etl::handle<ValueNode_AnimatedFile> Handle;
 	typedef etl::handle<const ValueNode_AnimatedFile> ConstHandle;
 
-	static ValueNode_AnimatedFile* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
+	static ValueNode_AnimatedFile* create(const ValueBase& x, Canvas::LooseHandle canvas=nullptr);
 	virtual ~ValueNode_AnimatedFile();
 
 	virtual ValueBase operator()(Time t) const override;

--- a/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bone.cpp
@@ -132,7 +132,7 @@ ValueNode_Bone::get_bone_map(Canvas::ConstHandle canvas)
 }
 
 ValueNode_Bone::BoneList
-ValueNode_Bone::get_ordered_bones(etl::handle<const Canvas> canvas)
+ValueNode_Bone::get_ordered_bones(Canvas::ConstHandle canvas)
 {
 	std::multimap<ValueNode_Bone::Handle, ValueNode_Bone::Handle> uses;
 	std::multimap<ValueNode_Bone::Handle, ValueNode_Bone::Handle> is_used_by;
@@ -236,7 +236,7 @@ ValueNode_Bone::ValueNode_Bone():
 		"%s:%d ValueNode_Bone::ValueNode_Bone() this line should only appear once guid %s\n", __FILE__, __LINE__, get_guid().get_string().c_str());
 }
 
-ValueNode_Bone::ValueNode_Bone(const ValueBase &value, etl::loose_handle<Canvas> canvas):
+ValueNode_Bone::ValueNode_Bone(const ValueBase &value, Canvas::LooseHandle canvas):
 	LinkableValueNode(value.get_type())
 {
 	if (DEBUG_GETENV("SYNFIG_DEBUG_BONE_CONSTRUCTORS"))
@@ -339,7 +339,7 @@ ValueNode_Bone::set_guid(const GUID& new_guid)
 }
 
 void
-ValueNode_Bone::set_root_canvas(etl::loose_handle<Canvas> canvas)
+ValueNode_Bone::set_root_canvas(Canvas::LooseHandle canvas)
 {
 	GUID guid(get_guid());
 	Canvas::LooseHandle old_canvas(get_root_canvas());
@@ -645,7 +645,7 @@ ValueNode_Bone::find(const String& name)const
 }
 
 ValueNode_Bone::LooseHandle
-ValueNode_Bone::find(const String& name, etl::loose_handle<Canvas> canvas)
+ValueNode_Bone::find(const String& name, Canvas::LooseHandle canvas)
 {
 	// printf("%s:%d finding '%s' : ", __FILE__, __LINE__, name.c_str());
 
@@ -1017,7 +1017,7 @@ ValueNode_Bone_Root::set_guid(const GUID& new_guid)
 }
 
 void
-ValueNode_Bone_Root::set_root_canvas(etl::loose_handle<Canvas> canvas)
+ValueNode_Bone_Root::set_root_canvas(Canvas::LooseHandle canvas)
 {
 	DEBUG_LOG("SYNFIG_DEBUG_ROOT_BONE",
 		"%s:%d bypass set_root_canvas() for root bone\n", __FILE__, __LINE__);
@@ -1025,7 +1025,7 @@ ValueNode_Bone_Root::set_root_canvas(etl::loose_handle<Canvas> canvas)
 }
 
 ValueNode_Bone*
-ValueNode_Bone_Root::create(const ValueBase& /*x*/, etl::loose_handle<Canvas>)
+ValueNode_Bone_Root::create(const ValueBase& /*x*/, Canvas::LooseHandle)
 {
 	return get_root_bone().get();
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_const.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_const.cpp
@@ -103,7 +103,7 @@ ValueNode_Const::create(const ValueBase& x, Canvas::LooseHandle canvas)
 
 
 ValueNode::Handle
-ValueNode_Const::clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid)const
+ValueNode_Const::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid)const
 {
 	{ ValueNode* x(find_value_node(get_guid()^deriv_guid).get()); if(x)return x; }
 	ValueNode* ret(new ValueNode_Const(value));

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.cpp
@@ -623,7 +623,7 @@ ValueNode_DynamicList::~ValueNode_DynamicList()
 }
 
 ValueNode_DynamicList*
-ValueNode_DynamicList::create(const ValueBase& value, etl::loose_handle<Canvas>)
+ValueNode_DynamicList::create(const ValueBase& value, Canvas::LooseHandle)
 {
 	//vector<ValueBase> value_list(value.operator vector<ValueBase>());
 	std::vector<ValueBase> value_list(value.get_list());
@@ -774,7 +774,7 @@ ValueNode_DynamicList::check_type(Type &type)
 }
 
 void
-ValueNode_DynamicList::set_member_canvas(etl::loose_handle<Canvas> canvas)
+ValueNode_DynamicList::set_member_canvas(Canvas::LooseHandle canvas)
 {
 	for (std::vector<ListEntry>::iterator iter = list.begin(); iter != list.end(); iter++)
 		iter->value_node->set_parent_canvas(canvas);

--- a/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_dynamiclist.h
@@ -121,8 +121,8 @@ public:
 
 	private:
 		int index;
-		etl::loose_handle<ValueNode> parent_;
-		void set_parent_value_node(const etl::loose_handle<ValueNode> &x) { parent_=x; }
+		ValueNode::LooseHandle parent_;
+		void set_parent_value_node(const ValueNode::LooseHandle& x) { parent_=x; }
 
 	public:
 
@@ -160,13 +160,13 @@ public:
 
 		int find(const Time& begin,const Time& end,std::vector<Activepoint*>& list);
 
-		const synfig::Node::time_set	&get_times() const;
+		const synfig::Node::time_set& get_times() const;
 
-		const etl::loose_handle<ValueNode> &get_parent_value_node()const { return parent_; }
+		const ValueNode::LooseHandle& get_parent_value_node() const { return parent_; }
 
 		ListEntry();
-		ListEntry(const ValueNode::Handle &value_node);
-		ListEntry(const ValueNode::Handle &value_node,Time begin, Time end);
+		ListEntry(const ValueNode::Handle& value_node);
+		ListEntry(const ValueNode::Handle& value_node, Time begin, Time end);
 	}; // END of struct ValueNode_DynamicList::ListEntry
 
 	std::vector<ListEntry> list;

--- a/synfig-core/src/synfig/valuenodes/valuenode_intstring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_intstring.cpp
@@ -80,7 +80,7 @@ ValueNode_IntString::create_new()const
 }
 
 ValueNode_IntString*
-ValueNode_IntString::create(const ValueBase& x, etl::loose_handle<Canvas>)
+ValueNode_IntString::create(const ValueBase& x, Canvas::LooseHandle)
 {
 	return new ValueNode_IntString(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_join.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_join.cpp
@@ -88,7 +88,7 @@ ValueNode_Join::create_new()const
 }
 
 ValueNode_Join*
-ValueNode_Join::create(const ValueBase& x, etl::loose_handle<Canvas>)
+ValueNode_Join::create(const ValueBase& x, Canvas::LooseHandle)
 {
 	return new ValueNode_Join(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.cpp
@@ -90,7 +90,7 @@ ValueNode_RadialComposite::~ValueNode_RadialComposite()
 }
 
 ValueNode_RadialComposite*
-ValueNode_RadialComposite::create(const ValueBase& value, etl::loose_handle<Canvas>)
+ValueNode_RadialComposite::create(const ValueBase& value, Canvas::LooseHandle)
 {
 	return new ValueNode_RadialComposite(value);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_realstring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_realstring.cpp
@@ -81,7 +81,7 @@ ValueNode_RealString::create_new()const
 }
 
 ValueNode_RealString*
-ValueNode_RealString::create(const ValueBase& x, etl::loose_handle<Canvas>)
+ValueNode_RealString::create(const ValueBase& x, Canvas::LooseHandle)
 {
 	return new ValueNode_RealString(x);
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_staticlist.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_staticlist.cpp
@@ -307,7 +307,7 @@ ValueNode_StaticList::create_on_canvas(Type &type, Canvas::LooseHandle canvas)
 }
 
 ValueNode_StaticList*
-ValueNode_StaticList::create(const ValueBase& value, etl::loose_handle<Canvas>)
+ValueNode_StaticList::create(const ValueBase& value, Canvas::LooseHandle)
 {
 	std::vector<ValueBase> value_list(value.get_list());
 
@@ -492,7 +492,7 @@ ValueNode_StaticList::get_children_vocab_vfunc() const
 }
 
 void
-ValueNode_StaticList::set_member_canvas(etl::loose_handle<Canvas> canvas) // line 723
+ValueNode_StaticList::set_member_canvas(Canvas::LooseHandle canvas) // line 723
 {
 	for (std::vector<ReplaceableListEntry>::iterator iter = list.begin(); iter != list.end(); iter++)
 	{

--- a/synfig-core/src/synfig/valuenodes/valuenode_timestring.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timestring.cpp
@@ -74,7 +74,7 @@ ValueNode_TimeString::create_new()const
 }
 
 ValueNode_TimeString*
-ValueNode_TimeString::create(const ValueBase& x, etl::loose_handle<Canvas>)
+ValueNode_TimeString::create(const ValueBase& x, Canvas::LooseHandle)
 {
 	return new ValueNode_TimeString(x);
 }

--- a/synfig-core/src/synfig/waypoint.cpp
+++ b/synfig-core/src/synfig/waypoint.cpp
@@ -67,7 +67,7 @@ Waypoint::Waypoint(ValueBase value, Time time):
 		after=before=INTERPOLATION_LINEAR;
 }
 
-Waypoint::Waypoint(etl::handle<ValueNode> value_node, Time time):
+Waypoint::Waypoint(ValueNode::Handle value_node, Time time):
 	priority_(0),
 	before(INTERPOLATION_TCB),
 	after(INTERPOLATION_TCB),
@@ -105,7 +105,7 @@ Waypoint::set_value(const ValueBase &x)
 }
 
 void
-Waypoint::set_value_node(const etl::handle<ValueNode> &x)
+Waypoint::set_value_node(const ValueNode::Handle& x)
 {
 
 	// printf("%s:%d Waypoint::set_value_node(%lx) = %lx (%s)\n", __FILE__, __LINE__, uintptr_t(this), uintptr_t(x), x->get_string().c_str());
@@ -142,7 +142,7 @@ Waypoint::set_value_node(const etl::handle<ValueNode> &x)
 }
 
 void
-Waypoint::set_parent_value_node(const etl::loose_handle<ValueNode> &x)
+Waypoint::set_parent_value_node(const ValueNode::LooseHandle& x)
 {
 	// printf("%s:%d Waypoint::set_parent_value_node(%lx) = %lx (%s)\n", __FILE__, __LINE__, uintptr_t(this), uintptr_t(x.get()), x->get_string().c_str());
 	assert(get_value_node());

--- a/synfig-core/src/synfig/waypoint.cpp
+++ b/synfig-core/src/synfig/waypoint.cpp
@@ -187,7 +187,7 @@ Waypoint::apply_model(const Model &x)
 }
 
 Waypoint
-Waypoint::clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid)const
+Waypoint::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid)const
 {
 	Waypoint ret(*this);
 	ret.make_unique();

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3773,7 +3773,7 @@ App::open(std::string filename, /* std::string as, */ synfig::FileContainerZip::
 		// file to open inside canvas file-system
 		String canvas_filename = CanvasFileNaming::project_file(filename);
 
-		etl::handle<synfig::Canvas> canvas = open_canvas_as(canvas_file_system ->get_identifier(canvas_filename), filename, errors, warnings);
+		Canvas::Handle canvas = open_canvas_as(canvas_file_system ->get_identifier(canvas_filename), filename, errors, warnings);
 		if(canvas && get_instance(canvas))
 		{
 			get_instance(canvas)->find_canvas_view(canvas)->present();
@@ -3878,7 +3878,7 @@ App::open_from_temporary_filesystem(std::string temporary_filename)
 		// file to open inside canvas file system
 		String canvas_filename = CanvasFileNaming::project_file(canvas_file_system);
 
-		etl::handle<synfig::Canvas> canvas(open_canvas_as(canvas_file_system->get_identifier(canvas_filename), as, errors, warnings));
+		Canvas::Handle canvas(open_canvas_as(canvas_file_system->get_identifier(canvas_filename), as, errors, warnings));
 		if(canvas && get_instance(canvas))
 		{
 			get_instance(canvas)->find_canvas_view(canvas)->present();
@@ -4079,7 +4079,7 @@ App::open_from_plugin(const std::string& filename, const std::string& importer_i
 			FileSystem::Handle canvas_file_system = CanvasFileNaming::make_filesystem(container);
 			canvas_file_system = wrap_into_temporary_filesystem(canvas_file_system, filename_processed, filename, 0);
 			String canvas_filename = CanvasFileNaming::project_file(filename_processed);
-			etl::handle<synfig::Canvas> canvas = open_canvas_as(canvas_file_system->get_identifier(canvas_filename), filename, errors, warnings);
+			Canvas::Handle canvas = open_canvas_as(canvas_file_system->get_identifier(canvas_filename), filename, errors, warnings);
 			if ( !canvas )
 			{
 				errors += strprintf(_("Unable to load \"%s\":\n\n"),filename.c_str());
@@ -4224,7 +4224,7 @@ App::set_selected_canvas_view(etl::loose_handle<CanvasView> canvas_view)
 }
 
 etl::loose_handle<Instance>
-App::get_instance(etl::handle<synfig::Canvas> canvas)
+App::get_instance(Canvas::Handle canvas)
 {
 	if(!canvas) return nullptr;
 	canvas=canvas->get_root();

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3529,7 +3529,7 @@ void App::open_img_in_external(const std::string &uri)
 
 static std::unordered_map<std::string, int> vectorizer_configmap({ { "threshold", 8 },{ "accuracy", 9 },{ "despeckling", 5 },{ "maxthickness", 200 }});
 
-void App::open_vectorizerpopup(const etl::handle<synfig::Layer_Bitmap> my_layer_bitmap, const etl::handle<synfig::Layer> reference_layer)
+void App::open_vectorizerpopup(const etl::handle<synfig::Layer_Bitmap> my_layer_bitmap, const synfig::Layer::Handle reference_layer)
 {
 	String desc = my_layer_bitmap->get_description();
 	synfig::info("Opening Vectorizerpopup for :"+desc);

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -361,7 +361,7 @@ public:
 	static void set_selected_instance(etl::loose_handle<Instance> instance);
 	static void set_selected_canvas_view(etl::loose_handle<CanvasView>);
 
-	static etl::loose_handle<Instance> get_instance(etl::handle<synfig::Canvas> canvas);
+	static etl::loose_handle<Instance> get_instance(synfig::Canvas::Handle canvas);
 
 	static etl::loose_handle<Instance> get_selected_instance() { return selected_instance; }
 	static etl::loose_handle<CanvasView> get_selected_canvas_view() { return selected_canvas_view; }

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -467,7 +467,7 @@ public:
 	static void open_uri(const std::string &uri);
 	static void open_img_in_external(const std::string &uri);
 	static void open_vectorizerpopup(const etl::handle<synfig::Layer_Bitmap> my_layer_bitmap,
-	const etl::handle<synfig::Layer> reference_layer);
+	const synfig::Layer::Handle reference_layer);
 
 
 

--- a/synfig-studio/src/gui/asyncrenderer.cpp
+++ b/synfig-studio/src/gui/asyncrenderer.cpp
@@ -122,7 +122,7 @@ public:
 	}
 
 	virtual bool async_render_tile(
-		etl::handle<Canvas> canvas,
+		Canvas::Handle canvas,
 		ContextParams context_params,
 		RectInt rect,
 		RendDesc tile_desc,
@@ -149,7 +149,7 @@ public:
 	}
 
 	bool sync_render_tile(
-		etl::handle<Canvas> canvas,
+		Canvas::Handle canvas,
 		ContextParams context_params,
 		RectInt rect,
 		RendDesc tile_desc,

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1831,7 +1831,7 @@ CanvasView::close_instance()
 }
 
 etl::handle<CanvasView>
-CanvasView::create(etl::loose_handle<studio::Instance> instance, etl::handle<Canvas> canvas)
+CanvasView::create(etl::loose_handle<studio::Instance> instance, Canvas::Handle canvas)
 	{ return new CanvasView(instance,instance->Instance::find_canvas_interface(canvas)); }
 
 void

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -569,7 +569,7 @@ public:
 	void set_time(synfig::Time t) { time_model()->set_time(t); }
 	synfig::Time get_time() { return time_model()->get_time(); }
 
-	const etl::handle<synfig::Canvas>& get_canvas()const { return canvas_interface_->get_canvas(); }
+	const synfig::Canvas::Handle& get_canvas()const { return canvas_interface_->get_canvas(); }
 	const etl::loose_handle<Instance>& get_instance()const { return instance_; }
 
 	const etl::handle<synfigapp::CanvasInterface>& canvas_interface() { return canvas_interface_; }
@@ -705,7 +705,7 @@ protected:
  -- ** -- S T A T I C   P U B L I C   M E T H O D S ---------------------------
 	*/
 public:
-	static etl::handle<studio::CanvasView> create(etl::loose_handle<Instance> instance,etl::handle<synfig::Canvas> canvas);
+	static etl::handle<studio::CanvasView> create(etl::loose_handle<Instance> instance,synfig::Canvas::Handle canvas);
 	static std::list<int>& get_pixel_sizes();
 
 private:

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -204,7 +204,7 @@ public:
 		//valuewidget->grab_focus();
 	}
 
-	void set_canvas(const etl::handle<synfig::Canvas> &data)
+	void set_canvas(const Canvas::Handle &data)
 	{
 		assert(data);
 		if (valuewidget)
@@ -257,7 +257,7 @@ bool get_paragraph(synfig::String& text)
 CellRenderer_ValueBase::CellRenderer_ValueBase():
 	Glib::ObjectBase          (typeid(CellRenderer_ValueBase)),
 	property_value_	          (*this, "value",                   synfig::ValueBase()),
-	property_canvas_          (*this, "canvas",      etl::handle<synfig::Canvas>()),
+	property_canvas_          (*this, "canvas",                  Canvas::Handle()),
 	property_param_desc_      (*this, "param_desc",              synfig::ParamDesc()),
 	property_value_desc_      (*this, "value_desc",           synfigapp::ValueDesc()),
 	property_child_param_desc_(*this, "child_param_desc",        synfig::ParamDesc()),
@@ -430,12 +430,12 @@ CellRenderer_ValueBase::render_vfunc(
 	else
 	if (type == type_canvas)
 	{
-		if ( data.get(etl::handle<synfig::Canvas>()) )
+		if ( data.get(Canvas::Handle()) )
 		{
-			if (data.get( etl::handle<synfig::Canvas>())->is_inline() )
+			if (data.get( Canvas::Handle())->is_inline() )
 				property_text() = _("<Group>");
 			else
-				property_text() = data.get(etl::handle<synfig::Canvas>())->get_id();
+				property_text() = data.get(Canvas::Handle())->get_id();
 		}
 		else
 			property_text() = _("<No Image Selected>");

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
@@ -55,7 +55,7 @@ class CellRenderer_ValueBase : public Gtk::CellRendererText
 	sigc::signal<void, const Glib::ustring&, synfig::ValueBase> signal_edited_;
 
 	Glib::Property<synfig::ValueBase>            property_value_;
-	Glib::Property<etl::handle<synfig::Canvas> > property_canvas_;
+	Glib::Property<synfig::Canvas::Handle>       property_canvas_;
 	Glib::Property<synfig::ParamDesc>            property_param_desc_;
 	Glib::Property<synfigapp::ValueDesc>         property_value_desc_;
 	Glib::Property<synfig::ParamDesc>            property_child_param_desc_;
@@ -76,13 +76,13 @@ public:
 	{return signal_edited_; }
 
 	Glib::PropertyProxy<synfig::ValueBase>            property_value()            { return property_value_.get_proxy();}
-	Glib::PropertyProxy<etl::handle<synfig::Canvas> > property_canvas()           { return property_canvas_.get_proxy();}
+	Glib::PropertyProxy<synfig::Canvas::Handle>       property_canvas()           { return property_canvas_.get_proxy();}
 	Glib::PropertyProxy<synfig::ParamDesc>            property_param_desc()       { return property_param_desc_.get_proxy(); }
 	Glib::PropertyProxy<synfigapp::ValueDesc>         property_value_desc()       { return property_value_desc_.get_proxy(); }
 	Glib::PropertyProxy<synfig::ParamDesc>            property_child_param_desc() { return property_child_param_desc_.get_proxy(); }
 	Glib::PropertyProxy<bool>                         property_inconsistent()     { return property_foreground_set(); }
 
-	etl::handle<synfig::Canvas> get_canvas()const           { return property_canvas_; }
+	synfig::Canvas::Handle      get_canvas()const           { return property_canvas_; }
 	synfig::ParamDesc           get_param_desc()const       { return property_param_desc_; }
 	synfigapp::ValueDesc        get_value_desc()const       { return property_value_desc_; }
 	synfig::ParamDesc           get_child_param_desc()const { return property_child_param_desc_; }

--- a/synfig-studio/src/gui/dialogs/dialog_preview.h
+++ b/synfig-studio/src/gui/dialogs/dialog_preview.h
@@ -64,7 +64,7 @@ class Dialog_Preview : public Gtk::Window
 	Widget_Preview 	preview;
 	DialogSettings	settings;
 
-	//etl::handle<synfig::Canvas> canvas;
+	//Canvas::Handle canvas;
 
 public:
 	Dialog_Preview();

--- a/synfig-studio/src/gui/dialogs/dialog_waypoint.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_waypoint.cpp
@@ -52,7 +52,7 @@ using namespace studio;
 
 /* === M E T H O D S ======================================================= */
 
-Dialog_Waypoint::Dialog_Waypoint(Gtk::Window& parent,etl::handle<synfig::Canvas> canvas):
+Dialog_Waypoint::Dialog_Waypoint(Gtk::Window& parent,Canvas::Handle canvas):
 	Dialog(_("Waypoint Editor"),parent),
 	canvas(canvas)
 {

--- a/synfig-studio/src/gui/dialogs/dialog_waypoint.h
+++ b/synfig-studio/src/gui/dialogs/dialog_waypoint.h
@@ -50,7 +50,7 @@ class Widget_Waypoint;
 class Dialog_Waypoint : public Gtk::Dialog
 {
 	Widget_Waypoint *waypointwidget;
-	etl::handle<synfig::Canvas> canvas;
+	synfig::Canvas::Handle canvas;
 	synfigapp::ValueDesc value_desc_;
 
 	sigc::signal<void> signal_changed_;
@@ -65,7 +65,7 @@ class Dialog_Waypoint : public Gtk::Dialog
 	void refresh();
 
 public:
-	Dialog_Waypoint(Gtk::Window& parent,etl::handle<synfig::Canvas> canvas);
+	Dialog_Waypoint(Gtk::Window& parent,synfig::Canvas::Handle canvas);
 	~Dialog_Waypoint();
 
     void reset();

--- a/synfig-studio/src/gui/dialogs/vectorizersettings.cpp
+++ b/synfig-studio/src/gui/dialogs/vectorizersettings.cpp
@@ -255,7 +255,7 @@ VectorizerSettings::on_convert_pressed()
 	action->set_param("maxthickness",((int)adjustment_maxthickness->get_value()) / 2);
 	action->set_param("pparea",toggle_pparea.get_state());
 	action->set_param("addborder",toggle_add_border.get_state());
-	etl::handle<synfig::Canvas> canvas;
+	Canvas::Handle canvas;
 
 	// in case the "convert to vector" was clicked for layer inside a switch
 	// and pass canvas accordingly

--- a/synfig-studio/src/gui/dialogs/vectorizersettings.h
+++ b/synfig-studio/src/gui/dialogs/vectorizersettings.h
@@ -75,7 +75,7 @@ class VectorizerSettings : public Gtk::Dialog
 
 	Gtk::ComboBoxText comboboxtext_mode;
 	etl::handle<synfig::Layer_Bitmap> layer_bitmap_;
-	etl::handle<synfig::Layer> reference_layer_;
+	synfig::Layer::Handle reference_layer_;
 	etl::handle<Instance> instance;
 	std::unordered_map <std::string,int>* config_map;
 
@@ -84,7 +84,7 @@ public:
 	bool isOutline;
 	VectorizerSettings(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& refGlade);
 	static VectorizerSettings * create(Gtk::Window& parent,etl::handle<synfig::Layer_Bitmap> my_layer_bitmap,
-			etl::handle<studio::Instance> selected_instance,std::unordered_map <std::string,int>& configmap, etl::handle<synfig::Layer> reference_layer);
+			etl::handle<studio::Instance> selected_instance,std::unordered_map <std::string,int>& configmap, synfig::Layer::Handle reference_layer);
 	~VectorizerSettings();
 
 	// CenterlineConfiguration getCenterlineConfiguration() const;

--- a/synfig-studio/src/gui/docks/dock_canvases.cpp
+++ b/synfig-studio/src/gui/docks/dock_canvases.cpp
@@ -144,7 +144,7 @@ Dock_Canvases::get_selected_canvas_view()
 	return get_selected_instance()->find_canvas_view(get_selected_canvas());
 }
 
-etl::loose_handle<synfig::Canvas>
+Canvas::LooseHandle
 Dock_Canvases::get_selected_canvas()
 {
 	Glib::RefPtr<Gtk::TreeSelection> selection=canvas_tree->get_selection();
@@ -154,7 +154,7 @@ Dock_Canvases::get_selected_canvas()
 
 	studio::Instance::CanvasTreeModel canvas_tree_model;
 
-	return static_cast<etl::handle<synfig::Canvas> >((*selection->get_selected())[canvas_tree_model.canvas]);
+	return static_cast<Canvas::Handle>((*selection->get_selected())[canvas_tree_model.canvas]);
 }
 
 

--- a/synfig-studio/src/gui/docks/dock_canvases.h
+++ b/synfig-studio/src/gui/docks/dock_canvases.h
@@ -54,7 +54,7 @@ private:
 
 	etl::loose_handle<studio::Instance> get_selected_instance() { return selected_instance; }
 
-	etl::loose_handle<synfig::Canvas> get_selected_canvas();
+	synfig::Canvas::LooseHandle get_selected_canvas();
 
 	etl::loose_handle<studio::CanvasView> get_selected_canvas_view();
 

--- a/synfig-studio/src/gui/event_layerclick.h
+++ b/synfig-studio/src/gui/event_layerclick.h
@@ -45,10 +45,10 @@ struct EventLayerClick : public Smach::event
 {
 	synfig::Point pos;
 	MouseButton button;
-	etl::loose_handle<synfig::Layer> layer;
+	synfig::Layer::LooseHandle layer;
 	Gdk::ModifierType modifier;
 
-	EventLayerClick(etl::loose_handle<synfig::Layer> layer, MouseButton button, const synfig::Point& pos, Gdk::ModifierType modifier=Gdk::ModifierType(0)):
+	EventLayerClick(synfig::Layer::LooseHandle layer, MouseButton button, const synfig::Point& pos, Gdk::ModifierType modifier=Gdk::ModifierType(0)):
 		Smach::event(EVENT_WORKAREA_LAYER_CLICKED),
 		pos(pos),
 		button(button),

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -206,7 +206,7 @@ Instance::create(synfig::Canvas::Handle canvas, synfig::FileSystem::Handle conta
 }
 
 handle<CanvasView>
-Instance::find_canvas_view(etl::handle<synfig::Canvas> canvas)
+Instance::find_canvas_view(Canvas::Handle canvas)
 {
 	if(!canvas)
 		return 0;
@@ -224,7 +224,7 @@ Instance::find_canvas_view(etl::handle<synfig::Canvas> canvas)
 }
 
 void
-Instance::focus(etl::handle<synfig::Canvas> canvas)
+Instance::focus(Canvas::Handle canvas)
 {
 	handle<CanvasView> canvas_view=find_canvas_view(canvas);
 	assert(canvas_view);

--- a/synfig-studio/src/gui/instance.h
+++ b/synfig-studio/src/gui/instance.h
@@ -169,12 +169,12 @@ public:
 	//! Returns the number of instances that are currently open in the program
 	static int get_count() { return instance_count_; }
 
-	//etl::handle<synfig::Canvas> get_canvas()const { return synfigapp::Instance::get_canvas(); }
+	//Canvas::Handle get_canvas()const { return synfigapp::Instance::get_canvas(); }
 
-	etl::handle<CanvasView>	find_canvas_view(etl::handle<synfig::Canvas> canvas);
+	etl::handle<CanvasView>	find_canvas_view(synfig::Canvas::Handle canvas);
 
 	//! Sets the focus to a specific canvas
-	void focus(etl::handle<synfig::Canvas> canvas);
+	void focus(synfig::Canvas::Handle canvas);
 
 	CanvasViewList & canvas_view_list() { return canvas_view_list_; }
 

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -251,7 +251,7 @@ void studio::Preview::clear()
 	frames.clear();
 }
 
-const etl::handle<synfig::Canvas>&
+const Canvas::Handle&
 studio::Preview::get_canvas() const
 	{return canvasview->get_canvas();}
 

--- a/synfig-studio/src/gui/preview.h
+++ b/synfig-studio/src/gui/preview.h
@@ -162,7 +162,7 @@ public:
 	int		get_quality() const {return quality;}
 	void	set_quality(int i)	{quality = i;}
 
-	const etl::handle<synfig::Canvas>& get_canvas() const;
+	const synfig::Canvas::Handle& get_canvas() const;
 	const etl::loose_handle<CanvasView>& get_canvasview() const;
 
 	void set_canvasview(const etl::loose_handle<CanvasView> &h);

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -236,7 +236,7 @@ RenderSettings::set_entry_filename()
 	String filename(filename_sans_extension(canvas_interface_->get_canvas()->get_file_name()));
 
 	// if this isn't the root canvas, append (<canvasname>) to the filename
-	etl::handle<synfig::Canvas> canvas = canvas_interface_->get_canvas();
+	Canvas::Handle canvas = canvas_interface_->get_canvas();
 	if (!canvas->is_root())
 	{
 		if(canvas->get_name().empty())

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -1473,7 +1473,7 @@ StateLasso_Context::new_bline(std::list<synfig::BLinePoint> bline,std::list<synf
                 
                 synfigapp::Action::Handle action(synfigapp::Action::create("LayerEncapsulate"));
                
-                etl::handle<synfig::Canvas> cv( layer_list.back()->get_canvas() );
+                Canvas::Handle cv( layer_list.back()->get_canvas() );
                         
                 action->set_param("layer",*(layer_list.rbegin()));
                 layer_list.pop_back();

--- a/synfig-studio/src/gui/trees/canvastreestore.h
+++ b/synfig-studio/src/gui/trees/canvastreestore.h
@@ -134,7 +134,7 @@ public:
 
 	const Model model;
 
-	//std::multimap<etl::handle<ValueNode>, sigc::connection> connection_map;
+	//std::multimap<ValueNode::Handle, sigc::connection> connection_map;
 
 	/*
  -- ** -- P R I V A T E   D A T A ---------------------------------------------

--- a/synfig-studio/src/gui/trees/layergrouptree.h
+++ b/synfig-studio/src/gui/trees/layergrouptree.h
@@ -69,7 +69,7 @@ private:
 
 	Glib::RefPtr<LayerGroupTreeStore> layer_group_tree_store_;
 
-	sigc::signal<void,etl::handle<synfig::Layer> > signal_popup_layer_menu_;
+	sigc::signal<void,synfig::Layer::Handle> signal_popup_layer_menu_;
 
 	Glib::RefPtr<Gtk::TreeSelection> tree_selection;
 	/*
@@ -100,7 +100,7 @@ public:
 
 	Glib::RefPtr<LayerGroupTreeStore> get_model() { return layer_group_tree_store_; }
 
-	sigc::signal<void,etl::handle<synfig::Layer> >& signal_popup_layer_menu() { return signal_popup_layer_menu_; }
+	sigc::signal<void,synfig::Layer::Handle>& signal_popup_layer_menu() { return signal_popup_layer_menu_; }
 
 	void set_model(Glib::RefPtr<LayerGroupTreeStore> layer_group_tree_store_);
 

--- a/synfig-studio/src/gui/trees/layergrouptreestore.cpp
+++ b/synfig-studio/src/gui/trees/layergrouptreestore.cpp
@@ -862,7 +862,7 @@ LayerGroupTreeStore::on_group_changed(synfig::String /*group*/)
 }
 
 void
-LayerGroupTreeStore::on_group_pair_added(synfig::String group, etl::handle<synfig::Layer> layer)
+LayerGroupTreeStore::on_group_pair_added(synfig::String group, synfig::Layer::Handle layer)
 {
 	if(!layer->get_canvas())
 		return;
@@ -879,7 +879,7 @@ LayerGroupTreeStore::on_group_pair_added(synfig::String group, etl::handle<synfi
 }
 
 void
-LayerGroupTreeStore::on_group_pair_removed(synfig::String group, etl::handle<synfig::Layer> layer)
+LayerGroupTreeStore::on_group_pair_removed(synfig::String group, synfig::Layer::Handle layer)
 {
 	if(!layer->get_canvas())
 		return;

--- a/synfig-studio/src/gui/trees/layergrouptreestore.h
+++ b/synfig-studio/src/gui/trees/layergrouptreestore.h
@@ -132,8 +132,8 @@ private:
 	virtual bool  row_drop_possible_vfunc (const TreeModel::Path& dest, const Gtk::SelectionData& selection_data)const;
 
 
-	void on_group_pair_added(synfig::String group, etl::handle<synfig::Layer> layer);
-	void on_group_pair_removed(synfig::String group, etl::handle<synfig::Layer> layer);
+	void on_group_pair_added(synfig::String group, synfig::Layer::Handle layer);
+	void on_group_pair_removed(synfig::String group, synfig::Layer::Handle layer);
 
 	void on_activity();
 

--- a/synfig-studio/src/gui/trees/layerparamtreestore.cpp
+++ b/synfig-studio/src/gui/trees/layerparamtreestore.cpp
@@ -520,7 +520,7 @@ LayerParamTreeStore::refresh_row(Gtk::TreeModel::Row &row)
 		}
 	}
 
-	//handle<ValueNode> value_node=row[model.value_node];
+	//ValueNode::Handle value_node=row[model.value_node];
 	//if(value_node)
 	{
 		CanvasTreeStore::refresh_row(row);

--- a/synfig-studio/src/gui/trees/layertreestore.cpp
+++ b/synfig-studio/src/gui/trees/layertreestore.cpp
@@ -242,7 +242,7 @@ LayerTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int column
 						layer->get_parent_paste_canvas_layer() );
 				if(paste)
 				{
-					//etl::handle<synfig::Canvas> sub_canvas=paste->get_param("canvas").get(sub_canvas);
+					//Canvas::Handle sub_canvas=paste->get_param("canvas").get(sub_canvas);
 					Canvas::Handle sub_canvas=paste->get_param("canvas").get(Canvas::Handle());
 					if(sub_canvas && !sub_canvas->is_inline())
 					{

--- a/synfig-studio/src/gui/trees/layertreestore.cpp
+++ b/synfig-studio/src/gui/trees/layertreestore.cpp
@@ -919,7 +919,7 @@ LayerTreeStore::set_row_layer(Gtk::TreeRow &row, const synfig::Layer::Handle &ha
 		}
 
 		/*
-		etl::handle<ValueNode> value_node;
+		ValueNode::Handle value_node;
 		if(handle.constant()->dynamic_param_list().count(iter->get_name()))
 			value_node=handle->dynamic_param_list()[iter->get_name()];
 

--- a/synfig-studio/src/gui/trees/layertreestore.h
+++ b/synfig-studio/src/gui/trees/layertreestore.h
@@ -237,7 +237,7 @@ public:
 	static int z_sorter(const Gtk::TreeModel::iterator &rhs,const Gtk::TreeModel::iterator &lhs);
 	static int index_sorter(const Gtk::TreeModel::iterator &rhs,const Gtk::TreeModel::iterator &lhs);
 
-	//void set_row_param(Gtk::TreeRow &row,synfig::Layer::Handle &handle,const std::string& name, const std::string& local_name, const synfig::ValueBase &value, etl::handle<synfig::ValueNode> value_node,synfig::ParamDesc *param_desc);
+	//void set_row_param(Gtk::TreeRow &row,synfig::Layer::Handle &handle,const std::string& name, const std::string& local_name, const synfig::ValueBase &value, synfig::ValueNode::Handle value_node,synfig::ParamDesc *param_desc);
 
 	//virtual void set_row(Gtk::TreeRow row,synfigapp::ValueDesc value_desc);
 	static bool search_func(const Glib::RefPtr<TreeModel>&,int,const Glib::ustring&,const TreeModel::iterator&);

--- a/synfig-studio/src/gui/widgets/widget_canvaschooser.cpp
+++ b/synfig-studio/src/gui/widgets/widget_canvaschooser.cpp
@@ -120,7 +120,7 @@ Widget_CanvasChooser::set_value(synfig::Canvas::Handle data)
 		set_active(0);
 }
 
-const etl::handle<synfig::Canvas> &
+const Canvas::Handle &
 Widget_CanvasChooser::get_value()
 {
 	return canvas;

--- a/synfig-studio/src/gui/widgets/widget_filename.h
+++ b/synfig-studio/src/gui/widgets/widget_filename.h
@@ -49,7 +49,7 @@ class Widget_Filename : public Gtk::Grid
 {
 	Gtk::Entry *entry_filename;
 	Gtk::Button *button_choose;
-	etl::handle<synfig::Canvas> canvas;
+	synfig::Canvas::Handle canvas;
 
 	void on_button_choose_pressed();
 
@@ -61,7 +61,7 @@ public:
 
 	void on_value_changed();
 
-	void set_canvas(etl::handle<synfig::Canvas> x) { canvas=x; assert(canvas); }
+	void set_canvas(synfig::Canvas::Handle x) { canvas=x; assert(canvas); }
 	void set_value(const  std::string &data);
 	std::string get_value() const;
 	void set_has_frame(bool x);

--- a/synfig-studio/src/gui/widgets/widget_value.cpp
+++ b/synfig-studio/src/gui/widgets/widget_value.cpp
@@ -325,7 +325,7 @@ Widget_ValueBase::set_value(const synfig::ValueBase &data)
 		{
 			assert(canvas);
 			canvas_widget->set_parent_canvas(canvas);
-			canvas_widget->set_value(value.get(etl::loose_handle<synfig::Canvas>()));
+			canvas_widget->set_value(value.get(Canvas::LooseHandle()));
 			canvas_widget->show();
 		}
 		else
@@ -373,7 +373,7 @@ Widget_ValueBase::set_value(const synfig::ValueBase &data)
 }
 
 void
-Widget_ValueBase::set_canvas(etl::handle<synfig::Canvas> x)
+Widget_ValueBase::set_canvas(Canvas::Handle x)
 {
 	assert(x);
 	canvas=x;

--- a/synfig-studio/src/gui/widgets/widget_value.h
+++ b/synfig-studio/src/gui/widgets/widget_value.h
@@ -92,7 +92,7 @@ class Widget_ValueBase : public Gtk::HBox
 	synfig::ParamDesc param_desc;
 	synfigapp::ValueDesc value_desc;
 	synfig::ParamDesc child_param_desc;
-	etl::handle<synfig::Canvas> canvas;
+	synfig::Canvas::Handle canvas;
 	sigc::signal<void> signal_value_changed_;
 	sigc::signal<void> signal_activate_;
 
@@ -125,7 +125,7 @@ public:
 	//void set_hint(std::string x) { hint=x; }
 //	std::string get_hint() { return hint; }
 
-	void set_canvas(etl::handle<synfig::Canvas> x);
+	void set_canvas(synfig::Canvas::Handle x);
 	void inside_cellrenderer();
 	Widget_ValueBase();
 	~Widget_ValueBase();

--- a/synfig-studio/src/gui/widgets/widget_waypoint.cpp
+++ b/synfig-studio/src/gui/widgets/widget_waypoint.cpp
@@ -57,7 +57,7 @@ using namespace studio;
 
 /* === M E T H O D S ======================================================= */
 
-Widget_Waypoint::Widget_Waypoint(etl::handle<synfig::Canvas> canvas):
+Widget_Waypoint::Widget_Waypoint(Canvas::Handle canvas):
 	Gtk::Box(Gtk::ORIENTATION_VERTICAL),
 	waypoint(synfig::ValueBase(),0),
 	adj_tension(Gtk::Adjustment::create(0.0,-20,20,0.1,1)),

--- a/synfig-studio/src/gui/widgets/widget_waypoint.h
+++ b/synfig-studio/src/gui/widgets/widget_waypoint.h
@@ -71,7 +71,7 @@ class Widget_Waypoint : public Gtk::Box
 	Glib::RefPtr<Gtk::Adjustment> adj_tension, adj_continuity, adj_bias, adj_temporal_tension;
 
 public:
-	Widget_Waypoint(etl::handle<synfig::Canvas> canvas);
+	Widget_Waypoint(synfig::Canvas::Handle canvas);
 	void set_canvas(synfig::Canvas::Handle x);
 	void set_waypoint(synfig::Waypoint &x);
 	void set_valuedesc(synfigapp::ValueDesc &x);

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -2257,7 +2257,7 @@ studio::WorkArea::set_zoom(float z)
 }
 
 void
-WorkArea::set_selected_value_node(etl::loose_handle<synfig::ValueNode> x)
+WorkArea::set_selected_value_node(synfig::ValueNode::LooseHandle x)
 {
 	if(x!=selected_value_node_)
 	{
@@ -2267,7 +2267,7 @@ WorkArea::set_selected_value_node(etl::loose_handle<synfig::ValueNode> x)
 }
 
 void
-WorkArea::set_active_bone_value_node(etl::loose_handle<synfig::ValueNode> x)
+WorkArea::set_active_bone_value_node(synfig::ValueNode::LooseHandle x)
 {
 	if(x!=active_bone_)
 	{

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -178,7 +178,7 @@ private:
 	synfig::Point previous_focus;
 
 	//! Active Bone
-	etl::loose_handle<synfig::ValueNode> active_bone_;
+	synfig::ValueNode::LooseHandle active_bone_;
 	bool highlight_active_bone;
 
 	//! This state is true if ruler should be shown
@@ -222,7 +222,7 @@ private:
 	// render future and past frames in background
 	bool background_rendering;
 
-	etl::loose_handle<synfig::ValueNode> selected_value_node_;
+	synfig::ValueNode::LooseHandle selected_value_node_;
 
 	bool allow_duck_clicks;
 	bool allow_bezier_clicks;
@@ -280,7 +280,7 @@ private:
 
 	void set_drag_mode(DragMode mode);
 
-	void set_active_bone_value_node(etl::loose_handle<synfig::ValueNode> x);
+	void set_active_bone_value_node(synfig::ValueNode::LooseHandle x);
 
 public:
 	/*
@@ -292,7 +292,7 @@ public:
 
 	void view_window_changed() { signal_view_window_changed()(); }
 
-	const etl::loose_handle<synfig::ValueNode>& get_selected_value_node() { return  selected_value_node_; }
+	const synfig::ValueNode::LooseHandle& get_selected_value_node() { return  selected_value_node_; }
 	const synfig::Point& get_drag_point()const { return drag_point; }
 
 	synfig::VectorInt get_windows_offset() const;
@@ -322,9 +322,9 @@ public:
 	void set_background_rendering(bool x);
 	bool get_background_rendering() const { return background_rendering; }
 
-	void set_selected_value_node(etl::loose_handle<synfig::ValueNode> x);
+	void set_selected_value_node(synfig::ValueNode::LooseHandle x);
 
-	const etl::loose_handle<synfig::ValueNode>& get_active_bone_value_node(){return active_bone_;}
+	const synfig::ValueNode::LooseHandle& get_active_bone_value_node(){return active_bone_;}
 	bool get_active_bone_display(){return highlight_active_bone;}
 	void set_active_bone_display(bool x){highlight_active_bone=x;}
 

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -260,7 +260,7 @@ private:
 	sigc::signal<void, GdkDevice*> signal_input_device_changed_;
 	sigc::signal<void> signal_popup_menu_;
 	sigc::signal<void, synfig::Point> signal_user_click_[5]; //!< One signal per button
-	sigc::signal<void, etl::handle<synfig::Layer> > signal_layer_selected_; //!< Signal for when the user clicks on a layer
+	sigc::signal<void, synfig::Layer::Handle> signal_layer_selected_; //!< Signal for when the user clicks on a layer
 
 public:
 	sigc::signal<void>& signal_rendering() { return signal_rendering_; }
@@ -271,7 +271,7 @@ public:
 	sigc::signal<void, GdkDevice*>& signal_input_device_changed() { return signal_input_device_changed_; }
 	sigc::signal<void> &signal_popup_menu() { return signal_popup_menu_; }
 	sigc::signal<void, synfig::Point> &signal_user_click(int button=0){ return signal_user_click_[button]; } //!< One signal per button (5 buttons)
-	sigc::signal<void, etl::handle<synfig::Layer> >& signal_layer_selected() { return signal_layer_selected_; }
+	sigc::signal<void, synfig::Layer::Handle>& signal_layer_selected() { return signal_layer_selected_; }
 
 private:
 	/*

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -128,7 +128,7 @@ private:
 	std::set<etl::handle<WorkAreaRenderer> > renderer_set_;
 
 	etl::loose_handle<synfigapp::CanvasInterface> canvas_interface;
-	etl::handle<synfig::Canvas> canvas;
+	synfig::Canvas::Handle canvas;
 	etl::loose_handle<studio::Instance> instance;
 	etl::loose_handle<studio::CanvasView> canvas_view;
 	etl::handle<Renderer_Canvas> renderer_canvas;
@@ -343,9 +343,9 @@ public:
 	Glib::RefPtr<const Gtk::Adjustment> get_scrolly_adjustment() const { return scrolly_adjustment; }
 
 	void set_instance(etl::loose_handle<studio::Instance> x) { instance=x; }
-	void set_canvas(etl::handle<synfig::Canvas> x) { canvas=x; }
+	void set_canvas(synfig::Canvas::Handle x) { canvas=x; }
 	void set_canvas_view(etl::loose_handle<studio::CanvasView> x) { canvas_view=x; }
-	const etl::handle<synfig::Canvas>& get_canvas() const { return canvas; }
+	const synfig::Canvas::Handle& get_canvas() const { return canvas; }
 	const etl::loose_handle<studio::Instance>& get_instance() const { return instance; }
 	const etl::loose_handle<studio::CanvasView>& get_canvas_view() const { return canvas_view; }
 	const etl::handle<Renderer_Canvas>& get_renderer_canvas() const { return renderer_canvas; }

--- a/synfig-studio/src/synfigapp/actions/layerembed.h
+++ b/synfig-studio/src/synfigapp/actions/layerembed.h
@@ -51,7 +51,7 @@ class LayerEmbed :
 {
 private:
 	etl::handle<synfig::Layer_PasteCanvas> layer_pastecanvas;
-	etl::handle<synfig::Layer> layer_import;
+	synfig::Layer::Handle layer_import;
 
 public:
 	static ParamVocab get_param_vocab();

--- a/synfig-studio/src/synfigapp/actions/layerextract.h
+++ b/synfig-studio/src/synfigapp/actions/layerextract.h
@@ -50,7 +50,7 @@ class LayerExtract :
 	public Super
 {
 private:
-	etl::handle<synfig::Layer> layer;
+	synfig::Layer::Handle layer;
 	std::string filename;
 
 public:

--- a/synfig-studio/src/synfigapp/actions/vectorization.cpp
+++ b/synfig-studio/src/synfigapp/actions/vectorization.cpp
@@ -241,7 +241,7 @@ Action::Vectorization::perform()
 	gamma.invert();
 
     const etl::handle<UIInterface> ui_interface = get_canvas_interface()->get_ui_interface();
-    std::vector< etl::handle<synfig::Layer> > Result = vCore.vectorize(image_layer,ui_interface, configuration, gamma);
+    std::vector<synfig::Layer::Handle> Result = vCore.vectorize(image_layer,ui_interface, configuration, gamma);
 
     synfig::Canvas::Handle child_canvas;
     child_canvas=synfig::Canvas::create_inline(layer->get_canvas());

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -98,7 +98,7 @@ using namespace synfigapp;
 
 /* === M E T H O D S ======================================================= */
 
-CanvasInterface::CanvasInterface(etl::loose_handle<Instance> instance,etl::handle<synfig::Canvas> canvas):
+CanvasInterface::CanvasInterface(etl::loose_handle<Instance> instance,Canvas::Handle canvas):
 	instance_(instance),
 	canvas_(canvas),
 	cur_time_(canvas->rend_desc().get_frame_start()),
@@ -154,7 +154,7 @@ CanvasInterface::refresh_current_values()
 }
 
 etl::handle<CanvasInterface>
-CanvasInterface::create(etl::loose_handle<Instance> instance, etl::handle<synfig::Canvas> canvas)
+CanvasInterface::create(etl::loose_handle<Instance> instance, Canvas::Handle canvas)
 {
 	etl::handle<CanvasInterface> intrfc;
 	intrfc=new CanvasInterface(instance,canvas);
@@ -917,7 +917,7 @@ CanvasInterface::import(
 
 		//get_selection_manager()->set_selected_layer(layer);
 
-		//etl::handle<synfig::Canvas> canvas = get_canvas();
+		//Canvas::Handle canvas = get_canvas();
 		//etl::handle<CanvasView> view = get_instance()->find_canvas_view(canvas);
 		//view->layer_tree->select_layer(layer);
 

--- a/synfig-studio/src/synfigapp/canvasinterface.h
+++ b/synfig-studio/src/synfigapp/canvasinterface.h
@@ -158,25 +158,25 @@ public:	// Signal Interface
 	//sigc::signal<void>& signal_dirty_preview() { return signal_dirty_preview_; }
 	sigc::signal<void>& signal_dirty_preview() { return get_canvas()->signal_dirty(); }
 
-	sigc::signal<void,etl::handle<synfig::ValueNode>,etl::handle<synfig::ValueNode> >&
+	sigc::signal<void,synfig::ValueNode::Handle,synfig::ValueNode::Handle>&
 		signal_value_node_child_added() { return get_canvas()->signal_value_node_child_added(); }
-	sigc::signal<void,etl::handle<synfig::ValueNode>,etl::handle<synfig::ValueNode> >&
+	sigc::signal<void,synfig::ValueNode::Handle,synfig::ValueNode::Handle>&
 		signal_value_node_child_removed() { return get_canvas()->signal_value_node_child_removed(); }
 
 	//! Signal called when a ValueNode has changed
-	sigc::signal<void,etl::handle<synfig::ValueNode> >& signal_value_node_added() { return signal_value_node_added_; }
+	sigc::signal<void,synfig::ValueNode::Handle>& signal_value_node_added() { return signal_value_node_added_; }
 
 	//! Signal called when a ValueNode has been deleted
-	sigc::signal<void,etl::handle<synfig::ValueNode> >& signal_value_node_deleted() { return signal_value_node_deleted_; }
+	sigc::signal<void,synfig::ValueNode::Handle>& signal_value_node_deleted() { return signal_value_node_deleted_; }
 
 	//! Signal called when a ValueNode has been changed
-	sigc::signal<void,etl::handle<synfig::ValueNode> >& signal_value_node_changed() { return get_canvas()->signal_value_node_changed(); }
+	sigc::signal<void,synfig::ValueNode::Handle>& signal_value_node_changed() { return get_canvas()->signal_value_node_changed(); }
 
 	//! Signal called when a ValueDesc has been set
 	sigc::signal<void,synfigapp::ValueDesc,synfig::ValueBase>& signal_value_desc_set() { return signal_value_desc_set_; }
 
 	//! Signal called when a ValueNode has been renamed
-	sigc::signal<void,etl::handle<synfig::ValueNode> >& signal_value_node_renamed() { return get_canvas()->signal_value_node_renamed(); }
+	sigc::signal<void,synfig::ValueNode::Handle>& signal_value_node_renamed() { return get_canvas()->signal_value_node_renamed(); }
 
 	//! Signal called when the mode has changed
 	sigc::signal<void,Mode> signal_mode_changed() { return signal_mode_changed_; }

--- a/synfig-studio/src/synfigapp/canvasinterface.h
+++ b/synfig-studio/src/synfigapp/canvasinterface.h
@@ -70,11 +70,11 @@ public:
 
 private:
 	// Constructor is private to force the use of the "create()" constructor.
-	CanvasInterface(etl::loose_handle<Instance> instance,etl::handle<synfig::Canvas> canvas);
+	CanvasInterface(etl::loose_handle<Instance> instance,synfig::Canvas::Handle canvas);
 
 private:
 	etl::loose_handle<Instance> instance_;
-	etl::handle<synfig::Canvas> canvas_;
+	synfig::Canvas::Handle canvas_;
 	etl::handle<SelectionManager> selection_manager_;
 	etl::handle<UIInterface> ui_interface_;
 	synfig::Time cur_time_;
@@ -146,10 +146,10 @@ public:	// Signal Interface
 	sigc::signal<void,synfig::Layer::Handle,bool>& signal_layer_z_range_changed() { return signal_layer_z_range_changed_; }
 	
 	//! Signal called when a canvas has been added.
-	sigc::signal<void,etl::handle<synfig::Canvas> >& signal_canvas_added() { return signal_canvas_added_; }
+	sigc::signal<void,synfig::Canvas::Handle>& signal_canvas_added() { return signal_canvas_added_; }
 
 	//! Signal called when a canvas has been removed.
-	sigc::signal<void,etl::handle<synfig::Canvas> >& signal_canvas_removed() { return signal_canvas_removed_; }
+	sigc::signal<void,synfig::Canvas::Handle>& signal_canvas_removed() { return signal_canvas_removed_; }
 
 	//! Signal called when a layer's parameter has been changed
 	sigc::signal<void,synfig::Layer::Handle,synfig::String>& signal_layer_param_changed() { return signal_layer_param_changed_; }
@@ -239,7 +239,7 @@ public:
 	const etl::handle<UIInterface> &get_ui_interface() { return ui_interface_; }
 
 	//! Returns the Canvas associated with this interface
-	const etl::handle<synfig::Canvas>& get_canvas()const { return canvas_; }
+	const synfig::Canvas::Handle& get_canvas()const { return canvas_; }
 
 	//! Returns the Instance associated with this interface
 	const etl::loose_handle<Instance>& get_instance()const { return instance_; }
@@ -353,7 +353,7 @@ public:
 
 	~CanvasInterface();
 
-	static etl::handle<CanvasInterface> create(etl::loose_handle<Instance> instance,etl::handle<synfig::Canvas> canvas);
+	static etl::handle<CanvasInterface> create(etl::loose_handle<Instance> instance,synfig::Canvas::Handle canvas);
 }; // END of class CanvasInterface
 
 /*!	\class PushMode

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -93,7 +93,7 @@ using namespace synfigapp;
 
 /* === G L O B A L S ======================================================= */
 
-static std::map<loose_handle<Canvas>, loose_handle<Instance> > instance_map_;
+static std::map<Canvas::LooseHandle, loose_handle<Instance>> instance_map_;
 
 /* === P R O C E D U R E S ================================================= */
 
@@ -124,7 +124,7 @@ synfigapp::is_editable(synfig::ValueNode::Handle value_node)
 }
 
 etl::handle<Instance>
-synfigapp::find_instance(etl::handle<synfig::Canvas> canvas)
+synfigapp::find_instance(Canvas::Handle canvas)
 {
 	if(instance_map_.count(canvas)==0)
 		return 0;
@@ -133,7 +133,7 @@ synfigapp::find_instance(etl::handle<synfig::Canvas> canvas)
 
 /* === M E T H O D S ======================================================= */
 
-Instance::Instance(etl::handle<synfig::Canvas> canvas, synfig::FileSystem::Handle container):
+Instance::Instance(Canvas::Handle canvas, synfig::FileSystem::Handle container):
 	canvas_(canvas),
 	container_(container)
 {
@@ -145,7 +145,7 @@ Instance::Instance(etl::handle<synfig::Canvas> canvas, synfig::FileSystem::Handl
 } // END of synfigapp::Instance::Instance()
 
 handle<Instance>
-Instance::create(etl::handle<synfig::Canvas> canvas, synfig::FileSystem::Handle container)
+Instance::create(Canvas::Handle canvas, synfig::FileSystem::Handle container)
 {
 	// Construct a new instance
 	handle<Instance> instance(new Instance(canvas, container));

--- a/synfig-studio/src/synfigapp/instance.h
+++ b/synfig-studio/src/synfigapp/instance.h
@@ -142,7 +142,7 @@ private:
 	void process_filenames_undo(const ProcessFilenamesParams &params);
 
 protected:
-	Instance(etl::handle<synfig::Canvas>, synfig::FileSystem::Handle container);
+	Instance(synfig::Canvas::Handle, synfig::FileSystem::Handle container);
 
 	/*
  -- ** -- P U B L I C   M E T H O D S -----------------------------------------
@@ -203,10 +203,10 @@ public:
 
 
 public:	// Constructor interfaces
-	static etl::handle<Instance> create(etl::handle<synfig::Canvas> canvas, synfig::FileSystem::Handle container);
+	static etl::handle<Instance> create(synfig::Canvas::Handle canvas, synfig::FileSystem::Handle container);
 }; // END class Instance
 
-etl::handle<Instance> find_instance(etl::handle<synfig::Canvas> canvas);
+etl::handle<Instance> find_instance(synfig::Canvas::Handle canvas);
 
 bool is_editable(synfig::ValueNode::Handle value_node);
 

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
@@ -160,7 +160,7 @@ etl::handle<synfig::Layer> BezierToOutline(studio::PointList segment)
   
   etl::handle<synfig::ValueNode_BLine> bline_value_node; 
   etl::handle<synfig::ValueNode_DynamicList> value_node;
-  etl::handle<synfig::ValueNode> vn;
+  synfig::ValueNode::Handle vn;
 
 	vn=value_node=bline_value_node=synfig::ValueNode_BLine::create(bline_point_list, canvas);
   layer->connect_dynamic_param("bline",vn);

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
@@ -81,7 +81,7 @@ void PreProcessSegment(studio::PointList &segment)
 }
 
 
-etl::handle<synfig::Layer> BezierToOutline(studio::PointList segment)
+synfig::Layer::Handle BezierToOutline(studio::PointList segment)
 {
   int segment_size = segment.size();
   synfig::Layer::Handle layer(synfig::Layer::create("outline"));
@@ -412,7 +412,7 @@ public:
 
   Length lengthOf(unsigned int a, unsigned int b);
   void addMiddlePoints();
-  etl::handle<synfig::Layer> operator()(std::vector<unsigned int> *indices);
+  synfig::Layer::Handle operator()(std::vector<unsigned int> *indices);
 
   // Length construction methods
   bool parametrize(unsigned int a, unsigned int b);
@@ -468,7 +468,7 @@ inline void SequenceConverter::addMiddlePoints()
 
 //--------------------------------------------------------------------------
 
-etl::handle<synfig::Layer> SequenceConverter::operator()(std::vector<unsigned int> *indices) {
+synfig::Layer::Handle SequenceConverter::operator()(std::vector<unsigned int> *indices) {
   // Prepare Sequence
   inputIndices = indices;
   addMiddlePoints();
@@ -522,7 +522,7 @@ etl::handle<synfig::Layer> SequenceConverter::operator()(std::vector<unsigned in
   }
   controlPoints[0] = middleAddedSequence[0];
   
-  etl::handle<synfig::Layer> res = BezierToOutline(controlPoints);
+  synfig::Layer::Handle res = BezierToOutline(controlPoints);
 
   return res;
 }
@@ -879,11 +879,11 @@ bool SequenceConverter::penalty(unsigned int a, unsigned int b, Length &len)
 }
 
 //--------------------------------------------------------------------------
-inline etl::handle<synfig::Layer> convert(const Sequence &s, double penalty) 
+inline synfig::Layer::Handle convert(const Sequence &s, double penalty) 
 {
   SkeletonGraph *graph = s.m_graphHolder;
 
-  etl::handle<synfig::Layer> result;
+  synfig::Layer::Handle result;
 
   // First, we simplify the skeleton sequences found
   std::vector<unsigned int> reducedIndices;
@@ -936,7 +936,7 @@ inline etl::handle<synfig::Layer> convert(const Sequence &s, double penalty)
 // Stroke. 
 // In synfig we will be using outline layer instead of TStroke  
 
-void studio::conversionToStrokes(std::vector< etl::handle<synfig::Layer> > &strokes, VectorizerCoreGlobals &g,const etl::handle<synfig::Layer_Bitmap> &image) 
+void studio::conversionToStrokes(std::vector<synfig::Layer::Handle> &strokes, VectorizerCoreGlobals &g,const etl::handle<synfig::Layer_Bitmap> &image) 
 {
   SequenceList &singleSequences           = g.singleSequences;
   JointSequenceGraphList &organizedGraphs = g.organizedGraphs;

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinevectorizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinevectorizer.cpp
@@ -75,7 +75,7 @@ inline void deleteSkeletonList(SkeletonList *skeleton) {
 
 // takes two arguments ( image layer handle, config )
 
-std::vector< etl::handle<synfig::Layer> > 
+std::vector<synfig::Layer::Handle> 
 VectorizerCore::centerlineVectorize(etl::handle<synfig::Layer_Bitmap> &image,const etl::handle<synfigapp::UIInterface> &ui_interface, 
 const CenterlineConfiguration &configuration,const Gamma &gamma)
  {
@@ -109,7 +109,7 @@ const CenterlineConfiguration &configuration,const Gamma &gamma)
   ui_interface->amount_complete(8,10);
 
 
-  std::vector< etl::handle<synfig::Layer> > sortibleResult;
+  std::vector<synfig::Layer::Handle> sortibleResult;
   
   // step 5
   // Take samples of image colors to associate each sequence to its corresponding
@@ -125,10 +125,10 @@ const CenterlineConfiguration &configuration,const Gamma &gamma)
   return sortibleResult;
 }
 
-std::vector< etl::handle<synfig::Layer> > 
+std::vector<synfig::Layer::Handle> 
 VectorizerCore::vectorize(const etl::handle<synfig::Layer_Bitmap> &img,const etl::handle<synfigapp::UIInterface> &ui_interface, const VectorizerConfiguration &c, const Gamma &gamma) 
 {
-  std::vector< etl::handle<synfig::Layer> > result;
+  std::vector<synfig::Layer::Handle> result;
 
   if (c.m_outline)
   {

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinevectorizer.h
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinevectorizer.h
@@ -81,10 +81,10 @@ public:
 
   /*!Calls the appropriate technique to convert \b image to vectors depending on c.*/
  
-  std::vector< etl::handle<synfig::Layer> > vectorize(const etl::handle<synfig::Layer_Bitmap> &image, const etl::handle<synfigapp::UIInterface> &ui_interface,const VectorizerConfiguration &c,const synfig::Gamma &gamma);
+  std::vector<synfig::Layer::Handle> vectorize(const etl::handle<synfig::Layer_Bitmap> &image, const etl::handle<synfigapp::UIInterface> &ui_interface,const VectorizerConfiguration &c,const synfig::Gamma &gamma);
 
 private:
-  std::vector< etl::handle<synfig::Layer> > centerlineVectorize(Handle &image,const etl::handle<synfigapp::UIInterface> &ui_interface, const CenterlineConfiguration &configuration, const synfig::Gamma &gamma);
+  std::vector<synfig::Layer::Handle> centerlineVectorize(Handle &image,const etl::handle<synfigapp::UIInterface> &ui_interface, const CenterlineConfiguration &configuration, const synfig::Gamma &gamma);
 
 };
 

--- a/synfig-studio/src/synfigapp/vectorizer/polygonizerclasses.h
+++ b/synfig-studio/src/synfigapp/vectorizer/polygonizerclasses.h
@@ -482,7 +482,7 @@ void organizeGraphs(SkeletonList *skeleton, VectorizerCoreGlobals &g);
 
 // void junctionRecovery(Contours *polygons, VectorizerCoreGlobals &g);
 
-void conversionToStrokes(std::vector< etl::handle<synfig::Layer> > &strokes, VectorizerCoreGlobals &g, const etl::handle<synfig::Layer_Bitmap> &image) ;
+void conversionToStrokes(std::vector<synfig::Layer::Handle> &strokes, VectorizerCoreGlobals &g, const etl::handle<synfig::Layer_Bitmap> &image) ;
 
  void calculateSequenceColors(const etl::handle<synfig::Layer_Bitmap> &ras, VectorizerCoreGlobals &g, const synfig::Gamma &gamma);
 

--- a/synfig-studio/test/app_layerduplicate.cpp
+++ b/synfig-studio/test/app_layerduplicate.cpp
@@ -322,13 +322,13 @@ static void test_synfigapp_layerduplicate_both_layer_duplicate_and_linked_layers
 
 	auto layer2 = synfig::Layer::create("translate");
 	canvas->push_back(layer2);
-	ASSERT(layer2->connect_dynamic_param("origin", etl::handle<synfig::ValueNode>::cast_static(composite2)))
+	ASSERT(layer2->connect_dynamic_param("origin", synfig::ValueNode::Handle::cast_static(composite2)))
 
 	auto layer3 = synfig::Layer::create("circle");
 	canvas->push_back(layer3);
 	layer3->connect_dynamic_param("radius", valuenode);
 	auto composite3 = composite2->clone(canvas);
-	ASSERT(layer3->connect_dynamic_param("origin", etl::handle<synfig::ValueNode>::cast_static(composite3)))
+	ASSERT(layer3->connect_dynamic_param("origin", synfig::ValueNode::Handle::cast_static(composite3)))
 
 	synfigapp::Action::Handle action = synfigapp::Action::create("LayerDuplicate");
 	action->set_param("layer", layer1);


### PR DESCRIPTION
For classes `Canvas`, `ValueNode` and `Layer`.

Reason: `etl::handle` and alike will be moved to synfig namespace
(and maybe one day it'll use an C++ standard smart pointer).