### PR TITLE
feat: plugins can  have simple dialog and receive current time and selected layer xpath

### DIFF
--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -67,6 +67,7 @@
 #include <synfig/general.h>
 #include <synfig/layers/layer_switch.h>
 #include <synfig/savecanvas.h>
+#include <synfig/synfig_iterations.h>
 #include <synfig/valuenode_registry.h>
 #include <synfig/valuenodes/valuenode_composite.h>
 #include <synfig/valuenodes/valuenode_duplicate.h>
@@ -101,6 +102,92 @@ create_image_from_icon(const std::string& icon_name, Gtk::IconSize icon_size)
 	image->set_from_icon_name(icon_name, icon_size);
 	return image;
 #endif
+}
+
+static void get_layer_path(const Layer::Handle& l, const Canvas::LooseHandle root_canvas, std::string& path);
+
+struct ValueNodePathBuilder {
+
+	const Canvas::LooseHandle& canvas;
+	std::string path;
+	std::string link_name;
+
+	synfig::TraverseCallbackAction
+	operator() (ValueNode::Handle vn)
+	{
+		if (vn->get_type() != type_canvas)
+			return TRAVERSE_CALLBACK_SKIP;
+
+		if ((*vn)(canvas->get_time()).get(Canvas::Handle()) != canvas)
+			return TRAVERSE_CALLBACK_SKIP;
+
+		if (!link_name.empty())
+			path += "/" + link_name;
+
+		if (const auto constvn = ValueNode_Const::Handle::cast_dynamic(vn))
+			return TRAVERSE_CALLBACK_ABORT;
+
+		if (const auto linkable = LinkableValueNode::Handle::cast_dynamic(vn)) {
+			path += "/" + linkable->get_name();
+			for (int i=0; i < linkable->link_count(); i++) {
+				auto ith_link = linkable->get_link(i);
+				ValueNodePathBuilder builder {canvas};
+				builder.link_name = linkable->link_name(i);
+				traverse_valuenodes(ith_link, [&builder](ValueNode::Handle vn) -> synfig::TraverseCallbackAction {
+					auto action = builder(vn);
+					return action;
+				});
+				if (!builder.path.empty()) {
+					path += builder.path;
+					break;
+				}
+			}
+			return TRAVERSE_CALLBACK_ABORT; // hacked RECURSIVE above;
+		}
+		return TRAVERSE_CALLBACK_ABORT;
+	}
+};
+
+static void
+get_canvas_path(Canvas::LooseHandle canvas, const Canvas::LooseHandle root_canvas, std::string& path)
+{
+	if (canvas->is_inline()) {
+		if (auto layer = canvas->find_first_parent_of_type<Layer>()) {
+			for (const auto& param_item : layer->get_param_list()) {
+				if (param_item.second.get_type() == type_canvas) {
+					if (param_item.second.get(Canvas::LooseHandle()) == canvas) {
+						std::string dynamic_str;
+						auto dynamic_param_iter = layer->dynamic_param_list().find(param_item.first);
+						if (dynamic_param_iter != layer->dynamic_param_list().end()) {
+							ValueNodePathBuilder vn_path_builder {canvas};
+							traverse_valuenodes(dynamic_param_iter->second, [&vn_path_builder](ValueNode::Handle vn) -> TraverseCallbackAction {
+								return vn_path_builder(vn);
+							});
+							dynamic_str = vn_path_builder.path;
+						}
+						path = strprintf("/param[@name='%s']%s/canvas%s", param_item.first.c_str(), dynamic_str.c_str(), path.c_str());
+					}
+				}
+			}
+			get_layer_path(layer, root_canvas, path);
+		}
+	} else {
+		path = canvas->get_relative_id(root_canvas) + path;
+	}
+}
+
+static void
+get_layer_path(const Layer::Handle& l, const Canvas::LooseHandle root_canvas, std::string& path)
+{
+	if (l) {
+		auto canvas = l->get_canvas();
+		if (!canvas) {
+			warning("layer without canvas!");
+		} else {
+			path = strprintf("/layer[%i]", canvas->size() - canvas->get_depth(l)) + path;
+			get_canvas_path(canvas, root_canvas, path);
+		}
+	}
 }
 
 /* === M E T H O D S ======================================================= */
@@ -250,6 +337,47 @@ studio::Instance::run_plugin(std::string plugin_id, bool modify_canvas, std::vec
 {
 	handle<synfigapp::UIInterface> uim = this->find_canvas_view(this->get_canvas())->get_ui_interface();
 
+	std::unordered_map<std::string,std::string> view_state;
+
+	auto required_args = App::plugin_manager.get_script_args(plugin_id);
+
+	const bool require_selected_layers = required_args & PluginScript::NEED_SELECTED_LAYERS;
+
+	if (required_args) {
+		if (auto canvas_interface = find_canvas_interface(get_canvas())) {
+
+			// Current Time
+
+			view_state["time"] = canvas_interface->get_time();
+
+			if (auto selection = canvas_interface->get_selection_manager()) {
+
+				// Layers
+				if (require_selected_layers) {
+					for (const auto& layer : selection->get_selected_layers()) {
+						std::string xpath;
+						get_layer_path(layer, get_canvas(), xpath);
+						auto& sel_layers = view_state["sel_layers"];
+						if (!sel_layers.empty())
+							sel_layers.append(",");
+						sel_layers += '"' + xpath + '"';
+					}
+				}
+
+
+			}
+		}
+
+		if (require_selected_layers && view_state.count("sel_layers") == 0) {
+			App::dialog_message_1b(
+					"ERROR",
+					_("The plugin operation has failed."),
+					_("You must select layer(s)"),
+					_("Close"));
+			return;
+		}
+	}
+
 	if ( modify_canvas )
 	{
 		String message = strprintf(_("Do you really want to run plugin for file \"%s\"?" ),
@@ -343,7 +471,8 @@ studio::Instance::run_plugin(std::string plugin_id, bool modify_canvas, std::vec
 
 		one_moment.hide();
 		extra_args.insert(extra_args.begin(), filename_processed);
-		bool result = App::plugin_manager.run(plugin_id, extra_args);
+
+		bool result = App::plugin_manager.run(plugin_id, extra_args, view_state);
 
 		if (result && modify_canvas){
 			// Restore file copy

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -360,7 +360,7 @@ studio::Instance::run_plugin(std::string plugin_id, bool modify_canvas, std::vec
 						auto& sel_layers = view_state["sel_layers"];
 						if (!sel_layers.empty())
 							sel_layers.append(",");
-						sel_layers += '"' + xpath + '"';
+						sel_layers += '"' + JSON::escape_string(xpath) + '"';
 					}
 				}
 

--- a/synfig-studio/src/gui/pluginmanager.cpp
+++ b/synfig-studio/src/gui/pluginmanager.cpp
@@ -36,6 +36,7 @@
 
 #include <libxml++/libxml++.h>
 #include <glibmm/fileutils.h>
+#include <glibmm/markup.h>
 #include <glibmm/miscutils.h>
 #include <glibmm/spawn.h>
 
@@ -525,8 +526,8 @@ bool studio::PluginManager::check_and_run_dialog(const PluginScript& script, std
 				}
 			} catch (const Glib::FileError& ex) {
 				error_msg = ex.what();
-//			} catch (const Glib::MarkupError& ex) {
-//				error_msg = ex.what();
+			} catch (const Glib::MarkupError& ex) {
+				error_msg = ex.what();
 			} catch (const Gtk::BuilderError& ex) {
 				error_msg = ex.what();
 			} catch(...) {

--- a/synfig-studio/src/gui/pluginmanager.cpp
+++ b/synfig-studio/src/gui/pluginmanager.cpp
@@ -65,6 +65,33 @@
 
 #endif
 
+std::string
+JSON::escape_string(const std::string& str)
+{
+	std::string value;
+	for (char c : str) {
+		switch (c) {
+		case '"':  value += "\\\""; break;
+		case '\\': value += "\\\\"; break;
+		case '/':  value += "\\/"; break;
+		case '\b': value += "\\b"; break;
+		case '\f': value += "\\f"; break;
+		case '\n': value += "\\n"; break;
+		case '\r': value += "\\r"; break;
+		case '\t': value += "\\t"; break;
+		default:
+			if ((unsigned char)c >= 0x20)
+				value.push_back(c);
+			else {
+				char unicode[8];
+				snprintf(unicode, 8, "\\u00%02x", (unsigned char)c);
+				value += unicode;
+			}
+		}
+	}
+	return value;
+}
+
 static bool
 parse_boolean_string(const std::string& str)
 {
@@ -476,7 +503,7 @@ bool studio::PluginManager::check_and_run_dialog(const PluginScript& script, std
 					for (const auto& d : dialog_data) {
 						if (!dialog_args.empty())
 							dialog_args.push_back(',');
-						dialog_args += synfig::strprintf("\"%s\":\"%s\"", d.first.c_str(), d.second.c_str());
+						dialog_args += synfig::strprintf("\"%s\":\"%s\"", JSON::escape_string(d.first).c_str(), JSON::escape_string(d.second).c_str());
 					}
 					dialog_args = "{" + dialog_args + "}";
 				}

--- a/synfig-studio/src/gui/pluginmanager.cpp
+++ b/synfig-studio/src/gui/pluginmanager.cpp
@@ -404,10 +404,19 @@ studio::PluginManager::load_plugin( const std::string &file, const std::string &
 						plugin.version = std::atoi(text->get_content().c_str());
 				}
 			}
+			for ( const xmlpp::Node* node : pNode->find("./url") )
+			{
+				if ( node ) {
+					const xmlpp::Element* element = dynamic_cast<const xmlpp::Element*>(node);
+					if ( const xmlpp::TextNode* text = element->get_child_text() )
+						plugin.url = text->get_content();
+				}
+			}
+			plugin.description = PluginString::load(*pNode, "description");
 
 			if ( !plugin.is_valid() || !script.is_valid() )
 			{
-				synfig::warning("Invalid plugin description");
+				synfig::warning("Invalid plugin metadata description");
 			}
 			else
 			{

--- a/synfig-studio/src/gui/pluginmanager.h
+++ b/synfig-studio/src/gui/pluginmanager.h
@@ -38,8 +38,11 @@ namespace xmlpp {
 	class Node;
 } // namespace xmlpp
 
-namespace studio {
+namespace JSON {
+std::string escape_string(const std::string& str);
+}
 
+namespace studio {
 
 class PluginString
 {

--- a/synfig-studio/src/gui/pluginmanager.h
+++ b/synfig-studio/src/gui/pluginmanager.h
@@ -132,6 +132,8 @@ private:
 		const std::string& name, std::vector<ImportExport>& output
 	);
 
+	static bool check_and_run_dialog(const PluginScript& script, std::string& dialog_args);
+
 public:
 	void load_dir( const std::string &pluginsprefix );
 	void load_plugin( const std::string &file, const std::string &plugindir );

--- a/synfig-studio/src/gui/pluginmanager.h
+++ b/synfig-studio/src/gui/pluginmanager.h
@@ -122,6 +122,9 @@ public:
 	std::string author;
 	PluginString release;
 	int version;
+	std::string url;
+
+	PluginString description;
 
 	bool is_valid() const;
 };

--- a/synfig-studio/src/gui/pluginmanager.h
+++ b/synfig-studio/src/gui/pluginmanager.h
@@ -74,6 +74,16 @@ struct PluginScript
 	std::string script;
 	std::string working_directory;
 
+	// Behavior
+	bool modify_document = true;
+	// Required arguments
+
+	static const unsigned int NEED_CURRENT_TIME       = 0x01;
+	static const unsigned int NEED_SELECTED_LAYERS    = 0x04;
+
+	/** Bitwise-OR flags NEED_* above */
+	unsigned int extra_info = 0;
+
 	static PluginScript load(const xmlpp::Node& node, const std::string& working_directory);
 	static PluginStream stream_from_name(const std::string& name, PluginStream default_value);
 
@@ -100,6 +110,10 @@ public:
 	std::string id;
 	PluginString name;
 
+	std::string author;
+	PluginString release;
+	int version;
+
 	bool is_valid() const;
 };
 
@@ -122,10 +136,13 @@ public:
 	void load_dir( const std::string &pluginsprefix );
 	void load_plugin( const std::string &file, const std::string &plugindir );
 
-	bool run(const PluginScript& script, std::vector<std::string> args) const;
-	bool run(const std::string& script_id, const std::vector<std::string>& args) const;
+	bool run(const PluginScript& script, std::vector<std::string> args, const std::unordered_map<std::string,std::string>& view_state) const;
+	bool run(const std::string& script_id, const std::vector<std::string>& args, const std::unordered_map<std::string,std::string>& view_state = {}) const;
 
 	const std::vector<Plugin>& plugins() const { return plugins_; };
+
+	Plugin get_plugin(const std::string& id) const;
+	int get_script_args(const std::string& script_id) const;
 
 	const std::vector<ImportExport>& exporters() { return exporters_; };
 

--- a/synfig-studio/src/gui/pluginmanager.h
+++ b/synfig-studio/src/gui/pluginmanager.h
@@ -79,13 +79,19 @@ struct PluginScript
 
 	// Behavior
 	bool modify_document = true;
+
+	enum class ArgNecessity {
+		ARGUMENT_OPTIONAL,
+		ARGUMENT_MANDATORY,
+		ARGUMENT_UNUSED,
+	};
+
 	// Required arguments
-
-	static const unsigned int NEED_CURRENT_TIME       = 0x01;
-	static const unsigned int NEED_SELECTED_LAYERS    = 0x04;
-
-	/** Bitwise-OR flags NEED_* above */
-	unsigned int extra_info = 0;
+	struct ScriptArgs
+	{
+		ArgNecessity current_time = ArgNecessity::ARGUMENT_UNUSED;
+		ArgNecessity selected_layers = ArgNecessity::ARGUMENT_UNUSED;
+	} extra_args;
 
 	static PluginScript load(const xmlpp::Node& node, const std::string& working_directory);
 	static PluginStream stream_from_name(const std::string& name, PluginStream default_value);
@@ -147,7 +153,7 @@ public:
 	const std::vector<Plugin>& plugins() const { return plugins_; };
 
 	Plugin get_plugin(const std::string& id) const;
-	int get_script_args(const std::string& script_id) const;
+	PluginScript::ScriptArgs get_script_args(const std::string& script_id) const;
 
 	const std::vector<ImportExport>& exporters() { return exporters_; };
 


### PR DESCRIPTION
Plugins can now present to user a simple (not dynamic) configuration dialog and can also get the current state of the canvas (current time and selected layers).

### Configuration dialog
The dialog, if provided by the plugin, will be shown every time before the plugin actually runs.
It is static: it will not enable/disable widget according to user interaction, neither validate data unless the widgets themselves perform validation.

#### How to provide the configuration dialog
Synfig Studio will automatically search for a file in the plugin script folder, with the same filename, except the extension, that must be ".ui".

- The .ui file must be in Glade format, as it will be constructed via Gtk::Builder.
- Synfig Studio runs on Gtk3, not Gtk4, so write a compatible .ui file.
- Currently, we prefer to support Gtk 3.18. For now, avoid widgets provided later than this version.
- The root widget of the .ui file will be embeded in a dialog with two buttons: OK and Cancel.
- The root widget MUST be have its ID set as "`dialog_contents`".
- The configuration fields MUST be named (set "name", not "ID"). Keep in mind that the field name will be used to identify the data to be passed to script; so, set a unique name to each one.
- Supported control widgets (i.e. their data will be passed to plugin script):
  - Entry,
  - ComboBox (use item id),
  - ComboBoxText (use item id),
  - SpinButton,
  - FileChooserButton (a single file per button, for now),
  - ColorButtonChooser,
  - FontButtonChooser (the font value will be in [PangoDescription](https://docs.gtk.org/Pango/type_func.FontDescription.from_string.html) format),
  - CheckButton,
  - Switch,
  - ToggleButton,
  - Scale,
  - ScaleButton,
  - SpinButton,
  - Volume,
  - AppChooserButton
- Currently it doesn't support RadioButton widget.
- You can use visual (e.g. Label) and helper (e.g. Containers) widgets freely.

#### How to get what was set by user on the configuration dialog

If the dialog exists and user presses its OK button, the plugin script will receive, as its **second** argument, a filename. 
If using Python, get it via `sys.argv[2]`.

The file contains a [JSON](https://json.org) dictionary. The dict entry named "dialog" contains a nested dictionary with the data provided/chosen by user. The file may contain extra data, such as the Canvas state, as described in next section.

The "dialog" dictionary is a list of key-value pair, being the key the widget name (not ID) and the value that one provided by user.
Notes:
- ComboBox(Text) value is the ID of selected item, not the text presented to user.
- Boolean values (e.g. CheckButton) are "1" or "0".
- All field values will be passed as strings.
- The data file is temporary: it will deleted as soon as plugins finish running (successfully or not)

##### Example of data file contents
```json
{
  "dialog": {
    "my_entry": "what user typed",
    "the_checkbox": "1"
  }
}
```

### Canvas State
Synfig Studio can now pass the current canvas view state, and the plugin script can request them selectively.
These info are supported:
- current time (in seconds)
- the selected layers (list of pseudo XPath)

#### How to request
The metafile plugin.xml was extended to let plugin author tells Synfig Studio what info it needs.

The `<exec>` element now has two optional attributes:
- To receive current time, add this attribute to "exec" element: `current_time="mandatory"`.
- To receive XPath of selected layers, add this attribute to "exec" element: `selected_layers="optional"`.

Both attribute accepts one of three possible values:
- "unused": plugin does not need this info, and such data will not be passed to it (default)
- "mandatory": plugin depends on this info. If user does not provide it, an error message will pop up warning him/her.
- "optional": plugin can run without that info, so if it does not exist, it is not a problem.

Example: If `selected_layers="mandatory"` attribute exists, the user MUST select at least one layer to run the plugin. Otherwise, Synfig Studio will warn user and abort the plugin execution (by not starting it).

#### How to get the data

If any of the canvas state request attribute exists, the plugin script will receive, as its **second** argument, a filename. 
If using Python, get it via `sys.argv[2]`.

The file contains a [JSON](https://json.org) dictionary. The dict entry named "canvas_state" contains a nested dictionary with the requested data. The file may contain extra data, such as the Config Dialog entries, as described in previous section.

The possible keys for "canvas_state" dict are:
- "current_time": value will be in seconds.
- "selected_layers": an JSON array of pseudo [XPath](https://en.wikipedia.org/wiki/XPath) to selected layers.

Notes:
- Only the requested data will be in the file.
- The XPath for each layer is not 100% compliant.:
  * It may start with a filename, if selected layer comes from an imported `sif` file. In this case, it will be followed by `#` character, to mark the file path end.
  * It may have a starting ":" and that means the root canvas element of the file.
  * If it is an exported canvas (or from an exported valuenode), it won't have the initial path, but its ID. So place properly `defs` path.

#### Examples of file contents
```json
{
  "canvas_state": {
    "current_time": "1.35"
  }
}
```
  Only "time" was requested
```json
{
  "canvas_state": {
    "selected_layers": [
      ":layer[2]"
    ]
  }
}
```
  Only "layers" was requested, and user only selected one layer before calling the plugin. That layer is in the root canvas, being the second one from bottom to top. 
```json
{
  "canvas_state": {
    "current_time": "1.35",
    "selected_layers": [
      ":layer[2]",
      ":layer[7]"
    ]
  }
}
```

### Metadata
Plugin can now provide its author name, release name and version number.

The file `plugin.xml` now has new elements:
- element `<plugin>` now supports some metadata child elements:
  - "author"  : author name [string]
  - "release" : release name [translatable string]
  - "version" : version number [integer]
  - "url"  : url pointing to the plugin project/website [string]
  - "description" : a description text to guide the user [translatable string]

For now, these information do not appear anywhere in the GUI.
They can be used in the future by a plugin manager dialog in Synfig Studio.