### PR TITLE
build: change exported cmake targets and provide a way to find deps

### DIFF
--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -149,13 +149,28 @@ install(
     RUNTIME DESTINATION bin
 )
 
+set (LIBSYNFIG_CMAKE_CONFIG_FILE_NAME synfig-libsynfig-config.cmake)
 export(
-    EXPORT libsynfig
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+    TARGETS libsynfig
+    NAMESPACE synfig::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${LIBSYNFIG_CMAKE_CONFIG_FILE_NAME}"
 )
 
 install(
     EXPORT libsynfig
-    FILE "${PROJECT_NAME}-config.cmake"
-    DESTINATION "lib/cmake/${PROJECT_NAME}"
+    NAMESPACE synfig::
+    FILE "${LIBSYNFIG_CMAKE_CONFIG_FILE_NAME}"
+    DESTINATION "lib/cmake/synfig"
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/synfig-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/synfig-config.cmake
+    INSTALL_DESTINATION synfig
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/synfig-config.cmake
+    DESTINATION "lib/cmake/synfig"
 )

--- a/synfig-core/src/synfig/synfig-config.cmake.in
+++ b/synfig-core/src/synfig/synfig-config.cmake.in
@@ -1,0 +1,21 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(ZLIB REQUIRED)
+find_dependency(PkgConfig REQUIRED)
+
+pkg_check_modules(SIGCPP REQUIRED IMPORTED_TARGET sigc++-2.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GLIBMM REQUIRED IMPORTED_TARGET glibmm-2.4)
+pkg_check_modules(GIOMM REQUIRED IMPORTED_TARGET giomm-2.4)
+pkg_check_modules(XMLPP REQUIRED IMPORTED_TARGET libxml++-2.6)
+pkg_check_modules(FFTW REQUIRED IMPORTED_TARGET fftw3)
+
+set(WITH_MLT "@MLT_FOUND@")
+
+if(WITH_MLT)
+    pkg_search_module(MLT IMPORTED_TARGET mlt++-7 mlt++)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/@LIBSYNFIG_CMAKE_CONFIG_FILE_NAME@")


### PR DESCRIPTION
I wanted to write a program that links against installed synfig, but the default generated cmake config file links against synfig's dependencies targets without providing a way to find them.

Now something like this works:
```cmake
find_package(synfig)
target_link_libraries(main synfig::libsynfig)
```

I also took the liberty to change the cmake installation folder from "synfig-core" to "synfig", but I'm not sure if that's okay.