### PR TITLE
fix: inconsequential fixes regarding synfig::rendering::Tokens

### DIFF
--- a/synfig-core/src/synfig/rendering/common/task/tasklayer.cpp
+++ b/synfig-core/src/synfig/rendering/common/task/tasklayer.cpp
@@ -52,8 +52,7 @@ using namespace rendering;
 /* === M E T H O D S ======================================================= */
 
 
-Task::Token TaskLayer::token(
-	DescAbstract<TaskLayer>("Contour") );
+Task::Token TaskLayer::token(DescAbstract<TaskLayer>("Layer"));
 
 
 Rect

--- a/synfig-core/src/synfig/rendering/surface.h
+++ b/synfig-core/src/synfig/rendering/surface.h
@@ -87,7 +87,7 @@ public:
 
 	public:
 		Token(const DescBase &desc):
-			synfig::Token(token.handle()),
+			synfig::Token(Surface::token.handle()),
 			DescBase(desc) { }
 
 		inline Handle handle() const

--- a/synfig-core/src/synfig/token.h
+++ b/synfig-core/src/synfig/token.h
@@ -70,7 +70,7 @@ public:
 	template<typename TT>
 	inline ConstRef<TT> as() const
 	{
-		TT *p = dynamic_cast<TT*>(pointer);
+		const TT *p = dynamic_cast<const TT*>(pointer);
 		return p ? ConstRef<TT>(*p) : ConstRef<TT>();
 	}
 


### PR DESCRIPTION
I'm trying to understand the Cobra renderer bit by bit. I wrote a [simple program](https://github.com/theartful/exploring-synfig/tree/master/rendering/tokens) to visualize the rendering tokens, and found these two asymptomatic bugs.

I will continue exploring the rendering engine of synfig, and might find similar stuff. Please tell me if these kinds of pull requests are not welcome.