### PR TITLE
fix: check type equality before replacing rhandles

### DIFF
--- a/ETL/ETL/_handle.h
+++ b/ETL/ETL/_handle.h
@@ -319,6 +319,10 @@ public:
 	template<typename U>
 	bool type_equal() const
 	{ return typeid(*obj) == typeid(U); }
+
+	template <typename U>
+	bool type_equal(const etl::handle<U> handle) const
+	{ return typeid(*obj) == typeid(*handle.get()); }
 }; // END of template class handle
 
 // ========================================================================
@@ -589,9 +593,13 @@ public:
 //		value_type*& obj(handle<T>::obj); // Required to keep gcc 3.4.2 from barfing
 		assert(obj);
 		assert(x.get()!=obj);
+		assert(this->type_equal(x));
 
 		if(x.get()==obj)
 			return 0;
+
+		if(!this->type_equal(x))
+			return -1;
 
 		rhandle<value_type> *iter;
 		rhandle<value_type> *next;


### PR DESCRIPTION
I was reading up on `etl::rshared_object`, and found this potential bug. If we have a number of rhandles pointing to the same object but with different types in the hierarchy tree, it is possible to replace the rhandle  with a parent class, which will cause rhandles with child classes to be in undefined state.
Example:
```C++
class Object : public etl::rshared_object
{
private:
    int some_data_to_make_class_not_empty = 0;
};

class Child : public Object
{
private:
    int* data_ptr;

public:
    Child() { data_ptr = new int(10); }
    ~Child() { delete data_ptr; }

    int data() { return *data_ptr; }
};

void buggy() {
    etl::handle<Child> obj{new Child()};
    etl::handle<Object> obj2{new Object()};

    etl::rhandle<Object> obj_replaceable1{obj};
    etl::rhandle<Child> obj_replaceable2{obj};

    // prints 10
    std::cout << "obj_replaceable2->data = " << obj_replaceable2->data()
              << '\n';

    obj_replaceable1.replace(obj2);

    // will crash
    std::cout << "obj_replaceable2->data = " << obj_replaceable2->data()
              << '\n';
}
```