### PR TITLE
feat: added embedded Python

### DIFF
--- a/1-setup-linux-native.sh
+++ b/1-setup-linux-native.sh
@@ -226,7 +226,7 @@ elif [ "$ID_LIKE" == "debian" ] || [ "$ID_LIKE" == "ubuntu" ] || [ "$ID_LIKE" ==
                 libsigc++-2.0-dev \
                 libxml++2.6-dev \
                 libmagick++-dev \
-                libxslt-dev python3 python3-lxml"
+                libxslt-dev python3 python3-lxml pybind11-dev python3-dev"
         else
             #  ALT Linux case
             PKG_LIST=" \

--- a/synfig-core/src/CMakeLists.txt
+++ b/synfig-core/src/CMakeLists.txt
@@ -5,6 +5,11 @@
 find_package(ZLIB REQUIRED)
 find_package(Intl REQUIRED)
 
+if(EMBED_PYTHON)
+	find_package(pybind11 REQUIRED)  # or add_subdirectory(pybind11)
+	add_definitions(-DEMBED_PYTHON)
+endif()
+
 ## ETL doesn't install a package configuration so find package will fail
 # find_package(ETL REQUIRED)
 

--- a/synfig-core/src/tool/CMakeLists.txt
+++ b/synfig-core/src/tool/CMakeLists.txt
@@ -23,6 +23,11 @@ if(TCMALLOC_LIBRARY)
     target_link_libraries(synfig_bin PRIVATE ${TCMALLOC_LIBRARY})
 endif()
 
+if (EMBED_PYTHON)
+    target_sources(synfig_bin PRIVATE "${CMAKE_CURRENT_LIST_DIR}/synfig_python_module.cpp")
+    target_link_libraries(synfig_bin PRIVATE pybind11::embed)
+endif()
+
 install (
     TARGETS synfig_bin
     DESTINATION bin

--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -52,6 +52,11 @@
 #include "printing_functions.h"
 #include "optionsprocessor.h"
 #include <glibmm/init.h>
+
+#ifdef EMBED_PYTHON
+#include <pybind11/embed.h>
+namespace py = pybind11;
+#endif
 #endif
 
 using namespace synfig;
@@ -194,6 +199,7 @@ SynfigCommandLineParser::SynfigCommandLineParser() :
 	add_option(og_info, "target-video-codecs",' ', show_codecs, _("Print out the list of available video codecs when encoding through FFMPEG"), "");
 	add_option(og_info, "valuenodes", ' ', show_value_nodes, 	_("Print out the list of available ValueNodes"), "");
 	add_option(og_info, "version",    ' ', show_version, 		_("Print out version information"), "");
+	add_option(og_info, "python-test", ' ', show_python_output, 		_("Print test python output"), "");
 
 #ifdef _DEBUG
 	//SynfigOptionGroup og_debug("debug", _("Synfig debug flags"), "Show Synfig debug flags help");
@@ -492,6 +498,22 @@ void SynfigCommandLineParser::process_info_options()
 			std::cout << (iter.first).c_str() << std::endl;
 		}
 
+		throw (SynfigToolException(SYNFIGTOOL_HELP));
+	}
+
+	if (show_python_output) {
+#ifdef EMBED_PYTHON
+		py::scoped_interpreter guard{}; // start the interpreter and keep it alive
+
+		py::exec(R"(
+import synfig
+
+result = synfig.add(10, 11)
+synfig.info(f"synfig result: {result}")
+synfig.warning(f"synfig result: {result}")
+synfig.error(f"synfig result: {result}")
+)");
+#endif
 		throw (SynfigToolException(SYNFIGTOOL_HELP));
 	}
 }

--- a/synfig-core/src/tool/optionsprocessor.h
+++ b/synfig-core/src/tool/optionsprocessor.h
@@ -144,6 +144,7 @@ private:
 	bool			show_codecs;
 	bool			show_value_nodes;
 	bool			show_version;
+	bool			show_python_output;
 
 	// Debug group
 #ifdef _DEBUG

--- a/synfig-core/src/tool/synfig_python_module.cpp
+++ b/synfig-core/src/tool/synfig_python_module.cpp
@@ -1,0 +1,44 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file pybind11.cpp
+**	\brief Template File
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+#include <pybind11/embed.h> // everything needed for embedding
+#include "synfig/general.h"
+
+namespace py = pybind11;
+
+PYBIND11_EMBEDDED_MODULE(synfig, m) {
+
+	m.doc() = "synfig pybind11 example module"; // optional module docstring
+
+	m.def("add", [](int i, int j) {
+		return i + j;
+	});
+
+	m.def("info",    static_cast<void (*)(const std::string&)>(&synfig::info),    "print info");
+	m.def("warning", static_cast<void (*)(const std::string&)>(&synfig::warning), "print warning");
+	m.def("error",   static_cast<void (*)(const std::string&)>(&synfig::error),   "print error");
+}
+
+


### PR DESCRIPTION
This is an example of how easy it is to embed Python to Synfig.

To test on Linux:
1) install build dependencies: `pybind11-dev python3-dev`
2) build and run `synfig --python-test`
Example output:
```
synfig(28100) [12:45:03] info: synfig result: 21
synfig(28100) [12:45:03] warning: synfig result: 21
synfig(28100) [12:45:03] error: synfig result: 21
```

But this adds a lot of questions:
1) Do we need plugin plugin support for console Synfig? If so, this will require separating plugins into GUI and console ones.

2) Should plugin system should be implemented as a Synfig module? At first glance, this will look strange - libsynfig loads a module that is linked to libsynfig. 

3) Do we need an API architecture or just export whatever the plugin author needs?

4) Best way to iterate over layers.
Do we need to export the entire Layer class or just part of it?