### PR TITLE
chore: fix typo in comment in `valuedescset.h`

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuedescset.h
+++ b/synfig-studio/src/synfigapp/actions/valuedescset.h
@@ -58,7 +58,7 @@ private:
 	bool lock_animation;
 	synfig::ValueNode_Animated::Handle value_node_animated;
 
-	/// convenient method to create a ValueDescSet action and and it to stack
+	/// convenient method to create a ValueDescSet action and add it to stack
 	void add_action_valuedescset(const synfig::ValueBase& value, const ValueDesc& value_desc, bool recursive = true);
 
 public:


### PR DESCRIPTION
Found it while working on #2953. The method creates a valuedescset action and adds it to the stack (which seems to be the undoable action list but I didn't look too much as that wasnt directly related to what I was doing).