### PR TITLE
refactor: remove deprecated `Widget::override_color()`

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -2148,13 +2148,11 @@ CanvasView::on_time_changed()
 	{
 		KeyframeList::iterator iter;
 		if (get_canvas()->keyframe_list().find(time, iter)) {
-			// Widget::override_color() is deprecated since Gtkmm 3.16: Use a custom style provider and style classes instead.
-			// This function is very slow!
-			current_time_widget->override_color(Gdk::RGBA("#FF0000"));
+			current_time_widget->get_style_context()->remove_class("color-black");
+			current_time_widget->get_style_context()->add_class("color-red");
 		} else {
-			// Widget::override_color() is deprecated since Gtkmm 3.16: Use a custom style provider and style classes instead.
-			// This function is very slow!
-			current_time_widget->override_color(Gdk::RGBA(0));
+			current_time_widget->get_style_context()->remove_class("color-red");
+			current_time_widget->get_style_context()->add_class("color-black");
 		}
 
 		// Shouldn't these trees just hook into
@@ -2542,9 +2540,6 @@ CanvasView::play_async()
 	if (timeout < 10) timeout = 10;
 
 	framedial->toggle_play_pause_button(is_playing());
-	// Widget::override_color() is deprecated since Gtkmm 3.16: Use a custom style provider and style classes instead.
-	// Also, this function is heavily slowdowns playback.
-	//current_time_widget->override_color(Gdk::RGBA(0));
 
 	soundProcessor.clear();
 	canvas_interface()->get_canvas()->fill_sound_processor(soundProcessor);

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -99,3 +99,15 @@
 #canvasview {
 	background: @theme_unfocused_bg_color;
 }
+
+.color-red {
+        color : #FF0000;
+}
+
+.color-black {
+        color : #000000;
+}
+
+.color-white {
+        color : #FFFFFF;
+}

--- a/synfig-studio/src/gui/splash.cpp
+++ b/synfig-studio/src/gui/splash.cpp
@@ -179,7 +179,7 @@ Splash::Splash():
 	versionlabel->set_label("" VERSION);
 	versionlabel->set_size_request(image_w,24);
 	versionlabel->set_use_underline(false);
-	versionlabel->override_color(Gdk::RGBA("#FFFFFF"));
+	versionlabel->get_style_context()->add_class("color-white");
 	versionlabel->show();
 
 	// Create the Gtk::Fixed container and put all of the widgets into it


### PR DESCRIPTION
Found this while looking through the code for #3014 . It also says this function heavily slows playback so I thought might as well replace it. 

I noticed there is also a synfig.mac.css, not sure if that is used for mac instead of the synfig.css or ig it is just to define an extra class for a fix. If it's not the latter I might have to redefine the classes there as well.

p.s. 
about four months back the whole style context class was deprecated from GTK and now instead for example it should just be
`versionlabel->add_class("color-white");`
the `add_class` method was moved directly to the widget base class, but it doesn't seem to be ported yet to gtkmm. I checked the docs for even the latest verision and it wasn't there.

p.s. 2
I don't know why the verision label is white while the background is white as well, maybe it's meant like so because its disabled ? Anyways, I just ported the original white color as is.