### PR TITLE
feat: add a CLI flag(--set-repeats) for rendering the same target multiple times

### DIFF
--- a/synfig-core/src/tool/definitions.cpp
+++ b/synfig-core/src/tool/definitions.cpp
@@ -38,6 +38,7 @@ SynfigToolGeneralOptions::SynfigToolGeneralOptions()
 	_should_be_quiet = false;
 	_should_print_benchmarks = false;
 	_threads = 1;
+	_repeats = 1;
 }
 
 std::string SynfigToolGeneralOptions::get_binary_path() const
@@ -88,4 +89,14 @@ bool SynfigToolGeneralOptions::should_print_benchmarks() const
 void SynfigToolGeneralOptions::set_should_print_benchmarks(bool print_benchmarks)
 {
 	_should_print_benchmarks = print_benchmarks;
+}
+
+int SynfigToolGeneralOptions::get_repeats() const
+{
+	return _repeats;
+}
+
+void SynfigToolGeneralOptions::set_repeats(int repeats)
+{
+	_repeats = repeats;
 }

--- a/synfig-core/src/tool/definitions.h
+++ b/synfig-core/src/tool/definitions.h
@@ -103,6 +103,10 @@ public:
 
 	void set_should_print_benchmarks(bool print_benchmarks);
 
+	int get_repeats() const;
+
+	void set_repeats(int repeats);
+
 private:
 	SynfigToolGeneralOptions();
 	std::string _binary_path;
@@ -110,6 +114,8 @@ private:
 	size_t _threads;
 	bool _should_be_quiet,
 		 _should_print_benchmarks;
+
+	int _repeats;
 };
 
 #endif

--- a/synfig-core/src/tool/joblistprocessor.cpp
+++ b/synfig-core/src/tool/joblistprocessor.cpp
@@ -266,13 +266,14 @@ void process_job (Job& job)
 		VERBOSE_OUT(1) << _("Rendering...") << std::endl;
 
 		bool should_print_benchmarks = SynfigToolGeneralOptions::instance()->should_print_benchmarks();
-		double dur = 0.f;
+
+		double total_duration = 0.f;
 		int repeats = SynfigToolGeneralOptions::instance()->get_repeats();
 
 		for(int i = 0; i < repeats; i++)
 		{
-			std::chrono::system_clock::time_point start_timepoint =
-				std::chrono::system_clock::now();
+			std::chrono::steady_clock::time_point start_timepoint =
+				std::chrono::steady_clock::now();
 
 			// Call the render member of the target
 			if(!job.target->render(&p))
@@ -280,10 +281,10 @@ void process_job (Job& job)
 
 			if(should_print_benchmarks)
 			{
-				std::chrono::duration<double> duration =
-					std::chrono::system_clock::now() - start_timepoint;
+				std::chrono::duration<double, std::milli> duration =
+					std::chrono::steady_clock::now() - start_timepoint;
 
-				dur += duration.count();
+				total_duration += duration.count();
 			}
 		}
 
@@ -293,11 +294,11 @@ void process_job (Job& job)
 				<< _(": Rendered ")
 				<< repeats
 				<< _( " times in ")
-				<< dur
-				<< _(" seconds.")
+				<< total_duration
+				<< _(" ms.")
 				<< _(" Average time per render: ")
-				<< dur / repeats
-				<< "." << std::endl;
+				<< total_duration / repeats
+				<< _(" ms.") << std::endl;
 		}
 	}
 

--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -107,6 +107,7 @@ SynfigCommandLineParser::SynfigCommandLineParser() :
 	set_dpi(),
 	set_dpi_x(),
 	set_dpi_y(),
+	set_repeats(),
 
 	// Switch group
 	sw_verbosity(),
@@ -165,6 +166,7 @@ SynfigCommandLineParser::SynfigCommandLineParser() :
 	add_option(og_set, "dpi",         ' ', set_dpi, 		_("Set the physical resolution (Dots-per-inch)"), "NUM");
 	add_option(og_set, "dpi-x",       ' ', set_dpi_x, 		_("Set the physical X resolution (Dots-per-inch)"), "NUM");
 	add_option(og_set, "dpi-y",       ' ', set_dpi_y, 		_("Set the physical Y resolution (Dots-per-inch)"), "NUM");
+	add_option(og_set, "repeats",	  ' ', set_repeats,		_("Set the number of times to render the same target"), "NUM");
 
 	// Switch options
 	//og_switch("switch", _("Switch options"), "Show switch help");
@@ -347,6 +349,11 @@ void SynfigCommandLineParser::process_settings_options() const
 	if (sw_print_benchmarks)
 	{
 		SynfigToolGeneralOptions::instance()->set_should_print_benchmarks(true);
+	}
+
+	if(set_repeats > 0)
+	{
+		SynfigToolGeneralOptions::instance()->set_repeats(set_repeats);
 	}
 
 	if (sw_quiet)

--- a/synfig-core/src/tool/optionsprocessor.h
+++ b/synfig-core/src/tool/optionsprocessor.h
@@ -116,6 +116,7 @@ private:
 	double			set_dpi;
 	double			set_dpi_x;
 	double			set_dpi_y;
+	int				set_repeats;
 
 	// Switch group
 	int				sw_verbosity;


### PR DESCRIPTION
Following my post #3017 , I decided to implement the feature.

Since synfig cli already had a flag for printing benchmark time, I only added the feature to render the same target multiple times.
The total and average time are printed.