### PR TITLE
refactor: remove useless return statement at the end of a function

### DIFF
--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -547,7 +547,6 @@ RenderSettings::submit_next_render_pass()
 		async_renderer->start();
 		App::dock_info_->set_async_render(async_renderer);
 	}
-	return;
 }
 
 void


### PR DESCRIPTION
Just caught my eye... It is not really affecting anything , compiler takes care of it anyways. But just for the sake of a cleaner code base ig :)

p.s. I have been collecting various typos and little things I noticed which seem off during the past week/2 weeks while going through the code in various places. I will wait a bit longer with the typos though just so that they could all be in one compact PR.