### PR TITLE
fix: added a missing `init_children_vocab()` call in ValueNode constructors

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinereversetangent.cpp
@@ -62,6 +62,7 @@ REGISTER_VALUENODE(ValueNode_BLineRevTangent, RELEASE_VERSION_0_61_08, "blinerev
 ValueNode_BLineRevTangent::ValueNode_BLineRevTangent(Type &x):
 	LinkableValueNode(x)
 {
+	init_children_vocab();
 }
 
 ValueNode_BLineRevTangent::ValueNode_BLineRevTangent(const ValueNode::Handle &x):

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneinfluence.cpp
@@ -68,6 +68,7 @@ ValueNode_BoneInfluence::ValueNode_BoneInfluence(Type &x):
 	checked_inverse_(),
 	has_inverse_()
 {
+	init_children_vocab();
 }
 
 ValueNode_BoneInfluence::ValueNode_BoneInfluence(const ValueNode::Handle &x, Canvas::LooseHandle canvas):
@@ -75,6 +76,7 @@ ValueNode_BoneInfluence::ValueNode_BoneInfluence(const ValueNode::Handle &x, Can
 	checked_inverse_(),
 	has_inverse_()
 {
+	init_children_vocab();
 	Type &type(x->get_type());
 	if (type == type_vector || type == type_bline_point)
 	{

--- a/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_boneweightpair.cpp
@@ -62,6 +62,7 @@ REGISTER_VALUENODE(ValueNode_BoneWeightPair, RELEASE_VERSION_0_62_00, "boneweigh
 ValueNode_BoneWeightPair::ValueNode_BoneWeightPair(const ValueBase &value, Canvas::LooseHandle canvas):
 	LinkableValueNode(value.get_type())
 {
+	init_children_vocab();
 	if (value.get_type() == type_bone_weight_pair)
 	{
 		BoneWeightPair bone_weight_pair(value.get(BoneWeightPair()));

--- a/synfig-core/src/synfig/valuenodes/valuenode_duplicate.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_duplicate.cpp
@@ -60,6 +60,7 @@ ValueNode_Duplicate::ValueNode_Duplicate(Type &x):
 	LinkableValueNode(x),
 	index()
 {
+	init_children_vocab();
 }
 
 ValueNode_Duplicate::ValueNode_Duplicate(const ValueBase &x):

--- a/synfig-core/src/synfig/valuenodes/valuenode_greyed.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_greyed.cpp
@@ -59,6 +59,7 @@ REGISTER_VALUENODE(ValueNode_Greyed, RELEASE_VERSION_0_62_00, "greyed", N_("Grey
 ValueNode_Greyed::ValueNode_Greyed(Type &x):
 	ValueNode_Reference(x)
 {
+	init_children_vocab();
 }
 
 ValueNode_Greyed::ValueNode_Greyed(const ValueNode::Handle &x):

--- a/synfig-core/src/synfig/valuenodes/valuenode_integer.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_integer.cpp
@@ -61,6 +61,7 @@ REGISTER_VALUENODE(ValueNode_Integer, RELEASE_VERSION_0_61_08, "fromint", N_("In
 ValueNode_Integer::ValueNode_Integer(Type &x):
 	LinkableValueNode(x)
 {
+	init_children_vocab();
 }
 
 ValueNode_Integer::ValueNode_Integer(const ValueBase &x):

--- a/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_real.cpp
@@ -60,6 +60,7 @@ REGISTER_VALUENODE(ValueNode_Real, RELEASE_VERSION_0_64_0, "fromreal", N_("Real"
 ValueNode_Real::ValueNode_Real(Type &x):
 	LinkableValueNode(x)
 {
+	init_children_vocab();
 }
 
 ValueNode_Real::ValueNode_Real(const ValueBase &x):

--- a/synfig-core/src/synfig/valuenodes/valuenode_reference.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reference.cpp
@@ -59,6 +59,7 @@ REGISTER_VALUENODE(ValueNode_Reference, RELEASE_VERSION_0_61_06, "reference", N_
 ValueNode_Reference::ValueNode_Reference(Type &x):
 	LinkableValueNode(x)
 {
+	init_children_vocab();
 }
 
 ValueNode_Reference::ValueNode_Reference(const ValueNode::Handle &x):

--- a/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_reverse.cpp
@@ -74,6 +74,7 @@ REGISTER_VALUENODE(ValueNode_Reverse, RELEASE_VERSION_1_0_2, "reverse", N_("Reve
 ValueNode_Reverse::ValueNode_Reverse(Type &x):
 	LinkableValueNode(x)
 {
+	init_children_vocab();
 }
 
 ValueNode_Reverse::ValueNode_Reverse(const ValueBase &x):

--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
@@ -59,6 +59,7 @@ REGISTER_VALUENODE(ValueNode_Switch, RELEASE_VERSION_0_61_08, "switch", N_("Swit
 ValueNode_Switch::ValueNode_Switch(Type &x):
 	LinkableValueNode(x)
 {
+	init_children_vocab();
 }
 
 ValueNode_Switch::ValueNode_Switch(const ValueBase &x):

--- a/synfig-core/src/synfig/valuenodes/valuenode_timeloop.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_timeloop.cpp
@@ -59,6 +59,7 @@ REGISTER_VALUENODE(ValueNode_TimeLoop, RELEASE_VERSION_0_61_08, "timeloop", N_("
 ValueNode_TimeLoop::ValueNode_TimeLoop(Type &x):
 	LinkableValueNode(x)
 {
+	init_children_vocab();
 }
 
 ValueNode_TimeLoop::ValueNode_TimeLoop(const ValueNode::Handle &x):


### PR DESCRIPTION
It turned out that some necessary initialization of the parameter name dictionary (`children_vocab`) is missing in certain places. 
Previously, it worked because a new dictionary was always created when calling `link_count()` or `get_children_vocab()` method (changes made in #2831).
After the changes, some ValueNodes can work incorrectly because the parameter dictionary became empty when accessing it.

This commit fixes this issue.

P.S. 
There are also ValueNodes with a dynamic set of parameters (`ValueNode_BLine`,`ValueNode_DynamicList`, `ValueNode_StaticList`), but they should work correctly because the parameter dictionary is repopulated when the reindex() method is called.

Related PR: #2831