### PR TITLE
fix: "Embed layer" doesn't embed ValueBase nodes

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
@@ -49,6 +49,8 @@
 
 #include <synfigapp/localization.h>
 
+#include <synfig/layers/layer_pastecanvas.h>
+
 #endif
 
 using namespace synfig;
@@ -159,7 +161,7 @@ Action::ValueDescExport::is_ready()const
 	return Action::CanvasSpecific::is_ready();
 }
 
-void Action::ValueDescExport::scan_canvas(synfig::Canvas::Handle prev_canvas, synfig::Canvas::Handle new_canvas, synfig::Canvas::Handle canvas)
+void Action::ValueDescExport::scan_canvas(synfig::Canvas::Handle prev_canvas, synfig::Canvas::Handle new_canvas, synfig::Canvas::Handle canvas, bool recursive)
 {
 	{ // scan children
 		std::list<Canvas::Handle> &children = canvas->children();
@@ -168,8 +170,18 @@ void Action::ValueDescExport::scan_canvas(synfig::Canvas::Handle prev_canvas, sy
 	}
 
 	{ // scan layers
-		for(IndependentContext i = canvas->get_independent_context(); *i; i++)
-			scan_layer(prev_canvas, new_canvas, *i);
+		for(IndependentContext i = canvas->get_independent_context(); *i; i++){
+			if(recursive && etl::handle<Layer_PasteCanvas>::cast_dynamic(*i)){
+				etl::handle<synfig::Layer_PasteCanvas> p = etl::handle<Layer_PasteCanvas>::cast_dynamic(*i);
+				scan_layer(prev_canvas, new_canvas, *i);
+				synfig::Canvas::Handle sub_canvas = p->get_sub_canvas();
+				if (sub_canvas){
+					for(IndependentContext j = sub_canvas->get_independent_context(); *j; j++)
+							scan_layer(prev_canvas, new_canvas, *j);
+				}
+			} else
+				scan_layer(prev_canvas, new_canvas, *i);
+		}
 	}
 
 	{ // scan values
@@ -272,7 +284,7 @@ Action::ValueDescExport::prepare()
 
 			// scan all layers and canvases and relink value nodes
 			scan_canvas(prev_canvas, canvas, get_canvas());
-			scan_canvas(prev_canvas, canvas, canvas);
+			scan_canvas(prev_canvas, canvas, canvas, true);
 		} else {
 			canvas->rend_desc()=get_canvas()->rend_desc();
 		}

--- a/synfig-studio/src/synfigapp/actions/valuedescexport.h
+++ b/synfig-studio/src/synfigapp/actions/valuedescexport.h
@@ -52,7 +52,7 @@ private:
 	ValueDesc value_desc;
 	synfig::String name;
 
-	void scan_canvas(synfig::Canvas::Handle prev_canvas, synfig::Canvas::Handle new_canvas, synfig::Canvas::Handle canvas);
+	void scan_canvas(synfig::Canvas::Handle prev_canvas, synfig::Canvas::Handle new_canvas, synfig::Canvas::Handle canvas, bool recursive = false);
 	void scan_layer(synfig::Canvas::Handle prev_canvas, synfig::Canvas::Handle new_canvas, synfig::Layer::Handle layer);
 	void scan_linkable_value_node(synfig::Canvas::Handle prev_canvas, synfig::Canvas::Handle new_canvas, synfig::LinkableValueNode::Handle linkable_value_node);
 


### PR DESCRIPTION
fixes #426 ,
Name of the original issue is a little bit confusing ?!. But basically the problem was that "embed layer" is supposed to make the embedded layer independent of the original layer (this includes exported parameters). Now this works correctly for layers of the imported canvas, but it works incorrectly for when these very same layers are enclosed by a group (layer_pastecanvas).

description of what I did:
After some investigating I realized in `ValueDescExport` `scan_layers()` wasn't correctly scanning all the layers for the exported canvas. This was because it was only scanning the top layers, but some of these layers can be groups and have layers inside them. So I just allowed for it to scan all the layers of the canvas. This seems to fix the issue but i'm not sure if breaks stuff so I'll keep it as draft until I check more.