### PR TITLE
fix: sigsegv when `LANGUAGE`/`LANG` environment variable is not set

### DIFF
--- a/synfig-core/src/synfig/os.cpp
+++ b/synfig-core/src/synfig/os.cpp
@@ -37,6 +37,8 @@
 
 #include <cstdarg>
 
+#include <glibmm/miscutils.h>
+
 #include <synfig/filesystem.h>
 #include <synfig/general.h>
 #include <synfig/localization.h>
@@ -714,7 +716,7 @@ OS::get_user_lang()
 		return language_list;
 
 	{
-		std::string language_list_str = trim(getenv("LANGUAGE"));
+		std::string language_list_str = trim(Glib::getenv("LANGUAGE"));
 		if (!language_list_str.empty()) {
 			std::string::size_type pos = 0, prev_pos = 0;
 			while ((pos = language_list_str.find(':', pos)) != std::string::npos) {
@@ -733,7 +735,7 @@ OS::get_user_lang()
 	}
 
 	{
-		std::string lang = trim(getenv("LANG"));
+		std::string lang = trim(Glib::getenv("LANG"));
 		if (!lang.empty()) {
 			// remove encoding info
 			auto dot_pos = lang.find('.');

--- a/synfig-core/src/synfig/os.cpp
+++ b/synfig-core/src/synfig/os.cpp
@@ -36,8 +36,7 @@
 #include "os.h"
 
 #include <cstdarg>
-
-#include <glibmm/miscutils.h>
+#include <cstdlib>
 
 #include <synfig/filesystem.h>
 #include <synfig/general.h>
@@ -716,7 +715,8 @@ OS::get_user_lang()
 		return language_list;
 
 	{
-		std::string language_list_str = trim(Glib::getenv("LANGUAGE"));
+		const char* lang_env = getenv("LANGUAGE");
+		std::string language_list_str = lang_env ? trim(lang_env) : "";
 		if (!language_list_str.empty()) {
 			std::string::size_type pos = 0, prev_pos = 0;
 			while ((pos = language_list_str.find(':', pos)) != std::string::npos) {
@@ -735,7 +735,8 @@ OS::get_user_lang()
 	}
 
 	{
-		std::string lang = trim(Glib::getenv("LANG"));
+		const char* lang_env = getenv("LANG");
+		std::string lang = lang_env ? trim(lang_env) : "";
 		if (!lang.empty()) {
 			// remove encoding info
 			auto dot_pos = lang.find('.');


### PR DESCRIPTION
Synfig Studio crashes when trying to run on macOS.

`getenv()` can return NULL, so we pass NULL as a `std::string&` reference.

Example code:
```
#include <string>

bool is_empty(const std::string& str) {
    return str.empty();
}

int main() {
    is_empty(nullptr);
    return 0;
}
```

Output:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
```

Fixed by switching to Glibmm function. In this case, Glibmm returns an empty string.

Linked PR: #2998