### PR TITLE
refactor: prefer Layer_*::Handle and alike rather etl::handle

### DIFF
--- a/synfig-core/src/synfig/layers/layer_pastecanvas.cpp
+++ b/synfig-core/src/synfig/layers/layer_pastecanvas.cpp
@@ -270,7 +270,7 @@ Layer_PasteCanvas::update_renddesc()
 	sub_canvas->rend_desc()=get_canvas()->rend_desc();
 	for (IndependentContext iter = sub_canvas->get_independent_context(); !iter->empty(); iter++)
 	{
-		etl::handle<Layer_PasteCanvas> paste = etl::handle<Layer_PasteCanvas>::cast_dynamic(*iter);
+		Layer_PasteCanvas::Handle paste = Layer_PasteCanvas::Handle::cast_dynamic(*iter);
 		if (paste) paste->update_renddesc();
 	}
 }

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -1862,7 +1862,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 	}
 
 	DEBUG_LOG("SYNFIG_DEBUG_LOAD_CANVAS", "%s:%d creating linkable '%s' type '%s'\n", __FILE__, __LINE__, element->get_name().c_str(), type.description.name.c_str());
-	handle<LinkableValueNode> value_node=ValueNodeRegistry::create(element->get_name(),type);
+	LinkableValueNode::Handle value_node=ValueNodeRegistry::create(element->get_name(),type);
 	//ValueNode::Handle c[value_node->link_count()]; changed because of clang complain
 	std::vector<ValueNode::Handle> c(value_node->link_count());
 
@@ -2173,7 +2173,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 	{
 		if (version == "0.1" || version == "0.2" || version == "0.3")
 		{
-			handle<LinkableValueNode> scale_value_node=ValueNodeRegistry::create("scale",type);
+			LinkableValueNode::Handle scale_value_node=ValueNodeRegistry::create("scale",type);
 			scale_value_node->set_link("link", value_node);
 			scale_value_node->set_link("scalar", ValueNode_Const::create(Real(0.5)));
 
@@ -2185,7 +2185,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 	return value_node;
 }
 
-handle<ValueNode_StaticList>
+ValueNode_StaticList::Handle
 CanvasParser::parse_static_list(xmlpp::Element *element,Canvas::Handle canvas)
 {
 	assert(element->get_name()=="static_list");
@@ -2193,7 +2193,7 @@ CanvasParser::parse_static_list(xmlpp::Element *element,Canvas::Handle canvas)
 	if(!element->get_attribute("type"))
 	{
 		error(element,"Missing attribute \"type\" in <list>");
-		return handle<ValueNode_StaticList>();
+		return ValueNode_StaticList::Handle();
 	}
 
 	Type &type=ValueBase::ident_type(element->get_attribute("type")->get_value());
@@ -2201,17 +2201,17 @@ CanvasParser::parse_static_list(xmlpp::Element *element,Canvas::Handle canvas)
 	if(type == type_nil)
 	{
 		error(element,"Bad type in <list>");
-		return handle<ValueNode_StaticList>();
+		return ValueNode_StaticList::Handle();
 	}
 
-	handle<ValueNode_StaticList> value_node;
+	ValueNode_StaticList::Handle value_node;
 
 	value_node=ValueNode_StaticList::create_on_canvas(type);
 
 	if(!value_node)
 	{
 		error(element,strprintf(_("Unable to create <list>")));
-		return handle<ValueNode_StaticList>();
+		return ValueNode_StaticList::Handle();
 	}
 
 	value_node->set_root_canvas(canvas->get_root());
@@ -2284,7 +2284,7 @@ static bool is_bool_attribute_true(xmlpp::Element* element, const char* name) {
 }
 
 // This will also parse a bline
-handle<ValueNode_DynamicList>
+ValueNode_DynamicList::Handle
 CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 {
 	assert(element->get_name()=="dynamic_list" ||
@@ -2299,7 +2299,7 @@ CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 	if(!element->get_attribute("type"))
 	{
 		error(element,"Missing attribute \"type\" in <dynamic_list>");
-		return handle<ValueNode_DynamicList>();
+		return ValueNode_DynamicList::Handle();
 	}
 
 	Type &type = ValueBase::ident_type(element->get_attribute("type")->get_value());
@@ -2307,10 +2307,10 @@ CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 	if(type == type_nil)
 	{
 		error(element,"Bad type in <dynamic_list>");
-		return handle<ValueNode_DynamicList>();
+		return ValueNode_DynamicList::Handle();
 	}
 
-	handle<ValueNode_DynamicList> value_node;
+	ValueNode_DynamicList::Handle value_node;
 
 	bool must_rotate_point_list = false;
 
@@ -2344,7 +2344,7 @@ CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 	if(!value_node)
 	{
 		error(element,strprintf(_("Unable to create <dynamic_list>")));
-		return handle<ValueNode_DynamicList>();
+		return ValueNode_DynamicList::Handle();
 	}
 
 	value_node->set_root_canvas(canvas->get_root());
@@ -2777,7 +2777,7 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 		layer->set_exclude_from_rendering(!is_false(element->get_attribute("exclude_from_rendering")->get_value()));
 
 	// Load old groups
-	etl::handle<Layer_PasteCanvas> layer_pastecanvas = etl::handle<Layer_Group>::cast_dynamic(layer);
+	Layer_PasteCanvas::Handle layer_pastecanvas = etl::handle<Layer_Group>::cast_dynamic(layer);
 	bool old_pastecanvas = layer_pastecanvas && version=="0.1";
 	ValueNode::Handle origin_node;
 	ValueNode_Composite::Handle transformation_node;

--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -848,7 +848,7 @@ xmlpp::Element* encode_layer(xmlpp::Element* root,Layer::ConstHandle layer)
 			xmlpp::Element *node=root->add_child("param");
 			node->set_attribute("name",iter->get_name());
 
-			handle<const ValueNode> value_node=dynamic_param_list.find(iter->get_name())->second;
+			ValueNode::ConstHandle value_node=dynamic_param_list.find(iter->get_name())->second;
 
 			// If the valuenode has no ID, then it must be defined in-place
 			if(value_node->get_id().empty())

--- a/synfig-core/src/synfig/timepointcollect.cpp
+++ b/synfig-core/src/synfig/timepointcollect.cpp
@@ -88,7 +88,7 @@ synfig::waypoint_collect(std::set<Waypoint, std::less<UniqueID> >	&waypoint_set,
 		const Layer::DynamicParamList& dyn_param_list(layer->dynamic_param_list());
 		Layer::DynamicParamList::const_iterator iter;
 		int ret(0);
-		etl::handle<Layer_PasteCanvas> p = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer);
+		Layer_PasteCanvas::Handle p = Layer_PasteCanvas::Handle::cast_dynamic(layer);
 		if (!p || !ignore_dynamic_parameters){
 			for(iter=dyn_param_list.begin();iter!=dyn_param_list.end();++iter)
 				ret+=waypoint_collect(waypoint_set,time,iter->second);

--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -326,7 +326,7 @@ LayerActionManager::refresh()
 				}
 			}
 
-			if(!multiple_selected && etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+			if(!multiple_selected && Layer_PasteCanvas::Handle::cast_dynamic(layer))
 			{
 				if (select_all_child_layers_connection)
 					select_all_child_layers_connection.disconnect();
@@ -462,7 +462,7 @@ LayerActionManager::paste()
 			return;
 		}
 
-		etl::handle<Layer_PasteCanvas> paste = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer);
+		Layer_PasteCanvas::Handle paste = Layer_PasteCanvas::Handle::cast_dynamic(layer);
 		if (paste) paste->update_renddesc();
 
 		// synfig::info("DEPTH=%d",depth);

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1720,7 +1720,7 @@ CanvasView::popup_layer_menu(Layer::Handle layer)
 		}
 	}
 
-	if(etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+	if(Layer_PasteCanvas::Handle::cast_dynamic(layer))
 	{
 		Gtk::MenuItem *item = manage(new Gtk::ImageMenuItem(
 			*manage(create_image_from_icon("select_all_child_layers_icon", Gtk::ICON_SIZE_MENU)),

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_timetrack.cpp
@@ -85,7 +85,7 @@ get_time_offset_from_vdesc(const ValueDesc &v)
 
 	synfig::Layer::Handle layer = v.get_layer();
 
-	if (!etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+	if (!Layer_PasteCanvas::Handle::cast_dynamic(layer))
 		return Time::zero();
 
 	return layer->get_param("time_offset").get(Time());
@@ -109,7 +109,7 @@ get_time_dilation_from_vdesc(const ValueDesc &v)
 
 	Layer::Handle layer = v.get_layer();
 
-	if (!etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+	if (!Layer_PasteCanvas::Handle::cast_dynamic(layer))
 		return Time(1.0);
 
 	return layer->get_param("time_dilation").get(Time());

--- a/synfig-studio/src/gui/dialogs/vectorizersettings.cpp
+++ b/synfig-studio/src/gui/dialogs/vectorizersettings.cpp
@@ -260,7 +260,7 @@ VectorizerSettings::on_convert_pressed()
 	// in case the "convert to vector" was clicked for layer inside a switch
 	// and pass canvas accordingly
 	
-	if(etl::handle<synfig::Layer_PasteCanvas> paste = etl::handle<Layer_PasteCanvas>::cast_dynamic(reference_layer_))
+	if(etl::handle<synfig::Layer_PasteCanvas> paste = Layer_PasteCanvas::Handle::cast_dynamic(reference_layer_))
 	{
 			canvas = layer_bitmap_->get_canvas()->parent();
 			action->set_param("reference_layer",reference_layer_);

--- a/synfig-studio/src/gui/duckmatic.cpp
+++ b/synfig-studio/src/gui/duckmatic.cpp
@@ -239,7 +239,7 @@ Duckmatic::is_duck_group_selectable(const etl::handle<Duck>& x)const
 			layer_name == "polygon" || layer_name == "curve_gradient" || layer_name == "advanced_outline")
 			return false;
 
-		if(etl::handle<Layer_PasteCanvas>::cast_dynamic(layer) &&
+		if(Layer_PasteCanvas::Handle::cast_dynamic(layer) &&
 			!layer->get_param("children_lock").get(bool()))
 			return false;
 	}
@@ -1046,7 +1046,7 @@ Duckmatic::on_duck_changed(const studio::Duck &duck,const synfigapp::ValueDesc& 
 		  && duck.get_origin_duck()
 		  && duck.get_value_desc().is_valid()
 		  && duck.get_value_desc().parent_is_layer()
-		  && etl::handle<Layer_PasteCanvas>::cast_dynamic(duck.get_value_desc().get_layer())
+		  && Layer_PasteCanvas::Handle::cast_dynamic(duck.get_value_desc().get_layer())
 		  && duck.get_value_desc().get_param_name() == "origin" )
 		{
 			Point origin = duck.get_value_desc().get_value(get_time()).get(Point());
@@ -1610,7 +1610,7 @@ Duckmatic::add_ducks_layers(synfig::Canvas::Handle canvas, std::set<synfig::Laye
 			synfig::Rect& bbox = canvas_view->get_bbox();
 
 			// special calculations for Layer_PasteCanvas
-			etl::handle<Layer_PasteCanvas> layer_pastecanvas( etl::handle<Layer_PasteCanvas>::cast_dynamic(layer) );
+			Layer_PasteCanvas::Handle layer_pastecanvas( Layer_PasteCanvas::Handle::cast_dynamic(layer) );
 			synfig::Rect layer_bounds = layer_pastecanvas
 									  ? layer_pastecanvas->get_bounding_rect_context_dependent(canvas_view->get_context_params())
 									  : layer->get_bounding_rect();
@@ -1645,7 +1645,7 @@ Duckmatic::add_ducks_layers(synfig::Canvas::Handle canvas, std::set<synfig::Laye
 
 		// If this is a paste canvas layer, then we need to
 		// descend into it
-		if(etl::handle<Layer_PasteCanvas> layer_pastecanvas = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+		if(Layer_PasteCanvas::Handle layer_pastecanvas = Layer_PasteCanvas::Handle::cast_dynamic(layer))
 		{
 			transform_stack.push_back(
 				new Transform_Matrix(
@@ -1742,7 +1742,7 @@ Duckmatic::add_to_ducks(const synfigapp::ValueDesc& value_desc,etl::handle<Canva
 					add_to_ducks(value_desc_origin,canvas_view, transform_stack);
 
 					Layer::Handle layer=value_desc.get_layer();
-					if(etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+					if(Layer_PasteCanvas::Handle::cast_dynamic(layer))
 					{
 						Vector focus(layer->get_param("focus").get(Vector()));
 						duck->set_origin(last_duck()->get_point() + focus);
@@ -1847,9 +1847,9 @@ Duckmatic::add_to_ducks(const synfigapp::ValueDesc& value_desc,etl::handle<Canva
 	else
 	if (type == type_vector)
 	{
-		etl::handle<Layer_PasteCanvas> layer;
+		Layer_PasteCanvas::Handle layer;
 		if (value_desc.parent_is_layer())
-			layer = etl::handle<Layer_PasteCanvas>::cast_dynamic(value_desc.get_layer());
+			layer = Layer_PasteCanvas::Handle::cast_dynamic(value_desc.get_layer());
 		if (!layer) {
 			etl::handle<Duck> duck=new Duck();
 			set_duck_value_desc(*duck, value_desc, transform_stack);
@@ -1969,7 +1969,7 @@ Duckmatic::add_to_ducks(const synfigapp::ValueDesc& value_desc,etl::handle<Canva
 	{
 		if (value_desc.parent_is_layer() && param_desc)
 		{
-			etl::handle<Layer_PasteCanvas> layer = etl::handle<Layer_PasteCanvas>::cast_dynamic(value_desc.get_layer());
+			Layer_PasteCanvas::Handle layer = Layer_PasteCanvas::Handle::cast_dynamic(value_desc.get_layer());
 			if (layer)
 			{
 				synfigapp::ValueDesc origin_value_desc(value_desc.get_layer(), "origin");

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -1623,7 +1623,7 @@ Instance::gather_uri(std::set<synfig::String> &x, const synfig::Layer::Handle &l
 	if (etl::handle<Layer_Switch> layer_switch = etl::handle<Layer_Switch>::cast_dynamic(layer))
 		gather_uri(x, layer_inside_switch(layer_switch));
 
-	//if (etl::handle<Layer_PasteCanvas> paste = etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+	//if (Layer_PasteCanvas::Handle paste = Layer_PasteCanvas::Handle::cast_dynamic(layer))
 	//	gather_uri(x, paste->get_param("canvas").get(Canvas::Handle()));
 }
 

--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -714,7 +714,7 @@ StateBrush_Context::build_transform_stack(
 
 		// If this is a paste canvas layer, then we need to
 		// descend into it
-		if(etl::handle<Layer_PasteCanvas> layer_pastecanvas = etl::handle<Layer_PasteCanvas>::cast_dynamic(*i))
+		if(Layer_PasteCanvas::Handle layer_pastecanvas = Layer_PasteCanvas::Handle::cast_dynamic(*i))
 		{
 			transform_stack.push_back(
 				new Transform_Matrix(
@@ -742,11 +742,11 @@ StateBrush_Context::event_mouse_down_handler(const Smach::event& x)
 		{
 			// Enter the stroke state to get the stroke
 			Layer::Handle selected_layer = canvas_view_->get_selection_manager()->get_selected_layer();
-			etl::handle<Layer_Bitmap> layer = etl::handle<Layer_Bitmap>::cast_dynamic(selected_layer);
+			Layer_Bitmap::Handle layer = Layer_Bitmap::Handle::cast_dynamic(selected_layer);
 			if (!layer)
 			{
 				etl::handle<Layer_Switch> layer_switch = etl::handle<Layer_Switch>::cast_dynamic(selected_layer);
-				if (layer_switch) layer = etl::handle<Layer_Bitmap>::cast_dynamic(layer_switch->get_current_layer());
+				if (layer_switch) layer = Layer_Bitmap::Handle::cast_dynamic(layer_switch->get_current_layer());
 			}
 
 			// No image found to draw in, add it.
@@ -754,7 +754,7 @@ StateBrush_Context::event_mouse_down_handler(const Smach::event& x)
 			{
 				canvas_view_->add_layer("import");
 				selected_layer = canvas_view_->get_selection_manager()->get_selected_layer();
-				layer = etl::handle<Layer_Bitmap>::cast_dynamic(selected_layer);
+				layer = Layer_Bitmap::Handle::cast_dynamic(selected_layer);
 
 				// Set temporary description to generate the name
 				String temp_description(_("brush image"));

--- a/synfig-studio/src/gui/trees/layertreestore.cpp
+++ b/synfig-studio/src/gui/trees/layertreestore.cpp
@@ -237,8 +237,8 @@ LayerTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int column
 			{
 				Pango::Weight weight = Pango::WEIGHT_NORMAL;
 
-				etl::handle<Layer_PasteCanvas> paste=
-					etl::handle<Layer_PasteCanvas>::cast_dynamic(
+				Layer_PasteCanvas::Handle paste=
+					Layer_PasteCanvas::Handle::cast_dynamic(
 						layer->get_parent_paste_canvas_layer() );
 				if(paste)
 				{
@@ -249,7 +249,7 @@ LayerTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int column
 						Gtk::TreeRow row=*iter;
 						if(*row.parent() && RECORD_TYPE_LAYER == (RecordType)(*row.parent())[model.record_type])
 						{
-							paste = etl::handle<Layer_PasteCanvas>::cast_dynamic(
+							paste = Layer_PasteCanvas::Handle::cast_dynamic(
 									Layer::Handle((*row.parent())[model.layer]) );
 						}
 					}
@@ -836,7 +836,7 @@ LayerTreeStore::refresh_row(Gtk::TreeModel::Row &row)
 void
 LayerTreeStore::set_row_layer(Gtk::TreeRow &row, const synfig::Layer::Handle &handle)
 {
-	if (etl::handle<Layer_PasteCanvas> layer_paste = etl::handle<Layer_PasteCanvas>::cast_dynamic(handle))
+	if (Layer_PasteCanvas::Handle layer_paste = Layer_PasteCanvas::Handle::cast_dynamic(handle))
 	{
 		subcanvas_changed_connections[layer_paste].disconnect();
 		subcanvas_changed_connections[layer_paste] =
@@ -970,7 +970,7 @@ LayerTreeStore::on_layer_added(synfig::Layer::Handle layer)
 void
 LayerTreeStore::on_layer_removed(synfig::Layer::Handle handle)
 {
-	if (etl::handle<Layer_PasteCanvas>::cast_dynamic(handle))
+	if (Layer_PasteCanvas::Handle::cast_dynamic(handle))
 	{
 		subcanvas_changed_connections[handle].disconnect();
 		subcanvas_changed_connections.erase(handle);

--- a/synfig-studio/src/gui/waypointrenderer.cpp
+++ b/synfig-studio/src/gui/waypointrenderer.cpp
@@ -413,7 +413,7 @@ get_time_offset_from_vdesc(const ValueDesc &v)
 
 	synfig::Layer::Handle layer = v.get_layer();
 
-	if (!etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+	if (!Layer_PasteCanvas::Handle::cast_dynamic(layer))
 		return Time::zero();
 
 	return layer->get_param("time_offset").get(Time());
@@ -437,7 +437,7 @@ get_time_dilation_from_vdesc(const ValueDesc &v)
 
 	Layer::Handle layer = v.get_layer();
 
-	if (!etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+	if (!Layer_PasteCanvas::Handle::cast_dynamic(layer))
 		return Time(1.0);
 
 	return layer->get_param("time_dilation").get(Time());

--- a/synfig-studio/src/synfigapp/actions/layeradd.cpp
+++ b/synfig-studio/src/synfigapp/actions/layeradd.cpp
@@ -127,7 +127,7 @@ Action::LayerAdd::perform()
 	// Mark ourselves as dirty if necessary
 	//set_dirty(layer->active());
 
-	if (etl::handle<Layer_PasteCanvas>::cast_dynamic(layer)
+	if (Layer_PasteCanvas::Handle::cast_dynamic(layer)
 	 && layer->dynamic_param_list().count("transformation") == 0)
 			layer->connect_dynamic_param("transformation",
 				ValueNode_Composite::create(

--- a/synfig-studio/src/synfigapp/actions/layercopy.cpp
+++ b/synfig-studio/src/synfigapp/actions/layercopy.cpp
@@ -174,7 +174,7 @@ Action::LayerCopy::prepare()
 		new_layer->set_description(description);
 
 		// copy file
-		etl::handle<Layer_Bitmap> layer_bitmap = etl::handle<Layer_Bitmap>::cast_dynamic(layer);
+		Layer_Bitmap::Handle layer_bitmap = Layer_Bitmap::Handle::cast_dynamic(layer);
 		if (layer_bitmap && !filename.empty())
 		{
 			get_canvas_interface()

--- a/synfig-studio/src/synfigapp/actions/layerembed.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerembed.cpp
@@ -90,8 +90,8 @@ Action::LayerEmbed::is_candidate(const ParamList &x)
 	Layer::Handle layer=x.find("layer")->second.get_layer();
 	if(!layer) return false;
 
-	etl::handle<synfig::Layer_PasteCanvas> layer_pastecanvas
-		= etl::handle<synfig::Layer_PasteCanvas>::cast_dynamic(layer);
+	synfig::Layer_PasteCanvas::Handle layer_pastecanvas
+		= synfig::Layer_PasteCanvas::Handle::cast_dynamic(layer);
 	if (layer_pastecanvas)
 	{
 		Canvas::Handle canvas = layer_pastecanvas->get_sub_canvas();
@@ -219,8 +219,8 @@ Action::LayerEmbed::prepare()
 
 		etl::loose_handle<synfigapp::Instance> instance =
 			get_canvas_interface()->get_instance();
-		etl::handle<Layer_Bitmap> layer_bitmap =
-			etl::handle<Layer_Bitmap>::cast_dynamic(layer_import);
+		Layer_Bitmap::Handle layer_bitmap =
+			Layer_Bitmap::Handle::cast_dynamic(layer_import);
 		if (layer_bitmap && layer_bitmap->is_surface_modified()) {
 			// save surface to new place
 			instance->save_surface(layer_bitmap->rendering_surface, new_filename);

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -237,7 +237,7 @@ CanvasInterface::layer_create(
 		}
 
 	layer->set_canvas(canvas);
-	if (etl::handle<Layer_PasteCanvas>::cast_dynamic(layer))
+	if (Layer_PasteCanvas::Handle::cast_dynamic(layer))
 		layer->set_param("canvas", Canvas::create_inline(canvas));
 
 	return layer;

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -197,7 +197,7 @@ Instance::import_external_canvas(Canvas::Handle canvas, std::map<Canvas*, Canvas
 
 	for(IndependentContext i = canvas->get_independent_context(); *i; i++)
 	{
-		etl::handle<Layer_PasteCanvas> paste_canvas = etl::handle<Layer_PasteCanvas>::cast_dynamic(*i);
+		Layer_PasteCanvas::Handle paste_canvas = Layer_PasteCanvas::Handle::cast_dynamic(*i);
 		if (!paste_canvas) continue;
 
 		Canvas::Handle sub_canvas = paste_canvas->get_sub_canvas();
@@ -315,8 +315,8 @@ bool Instance::save_surface(const synfig::Surface &surface, const synfig::String
 	ext.erase(0, 1);
 	String tmpfile = FileSystemTemporary::generate_system_temporary_filename("surface");
 
-	etl::handle<Target_Scanline> target =
-		etl::handle<Target_Scanline>::cast_dynamic(
+	Target_Scanline::Handle target =
+		Target_Scanline::Handle::cast_dynamic(
 			Target::create(Target::ext_book()[ext],tmpfile,TargetParam()) );
 	if (!target)
 		return false;


### PR DESCRIPTION
Instead of etl::handle<Layer_*>, etl::handle<const Layer_*> and etl::loose_handle<Layer_*>

Reason: etl::handle and alike will be moved to synfig namespace (and maybe one day it'll use an C++ standard smart pointer). It'll avoid future changes everywhere.