### PR TITLE
fix: crash when clicking on rows of "Library Panel" 

### DIFF
--- a/synfig-studio/src/gui/trees/canvastreestore.cpp
+++ b/synfig-studio/src/gui/trees/canvastreestore.cpp
@@ -242,27 +242,27 @@ CanvasTreeStore::get_value_vfunc(const Gtk::TreeModel::iterator& iter, int colum
 	if(column==model.is_editable.index())
 	{
 		synfigapp::ValueDesc value_desc((*iter)[model.value_desc]);
-		if (value_desc) {
-			Glib::Value<bool> x;
-			g_value_init(x.gobj(),x.value_type());
-
-			x.set(
-				// Temporary fix crash when trying to edit bline point
-				// https://github.com/synfig/synfig/issues/264
-				// TODO: move this check into a more proper place
-					value_desc.get_value_type() != type_bline_point
-				&&	value_desc.get_value_type() != type_width_point
-				&&	value_desc.get_value_type() != type_dash_item
-				&&	(
-					!value_desc.is_value_node()
-				||	synfigapp::is_editable(value_desc.get_value_node())
-				)
-			);
-
-			g_value_init(value.gobj(),x.value_type());
-			g_value_copy(x.gobj(),value.gobj());
-		} else
+		if (!value_desc)
 			return Gtk::TreeStore::get_value_vfunc(iter,column,value);
+
+		Glib::Value<bool> x;
+		g_value_init(x.gobj(),x.value_type());
+
+		x.set(
+			// Temporary fix crash when trying to edit bline point
+			// https://github.com/synfig/synfig/issues/264
+			// TODO: move this check into a more proper place
+				value_desc.get_value_type() != type_bline_point
+			&&	value_desc.get_value_type() != type_width_point
+			&&	value_desc.get_value_type() != type_dash_item
+			&&	(
+				!value_desc.is_value_node()
+			||	synfigapp::is_editable(value_desc.get_value_node())
+			)
+		);
+
+		g_value_init(value.gobj(),x.value_type());
+		g_value_copy(x.gobj(),value.gobj());
 	}
 	else
 	if(column==model.type.index())

--- a/synfig-studio/src/gui/trees/childrentreestore.cpp
+++ b/synfig-studio/src/gui/trees/childrentreestore.cpp
@@ -79,11 +79,13 @@ ChildrenTreeStore::ChildrenTreeStore(etl::loose_handle<synfigapp::CanvasInterfac
 	canvas_row[model.label]=_("Canvases");
 	canvas_row[model.is_canvas] = false;
 	canvas_row[model.is_value_node] = false;
+	canvas_row[model.canvas] = canvas_interface_->get_canvas();
 
 	value_node_row=*append();
 	value_node_row[model.label]=_("ValueBase Nodes");
 	value_node_row[model.is_canvas] = false;
 	value_node_row[model.is_value_node] = false;
+	value_node_row[model.canvas] = canvas_interface_->get_canvas();
 
 	// Connect all the signals
 	canvas_interface()->signal_value_node_changed().connect(sigc::mem_fun(*this,&studio::ChildrenTreeStore::on_value_node_changed));

--- a/synfig-studio/src/gui/trees/childrentreestore.cpp
+++ b/synfig-studio/src/gui/trees/childrentreestore.cpp
@@ -79,13 +79,13 @@ ChildrenTreeStore::ChildrenTreeStore(etl::loose_handle<synfigapp::CanvasInterfac
 	canvas_row[model.label]=_("Canvases");
 	canvas_row[model.is_canvas] = false;
 	canvas_row[model.is_value_node] = false;
-	canvas_row[model.canvas] = canvas_interface_->get_canvas();
+	canvas_row[model.is_editable] = false;
 
 	value_node_row=*append();
 	value_node_row[model.label]=_("ValueBase Nodes");
 	value_node_row[model.is_canvas] = false;
 	value_node_row[model.is_value_node] = false;
-	value_node_row[model.canvas] = canvas_interface_->get_canvas();
+	value_node_row[model.is_editable] = false;
 
 	// Connect all the signals
 	canvas_interface()->signal_value_node_changed().connect(sigc::mem_fun(*this,&studio::ChildrenTreeStore::on_value_node_changed));


### PR DESCRIPTION
Brief bug description:

 Clicking on the value column of any of the canvases or valuebase nodes rows causes a crash
  this happens because when they are clicked a cellrenderer is in the process of creation 
  but it fails in an assertion of the canvas. Now anyways I think it makes no sense to 
  click on either of these and have a cellrenderer that could be used to edit anything.
  As far as I understand both of these row are just for the purpose of organization (under canvases 
  lies the canvases and under valuebase nodes lies all the exported valuebases etc..).

(Canvases and ValueBase Nodes rows -- old pic)
![image](https://user-images.githubusercontent.com/100296264/230830833-957731e5-2e12-4a27-bf77-fd5a7d442bb5.png)

 What I did:

Made the cell renderers for these two rows  to be inactive as they are  not needed. (Read next comment for more details)

Fixes #3039 