### PR TITLE
fix(canvas-dependencies): properly identify the file to avoid clash

### DIFF
--- a/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.cpp
@@ -46,6 +46,7 @@
 #include <gui/localization.h>
 #include <gui/resourcehelper.h>
 
+#include <synfig/canvasfilenaming.h>
 #include <synfig/general.h>
 #include <synfig/synfig_iterations.h>
 
@@ -130,21 +131,22 @@ struct ExternalValueNodeCollector {
 		for (const auto& param_desc : vocab) {
 			if (param_desc.get_hint() == "filename" || param_desc.get_name() == "filename") {
 				const std::string& param_name = param_desc.get_name();
+
+				std::set<ValueBase> values;
 				auto it = layer->dynamic_param_list().find(param_name);
 				if (it != layer->dynamic_param_list().end()) {
-					std::set<ValueBase> values;
 					it->second->get_values(values);
-					for (const auto& v : values) {
-						auto str_value = v.get(String());
-						if (!str_value.empty())
-							external_resource_stats[str_value]++;
-					}
 				} else {
 					ValueBase v = layer->get_param(param_name);
-					if (v.is_valid()) {
-						auto str_value = v.get(String());
-						if (!str_value.empty())
-							external_resource_stats[str_value]++;
+					if (v.is_valid())
+						values.insert(v);
+				}
+
+				for (const auto& v : values) {
+					auto filename_str = v.get(String());
+					if (!filename_str.empty()) {
+						filename_str = CanvasFileNaming::make_full_filename(layer->get_canvas()->get_file_name(), filename_str);
+						external_resource_stats[filename_str]++;
 					}
 				}
 			}
@@ -235,7 +237,8 @@ void Dialog_CanvasDependencies::refresh()
 	if (external_canvas_model) {
 		for (const auto& pair : collector.external_canvas_stats) {
 			Gtk::TreeIter row = external_canvas_model->append();
-			row->set_value(0, pair.first);
+			auto filename = CanvasFileNaming::make_short_filename(canvas->get_file_name(), pair.first);
+			row->set_value(0, filename);
 			row->set_value(1, pair.second.total);
 			for (const auto &vn_pair : pair.second.per_valuenode) {
 				if (vn_pair.first->get_id().empty())
@@ -251,7 +254,8 @@ void Dialog_CanvasDependencies::refresh()
 	if (external_resource_model) {
 		for (const auto& pair : collector.external_resource_stats) {
 			Gtk::TreeIter row = external_resource_model->append();
-			row->set_value(0, pair.first);
+			auto filename = CanvasFileNaming::make_short_filename(canvas->get_file_name(), pair.first);
+			row->set_value(0, filename);
 			row->set_value(1, pair.second);
 			Glib::RefPtr<Gdk::Pixbuf> pixbuf;
 			std::string ext = Glib::ustring(etl::filename_extension(pair.first)).lowercase();


### PR DESCRIPTION
Solve these cases:
* Suppose this file tree:
  - Doc_A.sif
  - mine.png
  - folder/Doc_B.sif
  - folder/mine.png
  
  In addition:
  - Doc_A.sif has a Layer_Import for the file "mine.png"
  - folder/Doc_B.sif has a Layer_Import for the file "mine.png" (pointing to folder/mine.png)
  - Doc_A.sif use a linked canvas (i.e. a Layer_PasteCanvas whose source is other file) to folder/Doc_B.sif

  In this (long) situation, both mine.png will be parsed as the same file.

* If a canvas has two Layer_Import, one for the file "something.png" and the other to "./something.png", they would be shown as different resources.