### PR TITLE
fix: possible invalid memory access on replacing valuenodes

### DIFF
--- a/synfig-core/src/synfig/synfig_iterations.cpp
+++ b/synfig-core/src/synfig/synfig_iterations.cpp
@@ -255,14 +255,21 @@ void
 synfig::replace_value_nodes(Layer::LooseHandle layer, std::function<ValueNode::LooseHandle(const ValueNode::LooseHandle&)> fetch_replacement_for)
 {
 	auto replace_value_nodes_from_layer = [fetch_replacement_for](Layer::LooseHandle layer, const TraverseLayerStatus& /*status*/) {
+		// parameter name -> new valuenode
+		std::vector<std::pair<String, ValueNode::LooseHandle>> pending_replacements;
+
 		const Layer::DynamicParamList& dyn_param_list = layer->dynamic_param_list();
 		for (const auto& dyn_param : dyn_param_list) {
 			if (ValueNode::LooseHandle new_vn = fetch_replacement_for(dyn_param.second)) {
-				layer->disconnect_dynamic_param(dyn_param.first);
-				layer->connect_dynamic_param(dyn_param.first, new_vn);
+				pending_replacements.emplace_back(dyn_param.first, new_vn);
 			} else {
 				replace_value_nodes(dyn_param.second, fetch_replacement_for);
 			}
+		}
+
+		for (const auto& item : pending_replacements) {
+			layer->disconnect_dynamic_param(item.first);
+			layer->connect_dynamic_param(item.first, item.second);
 		}
 	};
 	traverse_layers(layer, replace_value_nodes_from_layer);


### PR DESCRIPTION
As `dyn_param_list` is a reference to a vector, and the vector can change in the loop, it can have invalid "iterators"/items.

Possible solutions:
1. `dyn_param_list` be a copy not a reference
2. Implement a `Layer::replace_dynamic_param()`
3. Store all the changes in another variable and postpone the actual changes until we finish the loop

The first one can create a "large" copy.

The second one is interesting, but I `git grep` the code and it does not seem to be needed anywhere else XD The existent disconnections are for replacing with a (static) ValueBase.

Therefore, I opted for the 3rd solution. It is lighter than option 1 and less 'intrusive' than the second one.

fix #3049 