### PR TITLE
refactor: remove unused members of `CanvasView`

### DIFF
--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -273,9 +273,6 @@ private:
 	ChildrenTree *children_tree;
 	KeyframeTree *keyframe_tree;
 
-	Gtk::TreeRow children_canvas_row;
-	Gtk::TreeRow children_valuenode_row;
-
 	Gtk::Statusbar *statusbar;
 	Gtk::ProgressBar *progressbar;
 


### PR DESCRIPTION
Noticed this while working on #3046. 

They are supposed to be the two initial rows of the library panel. Maybe the original author thought they would be used here. But they are neither used nor initialized with the correct rows that their name indicates.