### PR TITLE
refactor: rename method to get_link_description to avoid ambiguity

### DIFF
--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -184,9 +184,6 @@ ValueNode::set_id(const String &x)
 String
 ValueNode::get_description(bool show_exported_name)const
 {
-	if (const LinkableValueNode* value_node = dynamic_cast<const LinkableValueNode*>(this))
-		return value_node->get_description(-1, show_exported_name);
-
 	String ret(_("ValueNode"));
 
 	if (show_exported_name && !is_exported())
@@ -674,7 +671,7 @@ void LinkableValueNode::get_times_vfunc(Node::time_set &set) const
 }
 
 String
-LinkableValueNode::get_description(int index, bool show_exported_name)const
+LinkableValueNode::get_link_description(int index, bool show_exported_name)const
 {
 	String description;
 
@@ -741,7 +738,7 @@ LinkableValueNode::get_description(int index, bool show_exported_name)const
 String
 LinkableValueNode::get_description(bool show_exported_name)const
 {
-	return get_description(-1, show_exported_name);
+	return get_link_description(-1, show_exported_name);
 }
 
 String

--- a/synfig-core/src/synfig/valuenode.h
+++ b/synfig-core/src/synfig/valuenode.h
@@ -333,20 +333,20 @@ private:
 
 public:
 
-	virtual ValueBase operator()(Time t)const;
+	ValueBase operator()(Time t) const override;
 
-	virtual String get_name()const;
+	String get_name() const override;
 
-	virtual String get_local_name()const;
+	String get_local_name() const override;
 
-	String get_string()const;
+	String get_string() const override;
 
-	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
+	ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid = GUID()) const override;
 
 	static Handle create(Type &type=type_nil);
 
 protected:
-	virtual void get_times_vfunc(Node::time_set &/*set*/) const {}
+	void get_times_vfunc(Node::time_set &/*set*/) const override {}
 }; // END of class PlaceholderValueNode
 
 
@@ -405,7 +405,7 @@ public:
 	virtual int get_link_index_from_name(const String &name)const;
 
 	//! Clones a Value Node
-	virtual ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
+	ValueNode::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID()) const override;
 
 	//! Sets a new Value Node link by its index
 	bool set_link(int i,ValueNode::Handle x);
@@ -417,15 +417,14 @@ public:
 	//! Returns a Loose Handle to the Value Node based on the link's name
 	ValueNode::LooseHandle get_link(const String &name)const { return get_link(get_link_index_from_name(name)); }
 	//! Return a full description of the linked ValueNode given by the index
-	String get_description(int index = -1, bool show_exported_name = true)const;
-	//! Return a full description of the linked ValueNode given by the index
-	//! Proper overload of the inherited function
-	String get_description(bool show_exported_name = true)const;
+	String get_link_description(int index, bool show_exported_name = true)const;
+	//! Return a full description of this linkable ValueNode
+	String get_description(bool show_exported_name = true)const override;
 
 	//! Gets the children vocabulary for linkable value nodes
 	virtual const Vocab& get_children_vocab()const;
 
-	virtual void set_root_canvas(etl::loose_handle<Canvas> x);
+	void set_root_canvas(etl::loose_handle<Canvas> x) override;
 
 	//! If get_inverse() can be called
 	enum InvertibleStatus {
@@ -458,7 +457,7 @@ protected:
 	virtual LinkableValueNode* create_new()const=0;
 
 	//! Returns the cached times values for all the children (linked Value Nodes)
-	virtual void get_times_vfunc(Node::time_set &set) const;
+	void get_times_vfunc(Node::time_set &set) const override;
 
 	//! Pure Virtual member to get the children vocabulary
 	virtual Vocab get_children_vocab_vfunc()const=0;
@@ -467,7 +466,7 @@ protected:
 	virtual void set_children_vocab(const Vocab& rvocab);
 	virtual void init_children_vocab();
 
-	virtual void get_values_vfunc(std::map<Time, ValueBase> &x) const;
+	void get_values_vfunc(std::map<Time, ValueBase> &x) const override;
 }; // END of class LinkableValueNode
 
 /*!	\class ValueNodeList

--- a/synfig-studio/src/synfigapp/value_desc.cpp
+++ b/synfig-studio/src/synfigapp/value_desc.cpp
@@ -88,7 +88,7 @@ ValueDesc::get_description(bool show_exported_name)const
 		{
 			synfig::LinkableValueNode::Handle value_node(synfig::LinkableValueNode::Handle::cast_reinterpret(get_parent_value_node()));
 			description = strprintf("%s %s", _("ValueNode"),
-									value_node->get_description(get_index(), show_exported_name).c_str());
+									value_node->get_link_description(get_index(), show_exported_name).c_str());
 		}
 		else if (parent_is_value_node_const())
 		{


### PR DESCRIPTION
There were two overloaded methods, and all of their arguments have default values:

* LinkableValueNode::get_description(bool show_exported_name = true)
* LinkableValueNode::get_description(int index = -1, bool show_exported_name = true)

The first one is an override of the `ValueNode::get_description` method.

There was an unnecessary ambiguity here. So I renamed the second method to `LinkableValueNode::get_link_description()` to make it explicit, and `index` argument is not optional now.