### PR TITLE
fix: update Tool tip when user changes its shortcut at runtime

### DIFF
--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -217,13 +217,29 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 	Glib::ustring tool_label = stock_item.get_label();
 	Gtk::RadioToolButton *tool_button = manage(new Gtk::RadioToolButton(*tool_icon, tool_label));
 	tool_button->set_group(radio_tool_button_group);
-	Gtk::AccelKey key;
-	//Have a look to global function init_ui_manager() from app.cpp for "accel_path" definition
-	Gtk::AccelMap::lookup_entry ("<Actions>/action_group_state_manager/state-"+name, key);
-	//Gets the, is exist, accelerator representation for labels
-	Glib::ustring accel_path = key.is_null() ? "" : gtk_accelerator_get_label(key.get_key(), GdkModifierType(key.get_mod()));
 	
-	tool_button->set_tooltip_text(stock_item.get_label()+"  "+accel_path);
+	// Keeps updating the tooltip if user changes the shortcut at runtime
+	tool_button->property_has_tooltip() = true;
+	tool_button->signal_query_tooltip().connect([name](int,int,bool,const Glib::RefPtr<Gtk::Tooltip>& tooltip) -> bool
+	{
+		Gtk::StockItem stock_item;
+		if (Gtk::Stock::lookup(Gtk::StockID("synfig-"+name), stock_item)) {
+			std::string tooltip_string = stock_item.get_label();
+
+			Gtk::AccelKey key;
+			if (Gtk::AccelMap::lookup_entry("<Actions>/action_group_state_manager/state-" + name, key)) {
+				tooltip_string += "  ";
+				tooltip_string += gtk_accelerator_get_label(key.get_key(), GdkModifierType(key.get_mod()));
+			}
+
+			tooltip->set_text(tooltip_string);
+		} else {
+			synfig::warning("There is no StockItem named 'synfig-%s", name.c_str());
+		}
+
+		return true;
+	});
+
 	tool_button->show();
 
 	tool_item_group->insert(*tool_button);


### PR DESCRIPTION
Otherwise, the shortcut in tooltip would be updated only when software restarts.