### PR TITLE
build: fix `make distcheck` build

### DIFF
--- a/synfig-core/bootstrap.sh
+++ b/synfig-core/bootstrap.sh
@@ -46,7 +46,7 @@ AUTOPOINT='intltoolize --automake --copy' autoreconf --force --install --verbose
 #       is fixed in intltool
 
 echo "patching po/Makefile.in.in..."
-sed 's/itlocaledir = $(prefix)\/$(DATADIRNAME)\/locale/itlocaledir = $(datarootdir)\/locale/' < po/Makefile.in.in > po/Makefile.in.in.tmp
+sed 's/itlocaledir = $(prefix)\/$(DATADIRNAME)\/locale/itlocaledir = $(datarootdir)\/locale/;s/rm -f .intltool-merge-cache/rm -f .intltool-merge-cache .intltool-merge-cache.lock/' < po/Makefile.in.in > po/Makefile.in.in.tmp
 # -- force didn't work under MacOS
 mv -f po/Makefile.in.in.tmp po/Makefile.in.in
 

--- a/synfig-core/test/Makefile.am
+++ b/synfig-core/test/Makefile.am
@@ -47,3 +47,4 @@ string_SOURCES=string.cpp
 
 surface_etl_SOURCES=surface_etl.cpp
 
+EXTRA_DIST = test_base.h

--- a/synfig-studio/bootstrap.sh
+++ b/synfig-studio/bootstrap.sh
@@ -30,7 +30,7 @@ AUTOPOINT='intltoolize --automake --copy' autoreconf --force --install --verbose
 #       is fixed in intltool
 
 echo "patching po/Makefile.in.in..."
-sed 's/itlocaledir = $(prefix)\/$(DATADIRNAME)\/locale/itlocaledir = $(datarootdir)\/locale/' < po/Makefile.in.in > po/Makefile.in.in.tmp
+sed 's/itlocaledir = $(prefix)\/$(DATADIRNAME)\/locale/itlocaledir = $(datarootdir)\/locale/;s/rm -f .intltool-merge-cache/rm -f .intltool-merge-cache .intltool-merge-cache.lock/' < po/Makefile.in.in > po/Makefile.in.in.tmp
 # -- force didn't work under MacOS
 mv -f po/Makefile.in.in.tmp po/Makefile.in.in
 

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -204,7 +204,7 @@ EXTRA_DIST = \
 	navigator_icon.sif \
 	palette_icon.sif \
 	parameters_icon.sif \
-	sound_icon \
+	sound_icon.sif \
 	time_track_icon.sif \
 	\
 	utils_chain_link_icons.sif \
@@ -463,10 +463,10 @@ appicondir= $(datadir)/icons/hicolor
 imagedir = $(synfig_datadir)/images
 image_DATA = $(IMAGES)
 
-classicthemedir="${synfig_datadir}/icons/classic"
-dist_classictheme_DATA=index.theme
+classicthemedir = ${synfig_datadir}/icons/classic
+dist_classictheme_DATA = index.theme
 
-iconsdir="${classicthemedir}/128x128"
+iconsdir = ${classicthemedir}/128x128
 icons_DATA = $(ICONS)
 
 win32iconsdir = $(datadir)/pixmaps

--- a/synfig-studio/test/Makefile.am
+++ b/synfig-studio/test/Makefile.am
@@ -8,7 +8,7 @@ check_PROGRAMS=$(TESTS)
 
 TESTS=app_layerduplicate smach
 
-app_layerduplicate_SOURCES=app_layerduplicate.cpp
+app_layerduplicate_SOURCES=app_layerduplicate.cpp test_base.h
 
 smach_SOURCES=smach.cpp
 


### PR DESCRIPTION
Fixed:
- "files left after uninstall" error for "distuninstallcheck" target

Backported fix from 1.4 branch: https://github.com/synfig/synfig/commit/e94ea8d6447f39547d762db42e4345258a62a9ae

- ERROR: files left in build directory after distclean: ./po/.intltool-merge-cache.lock

It looks like bug in `libtoolize`: https://bugs.launchpad.net/intltool/+bug/1712194
Fixed by rewriting generated `Makefile.in.in` file.

- bline.cpp:36:10: fatal error: test_base.h: No such file or directory

I'm not sure which way is preferable: using `EXTRA_DIST` or adding `test_base.h` to build the target?
