### PR TITLE
refactor: prefer prefix ++ operators for non-primitive types

### DIFF
--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -772,7 +772,7 @@ Canvas::surefind_canvas(const String &id, String &warnings)
 
 		// Search for the image in the image list,
 		// and return it if it is found
-		for(iter=children().begin();iter!=children().end();iter++)
+		for (iter = children().begin(); iter != children().end(); ++iter)
 			if(id==(*iter)->get_id())
 				return *iter;
 
@@ -858,7 +858,7 @@ Canvas::find_canvas(const String &id, String &warnings)const
 
 		// Search for the image in the image list,
 		// and return it if it is found
-		for(iter=children().begin();iter!=children().end();iter++)
+		for (iter = children().begin(); iter != children().end(); ++iter)
 			if(id==(*iter)->get_id())
 				return *iter;
 
@@ -1454,7 +1454,7 @@ Canvas::show_externals(String file, int line, String text) const
 {
 	printf("  .----- (externals for %lx '%s')\n  |  %s:%d %s\n", uintptr_t(this), get_name().c_str(), file.c_str(), line, text.c_str());
 	std::map<String, Handle>::iterator iter;
-	for (iter = externals_.begin(); iter != externals_.end(); iter++)
+	for (iter = externals_.begin(); iter != externals_.end(); ++iter)
 	{
 		synfig::String first(iter->first);
 		Canvas::LooseHandle second(iter->second);
@@ -1469,7 +1469,7 @@ Canvas::show_structure(int i) const
 	if(i==0)
 		printf("---Canvas Structure----\n");
 	IndependentContext iter;
-	for(iter=get_independent_context();*iter;iter++)
+	for (iter = get_independent_context(); *iter; ++iter)
 	{
 		Layer::Handle layer=*iter;
 		printf("%d: %s : %s", i, layer->get_name().c_str(), layer->get_non_empty_description().c_str());

--- a/synfig-core/src/synfig/color/color.cpp
+++ b/synfig-core/src/synfig/color/color.cpp
@@ -82,7 +82,7 @@ Color::set_hex(String& str)
 	String hex;
 
 	// use just the hex characters
-	for (String::const_iterator iter = str.begin(); iter != str.end(); iter++)
+	for (String::const_iterator iter = str.begin(); iter != str.end(); ++iter)
 		if (isxdigit(*iter))
 			hex.push_back(*iter);
 

--- a/synfig-core/src/synfig/context.cpp
+++ b/synfig-core/src/synfig/context.cpp
@@ -312,7 +312,8 @@ Context::accelerated_render(Surface *surface,int quality, const RendDesc &rendde
 			!composite->reads_context())
 		{
 			Layer::Handle layer = *context;
-			while (!context->empty()) context++; // skip the context
+			while (!context->empty())
+				++context; // skip the context
 			return layer->accelerated_render(context,surface,quality,renddesc, cb);
 		}
 		// Break out of the loop--we have found a good layer

--- a/synfig-core/src/synfig/filecontainerzip.cpp
+++ b/synfig-core/src/synfig/filecontainerzip.cpp
@@ -309,13 +309,12 @@ FileContainerZip::HistoryRecord FileContainerZip::decode_history(const String &c
 		if (root->get_name() == "history")
 		{
 			xmlpp::Element::NodeList list = root->get_children();
-			for(xmlpp::Element::NodeList::iterator i = list.begin(); i != list.end(); i++)
-			{
+			for (xmlpp::Element::NodeList::iterator i = list.begin(); i != list.end(); ++i) {
 				if ((*i)->get_name() == "prev_storage_size")
 				{
 					String s;
 					xmlpp::Element::NodeList list = (*i)->get_children();
-					for(xmlpp::Element::NodeList::iterator j = list.begin(); j != list.end(); j++)
+					for(xmlpp::Element::NodeList::iterator j = list.begin(); j != list.end(); ++j)
 						if (dynamic_cast<xmlpp::TextNode*>(*j))
 							s += dynamic_cast<xmlpp::TextNode*>(*j)->get_content();
 					history_record.prev_storage_size = strtoll(s.c_str(), nullptr, 10);
@@ -495,7 +494,7 @@ bool FileContainerZip::open_from_history(const String &container_filename, file_
 			files[ info.name ] = info;
 			i = files.begin();
 		}
-		else i++;
+		else ++i;
 	}
 
 	// loaded
@@ -522,7 +521,7 @@ bool FileContainerZip::save()
 	fseek(storage_file_, 0, SEEK_END);
 
 	// write headers of new directories
-	for(FileMap::iterator i = files_.begin(); i != files_.end(); i++)
+	for(FileMap::iterator i = files_.begin(); i != files_.end(); ++i)
 	{
 		FileInfo &info = i->second;
 		if (info.is_directory && !info.directory_saved)

--- a/synfig-core/src/synfig/filesystemtemporary.cpp
+++ b/synfig-core/src/synfig/filesystemtemporary.cpp
@@ -610,14 +610,12 @@ FileSystemTemporary::open_temporary(const String &filename)
 		if ((*i)->get_name() == "files")
 		{
 			xmlpp::Element::NodeList files_list = (*i)->get_children();
-			for(xmlpp::Element::NodeList::iterator j = files_list.begin(); j != files_list.end(); j++)
-			{
+			for (xmlpp::Element::NodeList::iterator j = files_list.begin(); j != files_list.end(); ++j) {
 				if ((*j)->get_name() == "entry")
 				{
 					FileInfo info;
 					xmlpp::Element::NodeList fields_list = (*j)->get_children();
-					for(xmlpp::Element::NodeList::iterator k = fields_list.begin(); k != fields_list.end(); k++)
-					{
+					for (xmlpp::Element::NodeList::iterator k = fields_list.begin(); k != fields_list.end(); ++k) {
 						if ((*k)->get_name() == "name")
 							info.name = fix_slashes(get_xml_node_text(*k));
 						if ((*k)->get_name() == "tmp-basename")

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -167,9 +167,12 @@ Gradient::operator+(const Gradient &rhs) const
 Gradient &
 Gradient::operator*=(const ColorReal &rhs)
 {
-	if (rhs == 0) cpoints.clear(); else
-		for (iterator iter = cpoints.begin(); iter!=cpoints.end(); iter++)
+	if (rhs == 0) {
+		cpoints.clear();
+	} else {
+		for (iterator iter = cpoints.begin(); iter!=cpoints.end(); ++iter)
 			(*iter).color *= rhs;
+	}
 	return *this;
 }
 
@@ -222,8 +225,7 @@ Gradient::proximity(const Real &x)
 	iterator iter;
 	Real dist(100000000);
 	Real prev_pos(-0230);
-	for(iter=begin();iter<end();iter++)
-	{
+	for (iter = begin(); iter < end(); ++iter) {
 		Real new_dist;
 
 		if(prev_pos==iter->pos)
@@ -233,13 +235,13 @@ Gradient::proximity(const Real &x)
 
 		if(new_dist>dist)
 		{
-			iter--;
+			--iter;
 			return iter;
 		}
 		dist=new_dist;
 		prev_pos=iter->pos;
 	}
-	iter--;
+	--iter;
 	return iter;
 }
 

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -332,7 +332,7 @@ Layer::connect_dynamic_param(const String& param, ValueNode::LooseHandle value_n
 		// connection was being deleted.  now we search the parameter
 		// list to see if another parameter uses the same valuenode
 		DynamicParamList::const_iterator iter;
-		for (iter = dynamic_param_list().begin(); iter != dynamic_param_list().end(); iter++)
+		for (iter = dynamic_param_list().begin(); iter != dynamic_param_list().end(); ++iter)
 			if (iter->second == previous)
 				break;
 		if (iter == dynamic_param_list().end())
@@ -365,7 +365,7 @@ Layer::disconnect_dynamic_param(const String& param)
 		// connection was being deleted.  now we search the parameter
 		// list to see if another parameter uses the same valuenode
 		DynamicParamList::const_iterator iter;
-		for (iter = dynamic_param_list().begin(); iter != dynamic_param_list().end(); iter++)
+		for (iter = dynamic_param_list().begin(); iter != dynamic_param_list().end(); ++iter)
 			if (iter->second == previous)
 				break;
 		if (iter == dynamic_param_list().end())
@@ -610,7 +610,7 @@ Layer::set_time(IndependentContext context, Time time)
 	Layer::ParamList params;
 	Layer::DynamicParamList::const_iterator iter;
 	// For each parameter of the layer sets the value by the operator()(time)
-	for(iter=dynamic_param_list().begin();iter!=dynamic_param_list().end();iter++)
+	for (iter = dynamic_param_list().begin(); iter != dynamic_param_list().end(); ++iter)
 		params[iter->first]=(*iter->second)(time);
 	// Sets the modified parameter list to the current context layer
 	const_cast<Layer*>(this)->set_param_list(params);
@@ -991,7 +991,7 @@ Layer::get_param_local_name(const String &param_name)const
 {
 	ParamVocab vocab = get_param_vocab();
 	// loop to find the parameter in the parameter vocab - this gives us its local name
-	for (ParamVocab::iterator iter = vocab.begin(); iter != vocab.end(); iter++)
+	for (ParamVocab::iterator iter = vocab.begin(); iter != vocab.end(); ++iter)
 		if (iter->get_name() == param_name)
 			return iter->get_local_name();
 	return String();

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -151,8 +151,7 @@
 { \
 	Vocab vocab(get_param_vocab()); \
 	Vocab::const_iterator viter; \
-	for(viter=vocab.begin();viter!=vocab.end();viter++) \
-	{ \
+	for (viter = vocab.begin(); viter != vocab.end(); ++viter) { \
 		ValueBase v=get_param(viter->get_name()); \
 		v.set_interpolation(viter->get_interpolation()); \
 		set_param(viter->get_name(), v); \

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -1743,7 +1743,7 @@ CanvasParser::parse_animated(xmlpp::Element *element,Canvas::Handle canvas)
 				//note: commented out as part of bones branch merge
 
 				// Warn if there is trash after the param value
-				for(iter++; iter != list.end(); ++iter)
+				for (++iter; iter != list.end(); ++iter)
 					if(dynamic_cast<xmlpp::Element*>(*iter))
 						warning((*iter),strprintf(_("Unexpected element <%s> after <waypoint> data, ignoring..."),(*iter)->get_name().c_str()));
 			}
@@ -1811,8 +1811,7 @@ CanvasParser::parse_animated(xmlpp::Element *element,Canvas::Handle canvas)
 			bool first = true;
 			Real angle, prev = 0;
 			WaypointList &wl = value_node->editable_waypoint_list();
-			for (WaypointList::iterator iter = wl.begin(); iter != wl.end(); iter++)
-			{
+			for (WaypointList::iterator iter = wl.begin(); iter != wl.end(); ++iter) {
 				angle = Angle::deg(iter->get_value(iter->get_time()).get(Angle())).get();
 				if (first)
 					first = false;
@@ -1888,8 +1887,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 		int index;
 		String id, name;
 		xmlpp::Element::AttributeList attrib_list(element->get_attributes());
-		for(xmlpp::Element::AttributeList::iterator iter = attrib_list.begin(); iter != attrib_list.end(); iter++)
-		{
+		for (xmlpp::Element::AttributeList::iterator iter = attrib_list.begin(); iter != attrib_list.end(); ++iter) {
 			name = (*iter)->get_name();
 			id = (*iter)->get_value();
 
@@ -3017,7 +3015,7 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 			}
 
 			// Warn if there is trash after the param value
-			for(iter++; iter != list.end(); ++iter)
+			for (++iter; iter != list.end(); ++iter)
 				if(dynamic_cast<xmlpp::Element*>(*iter))
 					warning((*iter),strprintf(_("Unexpected element <%s> after <param> data, ignoring..."),(*iter)->get_name().c_str()));
 			continue;
@@ -3428,12 +3426,13 @@ CanvasParser::parse_canvas(xmlpp::Element *element,Canvas::Handle parent,bool in
 	if(canvas->value_node_list().placeholder_count())
 	{
 		String nodes;
-		for (ValueNodeList::const_iterator iter = canvas->value_node_list().begin(); iter != canvas->value_node_list().end(); iter++)
+		for (ValueNodeList::const_iterator iter = canvas->value_node_list().begin(); iter != canvas->value_node_list().end(); ++iter) {
 			if(PlaceholderValueNode::Handle::cast_dynamic(*iter))
 			{
 				if (nodes != "") nodes += ", ";
 				nodes += "'" + (*iter)->get_id() + "'";
 			}
+		}
 		error(element,strprintf(_("Canvas '%s' has undefined %s: %s"),
 								canvas->get_id().c_str(),
 								canvas->value_node_list().placeholder_count() == 1 ? _("ValueNode") : _("ValueNodes"),

--- a/synfig-core/src/synfig/synfig_iterations.cpp
+++ b/synfig-core/src/synfig/synfig_iterations.cpp
@@ -78,7 +78,7 @@ do_traverse_layers(Layer::Handle layer, TraverseLayerStatus& status, TraverseLay
 			status.depth.push_back(-1);
 			Canvas::Handle subcanvas(iter->second.get(Canvas::Handle()));
 			if (subcanvas && (status.settings.traverse_static_non_inline_canvas || subcanvas->is_inline()))
-				for (IndependentContext iter = subcanvas->get_independent_context(); iter != subcanvas->end(); iter++)
+				for (IndependentContext iter = subcanvas->get_independent_context(); iter != subcanvas->end(); ++iter)
 					do_traverse_layers(*iter, status, callback);
 			status.depth.pop_back();
 			status.is_dynamic_canvas = previous_is_dynamic;

--- a/synfig-core/src/synfig/time.cpp
+++ b/synfig-core/src/synfig/time.cpp
@@ -304,7 +304,7 @@ Time::get_string(float fps, Time::Format format)const
 				// skip trailing zeros
 				int count = 0;
 				String::reverse_iterator i = seconds.rbegin();
-				for ( ; (*i) == '0'; i++)
+				for ( ; (*i) == '0'; ++i)
 					count++;
 
 				// if we removed too many, go back one place, leaving one zero

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -723,7 +723,7 @@ LinkableValueNode::get_link_description(int index, bool show_exported_name)const
 		String param;
 		const Layer::DynamicParamList &dynamic_param_list(parent_layer->dynamic_param_list());
 		// loop to find the parameter in the dynamic parameter list - this gives us its name
-		for (Layer::DynamicParamList::const_iterator iter = dynamic_param_list.begin(); iter != dynamic_param_list.end(); iter++)
+		for (Layer::DynamicParamList::const_iterator iter = dynamic_param_list.begin(); iter != dynamic_param_list.end(); ++iter)
 			if (iter->second == parent_linkable_vn)
 				param = String(":") + parent_layer->get_param_local_name(iter->first);
 		description = strprintf("(%s)%s>%s",
@@ -747,7 +747,8 @@ LinkableValueNode::link_name(int i)const
 	const auto& vocab = children_vocab;
 	Vocab::const_iterator iter(vocab.begin());
 	int j=0;
-	for(;iter!=vocab.end() && j<i; iter++, j++) {}
+	for( ; iter != vocab.end() && j < i; ++iter, ++j)
+	{}
 	return iter!=vocab.end()?iter->get_name():String();
 }
 
@@ -757,7 +758,8 @@ LinkableValueNode::link_local_name(int i)const
 	const auto& vocab = children_vocab;
 	Vocab::const_iterator iter(vocab.begin());
 	int j=0;
-	for(;iter!=vocab.end() && j<i; iter++, j++) {}
+	for( ; iter != vocab.end() && j < i; ++iter, ++j)
+	{}
 	return iter!=vocab.end()?iter->get_local_name():String();
 }
 
@@ -767,7 +769,7 @@ LinkableValueNode::get_link_index_from_name(const String &name)const
 	const auto& vocab = children_vocab;
 	Vocab::const_iterator iter(vocab.begin());
 	int j=0;
-	for(; iter!=vocab.end(); iter++, j++)
+	for( ; iter != vocab.end(); ++iter, ++j)
 		if(iter->get_name()==name) return j;
 	throw Exception::BadLinkName(name);
 }

--- a/synfig-core/src/tool/printing_functions.cpp
+++ b/synfig-core/src/tool/printing_functions.cpp
@@ -59,7 +59,7 @@ void print_child_canvases(const std::string& prefix,
 {
 	const synfig::Canvas::Children& children(canvas->children());
 	for (synfig::Canvas::Children::const_iterator child_canvas = children.begin();
-		 child_canvas != children.end(); child_canvas++)
+		 child_canvas != children.end(); ++child_canvas)
 	{
 		std::string new_prefix = prefix + ":" + (*child_canvas)->get_id();
 		std::cout << new_prefix << std::endl;
@@ -256,7 +256,7 @@ void print_canvas_info(const Job& job)
 		std::cout << std::endl << "# " << _("Metadata") << std::endl;
 
 		for (std::list<String>::iterator key = keys.begin();
-			 key != keys.end(); key++)
+			 key != keys.end(); ++key)
 			std::cout << (*key).c_str() << "=" << canvas->get_meta_data(*key).c_str()<< std::endl;
 	}
 }

--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -627,18 +627,18 @@ LayerActionManager::export_dup_nodes(synfig::Layer::Handle layer, Canvas::Handle
 		Layer::ParamList param_list(layer->get_param_list());
 		for (Layer::ParamList::const_iterator iter(param_list.begin())
 				 ; iter != param_list.end()
-				 ; iter++)
+				 ; ++iter)
 			if (layer->dynamic_param_list().count(iter->first)==0 && iter->second.get_type()==type_canvas)
 			{
 				Canvas::Handle subcanvas(iter->second.get(Canvas::Handle()));
 				if (subcanvas && subcanvas->is_inline())
-					for (IndependentContext iter = subcanvas->get_independent_context(); iter != subcanvas->end(); iter++)
+					for (IndependentContext iter = subcanvas->get_independent_context(); iter != subcanvas->end(); ++iter)
 						export_dup_nodes(*iter, canvas, index);
 			}
 
 		for (Layer::DynamicParamList::const_iterator iter(layer->dynamic_param_list().begin())
 				 ; iter != layer->dynamic_param_list().end()
-				 ; iter++)
+				 ; ++iter)
 			if (iter->second->get_type()==type_canvas)
 			{
 				Canvas::Handle canvas((*iter->second)(0).get(Canvas::Handle()));

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -963,7 +963,7 @@ DEFINE_ACTION("mask-bone-setup-ducks",          _("Show Bone Setup Handles"))
 DEFINE_ACTION("mask-bone-recursive-ducks",      _("Show Recursive Scale Bone Handles"))
 DEFINE_ACTION("mask-bone-ducks",                _("Next Bone Handles"))
 
-for(std::list<int>::iterator iter = CanvasView::get_pixel_sizes().begin(); iter != CanvasView::get_pixel_sizes().end(); iter++)
+for (std::list<int>::iterator iter = CanvasView::get_pixel_sizes().begin(); iter != CanvasView::get_pixel_sizes().end(); ++iter)
 DEFINE_ACTION(strprintf("lowres-pixel-%d", *iter), strprintf(_("Set Low-Res pixel size to %d"), *iter))
 
 DEFINE_ACTION("toggle-rulers-show",  _("Toggle Rulers Show"))
@@ -1121,7 +1121,7 @@ DEFINE_ACTION("switch-to-rightmost-tab",  _("Switch to Rightmost Tab"))
 "			<separator name='pixel-size-separator'/>"
 ;
 
-	for (std::list<int>::iterator iter = CanvasView::get_pixel_sizes().begin(); iter != CanvasView::get_pixel_sizes().end(); iter++)
+	for (std::list<int>::iterator iter = CanvasView::get_pixel_sizes().begin(); iter != CanvasView::get_pixel_sizes().end(); ++iter)
 		ui_info_menu += strprintf("			<menuitem action='lowres-pixel-%d' />", *iter);
 
 	ui_info_menu +=
@@ -1888,13 +1888,13 @@ App::add_recent_file(const std::string &file_name, bool emit_signal = true)
 	std::list<std::string>::iterator iter;
 	// Check to see if the file is already on the list.
 	// If it is, then remove it from the list
-	for(iter=recent_files.begin();iter!=recent_files.end();iter++)
+	for (iter = recent_files.begin(); iter != recent_files.end(); ++iter) {
 		if(*iter==filename)
 		{
 			recent_files.erase(iter);
 			break;
 		}
-
+	}
 
 	// Push the filename to the front of the list
 	recent_files.push_front(filename);
@@ -3310,7 +3310,7 @@ App::dialog_select_list_item(const std::string &title, const std::string &messag
 	Glib::RefPtr<Gtk::ListStore> list_store = Gtk::ListStore::create(model_columns);
 
 	int k = 0;
-	for(std::list<std::string>::const_iterator i = list.begin(); i != list.end(); i++) {
+	for(std::list<std::string>::const_iterator i = list.begin(); i != list.end(); ++i) {
 		Gtk::ListStore::iterator j = list_store->append();
 		j->set_value(model_columns.column_index, k++);
 		j->set_value(model_columns.column_main, Glib::ustring(*i));
@@ -4156,7 +4156,7 @@ App::dialog_open(std::string filename)
 			// build list of history entries for dialog (descending)
 			std::list<std::string> list;
 			int index = 0;
-			for(std::list<FileContainerZip::HistoryRecord>::const_iterator i = history.begin(); i != history.end(); ++i)
+			for (std::list<FileContainerZip::HistoryRecord>::const_iterator i = history.begin(); i != history.end(); ++i)
 				list.push_front(strprintf("%s%d", _("History entry #"), ++index));
 
 			// show dialog
@@ -4165,7 +4165,7 @@ App::dialog_open(std::string filename)
 				continue;
 
 			// find selected entry in list (descending)
-			for(std::list<FileContainerZip::HistoryRecord>::const_reverse_iterator i = history.rbegin(); i != history.rend(); i++)
+			for (std::list<FileContainerZip::HistoryRecord>::const_reverse_iterator i = history.rbegin(); i != history.rend(); ++i)
 				if (0 == index--)
 					truncate_storage_size = i->storage_size;
 		}

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1547,7 +1547,7 @@ void
 CanvasView::on_select_layers()
 {
 	Canvas::Handle canvas(get_canvas());
-	for (CanvasBase::iterator iter = canvas->begin(); iter != canvas->end(); iter++)
+	for (CanvasBase::iterator iter = canvas->begin(); iter != canvas->end(); ++iter)
 		layer_tree->select_all_children_layers(*iter);
 }
 
@@ -2297,7 +2297,7 @@ CanvasView::increase_low_res_pixel_size()
 		return;
 	}
 
-	for (std::list<int>::iterator iter = sizes.begin(); iter != sizes.end(); iter++)
+	for (std::list<int>::iterator iter = sizes.begin(); iter != sizes.end(); ++iter)
 		if (*iter == pixel_size) {
 			if (++iter != sizes.end()) {
 				Glib::RefPtr<Gtk::Action> action = action_group->get_action(synfig::strprintf("lowres-pixel-%d", *iter));
@@ -2622,8 +2622,7 @@ duplicate_waypoints(std::set<Waypoint, std::less<UniqueID> > waypoints,
 	Action::PassiveGrouper group(canvas_interface->get_instance().get(),_("Duplicate Waypoints"));
 
 	std::set<Waypoint, std::less<UniqueID> >::const_iterator iter;
-	for (iter = waypoints.begin(); iter != waypoints.end(); iter++)
-	{
+	for (iter = waypoints.begin(); iter != waypoints.end(); ++iter) {
 		Waypoint waypoint(*iter);
 		ValueNode::Handle value_node(iter->get_parent_value_node());
 		canvas_interface->waypoint_duplicate(value_node, waypoint);
@@ -2638,8 +2637,7 @@ remove_waypoints(std::set<Waypoint, std::less<UniqueID> > waypoints,
 	Action::PassiveGrouper group(canvas_interface->get_instance().get(),_("Remove Waypoints"));
 
 	std::set<Waypoint, std::less<UniqueID> >::const_iterator iter;
-	for (iter = waypoints.begin(); iter != waypoints.end(); iter++)
-	{
+	for (iter = waypoints.begin(); iter != waypoints.end(); ++iter) {
 		Waypoint waypoint(*iter);
 		ValueNode::Handle value_node(iter->get_parent_value_node());
 		canvas_interface->waypoint_remove(value_node, waypoint);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -980,8 +980,7 @@ Dialog_Setup::on_apply_pressed()
 			listviewtext_brushes_path->get_model());
 
 		for(Gtk::TreeIter ui_iter = liststore->children().begin();
-			ui_iter!=liststore->children().end();ui_iter++)
-		{
+			ui_iter != liststore->children().end(); ++ui_iter) {
 			const Gtk::TreeRow row = *(ui_iter);
 			// TODO utf_8 path : care to other locale than english ?
 			synfig::String path((row[prefs_brushpath.path]));
@@ -1312,8 +1311,7 @@ Dialog_Setup::refresh()
 		}
 	}
 	for (std::set<synfig::String>::iterator setiter = App::brushes_path.begin();
-			setiter != App::brushes_path.end(); setiter++)
-	{
+			setiter != App::brushes_path.end(); ++setiter) {
 		ui_iter = liststore->append();
 		(*ui_iter)[prefs_brushpath.path]=*setiter;
 	}

--- a/synfig-studio/src/gui/docks/dockdialog.cpp
+++ b/synfig-studio/src/gui/docks/dockdialog.cpp
@@ -130,8 +130,7 @@ bool
 DockDialog::on_delete_event(GdkEventAny * /* event */)
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
-	for(std::list<Dockable*>::iterator i = App::dock_manager->dockable_list_.begin(); i != App::dock_manager->dockable_list_.end(); i++)
-	{
+	for (std::list<Dockable*>::iterator i = App::dock_manager->dockable_list_.begin(); i != App::dock_manager->dockable_list_.end(); ++i) {
 		if ((*i)->get_parent_window() == get_window())
 		{
 			CanvasView *canvas_view = dynamic_cast<CanvasView*>(*i);

--- a/synfig-studio/src/gui/docks/dockmanager.cpp
+++ b/synfig-studio/src/gui/docks/dockmanager.cpp
@@ -800,7 +800,7 @@ std::string DockManager::layout_from_template(const std::string &tpl, float dx, 
 
 void DockManager::set_dock_area_visibility(bool visible, DockBook* source)
 {
-	for(auto iter=dockable_list_.begin();iter!=dockable_list_.end();++iter) {
+	for (auto iter = dockable_list_.begin(); iter != dockable_list_.end(); ++iter) {
 		Dockable * dockable = *iter;
 		if (!dockable->is_visible())
 			continue;
@@ -818,8 +818,7 @@ DockManager::update_window_titles()
 	typedef std::map< Glib::RefPtr<Gdk::Window>, std::string > TitleMap;
 	CanvasViewMap canvas_view_map;
 	TitleMap title_map;
-	for(std::list<Dockable*>::iterator i = dockable_list_.begin(); i != dockable_list_.end(); i++)
-	{
+	for (std::list<Dockable*>::iterator i = dockable_list_.begin(); i != dockable_list_.end(); ++i) {
 		if ((*i)->get_parent_window())
 		{
 			title_map[(*i)->get_parent_window()] = (*i)->get_parent_window() == App::main_window->get_window()
@@ -831,11 +830,11 @@ DockManager::update_window_titles()
 	}
 
 	// prepare titles
-	for(CanvasViewMap::iterator i = canvas_view_map.begin(); i != canvas_view_map.end(); i++)
+	for (CanvasViewMap::iterator i = canvas_view_map.begin(); i != canvas_view_map.end(); ++i)
 		title_map[ i->second->get_parent_window() ] =
 			i->second->get_local_name() + " - " + _("Synfig Studio");
 
 	// set titles
-	for(TitleMap::iterator i = title_map.begin(); i != title_map.end(); i++)
+	for (TitleMap::iterator i = title_map.begin(); i != title_map.end(); ++i)
 		i->first->set_title(i->second);
 }

--- a/synfig-studio/src/gui/duckmatic.cpp
+++ b/synfig-studio/src/gui/duckmatic.cpp
@@ -494,8 +494,7 @@ Duckmatic::update_ducks()
 				int index(c1->get_value_desc().get_index());
 				etl::handle<Duck> origin_duck=c1->get_origin_duck();
 				// Search all the rest of ducks
-				DuckList::iterator iter;
-				for (iter=duck_list.begin(); iter!=duck_list.end(); iter++)
+				for (DuckList::iterator iter = duck_list.begin(); iter != duck_list.end(); ++iter)
 					// if the other duck has the same origin and it is tangent type
 					if ( (*iter)->get_origin_duck()==origin_duck && (*iter)->get_type() == Duck::TYPE_TANGENT)
 					{
@@ -543,8 +542,7 @@ Duckmatic::update_ducks()
 				int index(c2->get_value_desc().get_index());
 				etl::handle<Duck> origin_duck=c2->get_origin_duck();
 				// Search all the rest of ducks
-				DuckList::iterator iter;
-				for (iter=duck_list.begin(); iter!=duck_list.end(); iter++)
+				for (DuckList::iterator iter = duck_list.begin(); iter != duck_list.end(); ++iter) {
 					// if the other duck has the same origin and it is tangent type
 					if ( (*iter)->get_origin_duck()==origin_duck && (*iter)->get_type() == Duck::TYPE_TANGENT)
 					{
@@ -580,6 +578,7 @@ Duckmatic::update_ducks()
 							}
 						}
 					}
+				}
 			}
 		}
 	}
@@ -619,9 +618,7 @@ Duckmatic::update_ducks()
 				ValueNode::Handle vertex_amount_value_node(bline_vertex->get_link("amount"));
 				duck->set_point(point);
 
-				DuckList::iterator iter;
-				for (iter=duck_list.begin(); iter!=duck_list.end(); iter++)
-				{
+				for (DuckList::iterator iter = duck_list.begin(); iter != duck_list.end(); ++iter) {
 					if ( (*iter)->get_origin_duck()==duck /*&& !duck_is_selected(*iter)*/ )
 					{
 						ValueNode::Handle duck_value_node = (*iter)->get_value_desc().get_value_node();
@@ -683,9 +680,7 @@ Duckmatic::update_ducks()
 						int index(duck->get_value_desc().get_index());
 						etl::handle<Duck> origin_duck=duck->get_origin_duck();
 						// Search all the rest of ducks
-						DuckList::iterator iter;
-						for (iter=duck_list.begin(); iter!=duck_list.end(); iter++)
-						{
+						for (DuckList::iterator iter = duck_list.begin(); iter != duck_list.end(); ++iter) {
 							// if the other duck has the same origin and it is tangent type
 							if ( (*iter)->get_origin_duck()==origin_duck && (*iter)->get_type() == Duck::TYPE_TANGENT)
 							{
@@ -1637,8 +1632,7 @@ Duckmatic::add_ducks_layers(synfig::Canvas::Handle canvas, std::set<synfig::Laye
 			Layer::Vocab vocab=layer->get_param_vocab();
 			Layer::Vocab::iterator iter;
 
-			for(iter=vocab.begin();iter!=vocab.end();iter++)
-			{
+			for (iter = vocab.begin(); iter != vocab.end(); ++iter) {
 				if(!iter->get_hidden() && !iter->get_invisible_duck())
 				{
 					synfigapp::ValueDesc value_desc(layer,iter->get_name());

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -214,7 +214,7 @@ Instance::find_canvas_view(Canvas::Handle canvas)
 
 	CanvasViewList::iterator iter;
 
-	for(iter=canvas_view_list().begin();iter!=canvas_view_list().end();iter++)
+	for (iter = canvas_view_list().begin(); iter != canvas_view_list().end(); ++iter)
 		if((*iter)->get_canvas()==canvas)
 			return *iter;
 
@@ -666,7 +666,7 @@ Instance::close(bool remove_temporary_files)
 
 	// Remove us from the active instance list
 	std::list<etl::handle<studio::Instance> >::iterator iter;
-	for(iter=studio::App::instance_list.begin();iter!=studio::App::instance_list.end();iter++)
+	for (iter = studio::App::instance_list.begin(); iter != studio::App::instance_list.end(); ++iter)
 		if(*iter==this)
 			break;
 	assert(iter!=studio::App::instance_list.end());
@@ -732,7 +732,7 @@ Instance::insert_canvas(Gtk::TreeRow row, synfig::Canvas::Handle canvas)
 		synfig::Canvas::Children::iterator iter;
 		synfig::Canvas::Children &children(canvas->children());
 
-		for(iter=children.begin();iter!=children.end();iter++)
+		for (iter = children.begin(); iter != children.end(); ++iter)
 			insert_canvas(*(canvas_tree_store()->append(row.children())),*iter);
 	}
 }

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -1397,10 +1397,6 @@ StateBLine_Context::refresh_ducks(bool button_down)
 			bezier=0;
 		}
 
-		// Now we see if we need to create a bezier
-		std::list<ValueNode_Const::Handle>::iterator next(iter);
-		next++;
-
 		bezier=new WorkArea::Bezier();
 
 		// Add the tangent2 duck

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -985,15 +985,12 @@ StateDraw_Context::process_stroke(StrokeData stroke_data, WidthData width_data, 
 		// returned widths are homogeneous position
 		// let's convert it to standard position
 		// as it is the default for new adv. outlines layers
-		std::list<synfig::WidthPoint>::iterator iter;
-		for(iter=wplist.begin(); iter!=wplist.end(); iter++)
+		for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter)
 			iter->set_position(hom_to_std(ValueBase::List(bline.begin(), bline.end()), iter->get_position(), false, false));
 	}
 	// print out resutls
 	//synfig::info("-----------widths");
-	//std::list<synfig::WidthPoint>::iterator iter;
-	//for(iter=wplist.begin();iter!=wplist.end();iter++)
-	//{
+	//for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter) {
 		//if(!iter->get_dash())
 			//synfig::info("Widthpoint W=%f, P=%f", iter->get_width(), iter->get_position());
 	//}
@@ -1023,9 +1020,8 @@ StateDraw_Context::process_stroke(StrokeData stroke_data, WidthData width_data, 
 			tangent=bline.back().get_tangent1();
 			width=bline.back().get_width();
 			bline.pop_back();
-			std::list<synfig::WidthPoint>::iterator iter;
 			if(get_layer_advanced_outline_flag())
-				for(iter=wplist.begin(); iter!=wplist.end(); iter++)
+				for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter)
 					iter->set_position(iter->get_position()+1/(size-1));
 		}
 
@@ -1595,8 +1591,7 @@ debug_show_vertex_list(int iteration, std::list<synfigapp::ValueDesc>& vertex_li
 	int prev;
 	int dir = 0;
 	bool started = false;
-	for(;i!=vertex_list.end();i++,c++)
-	{
+	for ( ; i != vertex_list.end(); ++i, ++c) {
 		synfigapp::ValueDesc value_desc(*i);
 
 		if (value_desc.parent_is_value_node()) {
@@ -1852,13 +1847,14 @@ StateDraw_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real 
 		// rearrange the list so that the first and last node are on different blines
 		std::list<synfigapp::ValueDesc>::iterator iter, start;
 		ValueNode::Handle last_value_node = vertex_list.back().get_parent_value_node();
-		for(iter = vertex_list.begin(); iter!=vertex_list.end(); iter++)
+		for (iter = vertex_list.begin(); iter != vertex_list.end(); ++iter) {
 			if (iter->get_parent_value_node() != last_value_node)
 			{
 				vertex_list.insert(vertex_list.end(), vertex_list.begin(), iter);
 				vertex_list.erase(vertex_list.begin(), iter);
 				break;
 			}
+		}
 
 		debug_show_vertex_list(0, vertex_list, "before detecting direction and limits", -1);
 		// rearrange the list so that the first and last node are on different blines
@@ -1878,7 +1874,7 @@ StateDraw_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real 
 			// printf("there are %d points in this line - first is index %d\n", points_in_line, last_index);
 
 			// while we're looking at the same bline, keep going
-			iter++;
+			++iter;
 			while (iter != vertex_list.end() && iter->get_parent_value_node() == parent_value_node)
 			{
 				this_index = iter->get_index();
@@ -1903,7 +1899,7 @@ StateDraw_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real 
 					direction--;
 
 				last_index = this_index;
-				iter++;
+				++iter;
 			}
 
 			// printf("min %d and max %d\n", min_index, max_index);
@@ -1998,8 +1994,7 @@ StateDraw_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real 
 			iter=next++; // Set iter to the first value desc, and next to the second
 
 			int current = 0;
-			for(;iter!=vertex_list.end();prev=iter,iter++,next++,current++)
-			{
+			for ( ; iter != vertex_list.end(); prev = iter++, ++next, ++current) {
 				// we need to be able to erase(next) and can't do that if next is end()
 				if (next == vertex_list.end()) next = vertex_list.begin();
 				debug_show_vertex_list(i, vertex_list, "in loop around vertices", current);
@@ -2371,8 +2366,7 @@ StateDraw_Context::extend_bline_from_begin(ValueNode_BLine::Handle value_node,st
 				old_wplist.push_back(i->get(synfig::WidthPoint()));
 			std::list<synfig::WidthPoint>::iterator witer;
 			int i;
-			for(i=0, witer=old_wplist.begin(); witer!=old_wplist.end(); witer++, i++)
-			{
+			for (i = 0, witer = old_wplist.begin(); witer != old_wplist.end(); ++witer, ++i) {
 				synfigapp::Action::Handle action(synfigapp::Action::create("ValueDescSet"));
 				assert(action);
 				action->set_param("canvas", get_canvas());
@@ -2423,8 +2417,7 @@ StateDraw_Context::extend_bline_from_begin(ValueNode_BLine::Handle value_node,st
 			// Don't add the widthpoint with position equal to 0.0 if doing
 			// complete loops.
 			//
-			for(witer=wplist.begin(); witer!=wplist.end();witer++)
-			{
+			for (witer = wplist.begin(); witer != wplist.end(); ++witer) {
 				if(witer->get_position() == 1.0)
 					continue;
 				if(complete_loop && witer->get_position() == 0.0)
@@ -2554,8 +2547,7 @@ StateDraw_Context::extend_bline_from_end(ValueNode_BLine::Handle value_node,std:
 				old_wplist.push_back(i->get(synfig::WidthPoint()));
 			std::list<synfig::WidthPoint>::iterator witer;
 			int i;
-			for(i=0, witer=old_wplist.begin(); witer!=old_wplist.end(); witer++, i++)
-			{
+			for (i = 0, witer = old_wplist.begin(); witer != old_wplist.end(); ++witer, ++i) {
 				synfigapp::Action::Handle action(synfigapp::Action::create("ValueDescSet"));
 				assert(action);
 				action->set_param("canvas", get_canvas());
@@ -2606,8 +2598,7 @@ StateDraw_Context::extend_bline_from_end(ValueNode_BLine::Handle value_node,std:
 			// Don't add the widthpoint with position equal to 0.0 if doing
 			// complete loops.
 			//
-			for(witer=wplist.begin(); witer!=wplist.end();witer++)
-			{
+			for (witer = wplist.begin(); witer != wplist.end(); ++witer) {
 				if(witer->get_position() == 0.0)
 					continue;
 				if(complete_loop && witer->get_position() == 1.0)
@@ -2699,9 +2690,8 @@ StateDraw_Context::reverse_bline(std::list<synfig::BLinePoint> &bline)
 	std::list<synfig::BLinePoint>::iterator iter,eiter;
 	iter=bline.begin();
 	eiter=bline.end();
-	eiter--;
-	for(i=0;i<(int)bline.size()/2;++iter,--eiter,i++)
-	{
+	--eiter;
+	for (i = 0; i < (int)bline.size()/2; ++iter, --eiter, ++i) {
 		iter_swap(iter,eiter);
 		iter->reverse();
 		eiter->reverse();
@@ -2711,8 +2701,7 @@ StateDraw_Context::reverse_bline(std::list<synfig::BLinePoint> &bline)
 void
 StateDraw_Context::reverse_wplist(std::list<synfig::WidthPoint> &wplist)
 {
-	std::list<synfig::WidthPoint>::iterator iter;
-	for(iter=wplist.begin();iter!=wplist.end();iter++)
+	for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter)
 		iter->reverse();
 }
 

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -912,15 +912,12 @@ StateLasso_Context::process_stroke(StrokeData stroke_data, WidthData width_data,
 		// returned widths are homogeneous position
 		// let's convert it to standard position
 		// as it is the default for new adv. outlines layers
-		std::list<synfig::WidthPoint>::iterator iter;
-		for(iter=wplist.begin(); iter!=wplist.end(); iter++)
+		for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter)
 			iter->set_position(hom_to_std(ValueBase::List(bline.begin(), bline.end()), iter->get_position(), false, false));
 	}
 	// print out resutls
 	//synfig::info("-----------widths");
-	//std::list<synfig::WidthPoint>::iterator iter;
-	//for(iter=wplist.begin();iter!=wplist.end();iter++)
-	//{
+	//for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter) {
 		//if(!iter->get_dash())
 			//synfig::info("Widthpoint W=%f, P=%f", iter->get_width(), iter->get_position());
 	//}
@@ -950,9 +947,8 @@ StateLasso_Context::process_stroke(StrokeData stroke_data, WidthData width_data,
 			tangent=bline.back().get_tangent1();
 			width=bline.back().get_width();
 			bline.pop_back();
-			std::list<synfig::WidthPoint>::iterator iter;
 			if(get_layer_advanced_outline_flag())
-				for(iter=wplist.begin(); iter!=wplist.end(); iter++)
+				for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter)
 					iter->set_position(iter->get_position()+1/(size-1));
 		}
 
@@ -1518,8 +1514,7 @@ debug_show_vertex_list(int iteration, std::list<synfigapp::ValueDesc>& vertex_li
 	int prev;
 	int dir = 0;
 	bool started = false;
-	for(;i!=vertex_list.end();i++,c++)
-	{
+	for ( ; i != vertex_list.end(); ++i, ++c) {
 		synfigapp::ValueDesc value_desc(*i);
 
 		if (value_desc.parent_is_value_node()) {
@@ -1775,13 +1770,14 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 		// rearrange the list so that the first and last node are on different blines
 		std::list<synfigapp::ValueDesc>::iterator iter, start;
 		ValueNode::Handle last_value_node = vertex_list.back().get_parent_value_node();
-		for(iter = vertex_list.begin(); iter!=vertex_list.end(); iter++)
+		for (iter = vertex_list.begin(); iter != vertex_list.end(); ++iter) {
 			if (iter->get_parent_value_node() != last_value_node)
 			{
 				vertex_list.insert(vertex_list.end(), vertex_list.begin(), iter);
 				vertex_list.erase(vertex_list.begin(), iter);
 				break;
 			}
+		}
 
 		debug_show_vertex_list(0, vertex_list, "before detecting direction and limits", -1);
 		// rearrange the list so that the first and last node are on different blines
@@ -1801,7 +1797,7 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 			// printf("there are %d points in this line - first is index %d\n", points_in_line, last_index);
 
 			// while we're looking at the same bline, keep going
-			iter++;
+			++iter;
 			while (iter != vertex_list.end() && iter->get_parent_value_node() == parent_value_node)
 			{
 				this_index = iter->get_index();
@@ -1826,7 +1822,7 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 					direction--;
 
 				last_index = this_index;
-				iter++;
+				++iter;
 			}
 
 			// printf("min %d and max %d\n", min_index, max_index);
@@ -1921,8 +1917,7 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 			iter=next++; // Set iter to the first value desc, and next to the second
 
 			int current = 0;
-			for(;iter!=vertex_list.end();prev=iter,iter++,next++,current++)
-			{
+			for ( ; iter != vertex_list.end(); prev = iter++, ++next, ++current) {
 				// we need to be able to erase(next) and can't do that if next is end()
 				if (next == vertex_list.end()) next = vertex_list.begin();
 				debug_show_vertex_list(i, vertex_list, "in loop around vertices", current);
@@ -2282,8 +2277,7 @@ StateLasso_Context::extend_bline_from_begin(ValueNode_BLine::Handle value_node,s
 				old_wplist.push_back(i->get(synfig::WidthPoint()));
 			std::list<synfig::WidthPoint>::iterator witer;
 			int i;
-			for(i=0, witer=old_wplist.begin(); witer!=old_wplist.end(); witer++, i++)
-			{
+			for (i = 0, witer = old_wplist.begin(); witer != old_wplist.end(); ++witer, ++i) {
 				synfigapp::Action::Handle action(synfigapp::Action::create("ValueDescSet"));
 				assert(action);
 				action->set_param("canvas", get_canvas());
@@ -2334,8 +2328,7 @@ StateLasso_Context::extend_bline_from_begin(ValueNode_BLine::Handle value_node,s
 			// Don't add the widthpoint with position equal to 0.0 if doing
 			// complete loops.
 			//
-			for(witer=wplist.begin(); witer!=wplist.end();witer++)
-			{
+			for (witer = wplist.begin(); witer != wplist.end(); ++witer) {
 				if(witer->get_position() == 1.0)
 					continue;
 				if(complete_loop && witer->get_position() == 0.0)
@@ -2465,8 +2458,7 @@ StateLasso_Context::extend_bline_from_end(ValueNode_BLine::Handle value_node,std
 				old_wplist.push_back(i->get(synfig::WidthPoint()));
 			std::list<synfig::WidthPoint>::iterator witer;
 			int i;
-			for(i=0, witer=old_wplist.begin(); witer!=old_wplist.end(); witer++, i++)
-			{
+			for (i = 0, witer = old_wplist.begin(); witer != old_wplist.end(); ++witer, ++i) {
 				synfigapp::Action::Handle action(synfigapp::Action::create("ValueDescSet"));
 				assert(action);
 				action->set_param("canvas", get_canvas());
@@ -2517,8 +2509,7 @@ StateLasso_Context::extend_bline_from_end(ValueNode_BLine::Handle value_node,std
 			// Don't add the widthpoint with position equal to 0.0 if doing
 			// complete loops.
 			//
-			for(witer=wplist.begin(); witer!=wplist.end();witer++)
-			{
+			for (witer = wplist.begin(); witer != wplist.end(); ++witer) {
 				if(witer->get_position() == 0.0)
 					continue;
 				if(complete_loop && witer->get_position() == 1.0)
@@ -2610,9 +2601,8 @@ StateLasso_Context::reverse_bline(std::list<synfig::BLinePoint> &bline)
 	std::list<synfig::BLinePoint>::iterator iter,eiter;
 	iter=bline.begin();
 	eiter=bline.end();
-	eiter--;
-	for(i=0;i<(int)bline.size()/2;++iter,--eiter,i++)
-	{
+	--eiter;
+	for (i = 0; i < (int)bline.size()/2; ++iter, --eiter, ++i) {
 		iter_swap(iter,eiter);
 		iter->reverse();
 		eiter->reverse();
@@ -2622,8 +2612,7 @@ StateLasso_Context::reverse_bline(std::list<synfig::BLinePoint> &bline)
 void
 StateLasso_Context::reverse_wplist(std::list<synfig::WidthPoint> &wplist)
 {
-	std::list<synfig::WidthPoint>::iterator iter;
-	for(iter=wplist.begin();iter!=wplist.end();iter++)
+	for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter)
 		iter->reverse();
 }
 

--- a/synfig-studio/src/gui/trees/canvastreestore.cpp
+++ b/synfig-studio/src/gui/trees/canvastreestore.cpp
@@ -549,8 +549,7 @@ CanvasTreeStore::set_row(Gtk::TreeRow row,synfigapp::ValueDesc value_desc, bool 
 				row[model.link_count] = linkable->link_count();
 				const LinkableValueNode::Vocab& vocab(linkable->get_children_vocab());
 				LinkableValueNode::Vocab::const_iterator iter(vocab.begin());
-				for(int i=0;i<linkable->link_count();i++, iter++)
-				{
+				for (int i = 0; i < linkable->link_count(); ++i, ++iter) {
 					if(iter->get_hidden())
 						continue;
 					Gtk::TreeRow child_row=*(append(row.children()));

--- a/synfig-studio/src/gui/widgets/widget_gradient.cpp
+++ b/synfig-studio/src/gui/widgets/widget_gradient.cpp
@@ -67,9 +67,7 @@ studio::render_gradient_to_window(const Cairo::RefPtr<Cairo::Context>& cr,const 
 	Cairo::RefPtr<Cairo::LinearGradient> gpattern = Cairo::LinearGradient::create(ca.get_x(), ca.get_y(), ca.get_x()+width, ca.get_y());
 	double a, r, g, b;
 	Gradient::CPoint cp;
-	Gradient::const_iterator iter;
-	for(iter=gradient.begin();iter!=gradient.end(); iter++)
-	{
+	for (Gradient::const_iterator iter = gradient.begin(); iter != gradient.end(); ++iter) {
 		cp=*iter;
 		a=cp.color.get_a();
 		r=cp.color.get_r();
@@ -130,10 +128,9 @@ Widget_Gradient::on_draw(const ::Cairo::RefPtr< ::Cairo::Context>& cr)
 
 	render_gradient_to_window(cr,Gdk::Rectangle(0,0,w,h),gradient_);
 
-	Gradient::iterator iter,selected_iter;
+	Gradient::iterator selected_iter;
 	bool show_selected(false);
-	for(iter=gradient_.begin();iter!=gradient_.end();iter++)
-	{
+	for (Gradient::iterator iter = gradient_.begin(); iter != gradient_.end(); ++iter) {
 		if(*iter!=selected_cpoint)
 		{
 			get_style_context()->render_arrow(
@@ -286,10 +283,10 @@ Widget_Gradient::on_event(GdkEvent *event)
 				{
 					float begin(-100000000),end(100000000);
 					Gradient::iterator before(iter),after(iter);
-					after++;
+					++after;
 					if(iter!=gradient_.begin())
 					{
-						before--;
+						--before;
 						begin=before->pos;
 					}
 					if(after!=gradient_.end())

--- a/synfig-studio/src/gui/widgets/widget_timeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.cpp
@@ -106,8 +106,10 @@ calc_divisions(float fps, double range, double sub_range, double &out_step, int 
 	{
 		std::vector<double>::iterator next = synfig::binary_find(ranges.begin(), ranges.end(), mid_range);
 		std::vector<double>::iterator iter = next++;
-		if (iter == ranges.end()) iter--;
-		if (next == ranges.end()) next--;
+		if (iter == ranges.end())
+			--iter;
+		if (next == ranges.end())
+			--next;
 		if (fabs(*next - mid_range) < fabs(*iter - mid_range))
 			iter = next;
 		scale = *iter;

--- a/synfig-studio/src/synfigapp/actions/layercopy.cpp
+++ b/synfig-studio/src/synfigapp/actions/layercopy.cpp
@@ -94,7 +94,7 @@ Action::LayerCopy::is_candidate(const ParamList &x)
 		return false;
 
 	bool there_is_a_bitmap_layer = false;
-	for(ParamList::const_iterator i = x.begin(); i != x.end(); i++) {
+	for (ParamList::const_iterator i = x.begin(); i != x.end(); ++i) {
 		if (i->first == "layer") {
 			if (i->second.get_type() != Param::TYPE_LAYER)
 				return false;
@@ -136,8 +136,7 @@ Action::LayerCopy::prepare()
 	if(!first_time())
 		return;
 
-	for(std::list<Layer::Handle>::iterator i = layers.begin(); i != layers.end(); ++i)
-	{
+	for (std::list<Layer::Handle>::iterator i = layers.begin(); i != layers.end(); ++i) {
 		Layer::Handle layer(*i);
 
 		Canvas::Handle subcanvas(layer->get_canvas());

--- a/synfig-studio/src/synfigapp/actions/layerduplicate.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerduplicate.cpp
@@ -325,7 +325,7 @@ Action::LayerDuplicate::export_dup_nodes(synfig::Layer::Handle layer, Canvas::Ha
 		Layer::ParamList param_list(layer->get_param_list());
 		for (Layer::ParamList::const_iterator iter(param_list.begin())
 				 ; iter != param_list.end()
-				 ; iter++)
+				 ; ++iter) {
 			if (layer->dynamic_param_list().count(iter->first)==0 && iter->second.get_type()==type_canvas)
 			{
 				Canvas::Handle subcanvas(iter->second.get(Canvas::Handle()));
@@ -333,10 +333,11 @@ Action::LayerDuplicate::export_dup_nodes(synfig::Layer::Handle layer, Canvas::Ha
 					for (IndependentContext iter = subcanvas->get_independent_context(); iter != subcanvas->end(); iter++)
 						export_dup_nodes(*iter, canvas, index);
 			}
+		}
 
 		for (Layer::DynamicParamList::const_iterator iter(layer->dynamic_param_list().begin())
 				 ; iter != layer->dynamic_param_list().end()
-				 ; iter++)
+				 ; ++iter) {
 			if (iter->second->get_type()==type_canvas)
 			{
 				Canvas::Handle canvas((*iter->second)(0).get(Canvas::Handle()));
@@ -344,6 +345,7 @@ Action::LayerDuplicate::export_dup_nodes(synfig::Layer::Handle layer, Canvas::Ha
 					//! \todo do we need to implement this?  and if so, shouldn't we check all canvases, not just the one at t=0s?
 					warning("%s:%d not yet implemented - do we need to export duplicate valuenodes in dynamic canvas parameters?", __FILE__, __LINE__);
 			}
+		}
 	}
 }
 

--- a/synfig-studio/src/synfigapp/actions/layerembed.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerembed.cpp
@@ -166,8 +166,8 @@ Action::LayerEmbed::prepare()
 		// generate name
 		std::string fname = filesystem::Path::filename_sans_extension(filesystem::Path::basename(sub_canvas->get_file_name()));
 		static const char bad_chars[]=" :#@$^&()*";
-		for(std::string::iterator j = fname.begin(); j != fname.end(); j++)
-			for(const char *k = bad_chars; *k != 0; k++)
+		for (std::string::iterator j = fname.begin(); j != fname.end(); ++j)
+			for (const char *k = bad_chars; *k != 0; ++k)
 				if (*j == *k) { *j = '_'; break; }
 		if (fname.empty()) fname = "canvas";
 		if (fname[0]>='0' && fname[0]<='9')
@@ -175,13 +175,12 @@ Action::LayerEmbed::prepare()
 
 		std::string name;
 		bool found = false;
-		for(int j = 1; j < 1000; j++)
-		{
+		for (int j = 1; j < 1000; ++j) {
 			name = j == 1 ? fname : strprintf("%s_%d", fname.c_str(), j);
 			if (get_canvas()->value_node_list().count(name) == false)
 			{
 				found = true;
-				for(std::list<Canvas::Handle>::const_iterator iter=get_canvas()->children().begin();iter!=get_canvas()->children().end();iter++)
+				for (std::list<Canvas::Handle>::const_iterator iter = get_canvas()->children().begin(); iter != get_canvas()->children().end(); ++iter)
 					if(name==(*iter)->get_id())
 						{ found = false; break; }
 				if (found) break;

--- a/synfig-studio/src/synfigapp/actions/layerpaint.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerpaint.cpp
@@ -119,8 +119,7 @@ Action::LayerPaint::PaintStroke::paint_self(synfig::Surface &surface)
 	paint_prev(surface);
 	brushlib::SurfaceWrapper wrapper(&surface);
 	if (!points.empty()) reset(points.front());
-	for(std::vector<PaintPoint>::const_iterator i = points.begin(); i != points.end(); i++)
-	{
+	for (std::vector<PaintPoint>::const_iterator i = points.begin(); i != points.end(); ++i) {
 		brush_.stroke_to(&wrapper, i->x, i->y, i->pressure, 0.f, 0.f, i->dtime);
 		wrapper.offset_x = 0;
 		wrapper.offset_y = 0;

--- a/synfig-studio/src/synfigapp/actions/layerzdepthrangeset.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerzdepthrangeset.cpp
@@ -101,8 +101,7 @@ Action::LayerZDepthRangeSet::is_candidate(const ParamList &x)
 		return false;
 	// Check if all layers belong to the same canvas
 	Canvas::Handle canvas=0;
-	for(ParamList::const_iterator i = x.begin(); i != x.end(); i++) 
-	{
+	for (ParamList::const_iterator i = x.begin(); i != x.end(); ++i) {
 		if (i->first == "layer" && i->second.get_type() == Param::TYPE_LAYER) 
 		{
 			const Layer::Handle layer = i->second.get_layer();

--- a/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
@@ -163,19 +163,18 @@ void Action::ValueDescExport::scan_canvas(synfig::Canvas::Handle prev_canvas, sy
 {
 	{ // scan children
 		std::list<Canvas::Handle> &children = canvas->children();
-		for(std::list<Canvas::Handle>::iterator i = children.begin(); i != children.end(); i++)
+		for (std::list<Canvas::Handle>::iterator i = children.begin(); i != children.end(); ++i)
 			scan_canvas(prev_canvas, new_canvas, *i);
 	}
 
 	{ // scan layers
-		for(IndependentContext i = canvas->get_independent_context(); *i; i++)
+		for (IndependentContext i = canvas->get_independent_context(); *i; ++i)
 			scan_layer(prev_canvas, new_canvas, *i);
 	}
 
 	{ // scan values
 		const ValueNodeList &value_node_list = canvas->value_node_list();
-		for(ValueNodeList::const_iterator i = value_node_list.begin(); i != value_node_list.end(); i++)
-		{
+		for (ValueNodeList::const_iterator i = value_node_list.begin(); i != value_node_list.end(); ++i) {
 			LinkableValueNode::Handle linkable_value_node = etl::handle<LinkableValueNode>::cast_dynamic(*i);
 			if (linkable_value_node)
 				scan_linkable_value_node(prev_canvas, new_canvas, linkable_value_node);
@@ -187,8 +186,7 @@ void Action::ValueDescExport::scan_layer(synfig::Canvas::Handle prev_canvas, syn
 {
 	// dynamic params
 	const Layer::DynamicParamList &dynamic_param_list = layer->dynamic_param_list();
-	for(Layer::DynamicParamList::const_iterator i = dynamic_param_list.begin(); i != dynamic_param_list.end(); i++)
-	{
+	for (Layer::DynamicParamList::const_iterator i = dynamic_param_list.begin(); i != dynamic_param_list.end(); ++i) {
 		if (i->second->get_parent_canvas() == prev_canvas)
 		{
 			// create action
@@ -262,8 +260,7 @@ Action::ValueDescExport::prepare()
 		{
 			// clone value nodes
 			const ValueNodeList &value_node_list = prev_canvas->value_node_list();
-			for(ValueNodeList::const_iterator i = value_node_list.begin(); i != value_node_list.end(); i++)
-			{
+			for (ValueNodeList::const_iterator i = value_node_list.begin(); i != value_node_list.end(); ++i) {
 				ValueNode::Handle new_node = (*i)->clone(canvas, guid);
 				assert(new_node);
 				if (new_node)

--- a/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedesclink.cpp
@@ -476,8 +476,7 @@ Action::ValueDescLinkOpposite::is_candidate(const ParamList &x)
 	int total_tangents=0;
 	ParamList::const_iterator iter;
 	//Search thru all the Param and pick up the value descriptions
-	for(iter=x.begin(); iter!=x.end(); iter++)
-	{
+	for (iter = x.begin(); iter != x.end(); ++iter) {
 		if(iter->first == "value_desc")
 		{
 			ValueDesc v_desc(iter->second.get_value_desc());

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -130,7 +130,7 @@ CanvasInterface::set_time(synfig::Time x)
 	// update the time in all the child canvases
 	Canvas::Children children = get_canvas()->get_root()->children();
 	handle<CanvasInterface> interface;
-	for (Canvas::Children::iterator iter = children.begin(); iter != children.end(); iter++)
+	for (Canvas::Children::iterator iter = children.begin(); iter != children.end(); ++iter)
 		if ((interface = get_instance()->find_canvas_interface(*iter)) != this)
 			interface->set_time(interface->get_canvas()->get_time());
 
@@ -316,7 +316,7 @@ CanvasInterface::layer_set_defaults(const synfig::Layer::Handle &layer)
 				{
 					std::vector<ValueBase>::iterator iter2 = list.begin();
 					Type &type(iter2->get_type());
-					for (iter2++; iter2 != list.end(); iter2++)
+					for (++iter2; iter2 != list.end(); ++iter2)
 						if (iter2->get_type() != type)
 							break;
 					if (iter2 == list.end())

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -178,9 +178,7 @@ Instance::find_canvas_interface(synfig::Canvas::Handle canvas)
 	while(canvas->is_inline())
 		canvas=canvas->parent();
 
-	CanvasInterfaceList::iterator iter;
-
-	for(iter=canvas_interface_list().begin();iter!=canvas_interface_list().end();iter++)
+	for (CanvasInterfaceList::iterator iter = canvas_interface_list().begin(); iter != canvas_interface_list().end(); ++iter)
 		if((*iter)->get_canvas()==canvas)
 			return *iter;
 
@@ -230,8 +228,8 @@ Instance::import_external_canvas(Canvas::Handle canvas, std::map<Canvas*, Canvas
 			// generate name
 			std::string fname = filesystem::Path::filename_sans_extension(filesystem::Path::basename(sub_canvas->get_file_name()));
 			static const char bad_chars[]=" :#@$^&()*";
-			for(std::string::iterator j = fname.begin(); j != fname.end(); j++)
-				for(const char *k = bad_chars; *k != 0; k++)
+			for(std::string::iterator j = fname.begin(); j != fname.end(); ++j)
+				for (const char* k = bad_chars; *k != 0; ++k)
 					if (*j == *k) { *j = '_'; break; }
 			if (fname.empty()) fname = "canvas";
 			if (fname[0]>='0' && fname[0]<='9')
@@ -245,7 +243,7 @@ Instance::import_external_canvas(Canvas::Handle canvas, std::map<Canvas*, Canvas
 				if (canvas->value_node_list().count(name) == false)
 				{
 					found = true;
-					for(std::list<Canvas::Handle>::const_iterator iter=canvas->children().begin();iter!=canvas->children().end();iter++)
+					for (std::list<Canvas::Handle>::const_iterator iter = canvas->children().begin(); iter != canvas->children().end(); ++iter)
 						if(name==(*iter)->get_id())
 							{ found = false; break; }
 					if (found) break;
@@ -277,7 +275,7 @@ Instance::import_external_canvas(Canvas::Handle canvas, std::map<Canvas*, Canvas
 		}
 	}
 
-	for(std::list<Canvas::Handle>::const_iterator i = canvas->children().begin(); i != canvas->children().end(); i++)
+	for (std::list<Canvas::Handle>::const_iterator i = canvas->children().begin(); i != canvas->children().end(); ++i)
 		if (import_external_canvas(*i, imported))
 			return true;
 


### PR DESCRIPTION
And prefer the style of the `for` loop as discussed in the forums https://forums.synfig.org/t/trying-to-define-our-code-style/13097.
```c++
for (int a = 0; a < 30; ++a) {
}
```
(spaces surrounding operators, spaces after `(` and `;`, and bracket layout)