### PR TITLE
refactor(Time): change epsilon_() method to constant; remove c_str()

### DIFF
--- a/synfig-core/src/synfig/time.cpp
+++ b/synfig-core/src/synfig/time.cpp
@@ -60,6 +60,8 @@ using namespace synfig;
 
 /* === G L O B A L S ======================================================= */
 
+const Time::value_type Time::epsilon_ = static_cast<Time::value_type>(0.0005);
+
 /* === M E T H O D S ======================================================= */
 
 Time::Time(const String &str_, float fps):
@@ -209,7 +211,7 @@ Time::get_string(float fps, Time::Format format)const
 
 	if(fps<0)fps=0;
 
-	if(ceil(time.value_)-time.value_<epsilon_())
+	if(ceil(time.value_)-time.value_<epsilon_)
 		time.value_=ceil(time.value_);
 
 	int hour = 0, minute = 0;
@@ -277,12 +279,12 @@ Time::get_string(float fps, Time::Format format)const
 			started = true;
 		}
 
-		if(format<=FORMAT_FULL || std::fabs(frame) > epsilon_() || !started)
+		if(format<=FORMAT_FULL || std::fabs(frame) > epsilon_ || !started)
 		{
 			if (!(format<=FORMAT_NOSPACES) && started)
 				ret += " ";
 
-			if (fabs(frame-floor(frame)) >= epsilon_())
+			if (fabs(frame-floor(frame)) >= epsilon_)
 				ret += strprintf("%0.3ff", frame);
 			else
 				ret += strprintf("%0.0ff", frame);
@@ -297,7 +299,7 @@ Time::get_string(float fps, Time::Format format)const
 			if (!(format<=FORMAT_NOSPACES) && started)
 				ret += " ";
 
-			if(std::fabs(second-floor(second))>=epsilon_())
+			if(std::fabs(second-floor(second))>=epsilon_)
 			{
 				String seconds(strprintf("%0.8f",second));
 
@@ -328,14 +330,6 @@ Time::round(float fps)const
 	if (!approximate_greater_lp(fps, 0.f)) return *this;
 	return Time(floor(value_*fps + 0.5)/fps);
 }
-
-#ifdef _DEBUG
-const char *
-Time::c_str()const
-{
-	return get_string().c_str();
-}
-#endif
 
 //! \writeme
 bool

--- a/synfig-core/src/synfig/time.h
+++ b/synfig-core/src/synfig/time.h
@@ -70,7 +70,7 @@ public:
 private:
 	value_type value_;
 
-	static value_type epsilon_() { return static_cast<value_type>(0.0005); }
+	static const value_type epsilon_;
 
 public:
 	Time(): value_() { }
@@ -100,19 +100,15 @@ public:
 	static const Time zero() { return static_cast<synfig::Time>(0); }
 
 	//! The amount of allowable error in calculations
-	static Time epsilon() { return static_cast<synfig::Time>(epsilon_()); }
+	static Time epsilon() { return static_cast<synfig::Time>(epsilon_); }
 
 	//! The duration of discrete tick used for values comparison
-	static value_type tick() { return static_cast<value_type>(0.1*epsilon_()); }
+	static value_type tick() { return static_cast<value_type>(0.1*epsilon_); }
 
 	//! Returns a string describing the current time value
 	/*!	\see Format */
 	String get_string(float fps=0, Time::Format format=FORMAT_NORMAL) const;
 	std::string get_string(Time::Format format) const;
-
-#ifdef _DEBUG
-	const char *c_str()const;
-#endif
 
 	//! \writeme
 	bool is_valid()const;


### PR DESCRIPTION
Time::c_str() :
 - not used
 - not needed
 - wrong (returned value is invalid, due to be from a temp value)