### PR TITLE
refactor: prefer prefix ++ operators for non-primitive types (part 2)

### DIFF
--- a/synfig-core/src/synfig/filecontainerzip.cpp
+++ b/synfig-core/src/synfig/filecontainerzip.cpp
@@ -314,7 +314,7 @@ FileContainerZip::HistoryRecord FileContainerZip::decode_history(const String &c
 				{
 					String s;
 					xmlpp::Element::NodeList list = (*i)->get_children();
-					for(xmlpp::Element::NodeList::iterator j = list.begin(); j != list.end(); ++j)
+					for (xmlpp::Element::NodeList::iterator j = list.begin(); j != list.end(); ++j)
 						if (dynamic_cast<xmlpp::TextNode*>(*j))
 							s += dynamic_cast<xmlpp::TextNode*>(*j)->get_content();
 					history_record.prev_storage_size = strtoll(s.c_str(), nullptr, 10);
@@ -343,8 +343,7 @@ void FileContainerZip::read_history(std::list<HistoryRecord> &list, FILE *f, fil
 	bool found = false;
 	HistoryRecord history_record;
 
-	for(int i = read_size - sizeof(EndOfCentralDirectory); i >= 0; i--)
-	{
+	for (int i = read_size - sizeof(EndOfCentralDirectory); i >= 0; i--) {
 		EndOfCentralDirectory *e = (EndOfCentralDirectory*)&buffer[i];
 		if (e->signature == EndOfCentralDirectory::valid_signature__
 		 && e->comment_length == (uint16_t)(read_size - sizeof(EndOfCentralDirectory) - i))
@@ -425,8 +424,7 @@ bool FileContainerZip::open_from_history(const String &container_filename, file_
 	fseek(f, filesize - (long int)read_size, SEEK_SET);
 	read_size = fread(&buffer, 1, read_size, f);
 	bool found = false;
-	for(int i = read_size - sizeof(EndOfCentralDirectory); i >= 0; i--)
-	{
+	for (int i = read_size - sizeof(EndOfCentralDirectory); i >= 0; i--) {
 		EndOfCentralDirectory *e = (EndOfCentralDirectory*)&buffer[i];
 		if (e->signature == EndOfCentralDirectory::valid_signature__
 		 && e->comment_length == (uint16_t)(read_size - sizeof(EndOfCentralDirectory) - i))
@@ -442,8 +440,7 @@ bool FileContainerZip::open_from_history(const String &container_filename, file_
 	// read "central directory"
 	FileMap files;
 	fseek(f, ecd.offset, SEEK_SET);
-	for(int i = 0; i < ecd.current_records; i++)
-	{
+	for (int i = 0; i < ecd.current_records; i++) {
 		CentralDirectoryFileHeader cdfh;
 		if (sizeof(cdfh) != fread(&cdfh, 1, sizeof(cdfh), f))
 			{ fclose(f); return false; }
@@ -481,8 +478,7 @@ bool FileContainerZip::open_from_history(const String &container_filename, file_
 	}
 
 	// create directories
-	for(FileMap::iterator i = files.begin(); i != files.end();)
-	{
+	for (FileMap::iterator i = files.begin(); i != files.end(); ) {
 		if (!i->second.name_part_directory.empty()
 		 && files.find( i->second.name_part_directory ) == files.end())
 		{
@@ -521,8 +517,7 @@ bool FileContainerZip::save()
 	fseek(storage_file_, 0, SEEK_END);
 
 	// write headers of new directories
-	for(FileMap::iterator i = files_.begin(); i != files_.end(); ++i)
-	{
+	for (FileMap::iterator i = files_.begin(); i != files_.end(); ++i) {
 		FileInfo &info = i->second;
 		if (info.is_directory && !info.directory_saved)
 		{
@@ -547,8 +542,7 @@ bool FileContainerZip::save()
 
 	// write central directory
 	uint32_t central_directory_offset = (uint32_t)ftell(storage_file_);
-	for(FileMap::iterator i = files_.begin(); i != files_.end(); i++)
-	{
+	for (FileMap::iterator i = files_.begin(); i != files_.end(); ++i) {
 		FileInfo &info = i->second;
 		CentralDirectoryFileHeader cdfh;
 		cdfh.min_version = 20;
@@ -667,7 +661,7 @@ bool FileContainerZip::directory_scan(const String &dirname, FileList &out_files
 {
 	out_files.clear();
 	if (!is_directory(dirname)) return false;
-	for(FileMap::iterator i = files_.begin(); i != files_.end(); i++)
+	for (FileMap::iterator i = files_.begin(); i != files_.end(); ++i)
 		if (i->second.name_part_directory == fix_slashes(dirname))
 			out_files.push_back(i->second.name_part_localname);
 	return true;

--- a/synfig-core/src/synfig/filesystemgroup.cpp
+++ b/synfig-core/src/synfig/filesystemgroup.cpp
@@ -60,8 +60,7 @@ FileSystemGroup::FileSystemGroup(FileSystem::Handle default_file_system)
 const FileSystemGroup::Entry* FileSystemGroup::find_system(const String &filename, FileSystem::Handle &out_file_system, String &out_filename)
 {
 	String clean_filename = filesystem::Path::cleanup_path(filename);
-	for(std::list< Entry >::iterator i = entries_.begin(); i != entries_.end(); i++)
-	{
+	for (std::list< Entry >::iterator i = entries_.begin(); i != entries_.end(); ++i) {
 		if ( clean_filename.substr(0, i->prefix.size()) == i->prefix
 		  && ( i->is_separator
 			|| clean_filename.size() == i->prefix.size()
@@ -88,8 +87,7 @@ void FileSystemGroup::register_system(const String &prefix, const FileSystem::Ha
 	if (sub_file_system)
 	{
 		// keep list sorted by length of prefix desc
-		for(std::list< Entry >::iterator i = entries_.begin(); i != entries_.end(); i++)
-		{
+		for (std::list< Entry >::iterator i = entries_.begin(); i != entries_.end(); ++i) {
 			if (i->prefix == prefix)
 			{
 				i->sub_file_system = sub_file_system;
@@ -109,9 +107,10 @@ void FileSystemGroup::register_system(const String &prefix, const FileSystem::Ha
 
 void FileSystemGroup::unregister_system(const String &prefix)
 {
-	for(std::list< Entry >::iterator i = entries_.begin(); i != entries_.end();)
+	for (std::list< Entry >::iterator i = entries_.begin(); i != entries_.end(); )
 		if (i->prefix == prefix)
-			i = entries_.erase(i); else i++;
+			i = entries_.erase(i);
+		else ++i;
 }
 
 bool FileSystemGroup::is_file(const String &filename)
@@ -153,12 +152,12 @@ bool FileSystemGroup::directory_scan(const String &dirname, FileList &out_files)
 		FileList list;
 		if (!file_system->directory_scan(internal_dirname, list))
 			return false;
-		for(FileList::const_iterator i = list.begin(); i != list.end(); ++i)
+		for (FileList::const_iterator i = list.begin(); i != list.end(); ++i)
 			files.insert(*i);
 	}
 
 	String clean_dirname = filesystem::Path::cleanup_path(dirname);
-	for(std::list< Entry >::iterator i = entries_.begin(); i != entries_.end(); i++)
+	for (std::list< Entry >::iterator i = entries_.begin(); i != entries_.end(); ++i)
 		if (!i->is_separator && !i->prefix.empty() && clean_dirname == filesystem::Path::dirname(i->prefix))
 		{
 			if (is_exists(i->prefix))
@@ -167,7 +166,7 @@ bool FileSystemGroup::directory_scan(const String &dirname, FileList &out_files)
 				files.erase(filesystem::Path::basename(i->prefix));
 		}
 
-	for(std::set<String>::const_iterator i = files.begin(); i != files.end(); ++i)
+	for (std::set<String>::const_iterator i = files.begin(); i != files.end(); ++i)
 		out_files.push_back(*i);
 
 	return true;

--- a/synfig-core/src/synfig/filesystemtemporary.cpp
+++ b/synfig-core/src/synfig/filesystemtemporary.cpp
@@ -167,11 +167,11 @@ FileSystemTemporary::directory_scan(const String &dirname, FileList &out_files)
 		FileList list;
 		if (!get_sub_file_system()->directory_scan(clean_dirname, list))
 			return false;
-		for(FileList::const_iterator i = list.begin(); i != list.end(); ++i)
+		for (FileList::const_iterator i = list.begin(); i != list.end(); ++i)
 			files_set.insert(*i);
 	}
 
-	for(FileMap::iterator i = files.begin(); i != files.end(); i++)
+	for (FileMap::iterator i = files.begin(); i != files.end(); ++i) {
 		if (filesystem::Path::dirname(i->second.name) == clean_dirname)
 		{
 			if (i->second.is_removed)
@@ -179,8 +179,9 @@ FileSystemTemporary::directory_scan(const String &dirname, FileList &out_files)
 			else
 				files_set.insert(filesystem::Path::basename(i->second.name));
 		}
+	}
 
-	for(std::set<String>::const_iterator i = files_set.begin(); i != files_set.end(); ++i)
+	for (std::set<String>::const_iterator i = files_set.begin(); i != files_set.end(); ++i)
 		out_files.push_back(*i);
 	return true;
 }
@@ -195,7 +196,7 @@ FileSystemTemporary::file_remove(const String &filename)
 		// NB: This code can check temporary files only,
 		//     but directory may contain other not tracked real files.
 		String prefix = fix_slashes(filename + "/");
-		for(FileMap::iterator i = files.begin(); i != files.end(); i++)
+		for (FileMap::iterator i = files.begin(); i != files.end(); ++i)
 			if ( !i->second.is_removed
 			  && i->second.name.substr(0, prefix.size()) == prefix )
 				return false;
@@ -338,8 +339,7 @@ FileSystemTemporary::save_changes(
 	while(processed)
 	{
 		processed = false;
-		for(FileMap::iterator i = files.begin(); i != files.end(); i++)
-		{
+		for (FileMap::iterator i = files.begin(); i != files.end(); ++i) {
 			bool to_remove = i->second.is_directory
 					       ? target_file_system->is_file(i->second.name)
 					       : target_file_system->is_directory(i->second.name);
@@ -358,8 +358,7 @@ FileSystemTemporary::save_changes(
 	while(processed)
 	{
 		processed = false;
-		for(FileMap::iterator i = files.begin(); i != files.end(); i++)
-		{
+		for (FileMap::iterator i = files.begin(); i != files.end(); ++i) {
 			if (!i->second.is_removed
 			 && i->second.is_directory
 			 && target_file_system->directory_create(i->second.name))
@@ -372,8 +371,7 @@ FileSystemTemporary::save_changes(
 	}
 
 	// create files
-	for(FileMap::iterator i = files.begin(); i != files.end();)
-	{
+	for (FileMap::iterator i = files.begin(); i != files.end(); ) {
 		if (!i->second.is_removed
 		 && !i->second.is_directory
 		 && !i->second.tmp_filename.empty()
@@ -384,7 +382,7 @@ FileSystemTemporary::save_changes(
 				
 			files.erase(i++);
 		}
-		else i++;
+		else ++i;
 	}
 
 	return files.empty();
@@ -421,8 +419,7 @@ void
 FileSystemTemporary::discard_changes()
 {
 	// remove temporary files
-	for(FileMap::iterator i = files.begin(); i != files.end(); i++)
-	{
+	for (FileMap::iterator i = files.begin(); i != files.end(); ++i) {
 		if (!i->second.is_removed
 		 && !i->second.is_directory
 		 && !i->second.tmp_filename.empty())
@@ -502,16 +499,14 @@ FileSystemTemporary::save_temporary() const
 	xmlpp::Element *root = document.create_root_node("temporary-file-system");
 
 	xmlpp::Element *meta_node = root->add_child("meta");
-	for(std::map<String, String>::const_iterator i = meta.begin(); i != meta.end(); i++)
-	{
+	for (std::map<String, String>::const_iterator i = meta.begin(); i != meta.end(); ++i) {
 		xmlpp::Element *entry = meta_node->add_child("entry");
 		entry->add_child("key")->set_child_text(i->first);
 		entry->add_child("value")->set_child_text(i->second);
 	}
 
 	xmlpp::Element *files_node = root->add_child("files");
-	for(FileMap::const_iterator i = files.begin(); i != files.end(); i++)
-	{
+	for (FileMap::const_iterator i = files.begin(); i != files.end(); ++i) {
 		xmlpp::Element *entry = files_node->add_child("entry");
 		entry->add_child("name")->set_child_text(i->second.name);
 		entry->add_child("tmp-basename")->set_child_text(filesystem::Path::basename(i->second.tmp_filename));
@@ -549,7 +544,7 @@ FileSystemTemporary::get_xml_node_text(xmlpp::Node *node)
 	if (node)
 	{
 		xmlpp::Element::NodeList list = node->get_children();
-		for(xmlpp::Element::NodeList::iterator i = list.begin(); i != list.end(); i++)
+		for (xmlpp::Element::NodeList::iterator i = list.begin(); i != list.end(); ++i)
 			if (dynamic_cast<xmlpp::TextNode*>(*i))
 				s += dynamic_cast<xmlpp::TextNode*>(*i)->get_content();
 	}
@@ -584,19 +579,16 @@ FileSystemTemporary::open_temporary(const String &filename)
 	if (root->get_name() != "temporary-file-system") return false;
 
 	xmlpp::Element::NodeList list = root->get_children();
-	for(xmlpp::Element::NodeList::iterator i = list.begin(); i != list.end(); i++)
-	{
+	for (xmlpp::Element::NodeList::iterator i = list.begin(); i != list.end(); ++i) {
 		if ((*i)->get_name() == "meta")
 		{
 			xmlpp::Element::NodeList meta_list = (*i)->get_children();
-			for(xmlpp::Element::NodeList::iterator j = meta_list.begin(); j != meta_list.end(); j++)
-			{
+			for (xmlpp::Element::NodeList::iterator j = meta_list.begin(); j != meta_list.end(); ++j) {
 				if ((*j)->get_name() == "entry")
 				{
 					String key, value;
 					xmlpp::Element::NodeList fields_list = (*j)->get_children();
-					for(xmlpp::Element::NodeList::iterator k = fields_list.begin(); k != fields_list.end(); k++)
-					{
+					for (xmlpp::Element::NodeList::iterator k = fields_list.begin(); k != fields_list.end(); ++k) {
 						if ((*k)->get_name() == "key")
 							key = get_xml_node_text(*k);
 						if ((*k)->get_name() == "value")
@@ -644,8 +636,7 @@ FileSystemTemporary::generate_indexed_temporary_filename(const FileSystem::Handl
 {
 	String extension = filesystem::Path::filename_extension(filename);
 	String sans_extension = filesystem::Path::filename_sans_extension(filename);
-	for(int index = 1; index < 10000; ++index)
-	{
+	for (int index = 1; index < 10000; ++index) {
 		String indexed_filename = strprintf("%s_%04d%s", sans_extension.c_str(), index, extension.c_str());
 		if (!fs->is_exists(indexed_filename))
 			return indexed_filename;

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -248,8 +248,7 @@ Gradient::proximity(const Real &x)
 Gradient::iterator
 Gradient::find(const UniqueID &id)
 {
-	// TODO: return end() instead of exception
-	for(iterator i = begin(); i < end(); i++)
+	for (iterator i = begin(); i != end(); ++i)
 		if (id == *i) return i;
 	return end();
 }

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -163,8 +163,7 @@
 { \
 	Vocab vocab(get_param_vocab()); \
 	Vocab::const_iterator viter; \
-	for(viter=vocab.begin();viter!=vocab.end();viter++) \
-	{ \
+	for (viter = vocab.begin(); viter != vocab.end(); ++viter) { \
 		ValueBase v=get_param(viter->get_name()); \
 		v.set_static(viter->get_static()); \
 		set_param(viter->get_name(), v); \

--- a/synfig-core/src/synfig/layers/layer_mime.cpp
+++ b/synfig-core/src/synfig/layers/layer_mime.cpp
@@ -120,8 +120,7 @@ Layer_Mime::get_param_vocab()const
 
 	// Construct the vocabulary from the stored
 	// parameters
-	for(iter=param_list.begin();iter!=param_list.end();iter++)
-	{
+	for (iter = param_list.begin(); iter != param_list.end(); ++iter) {
 		// Make sure that we don't add the version
 		// into the vocabulary
 		if(iter->first!="Version")

--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -249,10 +249,8 @@ xmlpp::Element* encode_dash_item(xmlpp::Element* root, DashItem dash_item)
 xmlpp::Element* encode_gradient(xmlpp::Element* root,Gradient x)
 {
 	root->set_name("gradient");
-	Gradient::const_iterator iter;
 	x.sort();
-	for(iter=x.begin();iter!=x.end();iter++)
-	{
+	for (Gradient::const_iterator iter = x.begin(); iter != x.end(); ++iter) {
 		xmlpp::Element *cpoint(encode_color(root->add_child("color"),iter->color));
 		cpoint->set_attribute("pos",strprintf("%f",iter->pos));
 	}
@@ -677,10 +675,9 @@ xmlpp::Element* encode_linkable_value_node(xmlpp::Element* root,LinkableValueNod
 
 	root->set_attribute("type",value_node->get_type().description.name);
 
-	int i;
 	synfig::ParamVocab child_vocab(value_node->get_children_vocab());
 	synfig::ParamVocab::iterator iter(child_vocab.begin());
-	for(i=0;i<value_node->link_count();i++, iter++)
+	for (int i = 0; i < value_node->link_count(); ++i, ++iter)
 	{
 		// printf("saving link %d : %s\n", i, value_node->link_local_name(i).c_str());
 		ValueNode::ConstHandle link=value_node->get_link(i).constant();

--- a/synfig-core/src/synfig/valuenodes/valuenode_animatedinterface.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_animatedinterface.cpp
@@ -217,10 +217,8 @@ clamped_tangent<Gradient>(Gradient p1, Gradient p2, Gradient p3, Time t1, Time t
 {
 	Color c1, c2, c3;
 	Gradient::CPoint cp;
-	Gradient::const_iterator iter;
 	Gradient ret;
-	for(iter=p2.begin();iter!=p2.end();iter++)
-	{
+	for (Gradient::const_iterator iter = p2.begin(); iter != p2.end(); ++iter) {
 		cp=*iter;
 		c1=p1(cp.pos);
 		c2=cp.color;
@@ -1090,11 +1088,12 @@ ValueNode_AnimatedInterfaceConst::waypoint_is_only_use_of_valuenode(Waypoint &wa
 	assert(value_node);
 	WaypointList wp_list(waypoint_list());
 	WaypointList::iterator iter;
-	for (iter = wp_list.begin(); iter != wp_list.end(); iter++)
+	for (iter = wp_list.begin(); iter != wp_list.end(); ++iter) {
 		if (*iter == waypoint)
 			continue;
 		else if (iter->get_value_node() == value_node)
 			return false;
+	}
 	return true;
 }
 

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3638,7 +3638,7 @@ App::dialog_sets_entry(const std::string &action, const std::string &content, st
 	m_refTreeModel = Gtk::TreeStore::create(m_columns);
 	combo_entry->set_model(m_refTreeModel);
 
-	for(std::set<std::string>::iterator i = available_sets.begin(); i != available_sets.end(); i++){
+	for (std::set<std::string>::iterator i = available_sets.begin(); i != available_sets.end(); ++i) {
 		Gtk::TreeModel::Row row = *(m_refTreeModel->append());
 		row[m_columns.entry_set_name] = *i;
 	}

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -373,7 +373,7 @@ CellRenderer_ValueBase::render_vfunc(
 				enum_list = ((synfig::ParamDesc) property_child_param_desc_).get_enum_list();
 
 			std::list<synfig::ParamDesc::EnumData>::iterator iter;
-			for (iter = enum_list.begin(); iter != enum_list.end(); iter++)
+			for (iter = enum_list.begin(); iter != enum_list.end(); ++iter) {
 				if (iter->value == data.get(int()))
 				{
 					// don't show the key_board s_hortcut under_scores
@@ -385,6 +385,7 @@ CellRenderer_ValueBase::render_vfunc(
 						property_text() = local_name;
 					break;
 				}
+			}
 		}
 	}
 	else

--- a/synfig-studio/src/gui/docks/dockmanager.cpp
+++ b/synfig-studio/src/gui/docks/dockmanager.cpp
@@ -755,8 +755,7 @@ Gtk::Widget* DockManager::load_widget_from_string(const std::string &x)
 std::string DockManager::save_layout_to_string()
 {
 	std::string res;
-	for(std::list<DockDialog*>::iterator i = dock_dialog_list_.begin(); i != dock_dialog_list_.end(); i++)
-	{
+	for (std::list<DockDialog*>::iterator i = dock_dialog_list_.begin(); i != dock_dialog_list_.end(); ++i) {
 		write_widget(res, *i);
 		write_separator(res);
 	}

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -105,8 +105,7 @@ RenderSettings::RenderSettings(Gtk::Window& parent, etl::handle<synfigapp::Canva
 	target_names.push_back(String());
 	synfig::Target::Book::iterator iter;
 	synfig::Target::Book book(synfig::Target::book());
-	for(iter=book.begin();iter!=book.end();iter++)
-	{
+	for (iter = book.begin(); iter != book.end(); ++iter) {
 		comboboxtext_target.append(iter->first);
 		target_names.push_back(iter->first);
 	}

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -1735,7 +1735,7 @@ StateBLine_Context::bline_insert_vertex(synfig::ValueNode_Const::Handle value_no
 {
 	std::list<ValueNode_Const::Handle>::iterator iter;
 
-	for(iter=bline_point_list.begin();iter!=bline_point_list.end();++iter)
+	for (iter = bline_point_list.begin(); iter != bline_point_list.end(); ++iter) {
 		if(*iter==value_node)
 		{
 			BLinePoint bline_point;
@@ -1748,7 +1748,7 @@ StateBLine_Context::bline_insert_vertex(synfig::ValueNode_Const::Handle value_no
 				assert(loop_);
 				prev = bline_point_list.end();
 			}
-			prev--;
+			--prev;
 
 			prev_bline_point=(*prev)->get_value().get(BLinePoint());
 
@@ -1768,6 +1768,7 @@ StateBLine_Context::bline_insert_vertex(synfig::ValueNode_Const::Handle value_no
 
 			break;
 		}
+	}
 
 	if(iter==bline_point_list.end())
 	{

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -1989,7 +1989,8 @@ StateDraw_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real 
 			done=true;
 
 			std::list<synfigapp::ValueDesc>::iterator prev,next;
-			prev=vertex_list.end();prev--;	// Set prev to the last ValueDesc
+			prev=vertex_list.end();
+			--prev;	// Set prev to the last ValueDesc
 			next=vertex_list.begin();
 			iter=next++; // Set iter to the first value desc, and next to the second
 

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -1912,7 +1912,8 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 			done=true;
 
 			std::list<synfigapp::ValueDesc>::iterator prev,next;
-			prev=vertex_list.end();prev--;	// Set prev to the last ValueDesc
+			prev=vertex_list.end();
+			--prev;	// Set prev to the last ValueDesc
 			next=vertex_list.begin();
 			iter=next++; // Set iter to the first value desc, and next to the second
 
@@ -2140,8 +2141,7 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 		value_node_bline=ValueNode_BLine::create();
 
 		std::list<synfigapp::ValueDesc>::iterator iter;
-		for(iter=vertex_list.begin();iter!=vertex_list.end();++iter)
-		{
+		for (iter = vertex_list.begin(); iter != vertex_list.end(); ++iter) {
 			// Ensure that the vertex is exported.
 			get_canvas_interface()->auto_export(*iter);
 
@@ -2220,8 +2220,7 @@ StateLasso_Context::refresh_ducks()
 
 	std::list<std::shared_ptr<std::list<synfig::Point>>>::iterator iter;
 
-	for(iter=stroke_list.begin();iter!=stroke_list.end();++iter)
-	{
+	for (iter = stroke_list.begin(); iter != stroke_list.end(); ++iter) {
 		get_work_area()->add_stroke(*iter);
 	}
 
@@ -2273,7 +2272,7 @@ StateLasso_Context::extend_bline_from_begin(ValueNode_BLine::Handle value_node,s
 			std::list<synfig::WidthPoint> old_wplist;
 			ValueBase wplist_value_base((*wplist_value_node)(get_canvas()->get_time()));
 			const ValueBase::List &wplist_value_base_list = wplist_value_base.get_list();
-			for(ValueBase::List::const_iterator i = wplist_value_base_list.begin(); i != wplist_value_base_list.end(); ++i)
+			for (ValueBase::List::const_iterator i = wplist_value_base_list.begin(); i != wplist_value_base_list.end(); ++i)
 				old_wplist.push_back(i->get(synfig::WidthPoint()));
 			std::list<synfig::WidthPoint>::iterator witer;
 			int i;
@@ -2385,8 +2384,7 @@ StateLasso_Context::extend_bline_from_begin(ValueNode_BLine::Handle value_node,s
 	}
 
 	std::list<synfig::BLinePoint>::reverse_iterator iter;
-	for(iter=bline.rbegin();!(iter==bline.rend());++iter)
-	{
+	for (iter = bline.rbegin(); iter != bline.rend(); ++iter) {
 		ValueNode_Composite::Handle composite(ValueNode_Composite::create(*iter));
 
 		synfigapp::Action::Handle action(synfigapp::Action::create("ValueNodeDynamicListInsert"));
@@ -2454,7 +2452,7 @@ StateLasso_Context::extend_bline_from_end(ValueNode_BLine::Handle value_node,std
 			std::list<synfig::WidthPoint> old_wplist;
 			ValueBase wplist_value_base((*wplist_value_node)(get_canvas()->get_time()));
 			const ValueBase::List &wplist_value_base_list = wplist_value_base.get_list();
-			for(ValueBase::List::const_iterator i = wplist_value_base_list.begin(); i != wplist_value_base_list.end(); ++i)
+			for (ValueBase::List::const_iterator i = wplist_value_base_list.begin(); i != wplist_value_base_list.end(); ++i)
 				old_wplist.push_back(i->get(synfig::WidthPoint()));
 			std::list<synfig::WidthPoint>::iterator witer;
 			int i;
@@ -2566,8 +2564,7 @@ StateLasso_Context::extend_bline_from_end(ValueNode_BLine::Handle value_node,std
 	}
 
 	std::list<synfig::BLinePoint>::iterator iter;
-	for(iter=bline.begin();iter!=bline.end();++iter)
-	{
+	for (iter = bline.begin(); iter != bline.end(); ++iter) {
 		ValueNode_Composite::Handle composite(ValueNode_Composite::create(*iter));
 
 		synfigapp::Action::Handle action(synfigapp::Action::create("ValueNodeDynamicListInsert"));

--- a/synfig-studio/src/gui/trees/keyframetreestore.cpp
+++ b/synfig-studio/src/gui/trees/keyframetreestore.cpp
@@ -665,7 +665,7 @@ KeyframeTreeStore::get_value_vfunc (const Gtk::TreeModel::iterator& gtk_iter, in
 		synfig::Keyframe keyframe;
 		{
 			KeyframeList::iterator tmp(iter->iter);
-			tmp++;
+			++tmp;
 			if(tmp==get_canvas()->keyframe_list().end())
 			{
 				x.set(Time(0));

--- a/synfig-studio/src/gui/trees/layerparamtreestore.cpp
+++ b/synfig-studio/src/gui/trees/layerparamtreestore.cpp
@@ -241,9 +241,7 @@ LayerParamTreeStore::set_value_impl(const Gtk::TreeModel::iterator& iter, int co
 				LayerList mylist(layer_list);
 				LayerList::iterator iter2(mylist.begin());
 
-				//for(;iter2!=layer_list.end();++iter2)
-				for(;iter2!=mylist.end();iter2++)
-				{
+				for ( ; iter2 != mylist.end(); ++iter2) {
 					if(!canvas_interface()->change_value(synfigapp::ValueDesc(*iter2,param_desc.get_name()),x.get()))
 					{
 						// ERROR!
@@ -348,7 +346,7 @@ LayerParamTreeStore::rebuild()
 			ParamVocab x = layer_n->get_param_vocab();
 			ParamVocab::iterator iter;
 
-			for(iter=vocab.begin();iter!=vocab.end();++iter)
+			for (iter = vocab.begin(); iter != vocab.end(); ++iter)
 			{
 				String name(iter->get_name());
 				ParamVocab::iterator iter2(find_param_desc(x,name));
@@ -358,7 +356,7 @@ LayerParamTreeStore::rebuild()
 					// remove it and start over
 					vocab.erase(iter);
 					iter=vocab.begin();
-					iter--;
+					--iter;
 					continue;
 				}
 			}

--- a/synfig-studio/src/gui/trees/layertreestore.cpp
+++ b/synfig-studio/src/gui/trees/layertreestore.cpp
@@ -740,11 +740,11 @@ LayerTreeStore::rebuild()
 
 	// disconnect any subcanvas_changed connections
 	std::map<synfig::Layer::Handle, sigc::connection>::iterator iter;
-	for (iter = subcanvas_changed_connections.begin(); iter != subcanvas_changed_connections.end(); iter++)
+	for (iter = subcanvas_changed_connections.begin(); iter != subcanvas_changed_connections.end(); ++iter)
 		iter->second.disconnect();
 	subcanvas_changed_connections.clear();
 
-	for (iter = switch_changed_connections.begin(); iter != switch_changed_connections.end(); iter++)
+	for (iter = switch_changed_connections.begin(); iter != switch_changed_connections.end(); ++iter)
 		iter->second.disconnect();
 	switch_changed_connections.clear();
 
@@ -1079,7 +1079,7 @@ LayerTreeStore::on_layer_lowered(synfig::Layer::Handle layer)
 		// Save the selection data
 		//synfigapp::SelectionManager::LayerList layer_list=canvas_interface()->get_selection_manager()->get_selected_layers();
 		iter2=iter;
-		iter2++;
+		++iter2;
 		if(!iter2 || RECORD_TYPE_LAYER != (*iter2)[model.record_type])
 		{
 			rebuild();
@@ -1115,7 +1115,7 @@ LayerTreeStore::on_layer_raised(synfig::Layer::Handle layer)
 			synfig::Layer::Handle layer2=row2[model.layer];
 
 			erase(iter2);
-			iter++;
+			++iter;
 			row2=*insert(iter);
 			set_row_layer(row2,layer2);
 

--- a/synfig-studio/src/gui/widgets/widget_bonechooser.cpp
+++ b/synfig-studio/src/gui/widgets/widget_bonechooser.cpp
@@ -114,8 +114,7 @@ Widget_BoneChooser::set_value(synfig::ValueNode_Bone::Handle data)
 			append(_("<None>"));
 		}
 
-		for (ValueNode_Bone::BoneSet::iterator iter=parent_set.begin(); iter!=parent_set.end(); iter++)
-		{
+		for (ValueNode_Bone::BoneSet::iterator iter = parent_set.begin(); iter != parent_set.end(); ++iter) {
 			ValueNode_Bone::Handle bone_value_node(*iter);
 
 			String label((*(bone_value_node->get_link("name")))(time).get(String()));

--- a/synfig-studio/src/gui/widgets/widget_canvaschooser.cpp
+++ b/synfig-studio/src/gui/widgets/widget_canvaschooser.cpp
@@ -91,7 +91,6 @@ Widget_CanvasChooser::set_value(synfig::Canvas::Handle data)
 	assert(parent_canvas);
 	canvas=data;
 
-	synfig::Canvas::Children::iterator iter;
 	synfig::Canvas::Children &children(parent_canvas->children());
 	String label;
 
@@ -106,13 +105,14 @@ Widget_CanvasChooser::set_value(synfig::Canvas::Handle data)
 		append(label);
 	}
 
-	for(iter=children.begin();iter!=children.end();iter++)
+	for (synfig::Canvas::Children::iterator iter = children.begin(); iter != children.end(); ++iter) {
 		if(*iter!=canvas)
 		{
 			label=(*iter)->get_name().empty()?(*iter)->get_id():(*iter)->get_name();
 			canvases.push_back(*iter);
 			append(label);
 		}
+	}
 
 	append(_("Other..."));
 

--- a/synfig-studio/src/gui/widgets/widget_enum.cpp
+++ b/synfig-studio/src/gui/widgets/widget_enum.cpp
@@ -84,12 +84,11 @@ Widget_Enum::set_param_desc(const synfig::ParamDesc &x)
 	std::list<synfig::ParamDesc::EnumData> enum_list=param_desc.get_enum_list();
 	std::list<synfig::ParamDesc::EnumData>::iterator iter;
 	// Fill the combo with the values
-	for(iter=enum_list.begin();iter!=enum_list.end();iter++)
-		{
-			Gtk::TreeModel::Row row = *(enum_TreeModel->append());
-			row[enum_model.value] = iter->value;
-			row[enum_model.local_name] = iter->local_name;
-		}
+	for (iter = enum_list.begin(); iter != enum_list.end(); ++iter) {
+		Gtk::TreeModel::Row row = *(enum_TreeModel->append());
+		row[enum_model.value] = iter->value;
+		row[enum_model.local_name] = iter->local_name;
+	}
 	refresh();
 }
 
@@ -109,7 +108,7 @@ Widget_Enum::refresh()
 {
 	typedef Gtk::TreeModel::Children type_children;
 	type_children children = enum_TreeModel->children();
-	for(type_children::iterator iter = children.begin();
+	for (type_children::iterator iter = children.begin();
 		iter != children.end(); ++iter)
 	{
 		Gtk::TreeModel::Row row = *iter;

--- a/synfig-studio/src/synfigapp/actions/layerfit.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerfit.cpp
@@ -83,7 +83,7 @@ Action::LayerFit::is_candidate(const ParamList &x)
 {
 	if (!candidate_check(get_param_vocab(),x))
 		return false;
-	for(ParamList::const_iterator i = x.begin(); i != x.end(); i++) {
+	for (ParamList::const_iterator i = x.begin(); i != x.end(); ++i) {
 		if (i->first == "layer") {
 			if (i->second.get_type() != Param::TYPE_LAYER) return false;
 			const Layer::Handle layer = i->second.get_layer();

--- a/synfig-studio/src/synfigapp/actions/valuedescset.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescset.cpp
@@ -928,8 +928,7 @@ Action::ValueDescSet::prepare()
 					}
 
 					synfig::ValueNode_Animated::WaypointList::const_iterator iter;
-					for(iter=animated->waypoint_list().begin(); iter<animated->waypoint_list().end(); iter++)
-					{
+					for (iter = animated->waypoint_list().begin(); iter < animated->waypoint_list().end(); ++iter) {
 						waypoint=*iter;
 						ValueBase waypoint_value(waypoint.get_value());
 						if (type == type_integer)

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -369,7 +369,7 @@ CanvasInterface::layer_set_defaults(const synfig::Layer::Handle &layer)
 							}
 						}
 					}
-					for (iter2 = list.begin(); iter2 != list.end(); iter2++)
+					for (iter2 = list.begin(); iter2 != list.end(); ++iter2)
 						if (iter2->get_type() != type_width_point)
 							break;
 					if (iter2 == list.end())
@@ -377,7 +377,7 @@ CanvasInterface::layer_set_defaults(const synfig::Layer::Handle &layer)
 						value_node=ValueNodeRegistry::create("wplist",iter->second);
 						ValueNode_WPList::Handle::cast_dynamic(value_node)->set_member_canvas(canvas);
 					}
-					for (iter2 = list.begin(); iter2 != list.end(); iter2++)
+					for (iter2 = list.begin(); iter2 != list.end(); ++iter2)
 						if (iter2->get_type() != type_dash_item)
 							break;
 					if (iter2 == list.end())
@@ -583,8 +583,7 @@ CanvasInterface::generate_param_list(const std::list<synfigapp::ValueDesc> &valu
 	param_list.add("canvas",get_canvas());
 
 	std::list<synfigapp::ValueDesc>::const_iterator iter;
-	for(iter=value_desc_list.begin();iter!=value_desc_list.end();++iter)
-	{
+	for (iter = value_desc_list.begin(); iter != value_desc_list.end(); ++iter) {
 		param_list.add("value_desc",*iter);
 		if(iter->is_value_node())
 		{
@@ -1388,9 +1387,7 @@ _process_value_desc(const synfigapp::ValueDesc& value_desc,std::vector<synfigapp
 			}
 			// Process the linkable ValueNode's children
 			LinkableValueNode::Handle value_node_copy(LinkableValueNode::Handle::cast_dynamic(value_node));
-			int i;
-			for(i=0;i<value_node_copy->link_count();i++)
-			{
+			for (int i = 0; i < value_node_copy->link_count(); i++) {
 				ValueNode::Handle link(value_node_copy->get_link(i));
 				if(!link->is_exported())
 					ret+=_process_value_desc(ValueDesc(value_node_copy,i),out,guid_set);
@@ -1423,8 +1420,7 @@ CanvasInterface::find_important_value_descs(synfig::Canvas::Handle canvas,std::v
 
 	IndependentContext iter;
 
-	for(iter=canvas->get_independent_context();iter!=canvas->end();++iter)
-	{
+	for (iter = canvas->get_independent_context(); iter != canvas->end(); ++iter) {
 		Layer::Handle layer(*iter);
 
 		Layer::DynamicParamList::const_iterator iter;

--- a/synfig-studio/src/synfigapp/inputdevice.cpp
+++ b/synfig-studio/src/synfigapp/inputdevice.cpp
@@ -132,7 +132,7 @@ public:
 		std::vector<InputDevice::AxisUse> axes = input_device->get_axes();
 		value = strprintf("%zu", axes.size());
 		std::vector<InputDevice::AxisUse>::const_iterator itr;
-		for (itr = axes.begin(); itr != axes.end(); itr++)
+		for (itr = axes.begin(); itr != axes.end(); ++itr)
 			value += strprintf(" %u", (unsigned int) *itr);
 	}
 
@@ -141,7 +141,7 @@ public:
 		std::vector<InputDevice::DeviceKey> keys = input_device->get_keys();
 		value = strprintf("%zu", keys.size());
 		std::vector<InputDevice::DeviceKey>::const_iterator itr;
-		for (itr = keys.begin(); itr != keys.end(); itr++)
+		for (itr = keys.begin(); itr != keys.end(); ++itr)
 			value += strprintf(" %u %u", itr->keyval, itr->modifiers);
 	}
 

--- a/synfig-studio/src/synfigapp/vectorizer/centerlineskeletonizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlineskeletonizer.cpp
@@ -837,7 +837,7 @@ inline void Event::calculateSplitEvent()
   for (i = 0; i < activeTable.m_columns.size(); ++i) 
   {
     for (currentContour = activeTable[i]->begin();
-         currentContour != activeTable[i]->end(); currentContour++) 
+		 currentContour != activeTable[i]->end(); ++currentContour)
     {
       // Da spostare sopra il 2o for
       if (activeTable.m_identifiers[(*currentContour)->m_ancestorContour] !=


### PR DESCRIPTION
And prefer the style of the `for` loop as discussed in the forums https://forums.synfig.org/t/trying-to-define-our-code-style/13097.
```c++
for (int a = 0; a < 30; ++a) {
}
```
(spaces surrounding operators, spaces before `(` and after and `;`, and bracket layout)