### PR TITLE
refactor: brush size increase/decrease buttons now use theme icons

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_defaults.cpp
+++ b/synfig-studio/src/gui/widgets/widget_defaults.cpp
@@ -36,6 +36,7 @@
 
 #include <gui/widgets/widget_defaults.h>
 
+#include <gtkmm/icontheme.h>
 #include <gtkmm/stylecontext.h>
 #include <gtkmm/toolitem.h>
 #include <gtkmm/toolitemgroup.h>
@@ -254,13 +255,23 @@ Widget_Defaults::Widget_Defaults():
 	widget_brush->set_size_request(56, 48);
 	widget_brush->set_tooltip_text(_("Brush Preview"));
 
-	brush_increase = Gtk::manage(new class Gtk::Button("+"));
+	const auto icon_theme = Gtk::IconTheme::get_default();
+
+	brush_increase = Gtk::manage(new Gtk::Button());
+	if (icon_theme->has_icon("brush_size_increase_icon"))
+		brush_increase->set_image_from_icon_name("brush_size_increase_icon", iconsize);
+	else
+		brush_increase->set_label("+");
 	brush_increase->set_tooltip_text(_("Increase brush size"));
 	brush_increase->set_relief(Gtk::RELIEF_NONE);
 	brush_increase->set_border_width(0);
 	brush_increase->signal_clicked().connect(sigc::mem_fun(*this,&studio::Widget_Defaults::on_brush_increase_clicked));
 
-	brush_decrease = Gtk::manage(new class Gtk::Button("-"));
+	brush_decrease = Gtk::manage(new Gtk::Button());
+	if (icon_theme->has_icon("brush_size_decrease_icon"))
+		brush_decrease->set_image_from_icon_name("brush_size_decrease_icon", iconsize);
+	else
+		brush_decrease->set_label("-");
 	brush_decrease->set_tooltip_text(_("Decrease brush size"));
 	brush_decrease->set_relief(Gtk::RELIEF_NONE);
 	brush_decrease->set_border_width(0);


### PR DESCRIPTION
As we don't have any specific icon for these actions, we use current +/- signs as fallback if icons do not exist in current icon theme

Requested-by: pablogil in https://forums.synfig.org/t/help-code-changes-in-order-to-add-an-icon/13585/19