### PR TITLE
feat: allow to change resource filepath in Canvas Dependencies dialog

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3625,7 +3625,8 @@ CanvasView::show_dependencies() const
 		synfig::warning("Can't load Dialog_CanvasDependencies");
 		return;
 	}
-	dialog->set_canvas(get_canvas());
+	dialog->set_modal();
+	dialog->set_canvas_interface(canvas_interface_);
 	dialog->run();
 	delete dialog;
 }

--- a/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.cpp
@@ -327,7 +327,7 @@ void Dialog_CanvasDependencies::refresh()
 				missing->set_halign(Gtk::ALIGN_END);
 			}
 			auto label = Gtk::manage(new Gtk::Label());
-			label->set_markup(strprintf(_("%s\t<small>(%d references)</small>"), filename.c_str(), pair.second.total));
+			label->set_markup(strprintf(_n("%s\t<small>(%d reference)</small>", "%s\t<small>(%d references)</small>", pair.second.total), filename.c_str(), pair.second.total));
 			label->set_halign(Gtk::ALIGN_START);
 			label->set_hexpand(true);
 			box->pack_start(*label);

--- a/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.cpp
@@ -34,6 +34,8 @@
 
 #include <gui/dialogs/dialog_canvasdependencies.h>
 
+#include <glibmm/fileutils.h>
+
 #include <gtkmm/label.h>
 #include <gtkmm/treeview.h>
 
@@ -211,6 +213,7 @@ void Dialog_CanvasDependencies::refresh()
 			auto filename = CanvasFileNaming::make_short_filename(canvas->get_file_name(), pair.first);
 			row->set_value(0, filename);
 			row->set_value(1, pair.second.total);
+			row->set_value(3, !Glib::file_test(pair.first, Glib::FILE_TEST_EXISTS | Glib::FILE_TEST_IS_REGULAR));
 			for (const auto &vn_pair : pair.second.per_valuenode) {
 				if (vn_pair.first->get_id().empty())
 					continue;
@@ -218,6 +221,7 @@ void Dialog_CanvasDependencies::refresh()
 				child->set_value(0, vn_pair.first->get_id());
 				child->set_value(1, vn_pair.second);
 				child->set_value(2, get_tree_pixbuf(vn_pair.first->get_type()));
+				child->set_value(3, false);
 			}
 		}
 	}
@@ -245,6 +249,7 @@ void Dialog_CanvasDependencies::refresh()
 			else if (std::find(lipsync_ext.begin(), lipsync_ext.end(), ext) != lipsync_ext.end())
 				pixbuf = get_tree_pixbuf_layer("text");
 			row->set_value(2, pixbuf);
+			row->set_value(3, !Glib::file_test(pair.first, Glib::FILE_TEST_EXISTS | Glib::FILE_TEST_IS_REGULAR));
 		}
 	}
 }

--- a/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.h
+++ b/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.h
@@ -72,6 +72,8 @@ public:
 
 private:
 	void refresh();
+
+	void on_replace_button_pressed(const synfig::filesystem::Path& filename, const std::map<std::pair<synfig::Layer::LooseHandle, std::string>, int>& parameter_list, int is_dynamic);
 };
 
 };

--- a/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.h
+++ b/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.h
@@ -33,9 +33,11 @@
 
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
+#include <gtkmm/listbox.h>
+#include <gtkmm/liststore.h>
 #include <gtkmm/treestore.h>
 
-#include <synfig/canvas.h>
+#include <synfigapp/canvasinterface.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -54,17 +56,19 @@ class Dialog_CanvasDependencies : public Gtk::Dialog
 	const Glib::RefPtr<Gtk::Builder> builder;
 
 	Glib::RefPtr<Gtk::TreeStore> external_canvas_model;
-	Glib::RefPtr<Gtk::TreeStore> external_resource_model;
-	Gtk::Label * canvas_filepath_label;
+	Glib::RefPtr<Gtk::ListStore> external_resource_model;
+	Gtk::Label* canvas_filepath_label;
+	Gtk::ListBox* resources_listbox;
 
 	synfig::Canvas::Handle canvas;
+	etl::handle<synfigapp::CanvasInterface> canvas_interface;
 
 public:
 	Dialog_CanvasDependencies(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& refGlade);
-	static Dialog_CanvasDependencies * create(Gtk::Window& parent);
+	static Dialog_CanvasDependencies* create(Gtk::Window& parent);
 	virtual ~Dialog_CanvasDependencies();
 
-	void set_canvas(synfig::Canvas::Handle canvas);
+	void set_canvas_interface(etl::handle<synfigapp::CanvasInterface> canvas_interface);
 
 private:
 	void refresh();

--- a/synfig-studio/src/gui/localization.h
+++ b/synfig-studio/src/gui/localization.h
@@ -40,9 +40,11 @@
 #define _(x) gettext(x)
 #define gettext_noop(x) x
 #define N_(x) gettext_noop(x)
+#define _n(x,y,n) ngettext(x, y, n)
 #else
 #define _(x) (x)
 #define N_(x) (x)
+#define _n(x,y,n) (y)
 #endif
 
 /* === T Y P E D E F S ===================================================== */

--- a/synfig-studio/src/gui/resources/ui/dialog_canvasdependencies.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_canvasdependencies.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 
+<!-- Generated with glade 3.40.0 
 
 Copyright (C) Synfig Contributors
 
@@ -32,18 +32,6 @@ Author: Rodolfo Ribeiro Gomes
       <!-- column-name File -->
       <column type="gchararray"/>
       <!-- column-name Dependency_Number -->
-      <column type="gint"/>
-      <!-- column-name Type_Icon -->
-      <column type="GdkPixbuf"/>
-      <!-- column-name Exists -->
-      <column type="gboolean"/>
-    </columns>
-  </object>
-  <object class="GtkTreeStore" id="external_resources_treestore">
-    <columns>
-      <!-- column-name File -->
-      <column type="gchararray"/>
-      <!-- column-name Usage_Number -->
       <column type="gint"/>
       <!-- column-name Type_Icon -->
       <column type="GdkPixbuf"/>
@@ -216,64 +204,16 @@ Author: Rodolfo Ribeiro Gomes
             <property name="can-focus">True</property>
             <property name="shadow-type">in</property>
             <child>
-              <object class="GtkTreeView" id="external_resources_treeview">
+              <object class="GtkViewport">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="model">external_resources_treestore</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection"/>
-                </child>
+                <property name="can-focus">False</property>
                 <child>
-                  <object class="GtkTreeViewColumn" id="filename_column">
-                    <property name="resizable">True</property>
-                    <property name="title" translatable="yes">Filename</property>
-                    <property name="expand">True</property>
-                    <property name="alignment">0.5</property>
-                    <property name="reorderable">True</property>
-                    <property name="sort-indicator">True</property>
-                    <property name="sort-column-id">0</property>
-                    <child>
-                      <object class="GtkCellRendererPixbuf"/>
-                      <attributes>
-                        <attribute name="pixbuf">2</attribute>
-                      </attributes>
-                    </child>
-                    <child>
-                      <object class="GtkCellRendererText">
-                        <property name="ellipsize">start</property>
-                      </object>
-                      <attributes>
-                        <attribute name="text">0</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkTreeViewColumn">
-                    <property name="sizing">fixed</property>
-                    <property name="title" translatable="yes">Usage</property>
-                    <property name="alignment">0.5</property>
-                    <property name="reorderable">True</property>
-                    <property name="sort-indicator">True</property>
-                    <property name="sort-column-id">1</property>
-                    <child>
-                      <object class="GtkCellRendererText"/>
-                      <attributes>
-                        <attribute name="text">1</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkTreeViewColumn">
-                    <property name="title" translatable="yes">Status</property>
-                    <child>
-                      <object class="GtkCellRendererPixbuf">
-                        <property name="icon-name">image-missing</property>
-                      </object>
-                      <attributes>
-                        <attribute name="visible">3</attribute>
-                      </attributes>
+                  <object class="GtkListBox" id="external_resources_listbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="activate-on-single-click">False</property>
+                    <child type="placeholder">
+                      <placeholder/>
                     </child>
                   </object>
                 </child>
@@ -283,10 +223,22 @@ Author: Rodolfo Ribeiro Gomes
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkListStore" id="external_resources_liststore">
+    <columns>
+      <!-- column-name File -->
+      <column type="gchararray"/>
+      <!-- column-name Usage_Number -->
+      <column type="gint"/>
+      <!-- column-name Type_Icon -->
+      <column type="GdkPixbuf"/>
+      <!-- column-name Exists -->
+      <column type="gboolean"/>
+    </columns>
   </object>
 </interface>

--- a/synfig-studio/src/gui/resources/ui/dialog_canvasdependencies.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_canvasdependencies.glade
@@ -35,6 +35,8 @@ Author: Rodolfo Ribeiro Gomes
       <column type="gint"/>
       <!-- column-name Type_Icon -->
       <column type="GdkPixbuf"/>
+      <!-- column-name Exists -->
+      <column type="gboolean"/>
     </columns>
   </object>
   <object class="GtkTreeStore" id="external_resources_treestore">
@@ -45,6 +47,8 @@ Author: Rodolfo Ribeiro Gomes
       <column type="gint"/>
       <!-- column-name Type_Icon -->
       <column type="GdkPixbuf"/>
+      <!-- column-name Exists -->
+      <column type="gboolean"/>
     </columns>
   </object>
   <object class="GtkDialog" id="dialog_canvasdependencies">
@@ -169,6 +173,19 @@ Author: Rodolfo Ribeiro Gomes
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkTreeViewColumn">
+                    <property name="title" translatable="yes">Status</property>
+                    <child>
+                      <object class="GtkCellRendererPixbuf">
+                        <property name="icon-name">image-missing</property>
+                      </object>
+                      <attributes>
+                        <attribute name="visible">3</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
           </object>
@@ -243,6 +260,19 @@ Author: Rodolfo Ribeiro Gomes
                       <object class="GtkCellRendererText"/>
                       <attributes>
                         <attribute name="text">1</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkTreeViewColumn">
+                    <property name="title" translatable="yes">Status</property>
+                    <child>
+                      <object class="GtkCellRendererPixbuf">
+                        <property name="icon-name">image-missing</property>
+                      </object>
+                      <attributes>
+                        <attribute name="visible">3</attribute>
                       </attributes>
                     </child>
                   </object>


### PR DESCRIPTION
For now, it won't work on animated valuenodes or any other value node type. User is warned on those cases and no action is performed.