### PR TITLE
fix: make delete icon name independent of old Gtk

### DIFF
--- a/synfig-studio/src/gui/docks/dock_metadata.cpp
+++ b/synfig-studio/src/gui/docks/dock_metadata.cpp
@@ -77,9 +77,9 @@ Dock_MetaData::Dock_MetaData():
 		)
 	);
 
-	action_group->add(Gtk::Action::create(
+	action_group->add(Gtk::Action::create_with_icon_name(
 		"action-MetadataRemove",
-		Gtk::StockID("gtk-delete"),
+		"edit-delete",
 		_("Remove selected MetaData entry"),
 		_("Remove the selected MetaData entry")
 	),

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -453,7 +453,7 @@ studio::get_action_icon_name(const synfigapp::Action::BookEntry& action)
 	const std::map<std::string, std::string> action_icon_map = {
 		{"add",         "list-add"},
 		{"insert",      "list-add"},
-		{"remove",      "gtk-delete"},
+		{"remove",      "edit-delete"},
 		{"connect",     "gtk-connect"},
 		{"disconnect",  "gtk-disconnect"},
 		{"raise",       "go-up"},

--- a/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
@@ -104,7 +104,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="workspaces_delete_button">
-                    <property name="label">gtk-delete</property>
+                    <property name="label">edit-delete</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>


### PR DESCRIPTION
reported-by: pablogil

fix #3116 