### PR TITLE
fix: allow multiple layer selection for tools

### DIFF
--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -1378,7 +1378,7 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 			}
 
 			if (Layer::Handle layer = get_canvas()->find_layer(get_canvas_view()->get_context_params(), mouse_pos)) {
-				if (canvas_view->get_smach().process_event(EventLayerClick(layer, BUTTON_RIGHT, mouse_pos)) == Smach::RESULT_OK)
+				if (canvas_view->get_smach().process_event(EventLayerClick(layer, BUTTON_RIGHT, mouse_pos, modifier)) == Smach::RESULT_OK)
 					return false;
 				return true;
 			}


### PR DESCRIPTION
"Fix" because from the code in select tool `event_layer_click`
```	case BUTTON_LEFT:
		if(!(event.modifier&Gdk::CONTROL_MASK))
			canvas_view_->get_selection_manager()->clear_selected_layers();
		if(event.layer)
		{
			std::list<Layer::Handle> layer_list(canvas_view_->get_selection_manager()->get_selected_layers());
			std::set<Layer::Handle> layers(layer_list.begin(),layer_list.end());
			if(layers.count(event.layer))
			{
				layers.erase(event.layer);
				layer_list=std::list<Layer::Handle>(layers.begin(),layers.end());
				canvas_view_->get_selection_manager()->clear_selected_layers();
				canvas_view_->get_selection_manager()->set_selected_layers(layer_list);
			}
			else
			{
				canvas_view_->get_selection_manager()->set_selected_layer(event.layer);
			}
		}
```

It is visible that it is inteded if control is pressed then multiple selection should be allowed.

Also according to the user documentation(link(https://wiki.synfig.org/Transform_tool) although I'm not sure if that page is up to date or no longer so) of the select tool:

"Clicking an object in the canvas window with the "Transform tool" selects it. You can select multiple objects by holding down the Control key and clicking on the additional objects."


There is a possiblity though that the modifier wasn't sent to the event_layer_click on purpose to "disable" multiple selection. But I don't think that was so and I don't see a reason really for that.


p.s, 
little sneak peak
[Screencast from 07-13-2023 08:59:12 AM.webm](https://github.com/synfig/synfig/assets/100296264/1bc34ace-6169-4cef-ab8a-508101d8e9a0)
