### PR TITLE
refactor: make argument name consistent in method declaration and definition

### DIFF
--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -91,7 +91,7 @@ public:
 	CanvasView::Handle canvas_view_;
 	bool use_magnitude;
 	DuckDrag_Rotate();
-	void begin_duck_drag(Duckmatic* duckmatic, const synfig::Vector& begin);
+	void begin_duck_drag(Duckmatic* duckmatic, const synfig::Vector& offset);
 	bool end_duck_drag(Duckmatic* duckmatic);
 	void duck_drag(Duckmatic* duckmatic, const synfig::Vector& vector);
 


### PR DESCRIPTION
Nothing major just something I noticed while going through this area.