### PR TITLE
refactor: remove unneeded variable in `state_normal.cpp`

### DIFF
--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -76,7 +76,6 @@ class DuckDrag_Combo : public DuckDrag_Base
 	synfig::Vector last_move;
 	synfig::Vector drag_offset;
 	synfig::Vector center;
-	synfig::Vector snap;
 
 	synfig::Angle original_angle;
 	synfig::Real original_mag;
@@ -355,11 +354,7 @@ DuckDrag_Combo::begin_duck_drag(Duckmatic* duckmatic, const synfig::Vector& offs
 
 	bad_drag=false;
 
-		drag_offset=duckmatic->find_duck(offset)->get_trans_point();
-
-		//snap=drag_offset-duckmatic->snap_point_to_grid(drag_offset);
-		//snap=offset-drag_offset_;
-		snap=Vector(0,0);
+	drag_offset=duckmatic->find_duck(offset)->get_trans_point();
 
 	// Calculate center
 	Point vmin(100000000,100000000);
@@ -406,9 +401,9 @@ DuckDrag_Combo::duck_drag(Duckmatic* duckmatic, const synfig::Vector& vector)
 
 	synfig::Vector vect;
 	if (move_only || (!scale && !rotate))
-		vect= duckmatic->snap_point_to_grid(vector)-drag_offset+snap;
+		vect= duckmatic->snap_point_to_grid(vector)-drag_offset;
 	else
-		vect= duckmatic->snap_point_to_grid(vector)-center+snap;
+		vect= duckmatic->snap_point_to_grid(vector)-center;
 
 	last_move=vect;
 


### PR DESCRIPTION
Seems it was previously used when the following lines were not commented
``` 
		//snap=drag_offset-duckmatic->snap_point_to_grid(drag_offset);
		//snap=offset-drag_offset_;
```
but now its value is always zero.