### PR TITLE
fix: tool tooltip didn't show the shortcut/hotkey

### DIFF
--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -215,8 +215,10 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 
 	Gtk::RadioToolButton *tool_button = manage(new Gtk::RadioToolButton());
 	tool_button->set_group(radio_tool_button_group);
-	tool_button->set_related_action(App::get_state_manager()->get_action_group()->get_action("state-"+name));
-	
+	Glib::RefPtr<Gtk::Action> related_action = App::get_state_manager()->get_action_group()->get_action("state-"+name);
+	tool_button->set_related_action(related_action);
+	related_action->property_tooltip() = "";
+
 	// Keeps updating the tooltip if user changes the shortcut at runtime
 	tool_button->property_has_tooltip() = true;
 	tool_button->signal_query_tooltip().connect([name](int,int,bool,const Glib::RefPtr<Gtk::Tooltip>& tooltip) -> bool

--- a/synfig-studio/src/gui/statemanager.cpp
+++ b/synfig-studio/src/gui/statemanager.cpp
@@ -92,7 +92,7 @@ StateManager::add_state(const Smach::state_base *state)
 			"state-"+name,
 			state_icon_name(name),
 			stock_item.get_label(),
-			stock_item.get_label()
+			""
 		)
 	);
 	/*action->set_sensitive(false);*/


### PR DESCRIPTION
After commit 4e7a9f38a008d2ff4ebf70ebd465d12aecc27fe6 (PR #3109)

If set, related action tooltip overrides the query_tooltip slot.

(regression from #3066)