### PR TITLE
refactor: replaced Gtk::StockID in tool labels with custom implementation

### DIFF
--- a/synfig-studio/src/gui/_smach.h
+++ b/synfig-studio/src/gui/_smach.h
@@ -41,6 +41,8 @@
 
 #include <synfig/misc.h>
 
+#include <gui/localization.h>
+
 /* === M A C R O S ========================================================= */
 
 #define SMACH_STATE_STACK_SIZE		(32)
@@ -164,7 +166,8 @@ public:
 
 		virtual event_result process_event(void* state_context,const event& id)const=0;
 
-		virtual const char *get_name() const=0;
+		virtual const char* get_name() const = 0;
+		virtual const char* get_local_name() const = 0;
 	};
 
 	//! State class
@@ -183,16 +186,17 @@ public:
 
 		std::vector<event_def> event_list;
 
-		smach *nested;		//! Nested machine
-		event_key low,high;	//! Lowest and Highest event values
-		const char *name;	//! Name of the state
-		typename event_def::funcptr default_handler;	//! Default handler for unknown key
+		smach* nested;                               /*!< Nested machine */
+		event_key low, high;                         /*!< Lowest and Highest event values */
+		const char* name;                            /*!< Name of the state */
+		const char* local_name_;                     /*!< Local name (used by GUI) */
+		typename event_def::funcptr default_handler; /*!< Default handler for unknown key */
 
 	public:
 
 		//! Constructor
-		state(const char* n, smach* nest = nullptr)
-		    : nested(nest), name(n), default_handler(nullptr)
+		state(const char* n, const char* local_name, smach* nest = nullptr)
+			: nested(nest), name(n), local_name_(local_name), default_handler(nullptr)
 		{ }
 
 		virtual ~state() { }
@@ -204,8 +208,11 @@ public:
 		//! Sets the default handler
 		void set_default_handler(const typename event_def::funcptr &x) { default_handler=x; }
 
-		//! Returns given the name of the state
-		virtual const char *get_name() const { return name; }
+		//! Returns the name of the state
+		const char* get_name() const override { return name; }
+
+		//! Returns the localized name of the state
+		const char* get_local_name() const override { return _(local_name_); }
 
 		//! Adds an event_def onto the list and then make sure it is sorted correctly.
 		void

--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -221,26 +221,19 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 
 	// Keeps updating the tooltip if user changes the shortcut at runtime
 	tool_button->property_has_tooltip() = true;
-	tool_button->signal_query_tooltip().connect([name](int,int,bool,const Glib::RefPtr<Gtk::Tooltip>& tooltip) -> bool
+	tool_button->signal_query_tooltip().connect([state](int,int,bool,const Glib::RefPtr<Gtk::Tooltip>& tooltip) -> bool
 	{
-		Gtk::StockItem stock_item;
-		if (Gtk::Stock::lookup(Gtk::StockID("synfig-"+name), stock_item)) {
-			std::string tooltip_string = stock_item.get_label();
+		std::string tooltip_string = state->get_local_name();
 
-			Gtk::AccelKey key;
-			if (Gtk::AccelMap::lookup_entry("<Actions>/action_group_state_manager/state-" + name, key)) {
-				tooltip_string += "  ";
-				tooltip_string += gtk_accelerator_get_label(key.get_key(), GdkModifierType(key.get_mod()));
-			}
-
-			tooltip->set_text(tooltip_string);
-		} else {
-			synfig::warning("There is no StockItem named 'synfig-%s", name.c_str());
+		Gtk::AccelKey key;
+		if (Gtk::AccelMap::lookup_entry(std::string("<Actions>/action_group_state_manager/state-") + state->get_name(), key)) {
+			tooltip_string += "  ";
+			tooltip_string += gtk_accelerator_get_label(key.get_key(), GdkModifierType(key.get_mod()));
 		}
-
+		tooltip->set_text(tooltip_string);
 		return true;
 	});
-
+//	tool_button->set_tooltip_text(get_tooltip(name));
 	tool_button->show();
 
 	tool_item_group->insert(*tool_button);

--- a/synfig-studio/src/gui/statemanager.cpp
+++ b/synfig-studio/src/gui/statemanager.cpp
@@ -84,14 +84,11 @@ StateManager::add_state(const Smach::state_base *state)
 {
 	String name(state->get_name());
 
-	Gtk::StockItem stock_item;
-	Gtk::Stock::lookup(Gtk::StockID("synfig-"+name),stock_item);
-
 	Glib::RefPtr<Gtk::RadioAction> action(
 		Gtk::RadioAction::create_with_icon_name(radio_action_group,
 			"state-"+name,
 			state_icon_name(name),
-			stock_item.get_label(),
+			state->get_local_name(),
 			""
 		)
 	);

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -301,7 +301,7 @@ create_image_from_icon(const std::string& icon_name, Gtk::IconSize icon_size)
 /* === M E T H O D S ======================================================= */
 
 StateBLine::StateBLine():
-	Smach::state<StateBLine_Context>("bline")
+	Smach::state<StateBLine_Context>("bline", N_("Spline Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,		&StateBLine_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,						&StateBLine_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -215,7 +215,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateBone::StateBone() :
-	Smach::state<StateBone_Context>("bone")
+	Smach::state<StateBone_Context>("bone", N_("Skeleton Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,		&StateBone_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_REFRESH_DUCKS,				&StateBone_Context::event_hijack));

--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -232,7 +232,7 @@ const char * StateBrush_Context::BrushConfig::input_names[] = {
 
 
 StateBrush::StateBrush():
-	Smach::state<StateBrush_Context>("brush")
+	Smach::state<StateBrush_Context>("brush", N_("Brush Tool"))
 {
 	insert(event_def(EVENT_STOP,&StateBrush_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateBrush_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -276,7 +276,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateCircle::StateCircle():
-	Smach::state<StateCircle_Context>("circle")
+	Smach::state<StateCircle_Context>("circle", N_("Circle Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateCircle_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StateCircle_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -342,7 +342,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateDraw::StateDraw():
-	Smach::state<StateDraw_Context>("draw")
+	Smach::state<StateDraw_Context>("draw", N_("Draw Tool"))
 {
 	insert(event_def(EVENT_STOP,&StateDraw_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateDraw_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_eyedrop.cpp
+++ b/synfig-studio/src/gui/states/state_eyedrop.cpp
@@ -90,7 +90,7 @@ StateEyedrop studio::state_eyedrop;
 /* === M E T H O D S ======================================================= */
 
 StateEyedrop::StateEyedrop():
-	Smach::state<StateEyedrop_Context>("eyedrop")
+	Smach::state<StateEyedrop_Context>("eyedrop", N_("Eyedropper Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateEyedrop_Context::event_stop_handler));
 	insert(event_def(EVENT_STOP,&StateEyedrop_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_fill.cpp
+++ b/synfig-studio/src/gui/states/state_fill.cpp
@@ -91,7 +91,7 @@ StateFill studio::state_fill;
 /* === M E T H O D S ======================================================= */
 
 StateFill::StateFill():
-	Smach::state<StateFill_Context>("fill")
+	Smach::state<StateFill_Context>("fill", N_("Fill Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateFill_Context::event_stop_handler));
 	insert(event_def(EVENT_STOP,&StateFill_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -213,7 +213,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateGradient::StateGradient():
-	Smach::state<StateGradient_Context>("gradient")
+	Smach::state<StateGradient_Context>("gradient", N_("Gradient Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateGradient_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StateGradient_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -347,7 +347,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateLasso::StateLasso():
-	Smach::state<StateLasso_Context>("lasso")
+	Smach::state<StateLasso_Context>("lasso", N_("Cutout Tool"))
 {
 	insert(event_def(EVENT_STOP,&StateLasso_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateLasso_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_mirror.cpp
+++ b/synfig-studio/src/gui/states/state_mirror.cpp
@@ -144,7 +144,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateMirror::StateMirror():
-	Smach::state<StateMirror_Context>("mirror")
+	Smach::state<StateMirror_Context>("mirror", N_("Mirror Tool"))
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateMirror_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateMirror_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -203,7 +203,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateNormal::StateNormal():
-	Smach::state<StateNormal_Context>("normal")
+	Smach::state<StateNormal_Context>("normal", N_("Transform Tool"))
 {
 	insert(event_def(EVENT_STOP,&StateNormal_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateNormal_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -247,7 +247,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StatePolygon::StatePolygon():
-	Smach::state<StatePolygon_Context>("polygon")
+	Smach::state<StatePolygon_Context>("polygon", N_("Polygon Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StatePolygon_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StatePolygon_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -257,7 +257,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateRectangle::StateRectangle():
-	Smach::state<StateRectangle_Context>("rectangle")
+	Smach::state<StateRectangle_Context>("rectangle", N_("Rectangle Tool"))
 {
 	insert(event_def(EVENT_STOP,&StateRectangle_Context::event_stop_handler));
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateRectangle_Context::event_layer_selection_changed_handler));

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -143,7 +143,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateRotate::StateRotate():
-	Smach::state<StateRotate_Context>("rotate")
+	Smach::state<StateRotate_Context>("rotate", N_("Rotate Tool"))
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateRotate_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateRotate_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -132,7 +132,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateScale::StateScale():
-	Smach::state<StateScale_Context>("scale")
+	Smach::state<StateScale_Context>("scale", N_("Scale Tool"))
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateScale_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateScale_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -125,7 +125,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateSketch::StateSketch():
-	Smach::state<StateSketch_Context>("sketch")
+	Smach::state<StateSketch_Context>("sketch", N_("Sketch Tool"))
 {
 	insert(event_def(EVENT_STOP,&StateSketch_Context::event_stop_handler));
 	//insert(event_def(EVENT_REFRESH,&StateSketch_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -138,7 +138,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateSmoothMove::StateSmoothMove():
-	Smach::state<StateSmoothMove_Context>("smooth_move")
+	Smach::state<StateSmoothMove_Context>("smooth_move", N_("Smooth Move Tool"))
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateSmoothMove_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateSmoothMove_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -309,7 +309,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateStar::StateStar():
-	Smach::state<StateStar_Context>("star")
+	Smach::state<StateStar_Context>("star", N_("Star Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateStar_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StateStar_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_stroke.cpp
+++ b/synfig-studio/src/gui/states/state_stroke.cpp
@@ -99,7 +99,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateStroke::StateStroke():
-	Smach::state<StateStroke_Context>("stroke")
+	Smach::state<StateStroke_Context>("stroke", "")
 {
 	insert(event_def(EVENT_STOP,&StateStroke_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateStroke_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -194,7 +194,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateText::StateText():
-	Smach::state<StateText_Context>("text")
+	Smach::state<StateText_Context>("text", N_("Text Tool"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateText_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StateText_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -152,7 +152,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateWidth::StateWidth():
-	Smach::state<StateWidth_Context>("width")
+	Smach::state<StateWidth_Context>("width", N_("Width Tool"))
 {
 	insert(event_def(EVENT_STOP,&StateWidth_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateWidth_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_zoom.cpp
+++ b/synfig-studio/src/gui/states/state_zoom.cpp
@@ -39,6 +39,7 @@
 #include <gui/canvasview.h>
 #include <gui/docks/dock_toolbox.h>
 #include <gui/event_mouse.h>
+#include <gui/localization.h>
 #include <gui/states/state_normal.h>
 #include <gui/workarea.h>
 
@@ -93,7 +94,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateZoom::StateZoom():
-	Smach::state<StateZoom_Context>("zoom")
+	Smach::state<StateZoom_Context>("zoom", N_("Zoom Tool"))
 {
 	insert(event_def(EVENT_STOP,&StateZoom_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateZoom_Context::event_refresh_handler));

--- a/synfig-studio/test/smach.cpp
+++ b/synfig-studio/test/smach.cpp
@@ -77,7 +77,7 @@ public:
 class DefaultState : public Smach::state<DefaultStateContext>
 {
 public:
-	DefaultState():Smach::state<DefaultStateContext>("DefaultState")
+	DefaultState():Smach::state<DefaultStateContext>("DefaultState", "Default")
 	{
 		insert(event_def(EVENT_1,&DefaultStateContext::event1_handler));
 	}
@@ -113,7 +113,7 @@ public:
 class State1 : public Smach::state<State1Context>
 {
 public:
-	State1():Smach::state<State1Context>("State1")
+	State1():Smach::state<State1Context>("State1", "State1")
 	{
 		insert(event_def(EVENT_1,&State1Context::event1_handler));
 		insert(event_def(EVENT_3,&State1Context::event3_handler));
@@ -154,7 +154,7 @@ public:
 class State2 : public Smach::state<State2Context>
 {
 public:
-	State2():Smach::state<State2Context>("State2")
+	State2():Smach::state<State2Context>("State2", "State2")
 	{
 		insert(event_def(EVENT_1,&State2Context::event1_handler));
 		insert(event_def(EVENT_2,&State2Context::event2_handler));


### PR DESCRIPTION
avoids Gtk::StockID