### PR TITLE
feat: add constrained rotation in rotate tool

### DIFF
--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -43,6 +43,7 @@
 #include <gui/duck.h>
 #include <gui/localization.h>
 #include <gui/workarea.h>
+#include <gui/event_keyboard.h>
 
 #include <synfig/angle.h>
 #include <synfig/general.h>
@@ -86,16 +87,19 @@ class DuckDrag_Rotate : public DuckDrag_Base
 
 	bool bad_drag;
 	bool move_only;
+	bool rotate;
 
 public:
 	CanvasView::Handle canvas_view_;
 	bool use_magnitude;
+	bool constrain;
 	DuckDrag_Rotate();
 	void begin_duck_drag(Duckmatic* duckmatic, const synfig::Vector& begin);
 	bool end_duck_drag(Duckmatic* duckmatic);
 	void duck_drag(Duckmatic* duckmatic, const synfig::Vector& vector);
 
 	etl::handle<synfigapp::CanvasInterface> get_canvas_interface()const{return canvas_view_->canvas_interface();}
+
 };
 
 
@@ -115,6 +119,13 @@ class studio::StateRotate_Context : public sigc::trackable
 	Gtk::CheckButton scale_checkbutton;
 	Gtk::Box scale_box;
 
+	bool shift_pressed;
+
+	void set_shift_pressed(bool value);
+
+	void set_constrain_flag(bool x) { if(duck_dragger_ && x!=duck_dragger_->constrain)
+										  {duck_dragger_->constrain=x;} }
+
 public:
 
 	bool get_scale_flag()const { return scale_checkbutton.get_active(); }
@@ -122,6 +133,8 @@ public:
 
 	Smach::event_result event_stop_handler(const Smach::event& x);
 	Smach::event_result event_refresh_tool_options(const Smach::event& x);
+	Smach::event_result event_key_down_handler(const Smach::event& x);
+	Smach::event_result event_key_up_handler(const Smach::event& x);
 
 	void refresh_tool_options();
 
@@ -147,6 +160,9 @@ StateRotate::StateRotate():
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateRotate_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateRotate_Context::event_stop_handler));
+	insert(event_def(EVENT_WORKAREA_KEY_DOWN,&StateRotate_Context::event_key_down_handler));
+	insert(event_def(EVENT_WORKAREA_KEY_UP,&StateRotate_Context::event_key_up_handler));
+
 }
 
 StateRotate::~StateRotate()
@@ -188,7 +204,8 @@ StateRotate_Context::StateRotate_Context(CanvasView* canvas_view):
 	canvas_view_(canvas_view),
 	is_working(*canvas_view),
 	settings(synfigapp::Main::get_selected_input_device()->settings()),
-	duck_dragger_(new DuckDrag_Rotate())
+	duck_dragger_(new DuckDrag_Rotate()),
+	shift_pressed()
 {
 	duck_dragger_->canvas_view_=get_canvas_view();
 
@@ -254,6 +271,48 @@ StateRotate_Context::event_refresh_tool_options(const Smach::event& /*x*/)
 }
 
 Smach::event_result
+StateRotate_Context::event_key_down_handler(const Smach::event &x)
+{
+	const EventKeyboard& event(*reinterpret_cast<const EventKeyboard*>(&x));
+	switch(event.keyval)
+	{
+	case GDK_KEY_Shift_L:
+	case GDK_KEY_Shift_R:
+		set_shift_pressed(true);
+		break;
+	default:
+		set_shift_pressed(event.modifier&GDK_SHIFT_MASK);
+		break;
+	}
+	return Smach::RESULT_OK;
+
+}
+
+Smach::event_result
+StateRotate_Context::event_key_up_handler(const Smach::event &x)
+{
+	const EventKeyboard& event(*reinterpret_cast<const EventKeyboard*>(&x));
+	switch(event.keyval)
+	{
+	case GDK_KEY_Shift_L:
+	case GDK_KEY_Shift_R:
+		set_shift_pressed(false);
+		break;
+	default:
+		break;
+	}
+	return Smach::RESULT_OK;
+
+}
+
+void StateRotate_Context::set_shift_pressed(bool value)
+{
+	if (shift_pressed == value) return;
+	shift_pressed = value;
+	set_constrain_flag(shift_pressed);
+}
+
+Smach::event_result
 StateRotate_Context::event_stop_handler(const Smach::event& /*x*/)
 {
 	canvas_view_->stop();
@@ -282,7 +341,8 @@ DuckDrag_Rotate::DuckDrag_Rotate():
 	original_mag(),
 	bad_drag(),
 	move_only(),
-	use_magnitude(true)
+	use_magnitude(true),
+	constrain()
 { }
 
 void
@@ -343,6 +403,8 @@ DuckDrag_Rotate::duck_drag(Duckmatic* duckmatic, const synfig::Vector& vector)
 		return;
 
 	//std::set<etl::handle<Duck> >::iterator iter;
+	duckmatic->set_axis_lock(false);
+
 	synfig::Vector vect(duckmatic->snap_point_to_grid(vector)-center+snap);
 
 	const DuckList selected_ducks(duckmatic->get_selected_ducks());
@@ -376,6 +438,13 @@ DuckDrag_Rotate::duck_drag(Duckmatic* duckmatic, const synfig::Vector& vector)
 
 	Angle::tan angle(vect[1],vect[0]);
 	angle=original_angle-angle;
+	if (constrain){
+		Angle::deg angleDeg(static_cast<Angle>(angle));
+		float degrees = angleDeg.get()/15;
+		angleDeg= Angle::deg(degrees>0?std::floor(degrees)*15:std::ceil(degrees)*15);
+		angle = Angle::tan(static_cast<Angle>(angleDeg));
+	}
+
 	Real mag(vect.mag()/original_mag);
 	Real sine(Angle::sin(angle).get());
 	Real cosine(Angle::cos(angle).get());


### PR DESCRIPTION
@rodolforg suggested I add constrained rotation in the select tool and I realized the rotate tool is missing it (although transform tool already has it) so I thought it wouldn't hurt to add it to the rotate tool as well.