### PR TITLE
refactor: add fallthrough mark in switch cases to avoid unneeded warning

### DIFF
--- a/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
@@ -65,6 +65,22 @@ using namespace synfig;
 
 /* === M A C R O S ========================================================= */
 
+#ifdef __has_cpp_attribute
+# if __has_cpp_attribute(fallthrough)
+#  define fallthrough__ [[fallthrough]]
+# elif __has_cpp_attribute(noreturn)
+[[noreturn]] void fake_fallthrough___() {}
+#  define fallthrough__ fake_falthrough___()
+# endif
+#endif
+#ifndef fallthrough__
+# if __has_attribute(__fallthrough__)
+#  define fallthrough__ __attribute__((__fallthrough__))
+#else
+# define fallthrough__ do {} while (0)  /* fallthrough */
+#endif
+#endif
+
 /* === G L O B A L S ======================================================= */
 
 SYNFIG_LAYER_INIT(Advanced_Outline);
@@ -385,12 +401,14 @@ namespace {
 						break;
 					case WidthPoint::TYPE_INNER_PEAK:
 						s = -1;
+						fallthrough__;
 					case WidthPoint::TYPE_PEAK:
 						dst.move_to( Vector(i->first - s*i->second.w, 0) );
 						dst.line_to( Vector(i->first, i->second.w ) );
 						break;
 					case WidthPoint::TYPE_INNER_ROUNDED:
 						s = -1;
+						fallthrough__;
 					case WidthPoint::TYPE_ROUNDED:
 						dst.move_to( Vector(i->first - s*i->second.w, 0) );
 						dst.conic_to(
@@ -434,12 +452,14 @@ namespace {
 						break;
 					case WidthPoint::TYPE_INNER_PEAK:
 						s = -1;
+						fallthrough__;
 					case WidthPoint::TYPE_PEAK:
 						dst.line_to( Vector(i->first + s*i->second.w, 0) );
 						dst.close_mirrored_vert();
 						break;
 					case WidthPoint::TYPE_INNER_ROUNDED:
 						s = -1;
+						fallthrough__;
 					case WidthPoint::TYPE_ROUNDED:
 						dst.conic_to(
 							Vector(i->first + s*i->second.w*round_k0, i->second.w*round_k0),

--- a/synfig-core/src/synfig/rendering/primitive/contour.cpp
+++ b/synfig-core/src/synfig/rendering/primitive/contour.cpp
@@ -46,6 +46,22 @@ using namespace rendering;
 
 /* === M A C R O S ========================================================= */
 
+#ifdef __has_cpp_attribute
+# if __has_cpp_attribute(fallthrough)
+#  define fallthrough__ [[fallthrough]]
+# elif __has_cpp_attribute(noreturn)
+[[noreturn]] void fake_fallthrough___() {}
+#  define fallthrough__ fake_falthrough___()
+# endif
+#endif
+#ifndef fallthrough__
+# if __has_attribute(__fallthrough__)
+#  define fallthrough__ __attribute__((__fallthrough__))
+#else
+# define fallthrough__ do {} while (0)  /* fallthrough */
+#endif
+#endif
+
 /* === G L O B A L S ======================================================= */
 
 /* === P R O C E D U R E S ================================================= */
@@ -550,12 +566,15 @@ Contour::calc_bounds() const
 		switch(i->type) {
 		case CUBIC:
 			bounds.expand(i->pp1);
+			fallthrough__;
 		case CONIC:
 			bounds.expand(i->pp0);
+			fallthrough__;
 		case CLOSE:
 		case MOVE:
 		case LINE:
 			bounds.expand(i->p1);
+			fallthrough__;
 		default:
 			break;
 		}
@@ -571,12 +590,15 @@ Contour::calc_bounds(const Matrix &transform_matrix) const
 		switch(i->type) {
 		case CUBIC:
 			bounds.expand( transform_matrix.get_transformed(i->pp1) );
+			fallthrough__;
 		case CONIC:
 			bounds.expand( transform_matrix.get_transformed(i->pp0) );
+			fallthrough__;
 		case CLOSE:
 		case MOVE:
 		case LINE:
 			bounds.expand( transform_matrix.get_transformed(i->p1) );
+			fallthrough__;
 		default:
 			break;
 		}

--- a/synfig-studio/src/gui/dialogs/canvasresize.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasresize.cpp
@@ -47,6 +47,26 @@
 using namespace studio;
 using namespace synfig;
 
+/* === M A C R O S ========================================================= */
+
+#ifdef __has_cpp_attribute
+# if __has_cpp_attribute(fallthrough)
+#  define fallthrough__ [[fallthrough]]
+# elif __has_cpp_attribute(noreturn)
+[[noreturn]] void fake_fallthrough___() {}
+#  define fallthrough__ fake_falthrough___()
+# endif
+#endif
+#ifndef fallthrough__
+# if __has_attribute(__fallthrough__)
+#  define fallthrough__ __attribute__((__fallthrough__))
+#else
+# define fallthrough__ do {} while (0)  /* fallthrough */
+#endif
+#endif
+
+/* === M E T H O D S ======================================================= */
+
 CanvasResize::CanvasResize(Gtk::Window &parent, etl::handle<synfigapp::CanvasInterface> &ci, CanvasProperties &cp)
 	: Gtk::Dialog       ("", parent)
 	, canvas_interface  (ci)
@@ -187,6 +207,7 @@ void CanvasResize::on_action_signal_response(int response_id)
 	switch (response_id) {
 	case ADVANCED:
 		canvas_properties.present();
+		fallthrough__;
 	case CANCEL:
 	case CLOSE:
 		is_image_checked = was_image_checked;


### PR DESCRIPTION
and let us see only the valid warnings ;)

C++17 added the [[fallthrough]] attribute.
As we stick with C++11 for now, I made alternative ways I find out here: 
https://en.cppreference.com/w/cpp/feature_test
https://stackoverflow.com/questions/45129741/gcc-7-wimplicit-fallthrough-warnings-and-portable-way-to-clear-them/52707279#52707279
https://stackoverflow.com/questions/44511436/how-to-do-an-explicit-fall-through-in-c