### PR TITLE
perf: optimize `set_time` method

### DIFF
--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -610,8 +610,31 @@ Layer::set_time(IndependentContext context, Time time)
 	Layer::ParamList params;
 	Layer::DynamicParamList::const_iterator iter;
 	// For each parameter of the layer sets the value by the operator()(time)
-	for (iter = dynamic_param_list().begin(); iter != dynamic_param_list().end(); ++iter)
-		params[iter->first]=(*iter->second)(time);
+	for (iter = dynamic_param_list().begin(); iter != dynamic_param_list().end(); ++iter){
+		bool paramInMap = parameter_cache.find(iter->first) != parameter_cache.end();
+
+		//if parameter has changed remove it from the parameter list
+		if(paramInMap && iter->second->valueNodeChanged){
+			parameter_cache.erase(iter->first);
+		}
+
+		if (iter->second->valueNodeChanged)
+			iter->second->valueNodeChanged = false;
+
+		if(iter->first != "bline"){
+			//if this time is alread cached
+			if(paramInMap && parameter_cache[iter->first].find(time.get_string()) !=
+							  (parameter_cache[iter->first]).end()){
+				params[iter->first]=(parameter_cache[iter->first])[time.get_string()];
+			} else {
+				(parameter_cache[iter->first])[time.get_string()] = (*iter->second)(time);
+				params[iter->first]=(parameter_cache[iter->first])[time.get_string()];
+			}
+		} else{
+			params[iter->first]=(*iter->second)(time);
+		}
+	}
+
 	// Sets the modified parameter list to the current context layer
 	const_cast<Layer*>(this)->set_param_list(params);
 

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -33,6 +33,7 @@
 /* === H E A D E R S ======================================================= */
 
 #include <map>
+#include <unordered_map>
 
 #include <ETL/handle>
 
@@ -318,6 +319,8 @@ private:
 	void on_file_changed(const Glib::RefPtr<Gio::File>&, const Glib::RefPtr<Gio::File>&, Gio::FileMonitorEvent);
 	sigc::connection monitor_connection;
 	std::string monitored_path;
+
+	std::unordered_map<std::string, std::unordered_map<std::string, ValueBase>> parameter_cache;
 public:
 	bool monitor(const std::string& path); // append file monitor (returns true on success, false on fail)
 

--- a/synfig-core/src/synfig/valuenode.cpp
+++ b/synfig-core/src/synfig/valuenode.cpp
@@ -71,7 +71,7 @@ ValueNode::breakpoint()
 	return;
 }
 
-ValueNode::ValueNode(Type &type):type(&type)
+ValueNode::ValueNode(Type &type):type(&type), valueNodeChanged(true)
 {
 	value_node_count++;
 }

--- a/synfig-core/src/synfig/valuenode.h
+++ b/synfig-core/src/synfig/valuenode.h
@@ -115,6 +115,9 @@ public:
 
 	static void breakpoint();
 
+	//! used for valuenode caching
+	bool valueNodeChanged;
+
 	/*
  --	** -- D A T A -------------------------------------------------------------
 	*/

--- a/synfig-studio/src/synfigapp/actions/valuedescset.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescset.cpp
@@ -876,6 +876,7 @@ Action::ValueDescSet::prepare()
 		action->set_param("waypoint",waypoint);
 		if(!action->is_ready())
 			throw Error(Error::TYPE_NOTREADY);
+		value_node->valueNodeChanged = true;
 		add_action(action);
 		return;
 	}
@@ -893,6 +894,7 @@ Action::ValueDescSet::prepare()
 				if(!action->is_ready())
 					throw Error(Error::TYPE_NOTREADY);
 				add_action_front(action);
+				value_node->valueNodeChanged = true;
 				return;
 			}
 			else
@@ -954,6 +956,8 @@ Action::ValueDescSet::prepare()
 						action->set_param("waypoint",waypoint);
 						if(!action->is_ready())
 							throw Error(Error::TYPE_NOTREADY);
+						value_node->valueNodeChanged = true;
+
 						add_action(action);
 					}
 					return;


### PR DESCRIPTION
**Brief:** 

This is one of the parts in my project that was included but in a bit of a different manner. So basically what was agreed on was that since this "optimization" could possibly not have much improvement, then it would be done if it is found to have improvement. 

So basically right now I'm thinking of which ways would be best to test the performance here to see the effect of this optimization. If you have any ideas/suggestions it would be great if you can share them :).

**Feature brief:**

So basically the whole idea is that the 'set_time' method does some "redundant" calculations. Basically whenever the time we are at changes (or change a parameter) 'set_time' is called on each layer and then each layer recalulates all its (animated) values at the current time.

So for example if in our canvas we have 10 layers and in the animation each of the ten layers has origin, color, and radius parameters that are animated then when the animation is playing at each frame the current of value of these parameters is calculated according to the rule set for them (from the valuenodes () operator). Now with the current caching already in place (green stuff) that only happens the first time it is played. If you play for a second time without changing anything no problem is present and nothing is recalculated.

The problem comes when any parameter of any of the layers changes. For example if we only change the color of one of the layers then instead of (what this optimization does) recalculating only these new color values. Everything is recalculated.

However of course now the important question which comes up that would sort of only be answered by doing tests/benchmarks is that if retrieving the cached value from the map would be faster than simply recalculating the value.

If we talk theory then for the unordered map we are using 
>Average case: constant.
>Worst case: linear in container size

And for recalculating the value. We could say (at least as a general statement I haven't looked too deeply into each valuenodes oprator () overload) that it is always constant in time. However what we kind of want to figure out is how much this time is, and if it would be faster/slower than using a cache. 