### PR TITLE
refactor: add missing fallthrough mark in other switch cases

### DIFF
--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -40,7 +40,6 @@
 
 #include "blur.h"
 
-#include "general.h"
 #include <synfig/localization.h>
 
 #endif
@@ -50,6 +49,22 @@
 using namespace synfig;
 
 /* === M A C R O S ========================================================= */
+
+#ifdef __has_cpp_attribute
+# if __has_cpp_attribute(fallthrough)
+#  define fallthrough__ [[fallthrough]]
+# elif __has_cpp_attribute(noreturn)
+[[noreturn]] void fake_fallthrough___() {}
+#  define fallthrough__ fake_falthrough___()
+# endif
+#endif
+#ifndef fallthrough__
+# if __has_attribute(__fallthrough__)
+#  define fallthrough__ __attribute__((__fallthrough__))
+#else
+# define fallthrough__ do {} while (0)  /* fallthrough */
+#endif
+#endif
 
 /* === G L O B A L S ======================================================= */
 
@@ -378,6 +393,7 @@ bool Blur::operator()(const Surface &surface,
 			}
 
 			//if we don't qualify for disc blur just use box blur
+			fallthrough__;
 		}
 
 	case Blur::BOX: // B O X -------------------------------------------------------
@@ -778,6 +794,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			}
 
 			//if we don't qualify for disc blur just use box blur
+			fallthrough__;
 		}
 
 	case Blur::BOX: // B O X -------------------------------------------------------


### PR DESCRIPTION
...to avoid unneeded warning

PR #3143 (655a04290fba9f439eae14848ee571ba97e39941) missed them. My bad.