### PR TITLE
feat: double clicking guides opens edit dialog

### DIFF
--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -1190,6 +1190,11 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 					}
 				}
 			}
+			if(guide_highlighted){	
+				guide_dialog.show();
+				guide_dialog.set_current_guide(curr_guide);
+				return true;
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
as requested in issue  [#3084](https://github.com/synfig/synfig/issues/3084) 