### PR TITLE
fix: brush tool crashes synfig if no layer is selected in the dialog

### DIFF
--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -751,31 +751,34 @@ StateBrush_Context::event_mouse_down_handler(const Smach::event& x)
 			{
 				canvas_view_->add_layer("import");
 				selected_layer = canvas_view_->get_selection_manager()->get_selected_layer();
-				layer = Layer_Bitmap::Handle::cast_dynamic(selected_layer);
 
-				// Set temporary description to generate the name
-				String temp_description(_("brush image"));
-				layer->set_description(temp_description);
+				if (layer = Layer_Bitmap::Handle::cast_dynamic(selected_layer)){
+					// Set temporary description to generate the name
+					String temp_description(_("brush image"));
+					layer->set_description(temp_description);
 
-				if (selected_layer->get_param_list().count("filename") != 0)
-				{
-					// generate name based on description
-					String description, filename, filename_param;
-					get_canvas_interface()
-						->get_instance()
-						->generate_new_name(
-							layer,
-							description,
-							filename,
-							filename_param );
+					if (selected_layer->get_param_list().count("filename") != 0)
+					{
+						// generate name based on description
+						String description, filename, filename_param;
+						get_canvas_interface()
+							->get_instance()
+							->generate_new_name(
+								layer,
+								description,
+								filename,
+								filename_param );
 
-					// create and save surface
-					get_canvas_interface()
-						->get_instance()
-						->save_surface(layer->rendering_surface, filename);
+						// create and save surface
+						get_canvas_interface()
+							->get_instance()
+							->save_surface(layer->rendering_surface, filename);
 
-					selected_layer->set_param("filename", filename_param);
-					selected_layer->set_description(description);
+						selected_layer->set_param("filename", filename_param);
+						selected_layer->set_description(description);
+					}
+				} else {
+					return Smach::RESULT_ACCEPT;
 				}
 			}
 


### PR DESCRIPTION
Fixes one of the two issues in #1161

Opening brush tool and then clicking cancel in the file chooser dialog crashed Synfig (before this pr). The brush tool still crashes Synfig when used though on correct files I will work on that in another PR. 


Current state after fix:
[Screencast from 08-04-2023 06:00:38 PM.webm](https://github.com/synfig/synfig/assets/100296264/8e418927-d3c2-4ac3-a5a3-b7fdaa941651)
