### PR TITLE
feat: added path and button to open plugin folder in Preferences tab

### DIFF
--- a/synfig-studio/src/gui/dialogs/dialog_guide.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_guide.cpp
@@ -61,8 +61,8 @@ Dialog_Guide::Dialog_Guide(Gtk::Window& parent, etl::handle<synfig::Canvas> canv
 	canvas(canvas),
 	current_work_area(work_area),
 	angle_adjustment(Gtk::Adjustment::create(0,-2000000000,2000000000,1,1,0)),
-	x_adjustment(Gtk::Adjustment::create(0,-200,200,1,1,0)),
-	y_adjustment(Gtk::Adjustment::create(0,-200,200,1,1,0)),
+	x_adjustment(Gtk::Adjustment::create(0,-2000000000,2000000000,1,1,0)),
+	y_adjustment(Gtk::Adjustment::create(0,-2000000000,2000000000,1,1,0)),
 	degrees(true)
 {
 	this->set_resizable(false);
@@ -165,11 +165,12 @@ Dialog_Guide::on_ok_or_apply_pressed(bool ok)
 	} else if (!degrees && curr_guide->angle.get() != angle_widget->get_value()) {
 		curr_guide->angle = synfig::Angle::rad(angle_widget->get_value());
 	}
-	if(curr_guide->point[0] != x_widget->get_value()){
-		curr_guide->point[0] =  x_widget->get_value();
+
+	if(curr_guide->point[0] != (x_widget->get_value())/60){
+		curr_guide->point[0] =  (x_widget->get_value())/60;
 	}
-	if(curr_guide->point[1] != y_widget->get_value()){
-		curr_guide->point[1] =  y_widget->get_value();
+	if(curr_guide->point[1] != (y_widget->get_value())/60){
+		curr_guide->point[1] =  (y_widget->get_value())/60;
 	}
 	if (ok)
 		hide();
@@ -194,6 +195,6 @@ Dialog_Guide::init_widget_values()
 		angle_widget->set_value(synfig::Angle::deg(curr_guide->angle).get());
 	else
 		angle_widget->set_value(curr_guide->angle.get());
-	x_widget->set_value(curr_guide->point[0]); //needs proper formatting
-	y_widget->set_value(curr_guide->point[1]);
+	x_widget->set_value((curr_guide->point[0])*60);
+	y_widget->set_value(curr_guide->point[1]*60);
 }

--- a/synfig-studio/src/gui/dialogs/dialog_guide.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_guide.cpp
@@ -43,7 +43,7 @@
 #include <gui/workarea.h>
 #include <gui/duckmatic.h>
 #include <gui/app.h>
-#include <iostream>
+
 #endif
 
 using namespace synfig;
@@ -79,6 +79,7 @@ Dialog_Guide::Dialog_Guide(Gtk::Window& parent, etl::handle<synfig::Canvas> canv
 	(static_cast<Gtk::Label*>(angleFrame->get_label_widget()))->set_markup(_("<b>Rotate Guide</b>"));
 	angleFrame->set_margin_bottom(5);
 	angleFrame->set_margin_top(5);
+
 
 	auto guideGrid = manage(new Gtk::Grid());
 	guideGrid->get_style_context()->add_class("dialog-secondary-content");

--- a/synfig-studio/src/gui/dialogs/dialog_guide.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_guide.cpp
@@ -43,7 +43,7 @@
 #include <gui/workarea.h>
 #include <gui/duckmatic.h>
 #include <gui/app.h>
-
+#include <iostream>
 #endif
 
 using namespace synfig;
@@ -61,6 +61,8 @@ Dialog_Guide::Dialog_Guide(Gtk::Window& parent, etl::handle<synfig::Canvas> canv
 	canvas(canvas),
 	current_work_area(work_area),
 	angle_adjustment(Gtk::Adjustment::create(0,-2000000000,2000000000,1,1,0)),
+	x_adjustment(Gtk::Adjustment::create(0,-200,200,1,1,0)),
+	y_adjustment(Gtk::Adjustment::create(0,-200,200,1,1,0)),
 	degrees(true)
 {
 	this->set_resizable(false);
@@ -77,7 +79,6 @@ Dialog_Guide::Dialog_Guide(Gtk::Window& parent, etl::handle<synfig::Canvas> canv
 	(static_cast<Gtk::Label*>(angleFrame->get_label_widget()))->set_markup(_("<b>Rotate Guide</b>"));
 	angleFrame->set_margin_bottom(5);
 	angleFrame->set_margin_top(5);
-
 
 	auto guideGrid = manage(new Gtk::Grid());
 	guideGrid->get_style_context()->add_class("dialog-secondary-content");
@@ -96,8 +97,35 @@ Dialog_Guide::Dialog_Guide(Gtk::Window& parent, etl::handle<synfig::Canvas> canv
 	guideGrid->attach(*angle_widget      , 1, 0, 1, 1);
 	guideGrid->attach(angle_type_picker  , 2, 0, 1, 1);
 
+	Gtk::Frame* pivotFrame = manage(new Gtk::Frame(_("Set Pivot Position")));
+	pivotFrame->set_shadow_type(Gtk::SHADOW_NONE);
+	(static_cast<Gtk::Label*>(pivotFrame->get_label_widget()))->set_markup(_("<b>Set Pivot Position</b>"));
+	pivotFrame->set_margin_bottom(5);
+	pivotFrame->set_margin_top(5);
+	pivotFrame->set_margin_left(5);
+
+	auto posGrid = manage(new Gtk::Grid());
+	posGrid->get_style_context()->add_class("dialog-secondary-content");
+	posGrid->set_row_spacing(6);
+	posGrid->set_column_spacing(8);
+	
+
+	Gtk::Label* xPosLabel = manage(new Gtk::Label(_("_X:"), true));
+	Gtk::Label* yPosLabel = manage(new Gtk::Label(_("_Y:"), true));
+	x_widget=manage(new Gtk::SpinButton(x_adjustment,15,2));
+	x_widget->show();
+	y_widget=manage(new Gtk::SpinButton(y_adjustment,15,2));
+	y_widget->show();
+	
+	posGrid->attach(*xPosLabel, 0, 0, 1, 1);
+	posGrid->attach(*x_widget, 1,0,1,1);
+	posGrid->attach(*yPosLabel, 2, 0, 1, 1);
+	posGrid->attach(*y_widget, 3, 0, 1, 1);
+
 	guide_box->add(*angleFrame);
 	guide_box->add(*guideGrid);
+	guide_box->add(*pivotFrame);
+	guide_box->add(*posGrid);
 	guide_box->set_margin_bottom(5);
 
 	//Box end
@@ -136,7 +164,12 @@ Dialog_Guide::on_ok_or_apply_pressed(bool ok)
 	} else if (!degrees && curr_guide->angle.get() != angle_widget->get_value()) {
 		curr_guide->angle = synfig::Angle::rad(angle_widget->get_value());
 	}
-
+	if(curr_guide->point[0] != x_widget->get_value()){
+		curr_guide->point[0] =  x_widget->get_value();
+	}
+	if(curr_guide->point[1] != y_widget->get_value()){
+		curr_guide->point[1] =  y_widget->get_value();
+	}
 	if (ok)
 		hide();
 	else
@@ -160,4 +193,6 @@ Dialog_Guide::init_widget_values()
 		angle_widget->set_value(synfig::Angle::deg(curr_guide->angle).get());
 	else
 		angle_widget->set_value(curr_guide->angle.get());
+	x_widget->set_value(curr_guide->point[0]); //needs proper formatting
+	y_widget->set_value(curr_guide->point[1]);
 }

--- a/synfig-studio/src/gui/dialogs/dialog_guide.h
+++ b/synfig-studio/src/gui/dialogs/dialog_guide.h
@@ -62,6 +62,8 @@ class Dialog_Guide : public Gtk::Dialog
 	Gtk::SpinButton* x_widget;
 	Gtk::SpinButton* y_widget;
 	Glib::RefPtr<Gtk::Adjustment> angle_adjustment;
+	Glib::RefPtr<Gtk::Adjustment> x_adjustment;
+	Glib::RefPtr<Gtk::Adjustment> y_adjustment;
 
 	Gtk::ComboBoxText angle_type_picker;
 

--- a/synfig-studio/src/gui/dialogs/dialog_guide.h
+++ b/synfig-studio/src/gui/dialogs/dialog_guide.h
@@ -59,6 +59,8 @@ class Dialog_Guide : public Gtk::Dialog
 	WorkArea* current_work_area;
 
 	Gtk::SpinButton* angle_widget;
+	Gtk::SpinButton* x_widget;
+	Gtk::SpinButton* y_widget;
 	Glib::RefPtr<Gtk::Adjustment> angle_adjustment;
 
 	Gtk::ComboBoxText angle_type_picker;

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -106,6 +106,7 @@ class Dialog_Setup : public Dialog_Template
 	void on_preview_background_color_changed();
 	void on_brush_path_add_clicked();
 	void on_brush_path_remove_clicked();
+	void on_plugin_path_change_clicked();
 	void on_choose_editor_pressed();
 	bool select_path_dialog(const std::string &title, std::string &filename);
 
@@ -141,6 +142,8 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::Entry textbox_brushe_path;
 	Gtk::ListViewText* listviewtext_brushes_path;
 	Glib::RefPtr<Gtk::ListStore> brushpath_refmodel;
+
+	Gtk::Entry textbox_plugin_path;
 
 	Gtk::ComboBoxText* size_template_combo;
 	Gtk::ComboBoxText* fps_template_combo;


### PR DESCRIPTION
as requested in [#3119 ](https://github.com/synfig/synfig/issues/3119)
A path is displayed which is non-editable and a button which opens up a file explorer tab to the path.