### PR TITLE
fix: current time widget color in dark theme

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -2078,11 +2078,9 @@ CanvasView::on_time_changed()
 	{
 		KeyframeList::iterator iter;
 		if (get_canvas()->keyframe_list().find(time, iter)) {
-			current_time_widget->get_style_context()->remove_class("color-black");
 			current_time_widget->get_style_context()->add_class("color-red");
 		} else {
 			current_time_widget->get_style_context()->remove_class("color-red");
-			current_time_widget->get_style_context()->add_class("color-black");
 		}
 
 		// Shouldn't these trees just hook into

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -104,10 +104,6 @@
         color : #FF0000;
 }
 
-.color-black {
-        color : #000000;
-}
-
 .color-white {
         color : #FFFFFF;
 }


### PR DESCRIPTION
Before:
![image](https://github.com/synfig/synfig/assets/5604544/b03e69b0-dd0a-4181-87d0-8412d2bc07aa)


After:
![image](https://github.com/synfig/synfig/assets/5604544/ea2767b7-b6c7-4628-9620-a9a6ed16a10f)

fix: https://github.com/synfig/synfig/issues/3160