### PR TITLE
fix: build on Debian 9

### DIFF
--- a/synfig-core/src/synfig/filesystem_path.cpp
+++ b/synfig-core/src/synfig/filesystem_path.cpp
@@ -109,7 +109,7 @@ filesystem::Path::operator/=(const Path& p)
 		path_.erase(get_root_name_length());
 	else if (has_filename() || (!has_root_directory() && is_absolute()))
 		path_.push_back('/');
-	path_.append(p.path_, p.get_root_name_length());
+	path_.append(p.path_, p.get_root_name_length(), std::string::npos);
 	native_path_dirty_ = true;
 	return *this;
 }
@@ -368,7 +368,7 @@ filesystem::Path::lexically_relative(const Path& base) const
 	if (!p.empty() && a_pos < path_.length())
 		p += '/';
 	if (a_pos != std::string::npos)
-		p.append(path_, a_pos);
+		p.append(path_, a_pos, std::string::npos);
 	return Path(p);
 }
 


### PR DESCRIPTION
Currently it fails with error:
```
filesystem_path.cpp:371:24: error: no matching function for call to
'std::__cxx11::basic_string<char>::append(const string&, long unsigned int&)'
   p.append(path_, a_pos);
```