### PR TITLE
fix: wrong Copy and Cut icon names

### DIFF
--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -201,7 +201,7 @@ LayerActionManager::LayerActionManager():
 	);
 	action_copy_=Gtk::Action::create_with_icon_name(
 		"copy",
-		"gtk-copy", _("_Copy"), _("Copy")
+		"edit-copy", _("_Copy"), _("Copy")
 	);
 	action_copy_->signal_activate().connect(
 		sigc::mem_fun(

--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -191,7 +191,7 @@ LayerActionManager::LayerActionManager():
 {
 	action_cut_=Gtk::Action::create_with_icon_name(
 		"cut",
-		"edit-cut", _("_Cut"), _("Cut")
+		"edit-cut", _("Cu_t"), _("Cut")
 	);
 	action_cut_->signal_activate().connect(
 		sigc::mem_fun(

--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -191,7 +191,7 @@ LayerActionManager::LayerActionManager():
 {
 	action_cut_=Gtk::Action::create_with_icon_name(
 		"cut",
-		"edit-cut", _("Cu_t"), _("Cut")
+		"edit-cut", _("_Cut"), _("Cut")
 	);
 	action_cut_->signal_activate().connect(
 		sigc::mem_fun(


### PR DESCRIPTION
- Cut icon name had a minor typo
- Copy icon was referring to "gtk-copy" and it's not valid (at least in macOS), so I guess the correct one is "edit-copy" as happens with Cut and Paste ones.