### PR TITLE
refactor: remove unnecessary `const` in internal typedef

### DIFF
--- a/synfig-core/src/modules/mod_noise/valuenode_random.cpp
+++ b/synfig-core/src/modules/mod_noise/valuenode_random.cpp
@@ -116,7 +116,7 @@ ValueNode_Random::~ValueNode_Random()
 ValueBase
 ValueNode_Random::operator()(Time t)const
 {
-	typedef const RandomNoise::SmoothType Smooth;
+	typedef RandomNoise::SmoothType Smooth;
 
 	Real	radius	= (*radius_)(t).get(Real());
 	int		seed	= (*seed_)(t).get(int());


### PR DESCRIPTION
and prevents warning about it