### PR TITLE
fix: build on Debian 9

### DIFF
--- a/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
@@ -65,22 +65,21 @@ using namespace synfig;
 
 /* === M A C R O S ========================================================= */
 
-#ifdef __has_cpp_attribute
+#if defined(__has_cpp_attribute)
 # if __has_cpp_attribute(fallthrough)
 #  define fallthrough__ [[fallthrough]]
-# elif __has_cpp_attribute(noreturn)
-[[noreturn]] void fake_fallthrough___() {}
-#  define fallthrough__ fake_falthrough___()
 # endif
 #endif
-#ifndef fallthrough__
-# if __has_attribute(__fallthrough__)
-#  define fallthrough__ __attribute__((__fallthrough__))
-#else
-# define fallthrough__ do {} while (0)  /* fallthrough */
-#endif
-#endif
 
+#ifndef fallthrough__
+# if __GNUC__ >= 7
+#  define fallthrough__ __attribute__((fallthrough))
+# elif __clang__
+#  define fallthrough__ [[clang::fallthrough]]
+# else
+#  define fallthrough__ ((void)0)
+# endif
+#endif
 /* === G L O B A L S ======================================================= */
 
 SYNFIG_LAYER_INIT(Advanced_Outline);

--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -50,20 +50,20 @@ using namespace synfig;
 
 /* === M A C R O S ========================================================= */
 
-#ifdef __has_cpp_attribute
+#if defined(__has_cpp_attribute)
 # if __has_cpp_attribute(fallthrough)
 #  define fallthrough__ [[fallthrough]]
-# elif __has_cpp_attribute(noreturn)
-[[noreturn]] void fake_fallthrough___() {}
-#  define fallthrough__ fake_falthrough___()
 # endif
 #endif
+
 #ifndef fallthrough__
-# if __has_attribute(__fallthrough__)
-#  define fallthrough__ __attribute__((__fallthrough__))
-#else
-# define fallthrough__ do {} while (0)  /* fallthrough */
-#endif
+# if __GNUC__ >= 7
+#  define fallthrough__ __attribute__((fallthrough))
+# elif __clang__
+#  define fallthrough__ [[clang::fallthrough]]
+# else
+#  define fallthrough__ ((void)0)
+# endif
 #endif
 
 /* === G L O B A L S ======================================================= */

--- a/synfig-core/src/synfig/rendering/primitive/contour.cpp
+++ b/synfig-core/src/synfig/rendering/primitive/contour.cpp
@@ -46,22 +46,21 @@ using namespace rendering;
 
 /* === M A C R O S ========================================================= */
 
-#ifdef __has_cpp_attribute
+#if defined(__has_cpp_attribute)
 # if __has_cpp_attribute(fallthrough)
 #  define fallthrough__ [[fallthrough]]
-# elif __has_cpp_attribute(noreturn)
-[[noreturn]] void fake_fallthrough___() {}
-#  define fallthrough__ fake_falthrough___()
 # endif
 #endif
-#ifndef fallthrough__
-# if __has_attribute(__fallthrough__)
-#  define fallthrough__ __attribute__((__fallthrough__))
-#else
-# define fallthrough__ do {} while (0)  /* fallthrough */
-#endif
-#endif
 
+#ifndef fallthrough__
+# if __GNUC__ >= 7
+#  define fallthrough__ __attribute__((fallthrough))
+# elif __clang__
+#  define fallthrough__ [[clang::fallthrough]]
+# else
+#  define fallthrough__ ((void)0)
+# endif
+#endif
 /* === G L O B A L S ======================================================= */
 
 /* === P R O C E D U R E S ================================================= */

--- a/synfig-studio/src/gui/dialogs/canvasresize.cpp
+++ b/synfig-studio/src/gui/dialogs/canvasresize.cpp
@@ -49,20 +49,20 @@ using namespace synfig;
 
 /* === M A C R O S ========================================================= */
 
-#ifdef __has_cpp_attribute
+#if defined(__has_cpp_attribute)
 # if __has_cpp_attribute(fallthrough)
 #  define fallthrough__ [[fallthrough]]
-# elif __has_cpp_attribute(noreturn)
-[[noreturn]] void fake_fallthrough___() {}
-#  define fallthrough__ fake_falthrough___()
 # endif
 #endif
+
 #ifndef fallthrough__
-# if __has_attribute(__fallthrough__)
-#  define fallthrough__ __attribute__((__fallthrough__))
-#else
-# define fallthrough__ do {} while (0)  /* fallthrough */
-#endif
+# if __GNUC__ >= 7
+#  define fallthrough__ __attribute__((fallthrough))
+# elif __clang__
+#  define fallthrough__ [[clang::fallthrough]]
+# else
+#  define fallthrough__ ((void)0)
+# endif
 #endif
 
 /* === M E T H O D S ======================================================= */


### PR DESCRIPTION
Currently it fails with errors:
```
error: 'fake_falthrough___' was not declared in this scope
```
fixed misspelling

```
multiple definition of `fake_fallthrough___()'
```
made it static

```
warning: 'noreturn' function does return
```
if I understand correctly, `[[noreturn]]` marks functions which exits/interrupts/terminates program (but it not), so I replaced it with "inline"

fix #3185 