### PR TITLE
fix: revert Custom Workspaces Editor button labels to GTK ones

### DIFF
--- a/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
@@ -104,7 +104,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="workspaces_delete_button">
-                    <property name="label">gtk-delete</property>
+                    <property name="label" translatable="yes">_Delete</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
@@ -119,7 +119,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="workspaces_close_button">
-                    <property name="label">gtk-close</property>
+                    <property name="label" translatable="yes">_Close</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>

--- a/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_workspaces.glade
@@ -104,7 +104,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="workspaces_delete_button">
-                    <property name="label">edit-delete</property>
+                    <property name="label">gtk-delete</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
@@ -119,7 +119,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="workspaces_close_button">
-                    <property name="label">window-close</property>
+                    <property name="label">gtk-close</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>


### PR DESCRIPTION
Simple fix for https://github.com/synfig/synfig/issues/3174 as @rodolforg suggested.

Thanks