### PR TITLE
feat: added lock guides feature and button

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1285,6 +1285,19 @@ CanvasView::create_right_toolbar()
 		right_toolbar->append(*snap_guides);
 	}
 
+	{ // lock guide toggle button
+		lock_guides = Gtk::manage(new Gtk::ToggleToolButton());
+		lock_guides->set_active(work_area->get_lock_guides());
+		lock_guides->set_icon_name("show_guideline_icon");
+		lock_guides->signal_toggled().connect(
+			sigc::mem_fun(*this, &CanvasView::toggle_lock_guides));
+		lock_guides->set_label(_("Lock Guides"));
+		lock_guides->set_tooltip_text(_("Lock Guides when enabled"));
+		lock_guides->show();
+
+		right_toolbar->append(*lock_guides);
+	}
+
 	// Separator
 	right_toolbar->append(*create_tool_separator());
 
@@ -1474,6 +1487,7 @@ CanvasView::init_menus()
 		{"toggle-grid-snap",            "snap_grid_icon",            N_("Snap to Grid"),            "", &WorkArea::get_grid_snap, &CanvasView::toggle_snap_grid },
 		{"toggle-guide-show",           "show_guideline_icon",       N_("Show Guides"),             "", &WorkArea::get_show_guides, &CanvasView::toggle_show_guides },
 		{"toggle-guide-snap",           "snap_guideline_icon",       N_("Snap to Guides"),          "", &WorkArea::get_guide_snap, &CanvasView::toggle_snap_guides },
+		{"toggle-guide-lock",           "show_guideline_icon",       N_("Lock Guides"),             "", &WorkArea::get_lock_guides, &CanvasView::toggle_lock_guides },
 		{"toggle-low-res",              "",                          N_("Use Low-Res"),             "", &WorkArea::get_low_resolution_flag, &CanvasView::toggle_low_res_pixel_flag },
 		{"toggle-background-rendering", "background_rendering_icon", N_("Enable rendering in background"), "", &WorkArea::get_background_rendering, &CanvasView::toggle_background_rendering },
 		{"toggle-onion-skin",           "onion_skin_icon",           N_("Show Onion Skin"),         "", &WorkArea::get_onion_skin, &CanvasView::toggle_onion_skin },
@@ -1498,6 +1512,7 @@ CanvasView::init_menus()
 	grid_snap_toggle = Glib::RefPtr<Gtk::ToggleAction>::cast_static(action_group->get_action("toggle-grid-snap"));
 	guides_show_toggle = Glib::RefPtr<Gtk::ToggleAction>::cast_static(action_group->get_action("toggle-guide-show"));
 	guides_snap_toggle = Glib::RefPtr<Gtk::ToggleAction>::cast_static(action_group->get_action("toggle-guide-snap"));
+	guides_lock_toggle = Glib::RefPtr<Gtk::ToggleAction>::cast_static(action_group->get_action("toggle-guide-lock"));
 	background_rendering_toggle = Glib::RefPtr<Gtk::ToggleAction>::cast_static(action_group->get_action("toggle-background-rendering"));
 	onion_skin_toggle = Glib::RefPtr<Gtk::ToggleAction>::cast_static(action_group->get_action("toggle-onion-skin"));
 	onion_skin_keyframes_toggle = Glib::RefPtr<Gtk::ToggleAction>::cast_static(action_group->get_action("toggle-onion-skin-keyframes"));
@@ -2387,6 +2402,19 @@ CanvasView::toggle_show_guides()
 }
 
 void
+CanvasView::toggle_lock_guides()
+{
+	if(toggling_lock_guides)
+		return;
+	toggling_lock_guides=true;
+	work_area->toggle_lock_guides();
+	set_guides_lock_toggle(work_area->get_lock_guides());
+	lock_guides->set_active(work_area->get_lock_guides());
+	toggling_lock_guides=false;
+	std::cout << work_area->get_lock_guides();
+}
+
+void
 CanvasView::toggle_snap_guides()
 {
 	if(toggling_snap_guides)
@@ -3155,6 +3183,7 @@ CanvasView::on_meta_data_changed()
 	toggling_snap_grid=true;
 	toggling_show_guides=true;
 	toggling_snap_guides=true;
+	toggling_lock_guides=true;
 	toggling_onion_skin=true;
 	toggling_onion_skin_keyframes=true;
 	toggling_background_rendering=true;
@@ -3176,6 +3205,8 @@ CanvasView::on_meta_data_changed()
 		action->set_active((bool)(work_area->get_show_guides()));
 		action = Glib::RefPtr<Gtk::ToggleAction>::cast_dynamic(action_group->get_action("toggle-guide-snap"));
 		action->set_active((bool)(work_area->get_guide_snap()));
+		action = Glib::RefPtr<Gtk::ToggleAction>::cast_dynamic(action_group->get_action("toggle-guide-lock"));
+		action->set_active((bool)(work_area->get_lock_guides()));
 		// Update the toggle buttons
 		background_rendering_button->set_active(work_area->get_background_rendering());
 		onion_skin->set_active(work_area->get_onion_skin());
@@ -3184,6 +3215,7 @@ CanvasView::on_meta_data_changed()
 		show_grid->set_active(work_area->grid_status());
 		snap_guides->set_active(work_area->get_guide_snap());
 		show_guides->set_active(work_area->get_show_guides());
+		lock_guides->set_active(work_area->get_lock_guides());
 		// Update the onion skin spins
 		past_onion_spin->set_value(work_area->get_onion_skins()[0]);
 		future_onion_spin->set_value(work_area->get_onion_skins()[1]);
@@ -3194,6 +3226,7 @@ CanvasView::on_meta_data_changed()
 		toggling_snap_grid=false;
 		toggling_show_guides=false;
 		toggling_snap_guides=false;
+		toggling_lock_guides=false;
 		toggling_onion_skin=false;
 		toggling_onion_skin_keyframes=false;
 		toggling_background_rendering=false;
@@ -3202,6 +3235,7 @@ CanvasView::on_meta_data_changed()
 	toggling_snap_grid=false;
 	toggling_show_guides=false;
 	toggling_snap_guides=false;
+	toggling_lock_guides=false;
 	toggling_onion_skin=false;
 	toggling_onion_skin_keyframes=false;
 	toggling_background_rendering=false;

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -228,6 +228,7 @@ public:
 	void set_grid_show_toggle(bool flag) { grid_show_toggle->set_active(flag); }
 	void set_guides_snap_toggle(bool flag) { guides_snap_toggle->set_active(flag); }
 	void set_guides_show_toggle(bool flag) { guides_show_toggle->set_active(flag); }
+	void set_guides_lock_toggle(bool flag) { guides_lock_toggle->set_active(flag); }
 	void set_onion_skin_toggle(bool flag) { onion_skin_toggle->set_active(flag); }
 	void set_onion_skin_keyframes_toggle(bool flag) { onion_skin_keyframes_toggle->set_active(flag); }
 	void set_background_rendering_toggle(bool flag) { background_rendering_toggle->set_active(flag); }
@@ -305,6 +306,7 @@ private:
 	Gtk::ToggleToolButton *snap_grid;
 	Gtk::ToggleToolButton *show_guides;
 	Gtk::ToggleToolButton *snap_guides;
+	Gtk::ToggleToolButton *lock_guides;
 	Gtk::ToggleToolButton *onion_skin;
 	Gtk::ToolButton *render_options_button;
 	Gtk::ToolButton *preview_options_button;
@@ -313,6 +315,7 @@ private:
 	bool toggling_snap_grid;
 	bool toggling_show_guides;
 	bool toggling_snap_guides;
+	bool toggling_lock_guides;
 	bool toggling_onion_skin;
 	bool toggling_onion_skin_keyframes;
 	bool toggling_background_rendering;
@@ -342,6 +345,7 @@ private:
 	Glib::RefPtr<Gtk::ToggleAction> rulers_show_toggle;
 	Glib::RefPtr<Gtk::ToggleAction> guides_snap_toggle;
 	Glib::RefPtr<Gtk::ToggleAction> guides_show_toggle;
+	Glib::RefPtr<Gtk::ToggleAction> guides_lock_toggle;
 	Glib::RefPtr<Gtk::ToggleAction> onion_skin_toggle;
 	Glib::RefPtr<Gtk::ToggleAction> onion_skin_keyframes_toggle;
 	Glib::RefPtr<Gtk::ToggleAction> background_rendering_toggle;
@@ -467,6 +471,7 @@ private:
 	void toggle_snap_grid();
 	void toggle_show_guides();
 	void toggle_snap_guides();
+	void toggle_lock_guides();
 	void toggle_onion_skin();
 	void toggle_onion_skin_keyframes();
 	void toggle_background_rendering();

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -1484,12 +1484,11 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 	        break;
 		}
 		case DRAG_GUIDE: {
-			if(!get_lock_guides()){
-				if (!rotate_guide){
-						curr_guide->point[0] = mouse_pos[0];
-						curr_guide->point[1] = mouse_pos[1];
-					} else 
-				if(rotate_guide && !from_ruler_event) {
+			if(!get_lock_guides()) {
+				if (!rotate_guide) {
+					curr_guide->point[0] = mouse_pos[0];
+					curr_guide->point[1] = mouse_pos[1];
+				} else if(rotate_guide && !from_ruler_event) {
 					float slope = (mouse_pos[1] - curr_guide->point[1])/(mouse_pos[0] - curr_guide->point[0]);
 					//just change the angle of the ruler
 					curr_guide->angle = synfig::Angle::rad(atan(slope));

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -196,6 +196,9 @@ private:
 	//! This flag is set if the guides should be drawn
 	bool show_guides;
 
+	//! This flag is set if the guides should be editable
+	bool lock_guides = false;
+
 	//! Checker background size
 	synfig::Vector background_size;
 	//! Checker background first color
@@ -390,6 +393,12 @@ public:
 	void toggle_show_guides() { set_show_guides(!get_show_guides()); }
 	//! Toggles the snap of the guides
 	void toggle_guide_snap();
+	//! Returns the state of the lock_guides_flag
+	bool get_lock_guides()const { return lock_guides; }
+	//! Sets the locking of the grid
+	void set_lock_guides(bool x);
+	//! Toggles the locking of the guides
+	void toggle_lock_guides() { set_lock_guides(!get_lock_guides()); }
 	//! Sets the color of the guides
 	void set_guides_color(const synfig::Color &c);
 	//! Returns the color of the guides


### PR DESCRIPTION
closes #3158 
I couldnt find any lock icons in `iconcontroller.cpp` for the button other than the lock keyframes icons.