### PR TITLE
fix: memory leak that caused a crash in parameters panel

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.cpp
@@ -652,7 +652,7 @@ CellRenderer_ValueBase::start_editing_vfunc(
 
 		saved_data = data;
 
-		value_entry = manage(new ValueBase_Entry());
+		value_entry = new ValueBase_Entry();
 		value_entry->set_path(path);
 		value_entry->set_canvas(get_canvas());
 		value_entry->set_param_desc(get_param_desc());
@@ -672,8 +672,11 @@ CellRenderer_ValueBase::start_editing_vfunc(
 void
 CellRenderer_ValueBase::on_value_editing_done()
 {
-	if (value_entry && value_entry->property_editing_canceled())
+	if (value_entry && value_entry->property_editing_canceled()){
+		delete value_entry;
+		value_entry = nullptr;
 		return;
+	}
 
 	if (edit_value_done_called)
 	{
@@ -689,5 +692,7 @@ CellRenderer_ValueBase::on_value_editing_done()
 
 		if (saved_data != value)
 			signal_edited_(value_entry->get_path(), value);
+		delete value_entry;
+		value_entry = nullptr;
 	}
 }


### PR DESCRIPTION
Fixes #2310 , #3180 

The problem: A memory leak that was causing the crash as described more in #3180 

The solution: Delete the widget after the edit is done. What was previously being done was only deleting one of the multiple instances that could be created when editing a parameter.

A problem encountered:
I get this warning 
```
(synfigstudio:422780): GLib-GObject-WARNING **: 08:39:21.831: ../../../gobject/gsignal.c:2765: instance '0x55fbf2f35e20' has no handler with id '50829'
```

And this is the backtrace

```
Thread 1 "synfigstudio" received signal SIGTRAP, Trace/breakpoint trap.
0x00007ffff4f54447 in g_logv () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
(gdb) bt
#0  0x00007ffff4f54447 in g_logv () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#1  0x00007ffff4f54703 in g_log () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#2  0x00007ffff65cfe4a in g_signal_handler_disconnect ()
    at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#3  0x00007ffff674994c in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#4  0x00007ffff674a976 in gtk_cell_area_activate_cell () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#5  0x00007ffff674adee in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#6  0x00007ffff698cdf9 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#7  0x00007ffff6985a1f in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#8  0x00007ffff69e6ac7 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#9  0x00007ffff65b4d2f in g_closure_invoke () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#10 0x00007ffff65d0624 in  () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#11 0x00007ffff6727e14 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#12 0x00007ffff67282a8 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#13 0x00007ffff6729da1 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#14 0x00007ffff672a046 in gtk_bindings_activate_event () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#15 0x00007ffff697c93e in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#16 0x00007ffff69e6eb8 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#17 0x00007ffff65d1c26 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#18 0x00007ffff65d2863 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#19 0x00007ffff69ae724 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#20 0x00007ffff69bbbeb in gtk_window_propagate_key_event ()
    at /lib/x86_64-linux-gnu/libgtk-3.so.0
--Type <RET> for more, q to quit, c to continue without paging--c
#21 0x00007ffff69bbce3 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#22 0x00007ffff730fae9 in Gtk::Widget::on_key_press_event(_GdkEventKey*) () at /lib/x86_64-linux-gnu/libgtkmm-3.0.so.1
#23 0x0000555555aa940a in studio::MainWindow::on_key_press_event(_GdkEventKey*) (this=0x555556d7ef70, key_event=0x7fffe0006360) at /home/mohamed/synfig/synfig-studio/src/gui/mainwindow.cpp:351
#24 0x00007ffff7308a59 in Gtk::Widget_Class::key_press_event_callback(_GtkWidget*, _GdkEventKey*) () at /lib/x86_64-linux-gnu/libgtkmm-3.0.so.1
#25 0x00007ffff69e6eb8 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#26 0x00007ffff65d2700 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#27 0x00007ffff65d2863 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#28 0x00007ffff69ae724 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#29 0x00007ffff685173f in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#30 0x00007ffff685252a in gtk_main_do_event () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#31 0x00007ffff7532743 in  () at /lib/x86_64-linux-gnu/libgdk-3.so.0
#32 0x00007ffff75999a6 in  () at /lib/x86_64-linux-gnu/libgdk-3.so.0
#33 0x00007ffff4f4bd3b in g_main_context_dispatch () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#34 0x00007ffff4fa1258 in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#35 0x00007ffff4f493e3 in g_main_context_iteration () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#36 0x00007ffff4492fb5 in g_application_run () at /lib/x86_64-linux-gnu/libgio-2.0.so.0
#37 0x000055555589b975 in main(int, char**) (argc=1, argv=0x7fffffffde28) at /home/mohamed/synfig/synfig-studio/src/gui/main.cpp:95
(gdb) 
[8]+  Stopped                 G_DEBUG=fatal-warnings gdb --args ./output/Debug/bin/synfigstudio
```
It looks like it could be coming from the signal/handler not being disconnected properly after the widget is destroyed (assumption). But I'm kind of stuck trying to know it. @rodolforg @ice0 any ideas on what the problem might be ?