### PR TITLE
fix: timetrack toolbar dissappears on closing a file

### DIFF
--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -139,6 +139,7 @@ void Dock_Timetrack2::changed_canvas_view_vfunc(CanvasView::LooseHandle canvas_v
 
 		update_toolbar_action();
 		set_interp_buttons_sensitivity(current_widget_timetrack->get_num_waypoints_selected());
+		toolbar->show_all();
 
 		grid.attach(widget_kf_list,            0, 0, 1, 1);
 		grid.attach(widget_timeslider,         0, 1, 1, 1);


### PR DESCRIPTION
Fixes #3187 