### PR TITLE
fix(plugin): requesting current_time invalidates JSON data

### DIFF
--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -348,7 +348,7 @@ studio::Instance::run_plugin(std::string plugin_id, bool modify_canvas, std::vec
 
 		// Current Time
 
-		view_state["current_time"] = canvas_interface->get_time();
+		view_state["current_time"] = canvas_interface->get_time().get_string(synfig::Time::FORMAT_VIDEO);
 
 		// Selected Layers
 


### PR DESCRIPTION
it ends string sooner (not automatic string conversion).

https://github.com/synfig/synfig/pull/2996#issuecomment-1690726833

Reported-by: pgilfernandez 