### PR TITLE
perf: optimized Action_System so that the canvas only renders once during an action

### DIFF
--- a/synfig-studio/src/synfigapp/action_system.h
+++ b/synfig-studio/src/synfigapp/action_system.h
@@ -118,6 +118,15 @@ public:
 
 private:
 
+	class DirtySignalBlocker
+	{
+		Action::CanvasSpecific* canvas_specific_;
+
+	public:
+		DirtySignalBlocker(Action::CanvasSpecific* canvas_specific);
+		~DirtySignalBlocker();
+	};
+
 	Stack undo_action_stack_;
 	Stack redo_action_stack_;
 


### PR DESCRIPTION
The problem was that every time any property node emitted signal_changed() during an action, it would cause the canvas to queue a render. The number of times signal_changed() happens seems to grow non-linearly with the number of objects being modified during the action. This was a killer for bulk update actions, where this could easily trigger thousands or potentially even millions of unnecessary renders. I have seen a single bulk action take almost an hour.

The fix is to temporarily block the Canvas_Interface::signal_dirty_preview() signal while an action is in progress, and then manually trigger it once the action completes. This guarantees the scene will only render once the action is done, and seems to be a dramatic performance improvement in longer animations at least in my testing.

I ran some A-B comparisons on a test file. The file has a spline with 100 vertices linked to a bone, and the bone angle parameter has 600 waypoints.
 - Modify bone angle with Animate Mode off and apply offset:  ~3min 40s before -> ~1.5s after
 - Move a keyframe:  ~4min 25s before -> 0.7s after

[perf-test.zip](https://github.com/synfig/synfig/files/12515338/perf-test.zip)

(Please let me know if there's any other process stuff I should do. As far as I'm aware there's no specific issue for this)