### PR TITLE
refactor: increase the pixels per frame without render split in Target_Scanline

### DIFF
--- a/synfig-core/src/synfig/target_scanline.cpp
+++ b/synfig-core/src/synfig/target_scanline.cpp
@@ -57,7 +57,7 @@ using namespace rendering;
 
 /* === M A C R O S ========================================================= */
 
-#define DEFAULT_PIXEL_RENDERING_LIMIT 1500000
+#define DEFAULT_PIXEL_RENDERING_LIMIT 9000000 // 1500000 - original limit, 2100000 - full HD 1920x1080, 8300000 - 4k UHD, 33200000 - 8k UHD
 
 /* === G L O B A L S ======================================================= */
 

--- a/synfig-core/src/synfig/target_scanline.cpp
+++ b/synfig-core/src/synfig/target_scanline.cpp
@@ -125,13 +125,8 @@ bool
 synfig::Target_Scanline::render(ProgressCallback *cb)
 {
 	SuperCallback super_cb;
-	int
-		frames=0,
-		total_frames,
-		frame_start,
-		frame_end;
-	Time
-		t=0;
+	int frames = 0;
+	Time t = 0;
 
 	assert(canvas);
 	curr_frame_=0;
@@ -141,14 +136,14 @@ synfig::Target_Scanline::render(ProgressCallback *cb)
 		return false;
 	}
 
-	frame_start=desc.get_frame_start();
-	frame_end=desc.get_frame_end();
+	const int frame_start = desc.get_frame_start();
+	const int frame_end = desc.get_frame_end();
 
 	ContextParams context_params(desc.get_render_excluded_contexts());
 
 	// Calculate the number of frames
-	total_frames=frame_end-frame_start+1;
-	if(total_frames<=0)total_frames=1;
+	const int total_frames = frame_end >= frame_start ? (frame_end - frame_start + 1) : 1;
+
 
 	try {
 		do{
@@ -195,6 +190,7 @@ synfig::Target_Scanline::render(ProgressCallback *cb)
 
 					for(int i=0; i < rows; ++i)
 					{
+						const int y_offset = i * rowheight;
 						surface->reset();
 						RendDesc blockrd = desc;
 
@@ -202,11 +198,11 @@ synfig::Target_Scanline::render(ProgressCallback *cb)
 						if(i == rows-1)
 						{
 							if(!lastrowheight) break;
-							blockrd.set_subwindow(0,i*rowheight,desc.get_w(),lastrowheight);
+							blockrd.set_subwindow(0, y_offset, desc.get_w(), lastrowheight);
 						}
 						else
 						{
-							blockrd.set_subwindow(0,i*rowheight,desc.get_w(),rowheight);
+							blockrd.set_subwindow(0, y_offset, desc.get_w(), rowheight);
 						}
 
 						//synfig::info( " -- block %d/%d left, top, width, height: %d, %d, %d, %d",
@@ -225,9 +221,7 @@ synfig::Target_Scanline::render(ProgressCallback *cb)
 
 							const synfig::Surface &s = lock->get_surface();
 
-							int yoff = i*rowheight;
-
-							if(!process_block_alpha(s, s.get_w(), blockrd.get_h(), yoff, cb)) return false;
+							if(!process_block_alpha(s, s.get_w(), blockrd.get_h(), y_offset, cb)) return false;
 						}
 					}
 					surface->reset();

--- a/synfig-core/src/synfig/target_scanline.cpp
+++ b/synfig-core/src/synfig/target_scanline.cpp
@@ -94,7 +94,7 @@ synfig::Target_Scanline::call_renderer(
 	{
 		rendering::Renderer::Handle renderer = rendering::Renderer::get_renderer(get_engine());
 		if (!renderer)
-			throw "Renderer '" + get_engine() + "' not found";
+			throw strprintf(_("Renderer '%s' not found"), get_engine().c_str());
 
 		Vector p0 = renddesc.get_tl();
 		Vector p1 = renddesc.get_br();
@@ -171,8 +171,8 @@ synfig::Target_Scanline::render(ProgressCallback *cb)
 				if (is_rendering_split) {
 					SurfaceResource::Handle surface = new SurfaceResource();
 
-					synfig::info("Render split to %d block%s %d pixels tall, and a final block %d pixels tall",
-								 rows-1, rows==2?"":"s", rowheight, lastrowheight);
+					synfig::info(_("Render split to %d blocks %d pixels tall, and a final block %d pixels tall"),
+								 rows-1, rowheight, lastrowheight);
 
 					// loop through all the full rows
 					if(!start_frame())

--- a/synfig-core/src/synfig/target_scanline.cpp
+++ b/synfig-core/src/synfig/target_scanline.cpp
@@ -122,10 +122,6 @@ synfig::Target_Scanline::call_renderer(
 bool
 synfig::Target_Scanline::render(ProgressCallback *cb)
 {
-	SuperCallback super_cb;
-	int frames = 0;
-	Time t = 0;
-
 	assert(canvas);
 	curr_frame_=0;
 
@@ -151,6 +147,8 @@ synfig::Target_Scanline::render(ProgressCallback *cb)
 	const int lastrowheight = desc.get_h() - (rows - 1) * rowheight;
 
 	try {
+		Time t = 0;
+		int frames = 0;
 		do{
 			// Grab the time
 			frames=next_frame(t);

--- a/synfig-core/src/synfig/target_scanline.h
+++ b/synfig-core/src/synfig/target_scanline.h
@@ -54,6 +54,8 @@ class Target_Scanline : public Target
 
 	String engine_;
 
+	int pixel_rendering_limit_;
+
 	bool call_renderer(
 		const etl::handle<rendering::SurfaceResource> &surface,
 		Canvas &canvas,
@@ -100,8 +102,8 @@ public:
 	**	\see start_scanline()
 	*/
 	virtual bool end_scanline()=0;
-	//! Sets the number of threads
 
+	//! Sets the number of threads
 	void set_threads(int x) { threads_=x; }
 	//! Gets the number of threads
 	int get_threads()const { return threads_; }
@@ -109,6 +111,15 @@ public:
 	const String& get_engine()const { return engine_; }
 	//! Sets engine
 	void set_engine(const String &x) { engine_=x; }
+
+	/**
+	 * Sets the loose limit of pixels to render.
+	 *
+	 * It's actually internally rounded to fill a full row according to RendDesc
+	 */
+	void set_pixel_rendering_limit(int x) { pixel_rendering_limit_ = x; }
+	/** Get the loose limit of pixels to render. @see set_pixel_rendering_limit() */
+	int get_pixel_rendering_limit() const { return pixel_rendering_limit_; }
 
 	//! Puts the rendered surface onto the target.
 	bool add_frame(const synfig::Surface *surface, ProgressCallback* cb);


### PR DESCRIPTION
related to https://github.com/synfig/synfig/issues/2847

fix https://github.com/synfig/synfig/issues/2943