### PR TITLE
fix: selecting a handle while the Graphs window tooltip is open crashes the gui

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_curves.cpp
+++ b/synfig-studio/src/gui/widgets/widget_curves.cpp
@@ -818,7 +818,7 @@ Widget_Curves::on_draw(const Cairo::RefPtr<Cairo::Context> &cr)
 	}
 
 	// Draw info about hovered item
-	if (channel_point_sd.get_hovered_item().is_valid() || channel_point_sd.get_state() == channel_point_sd.POINTER_DRAGGING) {
+	if (channel_point_sd.has_hovered_item() || channel_point_sd.get_state() == channel_point_sd.POINTER_DRAGGING) {
 		const ChannelPoint* inspected_item = &channel_point_sd.get_hovered_item();
 		if (!inspected_item->is_valid() || channel_point_sd.get_state() == channel_point_sd.POINTER_DRAGGING)
 			inspected_item = channel_point_sd.get_active_item();


### PR DESCRIPTION
Reproduction steps:
1. Select an animated handle, and open the Graphs window.
2. Right click any waypoint in the Graphs window, and without selecting any menu item (or by selecting an item that's outside of the Graphs area), click in the Canvas work area. Notice the tooltip is still open.
3. Left click any other handle in the work area. Synfig crashes.

The problem was the tooltip draw event was directly referencing an iterator that gets invalidated when the new handle is selected. The next time it tries to draw, it dereferences the bad iterator and crashes.

A nice side effect of this change is the tooltip for the deleted waypoint goes away now after you delete it.

https://github.com/synfig/synfig/assets/143972888/aea7a137-3717-476a-b16a-d1a4419b84a8

The recording didn't capture the context menu. I selected Remove from the menu, and the crash happens after I select the new handle.
