### PR TITLE
refactor: rename 'renderer_bbox' file to 'renderer_boundingbox'

### DIFF
--- a/synfig-studio/po/POTFILES.in
+++ b/synfig-studio/po/POTFILES.in
@@ -233,8 +233,8 @@ src/gui/widgets/widget_waypointmodel.cpp
 src/gui/widgets/widget_waypointmodel.h
 src/gui/workarearenderer/renderer_background.cpp
 src/gui/workarearenderer/renderer_background.h
-src/gui/workarearenderer/renderer_bbox.cpp
-src/gui/workarearenderer/renderer_bbox.h
+src/gui/workarearenderer/renderer_boundingbox.cpp
+src/gui/workarearenderer/renderer_boundingbox.h
 src/gui/workarearenderer/renderer_bonedeformarea.cpp
 src/gui/workarearenderer/renderer_bonedeformarea.h
 src/gui/workarearenderer/renderer_bonesetup.cpp

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -50,7 +50,7 @@
 #include <gui/localization.h>
 #include <gui/workarearenderer/workarearenderer.h>
 #include <gui/workarearenderer/renderer_background.h>
-#include <gui/workarearenderer/renderer_bbox.h>
+#include <gui/workarearenderer/renderer_boundingbox.h>
 #include <gui/workarearenderer/renderer_bonedeformarea.h>
 #include <gui/workarearenderer/renderer_bonesetup.h>
 #include <gui/workarearenderer/renderer_canvas.h>

--- a/synfig-studio/src/gui/workarearenderer/CMakeLists.txt
+++ b/synfig-studio/src/gui/workarearenderer/CMakeLists.txt
@@ -1,7 +1,7 @@
 target_sources(synfigstudio
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/renderer_background.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/renderer_bbox.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/renderer_boundingbox.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer_canvas.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer_dragbox.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/renderer_ducks.cpp"

--- a/synfig-studio/src/gui/workarearenderer/Makefile_insert
+++ b/synfig-studio/src/gui/workarearenderer/Makefile_insert
@@ -1,6 +1,6 @@
 WORKAREARENDERER_HH = \
 	workarearenderer/renderer_background.h \
-	workarearenderer/renderer_bbox.h \
+	workarearenderer/renderer_boundingbox.h \
 	workarearenderer/renderer_canvas.h \
 	workarearenderer/renderer_dragbox.h \
 	workarearenderer/renderer_ducks.h \
@@ -14,7 +14,7 @@ WORKAREARENDERER_HH = \
 
 WORKAREARENDERER_CC = \
 	workarearenderer/renderer_background.cpp \
-	workarearenderer/renderer_bbox.cpp \
+	workarearenderer/renderer_boundingbox.cpp \
 	workarearenderer/renderer_canvas.cpp \
 	workarearenderer/renderer_dragbox.cpp \
 	workarearenderer/renderer_ducks.cpp \

--- a/synfig-studio/src/gui/workarearenderer/renderer_boundingbox.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_boundingbox.cpp
@@ -1,5 +1,5 @@
 /* === S Y N F I G ========================================================= */
-/*!	\file renderer_bbox.cpp
+/*!	\file renderer_boundingbox.cpp
 **  \brief Renderer_BBox class is used to render in the workarea the bounding box
 ** of the selected layer(s)
 **
@@ -34,7 +34,7 @@
 #	include <config.h>
 #endif
 
-#include "renderer_bbox.h"
+#include "renderer_boundingbox.h"
 #include <gui/canvasview.h>
 #include <gui/workarea.h>
 

--- a/synfig-studio/src/gui/workarearenderer/renderer_boundingbox.h
+++ b/synfig-studio/src/gui/workarearenderer/renderer_boundingbox.h
@@ -1,5 +1,5 @@
 /* === S Y N F I G ========================================================= */
-/*!	\file renderer_bbox.h
+/*!	\file renderer_boundingbox.h
 **  \brief Renderer_BBox class is used to render in the workarea the bounding box
 ** of the selected layer(s)
 **
@@ -26,8 +26,8 @@
 
 /* === S T A R T =========================================================== */
 
-#ifndef __SYNFIG_RENDERER_BBOX_H
-#define __SYNFIG_RENDERER_BBOX_H
+#ifndef __SYNFIG_RENDERER_BOUNDINGBOX_H
+#define __SYNFIG_RENDERER_BOUNDINGBOX_H
 
 /* === H E A D E R S ======================================================= */
 


### PR DESCRIPTION
I have always thought this would just make it much clearer for newcomers looking through the code-base. I mean other renderers are called "renderer_bonedeformarea" so i don't really think length is really the issue here but this way I feel it's much cleaner.

Now if necessary I can also rename the class itself too but I think it would  be cleaner to do it in another PR.