### PR TITLE
fix: fixed macOS Info.plist file

### DIFF
--- a/autobuild/osx/app-template/Contents/Info.plist
+++ b/autobuild/osx/app-template/Contents/Info.plist
@@ -18,13 +18,13 @@
 	<string>SynfigStudio</string>
 
 	<key>CFBundleGetInfoString</key>
-	<string>_VERSION_, © 2001-2023 Synfig developers & contributors</string>
+	<string>_VERSION_, © 2001-2023 Synfig developers &#38; contributors</string>
 	<key>CFBundleShortVersionString</key>
 	<string>_VERSION_</string>
 	<key>CFBundleVersion</key>
 	<string>_VERSION_</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>© 2001-2023 Synfig developers & contributors</string>
+	<string>© 2001-2023 Synfig developers &#38; contributors</string>
 	<key>CFBundleIconFile</key>
 	<string>SynfigStudio</string>
 	<key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
This PR closes https://github.com/synfig/synfig/issues/3222.

After a pretty deep analysis I found out the problem was simple: a `plist` file uses XML language and ampersand symbol "&" is an special character that can't be used alone, causing the XML file to be corrupted and so on the .plist file.

It was used for the following text twice in the file:
```
<string>© 2001-2023 Synfig developers & contributors</string>
```
while they should be:
```
<string>© 2001-2023 Synfig developers &#38; contributors</string>
```
This way the .plist file works fine and shows correctly not only the icon but the version and copyright tags:
<img width="531" alt="info_plist" src="https://github.com/synfig/synfig/assets/5942369/b8aefe85-76ce-41ad-8149-925bbf3c99a6">

Cheers
