### PR TITLE
feat: add CSS classes and id to widgets/panels to allow visual customization

### DIFF
--- a/synfig-studio/src/gui/docks/dock_children.cpp
+++ b/synfig-studio/src/gui/docks/dock_children.cpp
@@ -58,7 +58,9 @@ using namespace studio;
 Dock_Children::Dock_Children():
 	Dock_CanvasSpecific("children",_("Library"),"library_icon")
 {
-    //! \todo the combination of set_use_scrolled(false) and
+	set_name("library_panel");
+
+	//! \todo the combination of set_use_scrolled(false) and
 	//!       add(*tree_view) causes crashes when
 	//!       Dockable::prev_widget_ is left referencing a
 	//!       ChildrenTree that has already been destroyed.

--- a/synfig-studio/src/gui/docks/dock_keyframes.cpp
+++ b/synfig-studio/src/gui/docks/dock_keyframes.cpp
@@ -64,6 +64,7 @@ Dock_Keyframes::Dock_Keyframes():
 	Dock_CanvasSpecific("keyframes", _("Keyframes"),"keyframe_icon"),
 	keyframe_action_manager(new KeyframeActionManager())
 {
+	set_name("keyframes_panel");
 	// Make Keyframes toolbar small for space efficiency
 	get_style_context()->add_class("synfigstudio-efficient-workspace");
 

--- a/synfig-studio/src/gui/docks/dock_layergroups.cpp
+++ b/synfig-studio/src/gui/docks/dock_layergroups.cpp
@@ -64,6 +64,8 @@ Dock_LayerGroups::Dock_LayerGroups():
 	action_group_group_ops(Gtk::ActionGroup::create("action_group_dock_layergroups")),
 	group_action_manager(new GroupActionManager)
 {
+	set_name("layersets_panel");
+
 	// Make Sets toolbar buttons small for space efficiency
 	get_style_context()->add_class("synfigstudio-efficient-workspace");
 

--- a/synfig-studio/src/gui/docks/dock_layers.cpp
+++ b/synfig-studio/src/gui/docks/dock_layers.cpp
@@ -65,6 +65,8 @@ Dock_Layers::Dock_Layers():
 	Dock_CanvasSpecific("layers",_("Layers"),"layer_icon"),
 	layer_action_manager(new LayerActionManager)
 {
+	set_name("layers_panel");
+
 	// Make Layers button small for space efficiency
 	get_style_context()->add_class("synfigstudio-efficient-workspace");
 

--- a/synfig-studio/src/gui/docks/dock_params.cpp
+++ b/synfig-studio/src/gui/docks/dock_params.cpp
@@ -61,6 +61,7 @@ Dock_Params::Dock_Params():
 	action_group( Gtk::ActionGroup::create("action_group_dock_params") ),
 	vadjustment( Gtk::Adjustment::create(0, 0, 1, 1, 1) )
 {
+	set_name("parameters_panel");
 }
 
 Dock_Params::~Dock_Params()

--- a/synfig-studio/src/gui/docks/dock_timetrack2.cpp
+++ b/synfig-studio/src/gui/docks/dock_timetrack2.cpp
@@ -47,6 +47,8 @@ Dock_Timetrack2::Dock_Timetrack2()
 	: Dock_CanvasSpecific("timetrack", _("Timetrack"), "time_track_icon"),
 	  current_widget_timetrack(nullptr)
 {
+	set_name("timetrack_panel");
+
 	set_use_scrolled(false);
 
 	widget_kf_list.set_hexpand();

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -59,7 +59,7 @@
  * Our timetrack ruler is tight
  * Set some padding below to give it more space
  */
-#timetrack button {
+#timetrack_panel button {
 	padding-bottom: 5px;
 }
 

--- a/synfig-studio/src/gui/trees/childrentree.cpp
+++ b/synfig-studio/src/gui/trees/childrentree.cpp
@@ -134,6 +134,8 @@ ChildrenTree::ChildrenTree()
 	// This makes things easier to read.
 	tree_view.set_rules_hint();
 
+	get_style_context()->add_class("library");
+
 	// Make us more sensitive to several events
 	tree_view.add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK | Gdk::BUTTON1_MOTION_MASK | Gdk::BUTTON2_MOTION_MASK|Gdk::POINTER_MOTION_MASK);
 

--- a/synfig-studio/src/gui/trees/keyframetree.cpp
+++ b/synfig-studio/src/gui/trees/keyframetree.cpp
@@ -138,6 +138,8 @@ KeyframeTree::KeyframeTree() : editable_(false)
 	// This makes things easier to read.
 	set_rules_hint();
 
+	get_style_context()->add_class("keyframes");
+
 	// Make us more sensitive to several events
 	add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK);
 

--- a/synfig-studio/src/gui/trees/layergrouptree.cpp
+++ b/synfig-studio/src/gui/trees/layergrouptree.cpp
@@ -108,6 +108,8 @@ LayerGroupTree::LayerGroupTree()
 	// This makes things easier to read.
 	set_rules_hint();
 
+	get_style_context()->add_class("layersets");
+
 	// Make us more sensitive to several events
 	add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK | Gdk::BUTTON1_MOTION_MASK | Gdk::BUTTON2_MOTION_MASK|Gdk::POINTER_MOTION_MASK);
 

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -223,6 +223,8 @@ LayerTree::create_layer_tree()
 	// This makes things easier to read.
 	layer_tree_view().set_rules_hint();
 
+	layer_tree_view().get_style_context()->add_class("layers");
+
 	// Make us more sensitive to several events
 	//layer_tree_view().add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK | Gdk::BUTTON1_MOTION_MASK | Gdk::BUTTON2_MOTION_MASK|Gdk::POINTER_MOTION_MASK);
 
@@ -379,6 +381,8 @@ LayerTree::create_param_tree()
 
 	// This makes things easier to read.
 	param_tree_view().set_rules_hint();
+
+	param_tree_view().get_style_context()->add_class("parameters");
 
 	// Make us more sensitive to several events
 	param_tree_view().add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK | Gdk::BUTTON1_MOTION_MASK | Gdk::BUTTON2_MOTION_MASK|Gdk::POINTER_MOTION_MASK);

--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -59,6 +59,8 @@ Widget_Timetrack::Widget_Timetrack()
 	  is_update_param_list_geometries_queued(false),
 	  action_state(NONE)
 {
+	get_style_context()->add_class("timetrack");
+
 	add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK | Gdk::SCROLL_MASK | Gdk::POINTER_MOTION_MASK | Gdk::KEY_PRESS_MASK | Gdk::KEY_RELEASE_MASK);
 	set_can_focus(true);
 	setup_mouse_handler();
@@ -123,11 +125,6 @@ bool Widget_Timetrack::use_canvas_view(CanvasView::LooseHandle canvas_view)
 		synfig::error(_("Params treeview widget doesn't exist"));
 		return false;
 	}
-
-	// This parameter dock is connected to timetrack
-	// We have to set padding to this widget to achieve our intended padding
-	// behavior for our timetrack
-	params_treeview->set_name("timetrack");
 
 	set_time_model(canvas_view->time_model());
 	set_canvas_interface(canvas_view->canvas_interface());


### PR DESCRIPTION
- Timetrack panel named as `timetrack_panel`
- Timetrack widgets use class `timetrack`
- Keyframes panel named as `keyframes_panel`
- Keyframes widgets use class `keyframes`
- Layers panel named as `layers_panel`
- LayerTree widgets use class `layers`
- Parameters panel named as `parameters_panel`
- ParameterTree widgets use class `parameters`
- LayerSets panel named as `layersets_panel`
- LayerSetTree widgets use class `layersets`
- Library panel named as `library_panel`
- Library widgets use class `library`