### PR TITLE
feat: widget Timetrack now can have its own color for selected row

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -421,6 +421,15 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 	if (Widget_TimeGraphBase::on_draw(cr))
 		return true;
 
+	bool use_selected_color_from_parameter_tree = false;
+	{
+		auto context = get_style_context();
+		// if this widget style doesn't differentiate selected from not selected (default, as it is DrawingArea), we get it from param_treeview style
+		// Uses a deprecated method, but whatever... In Gtk4 we take care of it in a different way
+		if (context->get_background_color(context->get_state()) == context->get_background_color(context->get_state() | Gtk::STATE_FLAG_SELECTED))
+			use_selected_color_from_parameter_tree = true;
+	}
+
 	// Draw waypoints
 
 	// Maybe it's possible to be more efficient by redrawing only for the visible paths,
@@ -443,7 +452,7 @@ bool Widget_Timetrack::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
 			return false;
 
 		// is param selected?
-		draw_selected_background(cr, path, row_info);
+		draw_selected_background(cr, path, row_info, use_selected_color_from_parameter_tree);
 
 		const synfigapp::ValueDesc &value_desc = row_info.get_value_desc();
 
@@ -864,23 +873,22 @@ void Widget_Timetrack::draw_waypoints(const Cairo::RefPtr<Cairo::Context>& cr, c
 	}
 }
 
-void Widget_Timetrack::draw_selected_background(const Cairo::RefPtr<Cairo::Context>& cr, const Gtk::TreePath& path, const RowInfo &row_info) const
+void Widget_Timetrack::draw_selected_background(const Cairo::RefPtr<Cairo::Context>& cr, const Gtk::TreePath& path, const RowInfo& row_info, bool use_selected_color_from_parameter_tree) const
 {
 	if (!params_treeview)
 		return;
 	std::vector<Gtk::TreePath> path_list = params_treeview->get_selection()->get_selected_rows();
-	size_t n_drawn_selected_rows = 0;
+	if (path_list.empty())
+		return;
 
-	if (n_drawn_selected_rows < path_list.size() // avoid searching if all selected rows have been drawn yet
-		&& std::find(path_list.begin(), path_list.end(), path) != path_list.end())
-	{
+	if (std::find(path_list.begin(), path_list.end(), path) != path_list.end()) {
+		auto context = use_selected_color_from_parameter_tree ? params_treeview->get_style_context() : get_style_context();
+
 		Geometry geometry = row_info.get_geometry();
-		auto foreign_context = params_treeview->get_style_context();
-		Gtk::StateFlags old_state = foreign_context->get_state();
-		foreign_context->set_state(Gtk::STATE_FLAG_SELECTED);
-		foreign_context->render_background(cr, 0, geometry.y, get_width(), geometry.h);
-		foreign_context->set_state(old_state);
-		n_drawn_selected_rows++;
+		Gtk::StateFlags old_state = context->get_state();
+		context->set_state(Gtk::STATE_FLAG_SELECTED);
+		context->render_background(cr, 0, geometry.y, get_width(), geometry.h);
+		context->set_state(old_state);
 	}
 }
 

--- a/synfig-studio/src/gui/widgets/widget_timetrack.h
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.h
@@ -220,7 +220,7 @@ private:
 	void draw_static_intervals_for_row(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo &row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints) const;
 	void draw_discrete_animated_times(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo &row_info) const;
 	void draw_waypoints(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath &path, const RowInfo &row_info, const std::vector<std::pair<synfig::TimePoint, synfig::Time>> &waypoints) const;
-	void draw_selected_background(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath &path, const RowInfo &row_info) const;
+	void draw_selected_background(const Cairo::RefPtr<Cairo::Context> &cr, const Gtk::TreePath &path, const RowInfo &row_info, bool use_selected_color_from_parameter_tree) const;
 	void draw_active_point_status(const Cairo::RefPtr<Cairo::Context> &cr, const RowInfo &row_info, const synfigapp::ValueDesc &value_desc);
 
 	bool fetch_waypoints(const WaypointItem &wi, std::set<synfig::Waypoint, std::less<synfig::UniqueID> > &waypoint_set) const;


### PR DESCRIPTION
You can provide it with CSS selector:
.timetrack:selected

If it doesn't exist (i.e. provides the same color as its background), it uses the same color of Parameters Panel.