### PR TITLE
refactor: synfig::OS::get_binary_path() doesn't require a fallback anymore

### DIFF
--- a/synfig-core/src/modules/mod_ffmpeg/mptr_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/mptr_ffmpeg.cpp
@@ -92,7 +92,7 @@ ffmpeg_mptr::seek_to(const Time& time)
 		args.push_back("-");
 
 #ifdef _WIN32
-		synfig::filesystem::Path binary_path = synfig::OS::get_binary_path("");
+		synfig::filesystem::Path binary_path = synfig::OS::get_binary_path();
 		if (!binary_path.empty())
 			binary_path = binary_path.parent_path();
 		binary_path /= filesystem::Path("ffmpeg.exe");

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -176,7 +176,7 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 	synfig::filesystem::Path ffmpeg_binary_path;
 #ifdef _WIN32
 	// Windows always have ffmpeg
-	ffmpeg_binary_path = synfig::OS::get_binary_path(".").parent_path() / filesystem::Path("ffmpeg.exe");
+	ffmpeg_binary_path = synfig::OS::get_binary_path().parent_path() / filesystem::Path("ffmpeg.exe");
 	if (!FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
 		synfig::error("Expected FFmpeg binary not found: %s", ffmpeg_binary_path.u8_str());
 		ffmpeg_binary_path.clear();

--- a/synfig-core/src/synfig/main.cpp
+++ b/synfig-core/src/synfig/main.cpp
@@ -512,7 +512,7 @@ synfig::info(const String &str)
 
 // See also: http://libsylph.sourceforge.net/wiki/Full_path_to_binary
 filesystem::Path
-synfig::OS::get_binary_path(const String &fallback_path)
+synfig::OS::get_binary_path()
 {
 	
 	String result;
@@ -652,7 +652,7 @@ synfig::OS::get_binary_path(const String &fallback_path)
 	{
 		// In worst case use value specified as fallback 
 		// (usually should come from argv[0])
-		result = filesystem::Path::absolute_path(fallback_path);
+		return filesystem::absolute(OS::fallback_binary_path).u8string();
 	}
 	
 	

--- a/synfig-core/src/synfig/os.cpp
+++ b/synfig-core/src/synfig/os.cpp
@@ -70,6 +70,8 @@ using namespace synfig;
 /* === M A C R O S ========================================================= */
 /* === G L O B A L S ======================================================= */
 
+synfig::filesystem::Path synfig::OS::fallback_binary_path;
+
 /* === C L A S S E S ======================================================= */
 
 #ifdef WIN32_PIPE_TO_PROCCESSES

--- a/synfig-core/src/synfig/os.h
+++ b/synfig-core/src/synfig/os.h
@@ -223,9 +223,15 @@ const std::vector<std::string>& get_user_lang();
 
 /**
  * Return the absolute path to the current binary
- * @param fallback_path : if we can't figure out the binary path, use this value instead
+ * @see synfig::OS::fallback_binary_path
  */
-filesystem::Path get_binary_path(const std::string& fallback_path);
+filesystem::Path get_binary_path();
+
+/**
+ * If OS::get_binary_path() fails, use this path instead.
+ * Normally set to argv[0]
+ */
+extern filesystem::Path fallback_binary_path;
 
 /**
  * Returns the current working directory.

--- a/synfig-core/src/tool/definitions.cpp
+++ b/synfig-core/src/tool/definitions.cpp
@@ -44,12 +44,13 @@ SynfigToolGeneralOptions::SynfigToolGeneralOptions()
 std::string SynfigToolGeneralOptions::get_binary_path() const
 {
 	if (_binary_path.empty())
-		return synfig::OS::get_binary_path("").u8string();
+		return synfig::OS::get_binary_path().u8string();
 	return _binary_path;
 }
 
 void SynfigToolGeneralOptions::set_fallback_binary_path(const std::string& path) {
-	_binary_path = synfig::OS::get_binary_path(path).u8string();
+	synfig::OS::fallback_binary_path = path;
+	_binary_path = synfig::OS::get_binary_path().u8string();
 }
 
 size_t SynfigToolGeneralOptions::get_threads() const

--- a/synfig-core/src/tool/definitions.h
+++ b/synfig-core/src/tool/definitions.h
@@ -88,7 +88,7 @@ public:
 	/**
 	 * In the improbable case Synfig is unable to retrieve the current process filepath,
 	 * use this instead.
-	 * @param path the fallback to the binary path
+	 * @param path the fallback to the binary path (UTF-8 encoding)
 	 *
 	 * @see synfig::OS::get_binary_path()
 	 */

--- a/synfig-core/src/tool/main.cpp
+++ b/synfig-core/src/tool/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
 	} argv_guard(&argv);
  #endif
 
-	SynfigToolGeneralOptions::instance()->set_fallback_binary_path(argv[0]);
+	SynfigToolGeneralOptions::instance()->set_fallback_binary_path(argv[0]); // on MS Windows, already converted to UTF-8 via ArgVGuarg
 
 	const std::string binary_path =
 		SynfigToolGeneralOptions::instance()->get_binary_path();

--- a/synfig-studio/src/gui/main.cpp
+++ b/synfig-studio/src/gui/main.cpp
@@ -62,8 +62,8 @@ using namespace studio;
 
 int main(int argc, char **argv)
 {
-
-	const filesystem::Path rootpath = synfig::OS::get_binary_path(String(argv[0])).parent_path().parent_path();
+	synfig::OS::fallback_binary_path = filesystem::Path(Glib::filename_to_utf8(argv[0]));
+	const filesystem::Path rootpath = synfig::OS::get_binary_path().parent_path().parent_path();
 	
 #ifdef ENABLE_NLS
 	filesystem::Path locale_dir;

--- a/synfig-studio/src/player/main.cpp
+++ b/synfig-studio/src/player/main.cpp
@@ -91,7 +91,8 @@ int main(int argc, char **argv)
 
 	bool r_time;
 
-	filesystem::Path base_dir = OS::get_binary_path(argv[0]).parent_path();
+	OS::fallback_binary_path = std::string(argv[0]); // on MS Windows, already converted to UTF-8 via ArgVGuarg
+	filesystem::Path base_dir = OS::get_binary_path().parent_path();
 	TestCallback callback;
 
 	Main main(base_dir.u8string(), &callback);


### PR DESCRIPTION
Set synfig::OS::fallback_binary_path once instead