### PR TITLE
ci: added backtrace output in case of build fail

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -73,7 +73,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           ./1-setup-linux-native.sh
-          sudo apt-get install ccache ninja-build
+          sudo apt-get install ccache ninja-build gdb systemd-coredump
 
       - name: Setup ccache parameters and show statistics
         run: |
@@ -85,6 +85,7 @@ jobs:
       - name: Build (CMake+Ninja)
         if: matrix.toolchain == 'cmake-ninja'
         run: |
+          ulimit -c unlimited
           mkdir build-cmake && cd build-cmake
           cmake -GNinja -DENABLE_TESTS=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Release ..
           ninja
@@ -93,9 +94,14 @@ jobs:
       - name: Build (Autotools+Make)
         if: matrix.toolchain == 'autotools'
         run: |
+          ulimit -c unlimited # enable core dumps
           export PATH="/usr/lib/ccache/:${PATH}"
           echo ${PATH}
           ./2-build-debug.sh
+
+      - name: Collect core dump
+        if: runner.os == 'Linux' && failure()
+        run: sudo coredumpctl debug --debugger-arguments="-batch -ex 'thread apply all bt full'"
 
       - name: ccache statistics
         run: ccache --show-stats


### PR DESCRIPTION
Example output: https://github.com/ice0/crash_test/actions/runs/6526956239/job/17721247606

![image](https://github.com/synfig/synfig/assets/5604544/389cab03-625f-49ad-8395-afce64711376)
