### PR TITLE
fix: column 'name' of Layers panel should be the largest one

### DIFF
--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -186,6 +186,7 @@ LayerTree::create_layer_tree()
 		cellrenderer->signal_edited().connect(sigc::mem_fun(*this, &studio::LayerTree::on_layer_renamed));
 		cellrenderer->property_editable()=true;
 
+		column->set_expand();
 		column->set_reorderable();
 		column->set_resizable();
 		column->set_clickable(true);


### PR DESCRIPTION
and not the Z Depth...

From:
![image](https://github.com/synfig/synfig/assets/1323987/f35859f7-71c0-4fd8-9ed2-58b6a2532d64)
To:
![image](https://github.com/synfig/synfig/assets/1323987/aefdfafd-e2de-4dcb-b266-adc8d9d308d0)
