### PR TITLE
feat: add Layers, Parameters and Timetrack treeviews styles for even/odd rows

### DIFF
--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -107,3 +107,15 @@
 .color-white {
         color : #FFFFFF;
 }
+
+#parameters_panel .odd,
+#timetrack_panel .odd,
+#layers_panel .odd {
+   background-color: rgba(255,255,255,0.05);
+}
+
+#parameters_panel .even,
+#timetrack_panel .even,
+#layers_panel .even {
+   background-color: rgba(0,0,0,0.05);
+}

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -101,21 +101,21 @@
 }
 
 .color-red {
-        color : #FF0000;
+	color : #FF0000;
 }
 
 .color-white {
-        color : #FFFFFF;
+	color : #FFFFFF;
 }
 
 #parameters_panel .odd,
 #timetrack_panel .odd,
 #layers_panel .odd {
-   background-color: rgba(255,255,255,0.05);
+	background-color: rgba(255,255,255,0.05);
 }
 
 #parameters_panel .even,
 #timetrack_panel .even,
 #layers_panel .even {
-   background-color: rgba(0,0,0,0.05);
+	background-color: rgba(0,0,0,0.05);
 }


### PR DESCRIPTION
Following PR https://github.com/synfig/synfig/pull/3242 here are the proposed styles for having alternate even/odd rows in Synfig.

These styles are compatible with both light/dark themes:

<img width="965" alt="parameters_and_timetrack" src="https://github.com/synfig/synfig/assets/5942369/aa22d5ce-158d-4f0a-9a85-87f5053f27e2">


<img width="625" alt="layers" src="https://github.com/synfig/synfig/assets/5942369/7fd2ee5e-0300-4618-9fbc-195675b01b92">

Cheers