### PR TITLE
feat: allow to fix broken links on load

### DIFF
--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -570,19 +570,19 @@ Canvas::_get_relative_id(etl::loose_handle<const Canvas> x)const
 }
 
 ValueNode::Handle
-Canvas::find_value_node(const String &id, bool might_fail, CanvasBrokenUseIdMap* broken_links)
+Canvas::find_value_node(const String &id, bool might_fail, const Type& expected_type, CanvasBrokenUseIdMap* broken_links)
 {
 	return
 		ValueNode::Handle::cast_const(
-			const_cast<const Canvas*>(this)->find_value_node(id, might_fail, broken_links)
+			const_cast<const Canvas*>(this)->find_value_node(id, might_fail, expected_type, broken_links)
 		);
 }
 
 ValueNode::ConstHandle
-Canvas::find_value_node(const String &id, bool might_fail, CanvasBrokenUseIdMap* broken_links)const
+Canvas::find_value_node(const String &id, bool might_fail, const Type& expected_type, CanvasBrokenUseIdMap* broken_links)const
 {
 	if(is_inline() && parent_)
-		return parent_->find_value_node(id, might_fail, broken_links);
+		return parent_->find_value_node(id, might_fail, expected_type, broken_links);
 
 	if(id.empty())
 	{
@@ -607,16 +607,16 @@ Canvas::find_value_node(const String &id, bool might_fail, CanvasBrokenUseIdMap*
 		return find_canvas(canvas_id, warnings, broken_links)->value_node_list_.find(value_node_id, might_fail);
 	} catch (...) {
 		if (broken_links)
-			broken_links->add(id, "");
+			broken_links->add(id, expected_type.description.name);
 		throw;
 	}
 }
 
 ValueNode::Handle
-Canvas::surefind_value_node(const String &id, CanvasBrokenUseIdMap* broken_links)
+Canvas::surefind_value_node(const String &id, const Type& expected_type, CanvasBrokenUseIdMap* broken_links)
 {
 	if(is_inline() && parent_)
-		return parent_->surefind_value_node(id, broken_links);
+		return parent_->surefind_value_node(id, expected_type, broken_links);
 
 	if(id.empty())
 		throw Exception::IDNotFound("Empty ID");
@@ -636,7 +636,7 @@ Canvas::surefind_value_node(const String &id, CanvasBrokenUseIdMap* broken_links
 		return surefind_canvas(canvas_id,warnings, broken_links)->value_node_list_.surefind(value_node_id);
 	} catch (...) {
 		if (broken_links)
-			broken_links->add(id, "");
+			broken_links->add(id, expected_type.description.name);
 		throw;
 	}
 }

--- a/synfig-core/src/synfig/canvas.cpp
+++ b/synfig-core/src/synfig/canvas.cpp
@@ -607,7 +607,7 @@ Canvas::find_value_node(const String &id, bool might_fail, CanvasBrokenUseIdMap*
 		return find_canvas(canvas_id, warnings, broken_links)->value_node_list_.find(value_node_id, might_fail);
 	} catch (...) {
 		if (broken_links)
-			(*broken_links)[canvas_id].missing_items.push_back({value_node_id, ""});
+			broken_links->add(id, "");
 		throw;
 	}
 }
@@ -636,7 +636,7 @@ Canvas::surefind_value_node(const String &id, CanvasBrokenUseIdMap* broken_links
 		return surefind_canvas(canvas_id,warnings, broken_links)->value_node_list_.surefind(value_node_id);
 	} catch (...) {
 		if (broken_links)
-			(*broken_links)[canvas_id].missing_items.push_back({value_node_id, ""});
+			broken_links->add(id, "");
 		throw;
 	}
 }

--- a/synfig-core/src/synfig/canvas.h
+++ b/synfig-core/src/synfig/canvas.h
@@ -148,6 +148,8 @@ class GUID;
 class Canvas;
 class SoundProcessor;
 
+class CanvasBrokenUseIdMap;
+
 /*!	\class Canvas
 **	\brief Canvas is a list of Layers. It is the base class for a Synfig
 * document.
@@ -502,16 +504,16 @@ public:
 	/*!	\return If found, returns a handle to the ValueNode.
 	**		Otherwise, returns an empty handle.
 	*/
-	ValueNode::Handle find_value_node(const String &id, bool might_fail);
+	ValueNode::Handle find_value_node(const String &id, bool might_fail, CanvasBrokenUseIdMap* broken_links = nullptr);
 
 	//! \internal \writeme
-	ValueNode::Handle surefind_value_node(const String &id);
+	ValueNode::Handle surefind_value_node(const String &id, CanvasBrokenUseIdMap* broken_links = nullptr);
 
 	//! Finds the ValueNode in the Canvas with the given \a id
 	/*!	\return If found, returns a handle to the ValueNode.
 	**		Otherwise, returns an empty handle.
 	*/
-	ValueNode::ConstHandle find_value_node(const String &id, bool might_fail)const;
+	ValueNode::ConstHandle find_value_node(const String &id, bool might_fail, CanvasBrokenUseIdMap* broken_links = nullptr)const;
 
 	//! Adds a Value node by its Id.
 	/*! Throws an error if the Id is not
@@ -533,19 +535,19 @@ public:
 	**		If not found, it creates a new Canvas and returns it
 	**		If an error occurs, it returns an empty handle
 	*/
-	Handle surefind_canvas(const String &id,String &warnings);
+	Handle surefind_canvas(const String &id,String &warnings, CanvasBrokenUseIdMap* broken_links = nullptr);
 
 	//! Finds a child Canvas in the Canvas with the given \a id
 	/*!	\return If found, returns a handle to the child Canvas.
 	**		Otherwise, returns an empty handle.
 	*/
-	Handle find_canvas(const String &id, String &warnings);
+	Handle find_canvas(const String &id, String &warnings, CanvasBrokenUseIdMap* broken_links = nullptr);
 
 	//! Finds a child Canvas in the Canvas with the given \a id
 	/*!	\return If found, returns a handle to the child Canvas.
 	**		Otherwise, returns an empty handle.
 	*/
-	ConstHandle find_canvas(const String &id, String &warnings)const;
+	ConstHandle find_canvas(const String &id, String &warnings, CanvasBrokenUseIdMap* broken_links = nullptr)const;
 
 	//! Returns the file path from the file name
 	String get_file_path()const;

--- a/synfig-core/src/synfig/canvas.h
+++ b/synfig-core/src/synfig/canvas.h
@@ -504,16 +504,16 @@ public:
 	/*!	\return If found, returns a handle to the ValueNode.
 	**		Otherwise, returns an empty handle.
 	*/
-	ValueNode::Handle find_value_node(const String &id, bool might_fail, CanvasBrokenUseIdMap* broken_links = nullptr);
+	ValueNode::Handle find_value_node(const String &id, bool might_fail, const Type& expected_type = type_nil, CanvasBrokenUseIdMap* broken_links = nullptr);
 
 	//! \internal \writeme
-	ValueNode::Handle surefind_value_node(const String &id, CanvasBrokenUseIdMap* broken_links = nullptr);
+	ValueNode::Handle surefind_value_node(const String &id, const Type& expected_type = type_nil, CanvasBrokenUseIdMap* broken_links = nullptr);
 
 	//! Finds the ValueNode in the Canvas with the given \a id
 	/*!	\return If found, returns a handle to the ValueNode.
 	**		Otherwise, returns an empty handle.
 	*/
-	ValueNode::ConstHandle find_value_node(const String &id, bool might_fail, CanvasBrokenUseIdMap* broken_links = nullptr)const;
+	ValueNode::ConstHandle find_value_node(const String &id, bool might_fail, const Type& expected_type = type_nil, CanvasBrokenUseIdMap* broken_links = nullptr) const;
 
 	//! Adds a Value node by its Id.
 	/*! Throws an error if the Id is not
@@ -528,7 +528,7 @@ public:
 	void remove_value_node(ValueNode::Handle x, bool might_fail);
 
 	//! Removes a Value Node from the Canvas by its Id
-	void remove_value_node(const String &id, bool might_fail) { remove_value_node(find_value_node(id, might_fail), might_fail); }
+	void remove_value_node(const String &id, bool might_fail) { remove_value_node(find_value_node(id, might_fail, type_nil), might_fail); }
 
 	//! Finds a child Canvas in the Canvas with the given \a name
 	/*!	\return If found, returns a handle to the child Canvas.

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -84,6 +84,8 @@
 #include "valuenodes/valuenode_wplist.h"
 #include "valuenodes/valuenode_average.h"
 
+#include "canvasfilenaming.h"
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -158,7 +160,7 @@ static void _canvas_file_name_changed(Canvas *x)
 }
 
 Canvas::Handle
-synfig::open_canvas_as(const FileSystem::Identifier &identifier,const String &as,String &errors,String &warnings)
+synfig::open_canvas_as(const FileSystem::Identifier &identifier, const String &as, String &errors, String &warnings, CanvasBrokenUseIdMap *broken_links)
 {
 	String filename = FileSystem::fix_slashes(as);
 	if (CanvasParser::loading_.count(identifier))
@@ -182,14 +184,21 @@ synfig::open_canvas_as(const FileSystem::Identifier &identifier,const String &as
 	try
 	{
 		CanvasParser::loading_.insert(identifier);
+		if (broken_links)
+			parser.set_broken_use_ids(*broken_links);
 		canvas=parser.parse_from_file_as(identifier,filename,errors);
 	}
 	catch (...)
 	{
 		CanvasParser::loading_.erase(identifier);
+		if (broken_links)
+			*broken_links = parser.get_broken_use_ids();
 		throw;
 	}
+
 	CanvasParser::loading_.erase(identifier);
+	if (broken_links)
+		*broken_links = parser.get_broken_use_ids();
 
 	warnings = parser.get_warnings_text();
 
@@ -1483,7 +1492,6 @@ CanvasParser::parse_static(xmlpp::Element *element)
 	return false;
 }
 
-
 ValueBase
 CanvasParser::parse_value(xmlpp::Element *element,Canvas::Handle canvas)
 {
@@ -1703,26 +1711,35 @@ CanvasParser::parse_animated(xmlpp::Element *element,Canvas::Handle canvas)
 			ValueNode::Handle waypoint_value_node;
 			xmlpp::Element::NodeList list = child->get_children();
 
-			if(child->get_attribute("use"))
+			if(const auto use_attr = child->get_attribute("use"))
 			{
 				if(!list.empty())
 					warning(child,_("Found \"use\" attribute for <waypoint>, but it wasn't empty. Ignoring contents..."));
+
+				std::string use_id = use_attr->get_value();
+				fix_broken_use_id(canvas->get_file_name(), use_id);
 
 				// the waypoint might look like this, in which case we won't find "mycanvas" in the list of valuenodes, 'cos it's a canvas
 				//
 				//      <animated type="canvas">
 				//        <waypoint time="0s" use="mycanvas"/>
 				//      </animated>
-				if (type==type_canvas)
+				try
 				{
-					String warnings;
-					waypoint_value_node=ValueNode_Const::create(canvas->surefind_canvas(child->get_attribute("use")->get_value(), warnings));
-					warnings_text += warnings;
+					if (type==type_canvas)
+					{
+						String warnings;
+						waypoint_value_node=ValueNode_Const::create(canvas->surefind_canvas(use_id, warnings, &filepath_fix_map));
+						warnings_text += warnings;
+					}
+					else
+						waypoint_value_node=canvas->surefind_value_node(use_id, &filepath_fix_map);
+				} catch (Exception::IDNotFound&) {
+					register_broken_use_id(use_id, type.description.name);
 				}
-				else
-					waypoint_value_node=canvas->surefind_value_node(child->get_attribute("use")->get_value());
+
 				if(PlaceholderValueNode::Handle::cast_dynamic(waypoint_value_node))
-					error(child, strprintf(_("Unknown ID (%s) referenced in waypoint"),child->get_attribute("use")->get_value().c_str()));
+					error(child, strprintf(_("Unknown ID (%s) referenced in waypoint"),use_id.c_str()));
 			}
 			else
 			{
@@ -1922,6 +1939,8 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 			if (name == "guid" || name == "id" || name == "type")
 				continue;
 
+			fix_broken_use_id(canvas->get_file_name(), id);
+
 			try {
 				bool load_old_weighted_bonelink = false;
 				if (ValueNode_BoneLink::Handle::cast_dynamic(value_node) && name == "bone_weight_list")
@@ -1940,13 +1959,26 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 					continue;
 				}
 				int placeholders(canvas->value_node_list().placeholder_count());
-				c[index] = canvas->surefind_value_node(id);
-				// Don't accept links for unsolved exported Value Nodes.
-				// Except if it is parsing <bones>, as this section is defined before <defs>
-				if (!in_bones_section) {
-					if(placeholders == canvas->value_node_list().placeholder_count())
-						if(PlaceholderValueNode::Handle::cast_dynamic(c[index]) )
-							throw Exception::IDNotFound("parse_linkable_value_noode()");
+				try {
+					c[index] = canvas->surefind_value_node(id, &filepath_fix_map);
+					// Don't accept links for unsolved exported Value Nodes.
+					// Except if it is parsing <bones>, as this section is defined before <defs>
+					if (!in_bones_section) {
+						if(placeholders == canvas->value_node_list().placeholder_count())
+							if(PlaceholderValueNode::Handle::cast_dynamic(c[index]) )
+								throw Exception::IDNotFound("parse_linkable_value_node()");
+					}
+				} catch (Exception::IDNotFound&) {
+					register_broken_use_id(id, type.description.name);
+				} catch(...) {
+					register_broken_use_id(id, type.description.name);
+				}
+
+				if(placeholders == canvas->value_node_list().placeholder_count()) {
+					if(PlaceholderValueNode::Handle::cast_dynamic(c[index]) ) {
+						register_broken_use_id(id, type.description.name);
+						throw Exception::IDNotFound("parse_linkable_value_node()");
+					}
 				}
 
 				if (!c[index])
@@ -2251,17 +2283,20 @@ CanvasParser::parse_static_list(xmlpp::Element *element,Canvas::Handle canvas)
 		{
 			ValueNode::Handle list_entry;
 
-			if(child->get_attribute("use"))
+			if(const auto use_attr = child->get_attribute("use"))
 			{
 				// \todo does this need to be able to read 'use="canvas"', like waypoints can now?  (see 'surefind_canvas' in this file)
-				std::string id=child->get_attribute("use")->get_value();
+				std::string use_id = use_attr->get_value();
+				fix_broken_use_id(canvas->get_file_name(), use_id);
+
 				try
 				{
-					list_entry=canvas->surefind_value_node(id);
+					list_entry=canvas->surefind_value_node(use_id, &filepath_fix_map);
 				}
 				catch(Exception::IDNotFound&)
 				{
-					error(child,"\"use\" attribute in <entry> references unknown ID -- "+id);
+					error(child,"\"use\" attribute in <entry> references unknown ID -- "+use_id);
+					register_broken_use_id(use_id, type.description.name);
 					continue;
 				}
 			}
@@ -2509,19 +2544,21 @@ CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 				timing_info.sort();
 			}
 
-			if(child->get_attribute("use"))
+			if(const auto use_attr = child->get_attribute("use"))
 			{
 				// \todo does this need to be able to read 'use="canvas"', like waypoints can now?  (see 'surefind_canvas' in this file)
-				std::string id=child->get_attribute("use")->get_value();
+				std::string use_id = use_attr->get_value();
+				fix_broken_use_id(canvas->get_file_name(), use_id);
 				try
 				{
-					list_entry.value_node=canvas->surefind_value_node(id);
+					list_entry.value_node=canvas->surefind_value_node(use_id, &filepath_fix_map);
 					if(PlaceholderValueNode::Handle::cast_dynamic(list_entry.value_node))
 						throw Exception::IDNotFound("parse_dynamic_list()");
 				}
 				catch(Exception::IDNotFound&)
 				{
-					error(child,"\"use\" attribute in <entry> references unknown ID -- "+id);
+					error(child,"\"use\" attribute in <entry> references unknown ID -- "+use_id);
+					register_broken_use_id(use_id, type.description.name);
 					continue;
 				}
 			}
@@ -2856,7 +2893,7 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 			if (param_name == "pos" || param_name == "offset")
 				param_name = "origin";
 
-			if(child->get_attribute("use"))
+			if(const auto use_attr = child->get_attribute("use"))
 			{
 				// If the "use" attribute is used, then the
 				// element should be empty. Warn the user if
@@ -2864,27 +2901,33 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 				if(!list.empty())
 					warning(child,_("Found \"use\" attribute for <param>, but it wasn't empty. Ignoring contents..."));
 
-				String str=	child->get_attribute("use")->get_value();
+				std::string use_id = use_attr->get_value();
+				fix_broken_use_id(canvas->get_file_name(), use_id);
 
-				if (str.empty())
+				if (use_id.empty())
 					error(child,_("Empty use=\"\" value in <param>"));
 				else if(layer->get_param(param_name).get_type()==type_canvas)
 				{
 					String warnings;
-					Canvas::Handle c(canvas->surefind_canvas(str, warnings));
-					warnings_text += warnings;
-					if(!c) error((*iter),strprintf(_("Failed to load subcanvas '%s'"), str.c_str()));
-					if(!layer->set_param(param_name,c))
-						error((*iter),_("Layer rejected canvas link"));
-					//Parse the static option and sets it to the canvas ValueBase
-					ValueBase v=layer->get_param(param_name);
-					v.set_static(parse_static(child));
-					layer->set_param(param_name, v);
+					try {
+						Canvas::Handle c(canvas->surefind_canvas(use_id, warnings, &filepath_fix_map));
+						warnings_text += warnings;
+						if(!c) error(child,strprintf(_("Failed to load subcanvas '%s'"), use_id.c_str()));
+						if(!layer->set_param(param_name,c))
+							error(child,_("Layer rejected canvas link"));
+						//Parse the static option and sets it to the canvas ValueBase
+						ValueBase v=layer->get_param(param_name);
+						v.set_static(parse_static(child));
+						layer->set_param(param_name, v);
+					} catch (Exception::IDNotFound& ex) {
+						error(child,strprintf(_("Failed to load subcanvas '%s' referenced in parameter \"%s\""), use_id.c_str(), param_name.c_str()));
+						register_broken_use_id(use_id, layer->get_param(param_name).get_type().description.name);
+					}
 				}
 				else
 				try
 				{
-					ValueNode::Handle value_node=canvas->surefind_value_node(str);
+					ValueNode::Handle value_node = canvas->surefind_value_node(use_id, &filepath_fix_map);
 					if(PlaceholderValueNode::Handle::cast_dynamic(value_node))
 						throw Exception::IDNotFound("parse_layer()");
 
@@ -2928,7 +2971,8 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
     			}
 				catch(Exception::IDNotFound&)
 				{
-					error(child,strprintf(_("Unknown ID (%s) referenced in parameter \"%s\""),str.c_str(), param_name.c_str()));
+					error(child,strprintf(_("Unknown ID (%s) referenced in parameter \"%s\""),use_id.c_str(), param_name.c_str()));
+					register_broken_use_id(use_id, layer->get_param(param_name).get_type().description.name);
 				}
 
 				continue;
@@ -3171,7 +3215,7 @@ CanvasParser::parse_canvas(xmlpp::Element *element,Canvas::Handle parent,bool in
 			try
 			{
 				String warnings;
-				canvas=parent->find_canvas(element->get_attribute("id")->get_value(), warnings);
+				canvas=parent->find_canvas(element->get_attribute("id")->get_value(), warnings, &filepath_fix_map);
 				warnings_text += warnings;
 			}
 			catch(...)
@@ -3554,6 +3598,7 @@ CanvasParser::parse_from_file_as(const FileSystem::Identifier &identifier,const 
 				return canvas;
 			}
 		} else {
+			register_broken_use_id(as + "#", "file");
 			throw std::runtime_error(String("  * ") + _("Can't find linked file") + " \"" + identifier.filename.u8string() + "\"");
 		}
 	}
@@ -3647,4 +3692,31 @@ synfig::open_canvas(xmlpp::Element* node,String &errors,String &warnings){
 	return canvas;
 }
 
+const CanvasBrokenUseIdMap&
+CanvasParser::get_broken_use_ids() const
+{
+	return filepath_fix_map;
+}
 
+void
+CanvasParser::set_broken_use_ids(const CanvasBrokenUseIdMap& map)
+{
+	filepath_fix_map = map;
+}
+
+bool
+CanvasParser::fix_broken_use_id(const filesystem::Path& canvas_path, std::string& use_id) const
+{
+	auto pos = use_id.find('#');
+	if (pos != std::string::npos) {
+		auto file = CanvasFileNaming::make_full_filename(canvas_path.u8string(), use_id.substr(0, pos));
+		use_id = file + '#' + use_id.substr(pos + 1);
+	}
+	return filepath_fix_map.fix(use_id);
+}
+
+bool
+CanvasParser::register_broken_use_id(const std::string& use_id, const std::string& type)
+{
+	return filepath_fix_map.add(use_id, type);
+}

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -1733,7 +1733,7 @@ CanvasParser::parse_animated(xmlpp::Element *element,Canvas::Handle canvas)
 						warnings_text += warnings;
 					}
 					else
-						waypoint_value_node=canvas->surefind_value_node(use_id, &filepath_fix_map);
+						waypoint_value_node=canvas->surefind_value_node(use_id, type, &filepath_fix_map);
 				} catch (Exception::IDNotFound&) {
 					register_broken_use_id(use_id, type.description.name);
 				}
@@ -1960,7 +1960,7 @@ CanvasParser::parse_linkable_value_node(xmlpp::Element *element,Canvas::Handle c
 				}
 				int placeholders(canvas->value_node_list().placeholder_count());
 				try {
-					c[index] = canvas->surefind_value_node(id, &filepath_fix_map);
+					c[index] = canvas->surefind_value_node(id, type, &filepath_fix_map);
 					// Don't accept links for unsolved exported Value Nodes.
 					// Except if it is parsing <bones>, as this section is defined before <defs>
 					if (!in_bones_section) {
@@ -2291,7 +2291,7 @@ CanvasParser::parse_static_list(xmlpp::Element *element,Canvas::Handle canvas)
 
 				try
 				{
-					list_entry=canvas->surefind_value_node(use_id, &filepath_fix_map);
+					list_entry=canvas->surefind_value_node(use_id, type, &filepath_fix_map);
 				}
 				catch(Exception::IDNotFound&)
 				{
@@ -2551,7 +2551,7 @@ CanvasParser::parse_dynamic_list(xmlpp::Element *element,Canvas::Handle canvas)
 				fix_broken_use_id(canvas->get_file_name(), use_id);
 				try
 				{
-					list_entry.value_node=canvas->surefind_value_node(use_id, &filepath_fix_map);
+					list_entry.value_node=canvas->surefind_value_node(use_id, type, &filepath_fix_map);
 					if(PlaceholderValueNode::Handle::cast_dynamic(list_entry.value_node))
 						throw Exception::IDNotFound("parse_dynamic_list()");
 				}
@@ -2904,9 +2904,12 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 				std::string use_id = use_attr->get_value();
 				fix_broken_use_id(canvas->get_file_name(), use_id);
 
+				const ValueBase default_param_value = layer->get_param(param_name);
+				const Type& param_type = default_param_value.get_type();
+
 				if (use_id.empty())
 					error(child,_("Empty use=\"\" value in <param>"));
-				else if(layer->get_param(param_name).get_type()==type_canvas)
+				else if(param_type == type_canvas)
 				{
 					String warnings;
 					try {
@@ -2921,13 +2924,13 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 						layer->set_param(param_name, v);
 					} catch (Exception::IDNotFound& ex) {
 						error(child,strprintf(_("Failed to load subcanvas '%s' referenced in parameter \"%s\""), use_id.c_str(), param_name.c_str()));
-						register_broken_use_id(use_id, layer->get_param(param_name).get_type().description.name);
+						register_broken_use_id(use_id, param_type.description.name);
 					}
 				}
 				else
 				try
 				{
-					ValueNode::Handle value_node = canvas->surefind_value_node(use_id, &filepath_fix_map);
+					ValueNode::Handle value_node = canvas->surefind_value_node(use_id, param_type, &filepath_fix_map);
 					if(PlaceholderValueNode::Handle::cast_dynamic(value_node))
 						throw Exception::IDNotFound("parse_layer()");
 
@@ -2972,7 +2975,7 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 				catch(Exception::IDNotFound&)
 				{
 					error(child,strprintf(_("Unknown ID (%s) referenced in parameter \"%s\""),use_id.c_str(), param_name.c_str()));
-					register_broken_use_id(use_id, layer->get_param(param_name).get_type().description.name);
+					register_broken_use_id(use_id, param_type.description.name);
 				}
 
 				continue;

--- a/synfig-core/src/synfig/loadcanvas.h
+++ b/synfig-core/src/synfig/loadcanvas.h
@@ -81,7 +81,7 @@ struct BrokenUseIdInfo
 //! Map to fix broken links due to missing files
 //! (original_file_path, (new_file_path, [(valuenode_id, value_type), ...]))
 //! If new_file_path is null, there is no replacement file path to that item
-struct CanvasBrokenUseIdMap : std::map<filesystem::Path, BrokenUseIdInfo>
+struct CanvasBrokenUseIdMap : private std::map<filesystem::Path, BrokenUseIdInfo>
 {
 	bool
 	fix(std::string& use_id) const
@@ -121,6 +121,22 @@ struct CanvasBrokenUseIdMap : std::map<filesystem::Path, BrokenUseIdInfo>
 		return true;
 	}
 
+	bool
+	add_replacement(const filesystem::Path& broken_file, const filesystem::Path& replacement)
+	{
+		auto it = find(broken_file);
+		if (it == cend())
+			return false;
+		it->second.replacement = replacement;
+		return true;
+	}
+
+	using std::map<filesystem::Path, BrokenUseIdInfo>::empty;
+	using std::map<filesystem::Path, BrokenUseIdInfo>::size;
+	using std::map<filesystem::Path, BrokenUseIdInfo>::const_iterator;
+	using std::map<filesystem::Path, BrokenUseIdInfo>::cbegin;
+	using std::map<filesystem::Path, BrokenUseIdInfo>::cend;
+	using std::map<filesystem::Path, BrokenUseIdInfo>::at;
 };
 
 

--- a/synfig-core/src/synfig/loadcanvas.h
+++ b/synfig-core/src/synfig/loadcanvas.h
@@ -56,6 +56,75 @@ namespace xmlpp { class Node; class Element; };
 
 namespace synfig {
 
+
+
+struct CanvasMissingId
+{
+	std::string id;
+	std::string type_name;
+
+	bool
+	operator==(const CanvasMissingId& other) const
+	{
+		return id == other.id && type_name == other.type_name;
+	}
+};
+
+typedef std::vector<CanvasMissingId> CanvasMissingIdList;
+
+struct BrokenUseIdInfo
+{
+	filesystem::Path replacement;
+	CanvasMissingIdList missing_items;
+};
+
+//! Map to fix broken links due to missing files
+//! (original_file_path, (new_file_path, [(valuenode_id, value_type), ...]))
+//! If new_file_path is null, there is no replacement file path to that item
+struct CanvasBrokenUseIdMap : std::map<filesystem::Path, BrokenUseIdInfo>
+{
+	bool
+	fix(std::string& use_id) const
+	{
+		auto pos = use_id.find('#');
+		if (pos == std::string::npos || pos == 0)
+			return false;
+
+		try {
+			filesystem::Path filepath = use_id.substr(0, pos);
+			filepath = this->at(filepath).replacement;
+			use_id = filepath.u8string() + use_id.substr(pos);
+			return true;
+		} catch (...) {
+			return false;
+		}
+	}
+
+	bool
+	add(const std::string& use_id, const std::string& type_name)
+	{
+		auto pos = use_id.find('#');
+		if (pos == std::string::npos || pos == 0)
+			return false;
+
+		const CanvasMissingId item {use_id.substr(pos+1), type_name};
+
+		auto missing_file = filesystem::Path(use_id.substr(0, pos));
+		auto missing_file_iter = find(missing_file);
+		if (missing_file_iter == end()) {
+			(*this)[missing_file] = {{}, {item}};
+		} else {
+			CanvasMissingIdList& missing_items = missing_file_iter->second.missing_items;
+			if (missing_items.end() == std::find(missing_items.begin(), missing_items.end(), item))
+				missing_items.push_back(item);
+		}
+		return true;
+	}
+
+};
+
+
+
 /*!	\class CanvasParser
 **	\brief Class that handles xmlpp elements from a sif file and converts
 * them into Synfig objects
@@ -88,6 +157,7 @@ private:
 	//
 	bool in_bones_section;
 
+	CanvasBrokenUseIdMap filepath_fix_map;
 	/*
  --	** -- C O N S T R U C T O R S ---------------------------------------------
 	*/
@@ -133,6 +203,11 @@ public:
 	const synfig::String& get_errors_text()const { return errors_text; }
 	//! Gets warning text string
 	const synfig::String& get_warnings_text()const { return warnings_text; }
+
+	//! Gets the list of the broken use id due to missing files
+	const CanvasBrokenUseIdMap& get_broken_use_ids() const;
+	//! Sets the map of (missing file, replacement file)
+	void set_broken_use_ids(const CanvasBrokenUseIdMap& map);
 
 	//! Register a canvas in the canvas map
 	/*! \param canvas The handle to the canvas to register
@@ -236,6 +311,12 @@ private:
 	//! Static option for ValueBase parsing function
 	bool parse_static(xmlpp::Element *node);
 
+	//! Replace file path in use_id with the correspondent one in filepath_fix_map
+	//! \return true if replacement was done or use_id does not refer to an external canvas file
+	bool fix_broken_use_id(const filesystem::Path& canvas_path, std::string& use_id) const;
+	//! Register file path in use_id as broken
+	//! \return true if use_id refers to an external canvas file.
+	bool register_broken_use_id(const std::string& use_id, const std::string& type);
 }; // END of CanvasParser
 
 /* === E X T E R N S ======================================================= */
@@ -245,7 +326,7 @@ private:
 extern Canvas::Handle open_canvas(xmlpp::Element* node,String &errors,String &warnings);
 //!	Loads a canvas from \a filename and its absolute path
 /*!	\return	The Canvas's handle on success, an empty handle on failure */
-extern Canvas::Handle open_canvas_as(const FileSystem::Identifier &identifier,const String &as,String &errors,String &warnings);
+extern Canvas::Handle open_canvas_as(const FileSystem::Identifier &identifier, const String &as, String &errors, String &warnings, CanvasBrokenUseIdMap*broken_links = nullptr);
 
 //! Returns the Open Canvases Map.
 //! \see open_canvas_map_

--- a/synfig-studio/po/POTFILES.in
+++ b/synfig-studio/po/POTFILES.in
@@ -31,6 +31,7 @@ src/gui/dialogs/dialog_canvasdependencies.h
 src/gui/dialogs/canvasresize.cpp
 src/gui/dialogs/dialog_color.cpp
 src/gui/dialogs/dialog_color.h
+src/gui/dialogs/dialog_fixmissingfiles.cpp
 src/gui/dialogs/dialog_ffmpegparam.cpp
 src/gui/dialogs/dialog_gradient.cpp
 src/gui/dialogs/dialog_gradient.h
@@ -530,6 +531,7 @@ src/synfigapp/value_desc.h
 src/gui/resources/ui/canvas_options.glade
 src/gui/resources/ui/canvas_resize.glade
 src/gui/resources/ui/dialog_canvasdependencies.glade
+src/gui/resources/ui/dialog_fixmissingfiles.glade
 src/gui/resources/ui/dialog_pasteoptions.glade
 src/gui/resources/ui/dialog_workspaces.glade
 src/gui/resources/ui/preview_options.glade

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3680,6 +3680,7 @@ App::open(filesystem::Path filename, /* std::string as, */ synfig::FileContainer
 						if (!dialog) {
 							synfig::error(_("Couldn't open dialog for fixing missing files"));
 						} else {
+							dialog->set_canvas_filepath(filename);
 							dialog->set_broken_useids(broken_links);
 							if (dialog->run() == Gtk::RESPONSE_OK) {
 								continue;

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -79,6 +79,7 @@
 
 #include <gui/dialogs/about.h>
 #include <gui/dialogs/dialog_color.h>
+#include <gui/dialogs/dialog_fixmissingfiles.h>
 #include <gui/dialogs/dialog_gradient.h>
 #include <gui/dialogs/dialog_input.h>
 #include <gui/dialogs/dialog_setup.h>
@@ -3660,39 +3661,61 @@ App::open(filesystem::Path filename, /* std::string as, */ synfig::FileContainer
 		// file to open inside canvas file-system
 		String canvas_filename = CanvasFileNaming::project_file(filename.u8string());
 
-		Canvas::Handle canvas = open_canvas_as(canvas_file_system ->get_identifier(canvas_filename), filename.u8string(), errors, warnings);
-		if(canvas && get_instance(canvas))
-		{
-			get_instance(canvas)->find_canvas_view(canvas)->present();
-			info("%s is already open", canvas_filename.c_str());
-			// throw (String)strprintf(_("\"%s\" appears to already be open!"),filename.c_str());
-		}
-		else
-		{
-			if(!canvas)
-				throw (String)strprintf(_("Unable to load \"%s\":\n\n"), filename.u8_str()) + errors;
+		CanvasBrokenUseIdMap broken_links;
+		Canvas::Handle canvas;
 
-			// Set new pixel ratio
-			canvas->rend_desc().set_pixel_ratio(canvas->rend_desc().get_w(), canvas->rend_desc().get_h());
+		do {
+			canvas = open_canvas_as(canvas_file_system ->get_identifier(canvas_filename), filename.u8string(), errors, warnings, &broken_links);
+			if (canvas && get_instance(canvas)) {
+				get_instance(canvas)->find_canvas_view(canvas)->present();
+				info("%s is already open", canvas_filename.c_str());
+				// throw (String)strprintf(_("\"%s\" appears to already be open!"),filename.c_str());
+			} else {
+				if (!canvas) {
+					if (!broken_links.empty()) {
+						// show dialog
+						// if dialog cancelled, resume loop;
+						// if confirmed, continue.
+						auto dialog = Dialog_FixMissingFiles::create(*App::main_window);
+						if (!dialog) {
+							synfig::error(_("Couldn't open dialog for fixing missing files"));
+						} else {
+							dialog->set_broken_useids(broken_links);
+							if (dialog->run() == Gtk::RESPONSE_OK) {
+								continue;
+							}
+						}
+					}
+					throw (String)strprintf(_("Unable to load \"%s\":\n\n"), filename.u8_str()) + errors;
+				}
 
-			if (!warnings.empty())
-				dialog_message_1b(
-					"WARNING",
-					_("Warning"),
-					"details",
-					_("Close"),
-					warnings);
+				// Set new pixel ratio
+				canvas->rend_desc().set_pixel_ratio(canvas->rend_desc().get_w(), canvas->rend_desc().get_h());
 
-			if (filename.u8string().find(custom_filename_prefix) != 0)
-				add_recent_file(filename);
+				if (!warnings.empty())
+					dialog_message_1b(
+						"WARNING",
+						_("Warning"),
+						"details",
+						_("Close"),
+						warnings);
 
-			etl::handle<Instance> instance(Instance::create(canvas, container));
+				if (filename.u8string().find(custom_filename_prefix) != 0)
+					add_recent_file(filename);
 
-			if(!instance)
-				throw (String)strprintf(_("Unable to create instance for \"%s\""), filename.u8_str());
+				etl::handle<Instance> instance(Instance::create(canvas, container));
 
-			one_moment.hide();
-		}
+				if (!instance)
+					throw (String)strprintf(_("Unable to create instance for \"%s\""), filename.u8_str());
+
+				one_moment.hide();
+
+				if (!broken_links.empty()) {
+					// This file isn't saved! mark it as such
+					instance->inc_action_count();
+				}
+			}
+		} while (!canvas);
 	}
 	catch(String &x)
 	{

--- a/synfig-studio/src/gui/dialogs/CMakeLists.txt
+++ b/synfig-studio/src/gui/dialogs/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(synfigstudio
 		"${CMAKE_CURRENT_LIST_DIR}/canvasresize.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/dialog_canvasdependencies.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/dialog_color.cpp"
+		"${CMAKE_CURRENT_LIST_DIR}/dialog_fixmissingfiles.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/dialog_gradient.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/dialog_input.cpp"
 		"${CMAKE_CURRENT_LIST_DIR}/dialog_keyframe.cpp"

--- a/synfig-studio/src/gui/dialogs/Makefile_insert
+++ b/synfig-studio/src/gui/dialogs/Makefile_insert
@@ -5,6 +5,7 @@ DIALOGS_HH = \
 	dialogs/canvasresize.h \
 	dialogs/dialog_canvasdependencies.h \
 	dialogs/dialog_color.h \
+	dialogs/dialog_fixmissingfiles.h \
 	dialogs/dialog_gradient.h \
 	dialogs/dialog_input.h \
 	dialogs/dialog_keyframe.h \
@@ -28,6 +29,7 @@ DIALOGS_CC = \
 	dialogs/canvasresize.cpp \
 	dialogs/dialog_canvasdependencies.cpp \
 	dialogs/dialog_color.cpp \
+	dialogs/dialog_fixmissingfiles.cpp \
 	dialogs/dialog_gradient.cpp \
 	dialogs/dialog_input.cpp \
 	dialogs/dialog_keyframe.cpp \

--- a/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.cpp
@@ -1,0 +1,204 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file dialogs/dialog_fixmissingfiles.cpp
+**	\brief Implementation of Dialog_FixMissingFiles
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	Copyright (c) 2023-     Synfig Contributors
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+# include "pch.h"
+#else
+# ifdef HAVE_CONFIG_H
+#  include <config.h>
+# endif
+
+# include "dialog_fixmissingfiles.h"
+
+# include <gtkmm/button.h>
+# include <gtkmm/image.h>
+# include <gtkmm/label.h>
+# include <gtkmm/listbox.h>
+
+# include <synfig/string_helper.h>
+
+# include <gui/app.h>
+# include <gui/localization.h>
+# include <gui/resourcehelper.h>
+
+#endif
+
+/* === U S I N G =========================================================== */
+
+using namespace studio;
+
+/* === M A C R O S ========================================================= */
+
+/* === G L O B A L S ======================================================= */
+
+/* === P R O C E D U R E S ================================================= */
+
+static Gtk::Image*
+create_image_from_icon(const std::string& icon_name, Gtk::IconSize icon_size)
+{
+#if GTK_CHECK_VERSION(3,24,0)
+	return new Gtk::Image(icon_name, icon_size);
+#else
+	Gtk::Image* image = new Gtk::Image();
+	image->set_from_icon_name(icon_name, icon_size);
+	return image;
+#endif
+}
+
+/* === M E T H O D S ======================================================= */
+
+std::shared_ptr<Dialog_FixMissingFiles>
+Dialog_FixMissingFiles::create(Gtk::Window& parent)
+{
+	auto refBuilder = ResourceHelper::load_interface("dialog_fixmissingfiles.glade");
+	if (!refBuilder)
+		return nullptr;
+	Dialog_FixMissingFiles * dialog_ptr = nullptr;
+	refBuilder->get_widget_derived("dialog_fixmissingfiles", dialog_ptr);
+	if (dialog_ptr) {
+		dialog_ptr->set_transient_for(parent);
+	}
+	std::shared_ptr<Dialog_FixMissingFiles> dialog(dialog_ptr);
+	return dialog;
+}
+
+Dialog_FixMissingFiles::Dialog_FixMissingFiles(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& refGlade)
+	: Gtk::Dialog(cobject),
+	  builder_(refGlade)
+{
+	if (!builder_)
+		return;
+
+	missing_file_list_ = Glib::RefPtr<Gtk::ListBox>::cast_dynamic(builder_->get_object("missing_file_list"));
+
+	signal_response().connect(sigc::mem_fun(*this, &Dialog_FixMissingFiles::on_response));
+}
+
+void
+Dialog_FixMissingFiles::set_broken_useids(synfig::CanvasBrokenUseIdMap& map)
+{
+	map_ = &map;
+	replacer_map_.clear();
+
+	if (!missing_file_list_)
+		return;
+
+	auto rows = missing_file_list_->get_children();
+	for (const auto& row : rows)
+		missing_file_list_->remove(*row);
+
+	for (auto iter = map_->begin(); iter != map.end(); ++iter) {
+		replacer_map_[iter->first] = iter->second.replacement;
+
+		create_row(replacer_map_, iter);
+	}
+
+	Gtk::Button* button = static_cast<Gtk::Button*>(get_widget_for_response(Gtk::RESPONSE_OK));
+	button->set_sensitive(is_replacer_map_complete());
+}
+
+void
+Dialog_FixMissingFiles::on_response(int response_id)
+{
+	if (response_id != Gtk::RESPONSE_OK)
+		return;
+
+	for (auto& item : *map_) {
+		item.second.replacement = replacer_map_.at(item.first);
+	}
+}
+
+void
+Dialog_FixMissingFiles::create_row(Dialog_FixMissingFiles::FileReplacerMap& replacer_map, const synfig::CanvasBrokenUseIdMap::iterator& iter)
+{
+	synfig::filesystem::Path missing_path(iter->first.u8string());
+	const synfig::BrokenUseIdInfo& uses = iter->second;
+
+	auto box = Gtk::manage(new Gtk::Box());
+	box->set_hexpand(true);
+
+	if (!synfig::FileSystemNative::instance()->is_file(missing_path.u8string())) {
+		auto icon = Gtk::manage(create_image_from_icon("image-missing", Gtk::ICON_SIZE_MENU));
+		icon->set_tooltip_text("Missing file");
+		box->pack_start(*icon);
+	}
+
+	auto label = Gtk::manage(new Gtk::Label(missing_path.u8string()));
+	label->set_hexpand(true);
+	label->set_xalign(0);
+	label->set_ellipsize(Pango::ELLIPSIZE_START);
+	std::string reasons = _("Issues:");
+	for (const auto& item : iter->second.missing_items) {
+		reasons += '\n';
+		if (item.id.empty()) {
+			reasons += _("- Missing file");
+		} else {
+			reasons += synfig::strprintf(_("- Missing exported valuenode: %s (%s)"), item.id.c_str(), item.type_name.c_str());
+		}
+	}
+	label->set_tooltip_text(missing_path.u8string() + "\n\n" + reasons);
+	box->pack_start(*label);
+
+	label = Gtk::manage(new Gtk::Label());
+	label->set_hexpand(true);
+	label->set_xalign(0);
+	label->set_ellipsize(Pango::ELLIPSIZE_START);
+	if (!uses.replacement.empty()) {
+		label->set_markup(synfig::strprintf("(<small>%s</small>)", uses.replacement.u8_str()));
+		label->set_tooltip_text(uses.replacement.u8string());
+	}
+	box->pack_start(*label);
+
+	auto button = Gtk::manage(new Gtk::Button(_("Change")));
+	button->set_hexpand(false);
+	box->pack_end(*button, Gtk::PACK_SHRINK);
+
+	button->signal_clicked().connect(sigc::track_obj([this, label, missing_path, &replacer_map]() {
+		synfig::filesystem::Path replacement(missing_path);
+		if (App::dialog_open_file(replacer_map[missing_path].u8string(), replacement, "file")) {
+			label->set_markup(synfig::strprintf("(<small>%s</small>)", replacement.u8_str()));
+			label->set_tooltip_text(replacement.u8string());
+			replacer_map[missing_path] = replacement;
+		}
+		Gtk::Button* button = static_cast<Gtk::Button*>(get_widget_for_response(Gtk::RESPONSE_OK));
+		button->set_sensitive(is_replacer_map_complete());
+	}, *label));
+
+	box->show_all();
+	missing_file_list_->append(*box);
+}
+
+bool
+Dialog_FixMissingFiles::is_replacer_map_complete() const
+{
+	for (const auto& item : replacer_map_) {
+		if (item.second.empty())
+			return false;
+	}
+	return true;
+}

--- a/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.cpp
@@ -40,6 +40,8 @@
 # include <gtkmm/label.h>
 # include <gtkmm/listbox.h>
 
+# include <synfig/canvasfilenaming.h>
+# include <synfig/general.h>
 # include <synfig/string_helper.h>
 
 # include <gui/app.h>
@@ -68,6 +70,64 @@ create_image_from_icon(const std::string& icon_name, Gtk::IconSize icon_size)
 	image->set_from_icon_name(icon_name, icon_size);
 	return image;
 #endif
+}
+
+static synfig::Canvas::Handle
+load_canvas_file(const synfig::filesystem::Path& filename)
+{
+	// try open container
+	synfig::FileSystem::Handle container = synfig::CanvasFileNaming::make_filesystem_container(filename.u8string());
+	if (!container)
+		throw synfig::strprintf(_("Unable to open container \"%s\"\n\n"), filename.u8_str());
+
+	// make canvas file system
+	synfig::FileSystem::Handle canvas_file_system = synfig::CanvasFileNaming::make_filesystem(container);
+
+	// file to open inside canvas file-system
+	synfig::String canvas_filename = synfig::CanvasFileNaming::project_file(filename.u8string());
+
+	synfig::CanvasBrokenUseIdMap broken_links;
+	synfig::String errors;
+	synfig::String warnings;
+
+	auto canvas = open_canvas_as(canvas_file_system ->get_identifier(canvas_filename), filename.u8string(), errors, warnings, &broken_links);
+
+	return canvas;
+}
+
+static std::vector<std::string>
+check_canvas_has_missing_items(synfig::Canvas::LooseHandle canvas, const synfig::CanvasMissingIdList& missing_items)
+{
+	std::vector<std::string> still_missing_items;
+
+	if (!canvas)
+		return still_missing_items;
+	if (missing_items.empty())
+		return still_missing_items;
+
+	for (const auto& item : missing_items) {
+		if (item.id.empty())
+			continue;
+
+		try {
+			if (auto vn = canvas->find_value_node(item.id, true, synfig::type_nil, nullptr)) {
+				synfig::warning("found %s : %s - %s", item.id.c_str(), item.type_name.c_str(), vn->get_type().description.name.c_str());
+				if (item.type_name.empty())
+					synfig::warning("The type of %s was still empty!", item.id.c_str());
+				if (item.type_name.empty() || item.type_name == vn->get_type().description.name)
+					continue;
+			}
+			synfig::String warnings;
+			if (auto subcanvas = canvas->find_canvas(item.id, warnings, nullptr)) {
+				continue;
+			}
+		} catch (...) {
+			;
+		}
+
+		still_missing_items.push_back(item.id);
+	}
+	return still_missing_items;
 }
 
 /* === M E T H O D S ======================================================= */
@@ -171,7 +231,7 @@ Dialog_FixMissingFiles::create_row(Dialog_FixMissingFiles::FileReplacerMap& repl
 		if (item.id.empty()) {
 			reasons += _("- Missing file");
 		} else {
-			reasons += synfig::strprintf(_("- Missing exported valuenode: %s (%s)"), item.id.c_str(), item.type_name.c_str());
+			reasons += synfig::strprintf(_("- Missing exported valuenode or canvas: %s (%s)"), item.id.c_str(), item.type_name.c_str());
 		}
 	}
 	label->set_tooltip_text(missing_path.u8string() + "\n\n" + reasons);
@@ -203,11 +263,50 @@ Dialog_FixMissingFiles::on_replace_button_clicked(const synfig::filesystem::Path
 {
 	synfig::filesystem::Path replacement(missing_path);
 	if (App::dialog_open_file(replacer_map_[missing_path].u8string(), replacement, "file")) {
-		if (label) {
-			label->set_markup(synfig::strprintf("(<small>%s</small>)", replacement.u8_str()));
-			label->set_tooltip_text(replacement.relative_to(canvas_filepath_).u8string());
+		synfig::Canvas::Handle replacement_canvas;
+		try {
+			replacement_canvas = load_canvas_file(replacement);
+		} catch (...) {
+
 		}
-		replacer_map_[missing_path] = replacement;
+
+		if (!replacement_canvas) {
+			const std::string error_message = synfig::strprintf(_("File cannot be loaded: %s"), missing_path.u8_str());
+			synfig::error(error_message);
+			App::dialog_message_1b("ERROR",
+								   _("Cannot load file"),
+								   error_message,
+								   _("OK"));
+		} else {
+			auto still_missing_items = check_canvas_has_missing_items(replacement_canvas, map_->at(missing_path).missing_items);
+			if (!still_missing_items.empty()) {
+				std::string still_missing_items_str;
+				for (const auto& item : still_missing_items)
+					still_missing_items_str += item + ", ";
+				if (!still_missing_items_str.empty()) {
+					still_missing_items_str.pop_back(); // ' '
+					still_missing_items_str.pop_back(); // ','
+				}
+				const std::string error_message = synfig::strprintf(_("The file still misses some items: %s.\n"
+																"You should check if this proposed replacement file (%s) is the one"
+																"that has the missing items or try to fix it first (by opening it first)"
+																" before fix and load the broken %s"),
+															  still_missing_items_str.c_str(),
+															  replacement.u8_str(),
+															  missing_path.u8_str());
+				synfig::error(error_message);
+				App::dialog_message_1b("ERROR",
+									   _("File is not good enough"),
+									   error_message,
+									   _("OK"));
+			} else {
+				if (label) {
+					label->set_markup(synfig::strprintf("(<small>%s</small>)", replacement.u8_str()));
+					label->set_tooltip_text(replacement.relative_to(canvas_filepath_).u8string());
+				}
+				replacer_map_[missing_path] = replacement;
+			}
+		}
 	}
 	update_response_button_sensitivity();
 }

--- a/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.cpp
@@ -121,7 +121,7 @@ Dialog_FixMissingFiles::set_broken_useids(synfig::CanvasBrokenUseIdMap& map)
 	for (const auto& row : rows)
 		missing_file_list_->remove(*row);
 
-	for (auto iter = map_->begin(); iter != map.end(); ++iter) {
+	for (auto iter = map_->cbegin(); iter != map.cend(); ++iter) {
 		replacer_map_[iter->first] = iter->second.replacement;
 
 		create_row(replacer_map_, iter);
@@ -136,13 +136,13 @@ Dialog_FixMissingFiles::on_response(int response_id)
 	if (response_id != Gtk::RESPONSE_OK)
 		return;
 
-	for (auto& item : *map_) {
-		item.second.replacement = replacer_map_.at(item.first);
+	for (auto it = map_->cbegin(); it != map_->cend(); ++it) {
+		map_->add_replacement(it->first, replacer_map_.at(it->first));
 	}
 }
 
 void
-Dialog_FixMissingFiles::create_row(Dialog_FixMissingFiles::FileReplacerMap& replacer_map, const synfig::CanvasBrokenUseIdMap::iterator& iter)
+Dialog_FixMissingFiles::create_row(Dialog_FixMissingFiles::FileReplacerMap& replacer_map, const synfig::CanvasBrokenUseIdMap::const_iterator& iter)
 {
 	synfig::filesystem::Path missing_path(iter->first.u8string());
 	const synfig::BrokenUseIdInfo& uses = iter->second;

--- a/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.h
+++ b/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.h
@@ -68,14 +68,21 @@ private:
 	synfig::filesystem::Path canvas_filepath_;
 
 	Glib::RefPtr<Gtk::ListBox> missing_file_list_;
+	Glib::RefPtr<Gtk::Label> canvas_filepath_label_;
 	synfig::CanvasBrokenUseIdMap* map_;
 
+	/** maps (original file path, replacer file path) **/
 	typedef std::map<synfig::filesystem::Path, synfig::filesystem::Path> FileReplacerMap;
 	FileReplacerMap replacer_map_;
 
 	void create_row(FileReplacerMap& replacer_map_, const synfig::CanvasBrokenUseIdMap::iterator& iter);
 
+	void on_replace_button_clicked(const synfig::filesystem::Path& missing_path, Gtk::Label* label);
+
+	/** return true if all missing files have a correspondent replacement file **/
 	bool is_replacer_map_complete() const;
+
+	void update_response_button_sensitivity();
 }; // END of Dialog_FixMissingFiles
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.h
+++ b/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.h
@@ -1,0 +1,84 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file dialogs/dialog_fixmissingfiles.h
+**	\brief Header for Dialog_FixMissingFiles
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	Copyright (c) 2023-     Synfig Contributors
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef SYNFIG_STUDIO_DIALOG_FIXMISSINGFILES_H
+#define SYNFIG_STUDIO_DIALOG_FIXMISSINGFILES_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <gtkmm/builder.h>
+#include <gtkmm/dialog.h>
+
+#include <synfig/loadcanvas.h>
+
+/* === M A C R O S ========================================================= */
+
+/* === T Y P E D E F S ===================================================== */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace Gtk {
+class ListBox;
+}
+
+namespace studio {
+
+class Dialog_FixMissingFiles : public Gtk::Dialog
+{
+public:
+	static std::shared_ptr<Dialog_FixMissingFiles> create(Gtk::Window& parent);
+
+	Dialog_FixMissingFiles(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& refGlade);
+
+	void set_canvas_filepath(const synfig::filesystem::Path& path);
+
+	void set_broken_useids(synfig::CanvasBrokenUseIdMap& map);
+
+protected:
+	void on_response(int response_id) override;
+
+private:
+	Glib::RefPtr<Gtk::Builder> builder_;
+
+	synfig::filesystem::Path canvas_filepath_;
+
+	Glib::RefPtr<Gtk::ListBox> missing_file_list_;
+	synfig::CanvasBrokenUseIdMap* map_;
+
+	typedef std::map<synfig::filesystem::Path, synfig::filesystem::Path> FileReplacerMap;
+	FileReplacerMap replacer_map_;
+
+	void create_row(FileReplacerMap& replacer_map_, const synfig::CanvasBrokenUseIdMap::iterator& iter);
+
+	bool is_replacer_map_complete() const;
+}; // END of Dialog_FixMissingFiles
+
+}; // END of namespace studio
+
+/* === E N D =============================================================== */
+#endif // SYNFIG_STUDIO_DIALOG_FIXMISSINGFILES_H

--- a/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.h
+++ b/synfig-studio/src/gui/dialogs/dialog_fixmissingfiles.h
@@ -75,7 +75,7 @@ private:
 	typedef std::map<synfig::filesystem::Path, synfig::filesystem::Path> FileReplacerMap;
 	FileReplacerMap replacer_map_;
 
-	void create_row(FileReplacerMap& replacer_map_, const synfig::CanvasBrokenUseIdMap::iterator& iter);
+	void create_row(FileReplacerMap& replacer_map_, const synfig::CanvasBrokenUseIdMap::const_iterator& iter);
 
 	void on_replace_button_clicked(const synfig::filesystem::Path& missing_path, Gtk::Label* label);
 

--- a/synfig-studio/src/gui/resources/ui/CMakeLists.txt
+++ b/synfig-studio/src/gui/resources/ui/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UI_FILES
 	canvas_options.glade
 	canvas_resize.glade
 	dialog_canvasdependencies.glade
+	dialog_fixmissingfiles.glade
 	dialog_pasteoptions.glade
 	dialog_workspaces.glade
 	preview_options.glade

--- a/synfig-studio/src/gui/resources/ui/Makefile.am
+++ b/synfig-studio/src/gui/resources/ui/Makefile.am
@@ -4,6 +4,7 @@ UIFILES     = \
   canvas_options.glade \
   canvas_resize.glade \
   dialog_canvasdependencies.glade \
+  dialog_fixmissingfiles.glade \
   dialog_pasteoptions.glade \
   dialog_workspaces.glade \
   preview_options.glade \

--- a/synfig-studio/src/gui/resources/ui/dialog_fixmissingfiles.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_fixmissingfiles.glade
@@ -47,6 +47,18 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="canvas_filepath">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Canvas file path</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -60,7 +72,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -155,7 +167,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/synfig-studio/src/gui/resources/ui/dialog_fixmissingfiles.glade
+++ b/synfig-studio/src/gui/resources/ui/dialog_fixmissingfiles.glade
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.18"/>
+  <object class="GtkDialog" id="dialog_fixmissingfiles">
+    <property name="can-focus">False</property>
+    <property name="modal">True</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label" translatable="yes">_Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button2">
+                <property name="label" translatable="yes">_OK</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">The following files are missing or their libraries do not have the required elements (exported canvas or value nodes).</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkListBox" id="missing_file_list">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="activate-on-single-click">False</property>
+                    <child>
+                      <object class="GtkListBoxRow">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="activatable">False</property>
+                        <property name="selectable">False</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkLabel" id="filename">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="label" translatable="yes">label</property>
+                                <property name="ellipsize">start</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBoxText" id="missing_valuenodes">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="new_filename">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">&lt;small&gt;label&lt;/small&gt;</property>
+                                <property name="use-markup">True</property>
+                                <property name="ellipsize">start</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="button_change">
+                                <property name="label" translatable="yes">Change</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="pack-type">end</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">button1</action-widget>
+      <action-widget response="-5">button2</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -41,7 +41,6 @@
 #include <iostream>
 #include <synfig/context.h>
 #include <synfig/canvasfilenaming.h>
-#include <synfig/loadcanvas.h>
 #include <synfig/savecanvas.h>
 #include <synfig/filecontainerzip.h>
 #include <synfig/filesystem.h>


### PR DESCRIPTION
Currently, Synfig doesn't load a document if something is linked to a valuenode or canvas of a external file, and this file is not found. This usually happens when user renames, moves or deletes those files.

This PR allows Synfig Studio to track those missing files and presents a dialog where user can point the missing files to their new locations or names. If user deleted the file, however, 'nothing' can be done except creating a new file with the required library items...

The Synfig CLI is not affected by this feature/PR.