### PR TITLE
fix: unable to open file paths longer than 23 characters on Windows

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3546,7 +3546,7 @@ App::open(filesystem::Path filename, /* std::string as, */ synfig::FileContainer
 	std::vector<wchar_t> long_name;
 	long_name.resize(buf_size);
 	long_name[0] = 0;
-	if (GetLongPathNameW(filename.c_str(), long_name.data(), sizeof(long_name)) == 0)
+	if (GetLongPathNameW(filename.c_str(), long_name.data(), long_name.size()) == 0)
 		;
 	// when called from autorecover.cpp, filename doesn't exist, and so long_name is empty
 	// don't use it if that's the case


### PR DESCRIPTION
Attempting to open a file on Windows whose full path is longer than 23 characters shows an error message "Unable to load [first 23 characters of filepath]".

Looks like this started happening after fc26742, though I'm not sure why it wasn't happening before. That version used the same `sizeof` logic except on a `char*` (size 8) instead of a `std::vector<wchar_t>` (size 24) so I would have thought the issue would have happened in that version as well. Either way I guess.

`sizeof` is a doozy of an operator.