### PR TITLE
fix: layer ListImporter cannot fetch the right files on synfig CLI

### DIFF
--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -671,7 +671,7 @@ Job SynfigCommandLineParser::extract_job()
 			if (FileSystem::Handle file_system = CanvasFileNaming::make_filesystem(job.filename.u8string()))
 			{
 				FileSystem::Identifier identifier = file_system->get_identifier(CanvasFileNaming::project_file(job.filename.u8string()));
-				job.root = open_canvas_as(identifier, job.filename.u8string(), errors, warnings);
+				job.root = open_canvas_as(identifier, filesystem::absolute(job.filename).u8string(), errors, warnings);
 			}
 			else
 			{


### PR DESCRIPTION
GUI works fine because it already passes the full filename to synfig::open_canvas_as(), but CLI doesn't.

GUI opens a file via:
1. App::on_open()
2. App::dialog_open() followed by App::open()
3. App::open_recent()

And all three work well.

fix #3271