### PR TITLE
fix: dropped image file doesn't load (broken conversion URI to file path on Win32)

### DIFF
--- a/synfig-core/src/synfig/filesystem_path.cpp
+++ b/synfig-core/src/synfig/filesystem_path.cpp
@@ -40,6 +40,7 @@
 
 #include <glibmm/miscutils.h>
 
+#include <synfig/general.h>
 #include <synfig/os.h>
 
 # ifdef _WIN32
@@ -95,6 +96,138 @@ filesystem::Path
 filesystem::Path::from_native(const string_type& native_path)
 {
 	return Path(native_to_utf8(native_path));
+}
+
+filesystem::Path
+filesystem::Path::from_uri(const std::string& uri)
+{
+	if (uri.empty())
+		return {};
+
+	if (uri.size() >= 5 && uri.compare(0, 5, "file:") != 0) {
+		synfig::warning("String is not a file URI \"%s\"", uri.c_str());
+		return {};
+	}
+
+	bool is_unc_auth = false;
+	bool is_file_auth = false;
+
+	auto auth_pos = std::string::npos;
+	auto path_absolute_pos = std::string::npos;
+
+	std::string auth;
+
+	if (uri.size() >= 9 && uri.compare(5, 4, "////") == 0) { // "file:////"
+		is_unc_auth = true;
+
+		if (uri.size() >= 10 && uri[9] == '/') // "file://///"
+			auth_pos = 10;
+		else
+			auth_pos = 9;
+	} else if (uri.size() >= 7 && uri.compare(5, 2, "//") == 0) { // "file://"
+		is_file_auth = true;
+
+		auth_pos = 7;
+	}
+
+	if (!is_file_auth && !is_unc_auth) {
+		path_absolute_pos = 5;
+	} else {
+		path_absolute_pos = uri.find('/', auth_pos);
+
+		if (path_absolute_pos == std::string::npos) {
+			synfig::warning("URI has authority part \"%s\", but does not have the file absolute path in URI \"%s\"", uri.substr(auth_pos).c_str(), uri.c_str());
+			return {};
+		}
+
+		auth = uri.substr(auth_pos, path_absolute_pos - auth_pos);
+	}
+
+
+	std::string drive_letter;
+
+	if (!is_unc_auth) {
+		auto get_drive_letter = [] (const char* str) -> char {
+			if (str[1] == ':' || str[1] == '|') {
+				char letter = str[0];
+				if ((letter >= 'A' && letter <= 'Z') || (letter >= 'a' && letter <= 'z')) {
+					//return letter < 'Z' ? letter : (letter - 'a' + 'A');
+					return letter;
+				}
+			}
+			return 0;
+		};
+
+		if (path_absolute_pos + 3 < uri.size()) {
+			if (uri[path_absolute_pos] == '/') {
+				char letter = get_drive_letter(&uri[path_absolute_pos+1]);
+				if (letter) {
+					drive_letter.push_back(letter);
+					drive_letter.push_back(':');
+					path_absolute_pos += 3;
+				}
+			}
+		}
+		if (drive_letter.empty() && !is_file_auth && path_absolute_pos + 2 < uri.size()) {
+			char letter = get_drive_letter(&uri[path_absolute_pos]);
+			if (letter) {
+				drive_letter.push_back(letter);
+				drive_letter.push_back(':');
+				path_absolute_pos += 2;
+			}
+		}
+	}
+
+	// Just for safety, eliminate (improbable) query and fragment components
+	auto path_absolute_end_pos = uri.size();
+	{
+		auto query_pos = uri.find('?', path_absolute_end_pos);
+		if (query_pos != std::string::npos) {
+			path_absolute_end_pos = query_pos;
+		} else {
+			auto fragment_pos = uri.find('#', path_absolute_end_pos);
+			if (fragment_pos != std::string::npos) {
+				path_absolute_end_pos = fragment_pos;
+			}
+		}
+	}
+	// Decode percent-encoding
+	std::string file_absolute;
+
+	for (auto p = path_absolute_pos; p < path_absolute_end_pos; ++p) {
+		if (uri[p] != '%') {
+			file_absolute.push_back(uri[p]);
+		} else {
+			if (p + 2 < path_absolute_end_pos) {
+				// decode char
+				char c1 = uri[++p];
+				char c2 = uri[++p];
+				if (c1 >= '0' && c1 <= '9')
+					c1 -= '0';
+				else
+					c1 -= (c1 >= 'a') ? 'a' : 'A';
+				if (c1 < 0 || c1 > 15) {
+					break;
+				}
+				if (c2 >= '0' && c2 <= '9')
+					c2 -= '0';
+				else
+					c2 -= (c2 >= 'a') ? 'a' : 'A';
+				if (c2 < 0 || c2 > 15) {
+					break;
+				}
+				file_absolute.push_back(c1 << 4 | c2);
+			} else {
+				break;
+			}
+		}
+	}
+
+	if (!auth.empty() && auth != "localhost") { // section 2 says "localhost" is interpreted exactly as if no authority were present
+		return Path{"\\\\" + auth + (!drive_letter.empty() ? '/' + drive_letter : "") + file_absolute};
+	} else {
+		return Path{drive_letter + file_absolute};
+	}
 }
 
 filesystem::Path&

--- a/synfig-core/src/synfig/filesystem_path.h
+++ b/synfig-core/src/synfig/filesystem_path.h
@@ -76,6 +76,15 @@ public:
 	 */
 	static Path from_native(const string_type& native_path);
 
+	/**
+	 * Store a file system path from a file URI string.
+	 *
+	 * Supports a file URI as defined in IEEE RFC 8089 Appendix F.
+	 *
+	 * @param uri a file URI string in UTF-8 encoding ("file:///a%20file.txt")
+	 */
+	static Path from_uri(const std::string& uri);
+
 	// Concatenation ---------------------
 
 	/** Equivalent to append() */

--- a/synfig-core/test/filesystem_path.cpp
+++ b/synfig-core/test/filesystem_path.cpp
@@ -1392,6 +1392,28 @@ test_proximate_between_different_root_paths()
 #endif
 }
 
+void
+test_from_uri()
+{
+	ASSERT_EQUAL("/path/to/file", Path::from_uri("file:///path/to/file").u8string());
+	ASSERT_EQUAL("/path/to/file", Path::from_uri("file:/path/to/file").u8string());
+	ASSERT_EQUAL("/path/to/file", Path::from_uri("file://localhost/path/to/file").u8string());
+
+	ASSERT_EQUAL("c:/path/to/file", Path::from_uri("file:c:/path/to/file").u8string());
+	ASSERT_EQUAL("c:/path/to/file", Path::from_uri("file:///c:/path/to/file").u8string());
+	ASSERT_EQUAL("c:/path/to/file", Path::from_uri("file:/c:/path/to/file").u8string());
+	ASSERT_EQUAL("c:/path/to/file", Path::from_uri("file://localhost/c:/path/to/file").u8string());
+
+	ASSERT_EQUAL("c:/path/to/file", Path::from_uri("file:c|/path/to/file").u8string());
+	ASSERT_EQUAL("c:/path/to/file", Path::from_uri("file:///c|/path/to/file").u8string());
+	ASSERT_EQUAL("c:/path/to/file", Path::from_uri("file:/c|/path/to/file").u8string());
+	ASSERT_EQUAL("c:/path/to/file", Path::from_uri("file://localhost/c|/path/to/file").u8string());
+
+	ASSERT_EQUAL("\\\\host.example.com/path/to/file", Path::from_uri("file://host.example.com/path/to/file").u8string());
+	ASSERT_EQUAL("\\\\host.example.com/path/to/file", Path::from_uri("file:////host.example.com/path/to/file").u8string());
+	ASSERT_EQUAL("\\\\host.example.com/path/to/file", Path::from_uri("file://///host.example.com/path/to/file").u8string());
+}
+
 /* === E N T R Y P O I N T ================================================= */
 
 int main() {
@@ -1518,6 +1540,8 @@ int main() {
 	TEST_FUNCTION(test_lexically_proximate_from_cpp_reference_dot_com)
 	TEST_FUNCTION(test_fake_proximate_from_cpp_reference_dot_com)
 	TEST_FUNCTION(test_proximate_between_different_root_paths)
+
+	TEST_FUNCTION(test_from_uri)
 
 	TEST_SUITE_END()
 

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -2866,21 +2866,7 @@ CanvasView::on_drop_drag_data_received(const Glib::RefPtr<Gdk::DragContext>& con
 				if(URI.empty())
 					continue;
 
-				// Extract scheme name from URI.
-				auto scheme_end_pos = URI.find("://");
-				if (scheme_end_pos == std::string::npos) {
-					warning("Cannot extract protocol from URI \"%s\"", URI.c_str());
-					continue;
-				}
-
-				// Only 'file' scheme supported
-				const String scheme = URI.substr(0, scheme_end_pos);
-				if (scheme != "file") {
-					warning("Protocol \"%s\" is unsupported (URI \"%s\")", scheme.c_str(), URI.c_str());
-					continue;
-				}
-
-				filesystem::Path filename(URI.substr(scheme_end_pos + 3)); // scheme name + "://"
+				filesystem::Path filename = filesystem::Path::from_uri(URI);
 				if (filename.empty()) {
 					warning("Cannot extract filename from URI \"%s\"", URI.c_str());
 					continue;


### PR DESCRIPTION
It doesn't strip slash character '/' before drive letter

culprit: f31dd3a79b10d8e14d1f09fa85bccfd53928e855 (#3229)

fix #3279