### PR TITLE
Add "Add Layer" button to Toolbox

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1726,7 +1726,8 @@ void App::init(const synfig::String& rootpath)
 		if(!getenv("SYNFIG_DISABLE_BRUSH"  ) && App::enable_experimental_features) state_manager->add_state(&state_brush);
 		state_manager->add_state(&state_zoom);
 
-
+		App::dock_toolbox->new_layer();
+		
 		device_tracker->load_preferences();
 		// If the default bline width is modified before focus a canvas
 		// window, the Distance widget doesn't understand the given value

--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -113,6 +113,9 @@ Dock_Toolbox::Dock_Toolbox():
 	signal_drag_data_received().connect( sigc::mem_fun(*this, &studio::Dock_Toolbox::on_drop_drag_data_received) );
 
 	App::signal_present_all().connect(sigc::mem_fun0(*this,&Dock_Toolbox::present));
+	action_new_layer = Gtk::Action::create_with_icon_name("popup-layer-new", "list-add", _("New Layer"), _("New Layer"));
+	action_new_layer->signal_activate().connect(sigc::mem_fun(*this, &Dock_Toolbox::popup_add_layer_menu));
+
 }
 
 Dock_Toolbox::~Dock_Toolbox()
@@ -230,6 +233,28 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 
 
 	refresh();
+}
+void Dock_Toolbox::new_layer(){
+	Gtk::RadioToolButton *tool_button = manage(new Gtk::RadioToolButton());
+	tool_button->set_group(radio_tool_button_group);
+	tool_button->set_related_action(action_new_layer);
+
+	tool_button->show();
+
+	tool_item_group->insert(*tool_button);
+	tool_item_group->show_all();
+
+
+	refresh();
+
+}
+void Dock_Toolbox::popup_add_layer_menu()
+{
+	if (!action_new_layer->is_sensitive())
+		return;
+	Gtk::Menu* menu = dynamic_cast<Gtk::Menu*>(App::ui_manager()->get_widget("/popup-layer-new"));
+	if (menu)
+		menu->popup(0, gtk_get_current_event_time());
 }
 
 

--- a/synfig-studio/src/gui/docks/dock_toolbox.h
+++ b/synfig-studio/src/gui/docks/dock_toolbox.h
@@ -61,6 +61,8 @@ class Dock_Toolbox : public Dockable
 
 	Gtk::ToolItemGroup *tool_item_group;
 	Gtk::Paned *tool_box_paned;
+	Glib::RefPtr<Gtk::Action> action_new_layer;
+
 
 	std::map<synfig::String, Gtk::RadioToolButton*> state_button_map;
 
@@ -71,10 +73,12 @@ class Dock_Toolbox : public Dockable
 	void change_state_(const Smach::state_base *state);
 
 	void update_tools();
+	void popup_add_layer_menu();
 
 	void set_active_state(const synfig::String& statename);
 
 public:
+	void new_layer();
 
 	void change_state(const synfig::String& statename, bool force = false);
 


### PR DESCRIPTION
This commit addresses the issue #1139, where users were not noticing the "Add Layer" button in the "Layers Panel." The "Add Layer" button has been added to the Toolbox for better visibility. Fixes #1139