### PR TITLE
fix: mingw cross-build

### DIFF
--- a/synfig-core/src/synfig/os.h
+++ b/synfig-core/src/synfig/os.h
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include <synfig/filesystem_path.h>
+#include <synfig/localization.h>
 
 /* === M A C R O S ========================================================= */
 


### PR DESCRIPTION
Currently build fails with an error:

```
os.cpp:171:1: error: no declaration matches 'void synfig::OS::RunPipe::__printf__(const char*, ...)'
  171 | OS::RunPipe::printf(const char* __format, ...)
      | ^~
os.cpp:171:1: note: no functions named 'void synfig::OS::RunPipe::__printf__(const char*, ...)'
In file included from os.cpp:36:
os.h:129:8: note: 'struct synfig::OS::RunPipe' defined here
  129 | struct RunPipe {
```

This happens because `libintl` redefines printf, so it is redefined in `os.cpp` (as it includes `synfig/localization.h -> libintl.h`) but not redefined in `os.h`.

Another way to resolve this issue is to rename the `printf` method to something like `custom_printf`.