### PR TITLE
fix: undo didn't work properly after deleting last guide line

### DIFF
--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -1331,7 +1331,7 @@ CanvasInterface::set_meta_data(const synfig::String& key,const synfig::String& d
 void
 CanvasInterface::erase_meta_data(const synfig::String& key)
 {
-	if (key=="guide_x" || key=="guide_y")
+	if (key=="guide")
 	{
 		// Create an undoable action
 		synfigapp::Action::Handle action(synfigapp::Action::create("CanvasMetadataErase"));


### PR DESCRIPTION
1. Create two guide lines.
2. Delete one of them (by dragging back to ruler).
3. Delete the second one. There is no guideline anymore.
4. Undo (ctrl+Z). Wrong. The two guidelines reappear, but only one should.
5. Undo again. Error: only one guide is shown
6. Redo (ctrl+shift+Z or ctrl+Y). Error. Only one is now shown.

Due to changes in b172e3771a131dbd26879aae334b84ac26bcb6e6 (#2777)