### PR TITLE
fix: modifying waypoints for a group layer no longer modifies sibling layers

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_timetrack.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timetrack.cpp
@@ -963,10 +963,13 @@ bool Widget_Timetrack::fetch_waypoints(const WaypointItem &wi, std::set<synfig::
 		const synfigapp::ValueDesc &value_desc = param_info_map.at(wi.path.to_string()).get_value_desc();
 
 		etl::handle<synfig::Node> node;
-		if (value_desc.is_value_node())
-			node = value_desc.get_value_node() ;
-		else if (value_desc.parent_is_layer() && value_desc.get_layer()->get_param(value_desc.get_param_name()).get_type() == synfig::type_canvas)
-			node = value_desc.get_canvas();
+		if (value_desc.is_value_node()) {
+			node = value_desc.get_value_node();
+		} else if (value_desc.parent_is_layer()) {
+			synfig::ValueBase value = value_desc.get_layer()->get_param(value_desc.get_param_name());
+			if (value.get_type() == synfig::type_canvas)
+				node = value.get(synfig::Canvas::Handle());
+		}
 
 		if (node)
 			synfig::waypoint_collect(waypoint_set, wi.time_point.get_time(), node, true);


### PR DESCRIPTION
When a group layer is selected, the time track will show waypoints for child layers in the group. Modifying one of these waypoints (remove, move, or duplicate) was also pulling in waypoints of sibling layers of the group, not just child layers, if the sibling also happened to have a waypoint at the same time.

Reproduction steps:
1. Create 2 circle layers, and animate the location of both circles so that both have waypoints on the same frame
2. Put one of the circles into a group layer
3. Select the group layer, and right click a waypoint in the time track. Note that it says "Remove 2 Waypoints", even though there's only one layer in the group
4. Select Remove. Both circle layers are modified, even though only one of them is in the selected group.

I'm still a bit fuzzy on the relationship between canvases and group layers. I tested that waypoints for imported files still works, but I don't know if there's another way to create a canvas object that would need to be tested as well. 

