### PR TITLE
fix: add fill-color instead of outline-color to palette

### DIFF
--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -133,7 +133,7 @@ Dock_PalEdit::Dock_PalEdit():
 		"palette-add-color",
 		"list-add",
 		_("Add Color"),
-		_("Add current outline color\nto the palette")
+		_("Add current fill color\nto the palette")
 	),
 		sigc::mem_fun(
 			*this,
@@ -229,7 +229,7 @@ Dock_PalEdit::set_palette(const synfig::Palette& x)
 void
 Dock_PalEdit::on_add_pressed()
 {
-	add_color(synfigapp::Main::get_outline_color());
+	add_color(synfigapp::Main::get_fill_color());
 }
 
 void


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/synfig/synfig/issues/3215

Fill Color will be passed as the argument in the `add_color` method to add the fill color instead of the outline color to the palette.