### PR TITLE
ci(commitlint): disabled rule for `subject-case`

### DIFF
--- a/.github/workflows/conventional-commits-style.yml
+++ b/.github/workflows/conventional-commits-style.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Configure commitlint
         run: |
-          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
+          echo "module.exports = {extends: ['@commitlint/config-conventional'], rules: {'subject-case': [0, 'never']}}" > commitlint.config.js
 
       - name: Lint current pull request title
         run: jq --raw-output ".pull_request.title" "$GITHUB_EVENT_PATH" | npx commitlint --verbose


### PR DESCRIPTION
This will allow to start subjects from uppercase words. Currently it fails on something like:
```
fix: Gitlab CI pipeline fixed
build: CMake sets wrong Synfig Studio/ETL versions
```

P.S. If I understand correctly, this change does not violate the standard. 
Discussion here: https://github.com/conventional-changelog/commitlint/issues/2141

P.P.S. Puppeteer did the same: https://github.com/puppeteer/puppeteer/pull/8091/files