### PR TITLE
ci: bump github actions version

### DIFF
--- a/.github/workflows/conventional-commits-style.yml
+++ b/.github/workflows/conventional-commits-style.yml
@@ -16,7 +16,7 @@ jobs:
     name: Conventional commits style check
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install conventional commits linter
         run: npm install --save-dev @commitlint/config-conventional @commitlint/cli

--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -47,7 +47,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare ccache timestamp
         id: ccache_timestamp
@@ -55,7 +55,7 @@ jobs:
 
       - name: Download ccache archive
         id: ccache-archive
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .ccache
           key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ steps.ccache_timestamp.outputs.timestamp }}

--- a/.github/workflows/synfig-stable.yml
+++ b/.github/workflows/synfig-stable.yml
@@ -34,7 +34,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare ccache timestamp
         id: ccache_timestamp
@@ -42,7 +42,7 @@ jobs:
 
       - name: Download ccache archive
         id: ccache-archive
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .ccache
           key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ steps.ccache_timestamp.outputs.timestamp }}

--- a/.github/workflows/synfig-tests.yml
+++ b/.github/workflows/synfig-tests.yml
@@ -31,7 +31,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Synfig Studio (Check appdata.xml)"
         run: |


### PR DESCRIPTION
This is required because Node.js 16 actions are deprecated.
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.