### PR TITLE
ci: changed caching logic

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -49,18 +49,14 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      - name: Prepare ccache timestamp
-        id: ccache_timestamp
-        run: echo "::set-output name=timestamp::`date "+%Y%m%d-%H%M%S"`"
-
       - name: Download ccache archive
-        id: ccache-archive
-        uses: actions/cache@v4
+        id: ccache-archive-restore
+        uses: actions/cache/restore@v4
         with:
           path: .ccache
-          key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ steps.ccache_timestamp.outputs.timestamp }}
+          key: synfig-ccache-${{ matrix.os }}-${{ matrix.toolchain }}
           restore-keys:
-            ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-
+            synfig-ccache-${{ matrix.os }}-${{ matrix.toolchain }}
 
       - name: Install dependencies (Brew)
         if: runner.os == 'macOS'
@@ -105,3 +101,12 @@ jobs:
 
       - name: ccache statistics
         run: ccache --show-stats
+
+      - name: Save cache (only for master branch)
+        id: ccache-archive-save
+        if: github.ref_name == 'master'
+        uses: actions/cache/save@v4
+        with:
+          path: .ccache
+          key: synfig-ccache-${{ matrix.os }}-${{ matrix.toolchain }}
+

--- a/.github/workflows/synfig-stable.yml
+++ b/.github/workflows/synfig-stable.yml
@@ -36,18 +36,14 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      - name: Prepare ccache timestamp
-        id: ccache_timestamp
-        run: echo "::set-output name=timestamp::`date "+%Y%m%d-%H%M%S"`"
-
       - name: Download ccache archive
-        id: ccache-archive
-        uses: actions/cache@v4
+        id: ccache-archive-restore
+        uses: actions/cache/restore@v4
         with:
           path: .ccache
-          key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ steps.ccache_timestamp.outputs.timestamp }}
+          key: synfig-ccache-${{ matrix.os }}-${{ matrix.toolchain }}
           restore-keys:
-            ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-
+            synfig-ccache-${{ matrix.os }}-${{ matrix.toolchain }}
 
       - name: Install dependencies (Brew)
         if: runner.os == 'macOS'
@@ -78,3 +74,12 @@ jobs:
 
       - name: ccache statistics
         run: ccache --show-stats
+
+      - name: Save cache (only for master branch)
+        id: ccache-archive-save
+        if: github.ref_name == 'master'
+        uses: actions/cache/save@v4
+        with:
+          path: .ccache
+          key: synfig-ccache-${{ matrix.os }}-${{ matrix.toolchain }}
+


### PR DESCRIPTION
We are currently saving a lot of caches using this pattern:
`{OS}-ccache-{toolchain}-{timestamp}`
After this change there will be only one cache entry for each OS/toolchain.
Also cache entry will be saved only for the master branch.
So PR's can use this cache, but won’t change it.