### PR TITLE
perf: avoid canvas inspection when DockInfo is not shown

### DIFF
--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -58,6 +58,8 @@ using namespace synfig;
 
 void studio::Dock_Info::on_mouse_move()
 {
+	if (!get_mapped())
+		return;
 	CanvasView::LooseHandle canvas_view(get_canvas_view());
 	if(!canvas_view) return;
 	Point pos = canvas_view->get_work_area()->get_cursor_pos();
@@ -197,6 +199,8 @@ studio::Dock_Info::Dock_Info()
 	set_n_passes_requested(1); //Default
 	set_n_passes_pending  (0); //Default
 	set_render_progress (0.0); //Default, 0.0%
+
+	signal_map().connect(sigc::mem_fun(*this, &Dock_Info::on_mouse_move));
 }
 
 studio::Dock_Info::~Dock_Info()


### PR DESCRIPTION
On every mouse move on CanvasView, it reads what color is underneath the mouse pointer.

We can avoid calls to `Layer::get_color()` (that can parse all canvas layers) and their computation if DockInfo is not mapped.

'signal_map', in GTK words, is emitted 'when the widget is visible and all its parents up to the toplevel widget are also visible.'

DockInfo is not mapped when another tab/dock is being shown in its 'block' (DockBook), as it is in default workspace layout.