### PR TITLE
feat: add WebM video format to ffmpeg codecs list

### DIFF
--- a/synfig-core/src/tool/optionsprocessor.cpp
+++ b/synfig-core/src/tool/optionsprocessor.cpp
@@ -238,6 +238,8 @@ SynfigCommandLineParser::SynfigCommandLineParser() :
 	_allowed_video_codecs.push_back(VideoCodec("msmpeg4v2", "MPEG-4 part 2 Microsoft variant version 2."));
 	_allowed_video_codecs.push_back(VideoCodec("wmv1", "Windows Media Video 7."));
 	_allowed_video_codecs.push_back(VideoCodec("wmv2", "Windows Media Video 8."));
+	_allowed_video_codecs.push_back(VideoCodec("libvpx", "WebM VP8"));
+	_allowed_video_codecs.push_back(VideoCodec("libvpx-vp9", "WebM VP9"));
 
 }
 

--- a/synfig-studio/src/gui/dialogs/dialog_ffmpegparam.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_ffmpegparam.cpp
@@ -67,6 +67,8 @@ static const std::map<const char*, const char*> known_video_codecs = {
 	{"msmpeg4v2",        _("MPEG-4 part 2 Microsoft variant version 2")},
 	{"wmv1",             _("Windows Media Video 7")},
 	{"wmv2",             _("Windows Media Video 8")},
+	{"libvpx",           _("WebM VP8")},
+	{"libvpx-vp9",       _("WebM VP9")},
 };
 
 /* === P R O C E D U R E S ================================================= */


### PR DESCRIPTION
Hi,

I found out that Synfig could render WebM files (even with transparency) through FFMPEG but it wasn't clear enough for normal users so I just added VP8 and VP9 codecs to the FFMPEG "Available Video Codecs" list.

Now it's so easy to render this kind of videos for OBS or any other purpose ;-)