### PR TITLE
feat: confirmation dialog for duplicate palette color addition

### DIFF
--- a/synfig-core/src/synfig/palette.cpp
+++ b/synfig-core/src/synfig/palette.cpp
@@ -282,6 +282,17 @@ Palette::find_light()
 	return best_match;
 }
 
+bool
+Palette::is_color_present(const Color& color) const
+{
+	for (const_iterator iter = cbegin(); iter != cend(); ++iter) {
+		if (iter->color == color)
+			return true;
+	}
+
+	return false;
+}
+
 Palette
 Palette::grayscale(int steps, ColorReal gamma)
 {

--- a/synfig-core/src/synfig/palette.h
+++ b/synfig-core/src/synfig/palette.h
@@ -84,11 +84,14 @@ public:
 
 	iterator find_light();
 
+	bool is_color_present(const Color& color) const;
+
 	static Palette grayscale(int steps, ColorReal gamma);
 
 	void save_to_file(const synfig::filesystem::Path& filename)const;
 
 	static Palette load_from_file(const synfig::filesystem::Path& filename);
+        
 }; // END of class Palette
 
 }; // END of namespace synfig

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -397,6 +397,10 @@ Dock_PalEdit::show_menu(int i)
 int
 Dock_PalEdit::add_color(const synfig::Color& x)
 {
+	// Check for duplicate color addition to trigger confirmation dialog
+	if (palette_.is_color_present(x) && !confirm_duplicate_color_addition())
+		return -1;
+
 	palette_.push_back(x);
 	signal_changed()();
 	refresh();
@@ -439,8 +443,11 @@ Dock_PalEdit::add_from_clipboard()
 		col.set_hex(hexcolor);
 		col.set_a(1.0f);
 
-		palette_.push_back(col);
+		// Check for duplicate color addition to trigger confirmation dialog
+		if (palette_.is_color_present(col) && !confirm_duplicate_color_addition())
+			return;
 
+		palette_.push_back(col);
 		signal_changed()();
 		refresh();
 	}
@@ -461,6 +468,10 @@ Dock_PalEdit::copy_color(int i)
 void
 Dock_PalEdit::set_color(synfig::Color x, int i)
 {
+	// Check for duplicate color addition to trigger confirmation dialog
+	if (palette_.is_color_present(x) && !confirm_duplicate_color_addition())
+		return;
+
 	palette_[i].color=x;
 	signal_changed()();
 	refresh();
@@ -677,4 +688,15 @@ int
 Dock_PalEdit::size()const
 {
 	return palette_.size();
+}
+
+bool
+Dock_PalEdit::confirm_duplicate_color_addition() const
+{
+	return App::get_ui_interface()->confirmation(
+			_("The color already exists in the palette."),
+			_("Do you want to add the color again"),
+			_("Add"),
+			_("Cancel")
+		) == synfigapp::UIInterface::RESPONSE_OK;
 }

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
@@ -87,6 +87,7 @@ private:
 	synfig::Color get_color(int i)const;
 	void edit_color(int i);
 	void apply_color_to_selected_layer(int i) const;
+	bool confirm_duplicate_color_addition() const;
 
 public:
 	static Dock_PalEdit* get_instance() { return instance; }


### PR DESCRIPTION
This PR contains the enhancement discussed in #3215 

A confirmation dialog will be displayed to the User when they attempt to add a duplicate color again into the color palette.

A new public method `Palette::is_color_present` is implemented to check the duplicate color presence
Additional private method `Dock_PalEdit::confirm_duplicate_color_addition()` is implemented to be called within existing `Dock_PalEdit::add_color` method for modularity to trigger `UIInterface::confirmation`

closes #3215