### PR TITLE
feat: scroll to change the current time on the Timeline bar

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_timeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.cpp
@@ -487,7 +487,7 @@ Widget_Timeslider::on_motion_notify_event(GdkEventMotion* event) //for dragging
 }
 
 bool
-Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for moving timeline-bar
+Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for zooming/moving timeline-bar
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	etl::handle<TimeModel> &time_model = time_plot_data->time_model;
@@ -495,29 +495,36 @@ Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for moving timeline-
 	if (!time_model || get_width() <= 0 || get_height() <= 0)
 		return false;
 
-	Time time = time_model->get_time();
+	Time scroll_time = time_model->get_time(); //scroll is based on track time
+	Time zoom_time = time_plot_data->get_t_from_pixel_coord(event->x); //zoom is based on time represented by pixel
 
-//      modifies timeline-bar position, and scroll through the panel based on center
-	switch (event->direction)
-	{
-	case GDK_SCROLL_UP:
-	case GDK_SCROLL_RIGHT:
-		time_model->set_time(time + step);
-		if (time >= time_model->get_visible_center())
-		{
-			time_model->move_by(step);
-		}
-		return true;
-	case GDK_SCROLL_DOWN:
-	case GDK_SCROLL_LEFT:
-		time_model->set_time(time - step);
-		if (time <= time_model->get_visible_center())
-		{
-			time_model->move_by(-step);
-		}
-		return true;
-	default:
-		break;
+	switch (event->direction) {
+		case GDK_SCROLL_UP:
+		case GDK_SCROLL_RIGHT:
+			// zooming
+			if (event->state & GDK_CONTROL_MASK) {
+				time_model->zoom(zoominfactor, zoom_time);
+			} else {
+				// modifies timeline-bar position, and scroll through the panel based on center
+				time_model->set_time(scroll_time + step);
+				if (scroll_time >= time_model->get_visible_center()) {
+					time_model->move_by(step);
+				}
+			}
+			return true;
+		case GDK_SCROLL_DOWN:
+		case GDK_SCROLL_LEFT:
+			if (event->state & GDK_CONTROL_MASK) {
+				time_model->zoom(zoomoutfactor, zoom_time);
+			} else {
+				time_model->set_time(scroll_time - step);
+				if (scroll_time <= time_model->get_visible_center()) {
+					time_model->move_by(-step);
+				}
+			}
+			return true;
+		default:
+			break;
 	}
 
 	return false;

--- a/synfig-studio/src/gui/widgets/widget_timeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.cpp
@@ -487,7 +487,7 @@ Widget_Timeslider::on_motion_notify_event(GdkEventMotion* event) //for dragging
 }
 
 bool
-Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for zooming
+Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for moving timeline-bar
 {
 	SYNFIG_EXCEPTION_GUARD_BEGIN()
 	etl::handle<TimeModel> &time_model = time_plot_data->time_model;
@@ -495,20 +495,26 @@ Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for zooming
 	if (!time_model || get_width() <= 0 || get_height() <= 0)
 		return false;
 
-	Time time = time_plot_data->get_t_from_pixel_coord(event->x);
+	Time time = time_model->get_time();
 
-	switch(event->direction) {
-	case GDK_SCROLL_UP: //zoom in
-		time_model->zoom(zoominfactor, time);
-		return true;
-	case GDK_SCROLL_DOWN: //zoom out
-		time_model->zoom(zoomoutfactor, time);
-		return true;
+//      modifies timeline-bar position, and scroll through the panel based on center
+	switch (event->direction)
+	{
+	case GDK_SCROLL_UP:
 	case GDK_SCROLL_RIGHT:
-		time_model->move_by(step);
+		time_model->set_time(time + step);
+		if (time >= time_model->get_visible_center())
+		{
+			time_model->move_by(step);
+		}
 		return true;
+	case GDK_SCROLL_DOWN:
 	case GDK_SCROLL_LEFT:
-		time_model->move_by(-step);
+		time_model->set_time(time - step);
+		if (time <= time_model->get_visible_center())
+		{
+			time_model->move_by(-step);
+		}
 		return true;
 	default:
 		break;

--- a/synfig-studio/src/gui/widgets/widget_timeslider.cpp
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.cpp
@@ -498,28 +498,37 @@ Widget_Timeslider::on_scroll_event(GdkEventScroll* event) //for zooming/moving t
 	Time scroll_time = time_model->get_time(); //scroll is based on track time
 	Time zoom_time = time_plot_data->get_t_from_pixel_coord(event->x); //zoom is based on time represented by pixel
 
+	const bool is_control_pressed = event->state & GDK_CONTROL_MASK;
+	const bool is_shift_pressed = event->state & GDK_SHIFT_MASK;
+
 	switch (event->direction) {
 		case GDK_SCROLL_UP:
 		case GDK_SCROLL_RIGHT:
 			// zooming
-			if (event->state & GDK_CONTROL_MASK) {
+			if (is_control_pressed) {
 				time_model->zoom(zoominfactor, zoom_time);
 			} else {
 				// modifies timeline-bar position, and scroll through the panel based on center
-				time_model->set_time(scroll_time + step);
+				Time time_step = time_model->get_step_increment();
+				if (is_shift_pressed || App::get_time_format() != Time::Format::FORMAT_FRAMES)
+					time_step = step;
+				time_model->set_time(scroll_time + time_step);
 				if (scroll_time >= time_model->get_visible_center()) {
-					time_model->move_by(step);
+					time_model->move_by(time_step);
 				}
 			}
 			return true;
 		case GDK_SCROLL_DOWN:
 		case GDK_SCROLL_LEFT:
-			if (event->state & GDK_CONTROL_MASK) {
+			if (is_control_pressed) {
 				time_model->zoom(zoomoutfactor, zoom_time);
 			} else {
-				time_model->set_time(scroll_time - step);
+				Time time_step = time_model->get_step_increment();
+				if (is_shift_pressed || App::get_time_format() != Time::Format::FORMAT_FRAMES)
+					time_step = step;
+				time_model->set_time(scroll_time - time_step);
 				if (scroll_time <= time_model->get_visible_center()) {
-					time_model->move_by(-step);
+					time_model->move_by(-time_step);
 				}
 			}
 			return true;

--- a/synfig-studio/src/gui/widgets/widget_timeslider.h
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.h
@@ -83,7 +83,7 @@ protected: // implementation that other interfaces can see
 	virtual bool on_button_press_event(GdkEventButton *event); //for clicking
 	virtual bool on_button_release_event(GdkEventButton *event); //for clicking
 	virtual bool on_motion_notify_event(GdkEventMotion* event); //for dragging
-	virtual bool on_scroll_event(GdkEventScroll* event); //for zooming
+	virtual bool on_scroll_event(GdkEventScroll* event); //for moving timeline-bar
 	virtual bool on_leave_notify_event(GdkEventCrossing* event);
 	virtual bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr);
 

--- a/synfig-studio/src/gui/widgets/widget_timeslider.h
+++ b/synfig-studio/src/gui/widgets/widget_timeslider.h
@@ -83,7 +83,7 @@ protected: // implementation that other interfaces can see
 	virtual bool on_button_press_event(GdkEventButton *event); //for clicking
 	virtual bool on_button_release_event(GdkEventButton *event); //for clicking
 	virtual bool on_motion_notify_event(GdkEventMotion* event); //for dragging
-	virtual bool on_scroll_event(GdkEventScroll* event); //for moving timeline-bar
+	virtual bool on_scroll_event(GdkEventScroll* event); //for zooming or moving timeline-bar
 	virtual bool on_leave_notify_event(GdkEventCrossing* event);
 	virtual bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr);
 


### PR DESCRIPTION
closes #2931 

**Description:**

This pull request enhances the functionality of `Widget_Timeslider` by implementing scroll event updates. It achieves this by introducing repositioning of the timeline bar within the `on_scroll_event` method and updating the existing zoom functionality. Additionally, it enables smooth scrolling through the panel, adjusting based on the central position of the `TimeModel`. These updates significantly improve the user experience and enhance the overall usability of the `Widget_Timeslider`.

**Changes:**

- Implemented scroll event updates for `Widget_Timeslider`.
- Updated the zooming functionality hotkey as: `ctrl` +` scroll`.
- Added repositioning of the timeline bar within the `on_scroll_event` method.
- Enabled smooth panel scrolling, dynamically adjusting based on the central position of the `TimeModel`.
