### PR TITLE
feat: added toggle setting for plugin warnings

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -300,6 +300,10 @@ static int max_recent_files_=25;
 int    studio::App::get_max_recent_files()      { return max_recent_files_; }
 void   studio::App::set_max_recent_files(int x) {        max_recent_files_ = x; }
 
+static bool plugin_warn_enabled_=true;
+bool   studio::App::get_plugin_warning_enabled()      { return plugin_warn_enabled_; }
+void   studio::App::set_plugin_warning_enabled(bool x) {        plugin_warn_enabled_ = x; }
+
 static synfig::String app_base_path_;
 
 SoundProcessor *App::sound_render_done = nullptr;
@@ -452,6 +456,10 @@ public:
 			if(key=="file_history.size")
 			{
 				value=strprintf("%i",App::get_max_recent_files());
+				return true;
+			}
+			if(key=="plugin_warning"){
+				value=strprintf("%i",App::get_plugin_warning_enabled());
 				return true;
 			}
 			if(key=="distance_system")
@@ -650,6 +658,11 @@ public:
 				App::set_max_recent_files(i);
 				return true;
 			}
+			if(key=="plugin_warning"){
+				int i(atoi(value.c_str()));
+				App::set_plugin_warning_enabled(i);
+				return true;
+			}
 			if(key=="distance_system")
 			{
 				App::distance_system=Distance::ident_system(value);
@@ -822,6 +835,7 @@ public:
 		ret.push_back("time_format");
 		ret.push_back("distance_system");
 		ret.push_back("file_history.size");
+		ret.push_back("plugin_warning");
 		ret.push_back("autosave_backup");
 		ret.push_back("autosave_backup_interval");
 		ret.push_back("restrict_radius_ducks");

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -402,6 +402,9 @@ public:
 	static int get_max_recent_files();
 	static void set_max_recent_files(int x);
 
+	static bool get_plugin_warning_enabled();
+	static void set_plugin_warning_enabled(bool x);
+
 	static bool jack_is_locked();
 	static void jack_lock();
 	static void jack_unlock();

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -880,6 +880,16 @@ Dialog_Setup::create_interface_page(PageInfo pi)
 	toggle_handle_tooltip_transfo_value.set_halign(Gtk::ALIGN_START);
 	toggle_handle_tooltip_transfo_value.set_hexpand(false);
 
+	attach_label_section(pi.grid, _("Plugins"), ++row);
+	attach_label(pi.grid, _("Warning before you apply a plugin"), ++row);// HANDLE_TOOLTIP_TRANSFO_NAME
+	pi.grid->attach(plugin_warning, 1, row, 1, 1);
+	plugin_warning.set_halign(Gtk::ALIGN_START);
+	plugin_warning.set_hexpand(false);
+
+	plugin_warning.property_active().signal_changed().connect(
+		sigc::bind<int> (sigc::mem_fun(*this, &Dialog_Setup::on_value_change), CHANGE_NONE));
+
+
 	//! change resume signal connection
 	ui_language_combo.signal_changed().connect(
 			sigc::bind<int> (sigc::mem_fun(*this, &Dialog_Setup::on_value_change), CHANGE_UI_LANGUAGE));
@@ -911,6 +921,7 @@ Dialog_Setup::on_restore_pressed()
 		adj_recent_files->set_value(25);
 		timestamp_comboboxtext.set_active(5);
 		toggle_autobackup.set_active(true);
+		plugin_warning.set_active(true);
 		auto_backup_interval.set_value(15);
 		widget_enum->set_value(Distance::SYSTEM_POINTS);
 		toggle_restrict_radius_ducks.set_active(true);
@@ -981,6 +992,7 @@ void
 Dialog_Setup::on_apply_pressed()
 {
 	App::set_max_recent_files((int)adj_recent_files->get_value());
+	App::set_plugin_warning_enabled((bool) plugin_warning.get_active());
 
 	// Set the time format
 	App::set_time_format(get_time_format());
@@ -1276,6 +1288,7 @@ Dialog_Setup::refresh()
 	widget_enum->set_value(App::distance_system);
 
 	toggle_autobackup.set_active(App::auto_recover->get_enabled());
+	plugin_warning.set_active(App::get_plugin_warning_enabled());
 	// Refresh the value of the auto backup interval
 	auto_backup_interval.set_value(App::auto_recover->get_timeout_ms() / 1000);
 	auto_backup_interval.set_sensitive(App::auto_recover->get_enabled());

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -151,6 +151,7 @@ class Dialog_Setup : public Dialog_Template
 	Gtk::ComboBoxText icon_theme_combo;
 	Gtk::Switch toggle_handle_tooltip_transfo_value;
 	Gtk::Switch toggle_handle_tooltip_transfo_name;
+	Gtk::Switch plugin_warning;
 
 	Gtk::Entry textbox_custom_filename_prefix;
 	Glib::RefPtr<Gtk::Adjustment> adj_pref_x_size;


### PR DESCRIPTION
Added functional disable plugin warning setting as requested from issue #3186. 

New setting in preferences:
![image](https://github.com/synfig/synfig/assets/77250215/05a99481-77df-48d3-84c1-97e204fa0bb3)

New plugin warning:
![image](https://github.com/synfig/synfig/assets/77250215/32545fee-4aee-4eaa-8373-2be3d4825057)

