### PR TITLE
feat: add autobackup system and backup file settings

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1992,7 +1992,14 @@ App::save_backup()
 		return true;
 	}
 
-	FileSystemTemporary::Handle temporary_filesystem = FileSystemTemporary::Handle::cast_dynamic(App::get_selected_canvas_view()->get_canvas()->get_file_system());
+	CanvasView::LooseHandle canvas_view = App::get_selected_canvas_view();
+
+	// no canvas, return immediately
+	if (canvas_view.empty()){
+		return true;
+	}
+
+	FileSystemTemporary::Handle temporary_filesystem = FileSystemTemporary::Handle::cast_dynamic(canvas_view->get_canvas()->get_file_system());
 	// get original filename
 	String filename = temporary_filesystem->get_meta("filename");
 	String as = temporary_filesystem->get_meta("as");

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2020,13 +2020,25 @@ App::save_backup()
 	int file_ext_len = file_ext.u8string().length();
 
 	// make backup directory if not already created
-	if (!FileSystemNative::instance()->directory_create(backup_dir.u8string()))
+	if (!FileSystemNative::instance()->directory_create(backup_dir.u8string())){
+		dialog_message_1b(
+			"ERROR",
+			_("Autosave file backup error. Could not create backup directory..."),
+			"details",
+			_("Close"));
 		return false;
+	}
 
 	std::vector<String> files;
 
-	if (!FileSystemNative::instance()->directory_scan(backup_dir.u8string(), files))
+	if (!FileSystemNative::instance()->directory_scan(backup_dir.u8string(), files)){
+		dialog_message_1b(
+			"ERROR",
+			_("Could not scan backup directory..."),
+			"details",
+			_("Close"));
 		return false;
+	}
 
 	std::map<int, String> file_version_map;
 	
@@ -2061,12 +2073,22 @@ App::save_backup()
 		// delete files that go above max file limit
 		if(file_cur_name->first >= max_backups){
 			if(0 != remove(abs_cur_name.c_str())){
+				dialog_message_1b(
+					"ERROR",
+					_("Could not remove excess backup files..."),
+					"details",
+					_("Close"));
 				return false;
 			}
 			continue;
 		}
 		const synfig::String &file_new_name = (backup_dir / base_name).u8string() + "_" +std::to_string(file_cur_name->first + 1) +file_ext.u8string();
 		if (0 !=  rename(abs_cur_name.c_str(), file_new_name.c_str())){
+			dialog_message_1b(
+				"ERROR",
+				_("Could not update names of other backup files..."),
+				"details",
+				_("Close"));
 			return false;
 		}
 	}
@@ -2078,7 +2100,15 @@ App::save_backup()
 	FileSystem::Handle canvas_container = CanvasFileNaming::make_filesystem_container(file_name, truncate_storage_size);
 	FileSystem::Handle canvas_file_system = CanvasFileNaming::make_filesystem(canvas_container);
 
-	return temporary_filesystem->save_changes(canvas_file_system, true);
+	if(!temporary_filesystem->save_changes(canvas_file_system, true)){
+		dialog_message_1b(
+			"ERROR",
+			_("Could not make new backup file..."),
+			"details",
+			_("Close"));
+		return false;
+	}
+	return true;
 }
 
 

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -336,6 +336,8 @@ public:
 
 	static Gtk::Box* scale_imported_box();
 
+	static bool save_backup();
+
 	static synfig::String get_base_path();
 	static void save_settings();
 	static bool load_settings(const synfig::String& key_filter = "");
@@ -401,6 +403,9 @@ public:
 
 	static int get_max_recent_files();
 	static void set_max_recent_files(int x);
+
+	static int get_num_backup_files();
+	static void set_num_backup_files(int x);
 
 	static bool jack_is_locked();
 	static void jack_lock();

--- a/synfig-studio/src/gui/autorecover.cpp
+++ b/synfig-studio/src/gui/autorecover.cpp
@@ -101,14 +101,16 @@ AutoRecover::auto_backup()
 		for (const auto& instance : App::instance_list) {
 			try
 			{
-				if (instance->backup())
+				if (instance->backup()){
 					++count;
+				}
 			}
 			catch(...)
 			{
 				synfig::error("AutoRecover::auto_backup(): UNKNOWN EXCEPTION THROWN.");
 			}
 		}
+		App::save_backup();
 	}
 	catch(...)
 	{

--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -87,6 +87,7 @@ Dialog_Setup::Dialog_Setup(Gtk::Window& parent):
 	Dialog_Template(parent,_("Synfig Studio Preferences")),
 	input_settings(synfigapp::Main::get_selected_input_device()->settings()),
 	adj_recent_files(Gtk::Adjustment::create(15,1,50,1,1,0)),
+	adj_backup_files(Gtk::Adjustment::create(1,0,10,1,1,0)),
 	adj_undo_depth(Gtk::Adjustment::create(100,10,5000,1,1,1)),
 	time_format(Time::FORMAT_NORMAL),
 	listviewtext_brushes_path(manage (new Gtk::ListViewText(1, true, Gtk::SELECTION_BROWSE))),
@@ -202,6 +203,10 @@ Dialog_Setup::create_system_page(PageInfo pi)
 	pi.grid->attach(auto_backup_interval, 1, row, 1, 1);
 	auto_backup_interval.set_hexpand(false);
 
+	attach_label(pi.grid, _("Backup files"), ++row);
+	Gtk::SpinButton* back_up_spinbutton(manage(new Gtk::SpinButton(adj_backup_files,1,0)));
+	pi.grid->attach(*back_up_spinbutton, 1, row, 1, 1);
+
 	// System - Brushes path
 	{
 		attach_label_section(pi.grid, _("Brush Presets Path"), ++row);
@@ -246,6 +251,7 @@ Dialog_Setup::create_system_page(PageInfo pi)
 		plugin_path_change->signal_clicked().connect(
 			sigc::mem_fun(*this, &Dialog_Setup::on_plugin_path_change_clicked));
 	}
+
 	// System - 11 enable_experimental_features
 	attach_label_section(pi.grid, _("Experimental features (requires restart)"), ++row);
 	pi.grid->attach(toggle_enable_experimental_features, 1, row, 1, 1);
@@ -909,6 +915,7 @@ Dialog_Setup::on_restore_pressed()
 	{
 		// Assign (without applying) default values
 		adj_recent_files->set_value(25);
+		adj_backup_files->set_value(0);
 		timestamp_comboboxtext.set_active(5);
 		toggle_autobackup.set_active(true);
 		auto_backup_interval.set_value(15);
@@ -981,6 +988,7 @@ void
 Dialog_Setup::on_apply_pressed()
 {
 	App::set_max_recent_files((int)adj_recent_files->get_value());
+	App::set_num_backup_files((int)adj_backup_files->get_value());
 
 	// Set the time format
 	App::set_time_format(get_time_format());
@@ -1266,6 +1274,7 @@ Dialog_Setup::refresh()
 	pref_modification_flag = CHANGE_NONE;
 	
 	adj_recent_files->set_value(App::get_max_recent_files());
+	adj_backup_files->set_value(App::get_num_backup_files());
 
 	// Refresh the ui language
 	ui_language_combo.set_active_id(App::ui_language);

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -124,6 +124,7 @@ class Dialog_Setup : public Dialog_Template
 	std::map<std::string, synfig::Time::Format> time_formats;
 
 	Glib::RefPtr<Gtk::Adjustment> adj_recent_files;
+	Glib::RefPtr<Gtk::Adjustment> adj_backup_files;
 	Glib::RefPtr<Gtk::Adjustment> adj_undo_depth;
 
 	synfig::Time::Format time_format;


### PR DESCRIPTION
This PR implements a feature requested in issue #3189. 

Specifically, it is an autosave feature that saves the current temp file of the current sif file to a sif file in a backup folder created in the directory of the original sif file. Before saving the current temp file, it renames all other backup files by increasing their version name by 1.

For example, for mydir/project.sif:
- creates directory: mydir/backup/ 
- creates backup file from current temp file: mydir/backup/project_1.sif

Say there exists a project_1.sif and project_2.sif in the backup directory. Then, the files are renamed project_2.sif and project_3.sif respectively, before creating the new backup file project_1.sif. Leaving the backup file with project_1.sif, project_2.sif, and project_3.sif. Notably, I have also created a max backup file setting that limits the number of auto-backed up files. Mainly, if the limit was set to 2, instead of having 3 backup files in the previous example we would have 2 most current backup files with the third file being deleted.

I followed the backup file format [project_name]_[version].sif instead of the original issue requested format [project_name].sif[version] since synfig doesn't explicitly read files in the issue requested format.

Backup files setting in preferences:
![Untitled](https://github.com/synfig/synfig/assets/77250215/8740c0f4-2f10-4d83-b4cb-b397926a4898)
 
Files are backed up in time intervals defined by the interval autosave setting (in the image above it would save every 10 seconds) and if the backup files setting is set to 0 no files will be saved. Additionally, if autosave is turned off, no files will be backed up.