### PR TITLE
feat: erasing Tool word from toolbox menu

### DIFF
--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -210,7 +210,7 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 	tool_button->property_has_tooltip() = true;
 	tool_button->signal_query_tooltip().connect([state](int,int,bool,const Glib::RefPtr<Gtk::Tooltip>& tooltip) -> bool
 	{
-		std::string tooltip_string = state->get_local_name();
+		std::string tooltip_string = state->get_local_name() + std::string (" Tool") ;
 
 		Gtk::AccelKey key;
 		if (Gtk::AccelMap::lookup_entry(std::string("<Actions>/action_group_state_manager/state-") + state->get_name(), key)) {

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -300,7 +300,7 @@ create_image_from_icon(const std::string& icon_name, Gtk::IconSize icon_size)
 /* === M E T H O D S ======================================================= */
 
 StateBLine::StateBLine():
-	Smach::state<StateBLine_Context>("bline", N_("Spline Tool"))
+	Smach::state<StateBLine_Context>("bline", N_("Spline"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,		&StateBLine_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,						&StateBLine_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_bone.cpp
+++ b/synfig-studio/src/gui/states/state_bone.cpp
@@ -214,7 +214,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateBone::StateBone() :
-	Smach::state<StateBone_Context>("bone", N_("Skeleton Tool"))
+	Smach::state<StateBone_Context>("bone", N_("Skeleton"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,		&StateBone_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_REFRESH_DUCKS,				&StateBone_Context::event_hijack));

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -276,7 +276,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateCircle::StateCircle():
-	Smach::state<StateCircle_Context>("circle", N_("Circle Tool"))
+	Smach::state<StateCircle_Context>("circle", N_("Circle"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateCircle_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StateCircle_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -342,7 +342,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateDraw::StateDraw():
-	Smach::state<StateDraw_Context>("draw", N_("Draw Tool"))
+	Smach::state<StateDraw_Context>("draw", N_("Draw"))
 {
 	insert(event_def(EVENT_STOP,&StateDraw_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateDraw_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_eyedrop.cpp
+++ b/synfig-studio/src/gui/states/state_eyedrop.cpp
@@ -90,7 +90,7 @@ StateEyedrop studio::state_eyedrop;
 /* === M E T H O D S ======================================================= */
 
 StateEyedrop::StateEyedrop():
-	Smach::state<StateEyedrop_Context>("eyedrop", N_("Eyedropper Tool"))
+	Smach::state<StateEyedrop_Context>("eyedrop", N_("Eyedropper"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateEyedrop_Context::event_stop_handler));
 	insert(event_def(EVENT_STOP,&StateEyedrop_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_fill.cpp
+++ b/synfig-studio/src/gui/states/state_fill.cpp
@@ -91,7 +91,7 @@ StateFill studio::state_fill;
 /* === M E T H O D S ======================================================= */
 
 StateFill::StateFill():
-	Smach::state<StateFill_Context>("fill", N_("Fill Tool"))
+	Smach::state<StateFill_Context>("fill", N_("Fill"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateFill_Context::event_stop_handler));
 	insert(event_def(EVENT_STOP,&StateFill_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_gradient.cpp
+++ b/synfig-studio/src/gui/states/state_gradient.cpp
@@ -212,7 +212,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateGradient::StateGradient():
-	Smach::state<StateGradient_Context>("gradient", N_("Gradient Tool"))
+	Smach::state<StateGradient_Context>("gradient", N_("Gradient"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateGradient_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StateGradient_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -347,7 +347,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateLasso::StateLasso():
-	Smach::state<StateLasso_Context>("lasso", N_("Cutout Tool"))
+	Smach::state<StateLasso_Context>("lasso", N_("Cutout"))
 {
 	insert(event_def(EVENT_STOP,&StateLasso_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateLasso_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_mirror.cpp
+++ b/synfig-studio/src/gui/states/state_mirror.cpp
@@ -144,7 +144,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateMirror::StateMirror():
-	Smach::state<StateMirror_Context>("mirror", N_("Mirror Tool"))
+	Smach::state<StateMirror_Context>("mirror", N_("Mirror"))
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateMirror_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateMirror_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -203,7 +203,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateNormal::StateNormal():
-	Smach::state<StateNormal_Context>("normal", N_("Transform Tool"))
+	Smach::state<StateNormal_Context>("normal", N_("Transform"))
 {
 	insert(event_def(EVENT_STOP,&StateNormal_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateNormal_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_polygon.cpp
+++ b/synfig-studio/src/gui/states/state_polygon.cpp
@@ -247,7 +247,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StatePolygon::StatePolygon():
-	Smach::state<StatePolygon_Context>("polygon", N_("Polygon Tool"))
+	Smach::state<StatePolygon_Context>("polygon", N_("Polygon"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StatePolygon_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StatePolygon_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -257,7 +257,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateRectangle::StateRectangle():
-	Smach::state<StateRectangle_Context>("rectangle", N_("Rectangle Tool"))
+	Smach::state<StateRectangle_Context>("rectangle", N_("Rectangle"))
 {
 	insert(event_def(EVENT_STOP,&StateRectangle_Context::event_stop_handler));
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateRectangle_Context::event_layer_selection_changed_handler));

--- a/synfig-studio/src/gui/states/state_rotate.cpp
+++ b/synfig-studio/src/gui/states/state_rotate.cpp
@@ -143,7 +143,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateRotate::StateRotate():
-	Smach::state<StateRotate_Context>("rotate", N_("Rotate Tool"))
+	Smach::state<StateRotate_Context>("rotate", N_("Rotate"))
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateRotate_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateRotate_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_scale.cpp
+++ b/synfig-studio/src/gui/states/state_scale.cpp
@@ -132,7 +132,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateScale::StateScale():
-	Smach::state<StateScale_Context>("scale", N_("Scale Tool"))
+	Smach::state<StateScale_Context>("scale", N_("Scale"))
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateScale_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateScale_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_sketch.cpp
+++ b/synfig-studio/src/gui/states/state_sketch.cpp
@@ -125,7 +125,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateSketch::StateSketch():
-	Smach::state<StateSketch_Context>("sketch", N_("Sketch Tool"))
+	Smach::state<StateSketch_Context>("sketch", N_("Sketch"))
 {
 	insert(event_def(EVENT_STOP,&StateSketch_Context::event_stop_handler));
 	//insert(event_def(EVENT_REFRESH,&StateSketch_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_smoothmove.cpp
+++ b/synfig-studio/src/gui/states/state_smoothmove.cpp
@@ -138,7 +138,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateSmoothMove::StateSmoothMove():
-	Smach::state<StateSmoothMove_Context>("smooth_move", N_("Smooth Move Tool"))
+	Smach::state<StateSmoothMove_Context>("smooth_move", N_("Smooth Move"))
 {
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,&StateSmoothMove_Context::event_refresh_tool_options));
 	insert(event_def(EVENT_STOP,&StateSmoothMove_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_star.cpp
+++ b/synfig-studio/src/gui/states/state_star.cpp
@@ -309,7 +309,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateStar::StateStar():
-	Smach::state<StateStar_Context>("star", N_("Star Tool"))
+	Smach::state<StateStar_Context>("star", N_("Star"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateStar_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StateStar_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_text.cpp
+++ b/synfig-studio/src/gui/states/state_text.cpp
@@ -193,7 +193,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateText::StateText():
-	Smach::state<StateText_Context>("text", N_("Text Tool"))
+	Smach::state<StateText_Context>("text", N_("Text"))
 {
 	insert(event_def(EVENT_LAYER_SELECTION_CHANGED,&StateText_Context::event_layer_selection_changed_handler));
 	insert(event_def(EVENT_STOP,&StateText_Context::event_stop_handler));

--- a/synfig-studio/src/gui/states/state_width.cpp
+++ b/synfig-studio/src/gui/states/state_width.cpp
@@ -151,7 +151,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateWidth::StateWidth():
-	Smach::state<StateWidth_Context>("width", N_("Width Tool"))
+	Smach::state<StateWidth_Context>("width", N_("Width"))
 {
 	insert(event_def(EVENT_STOP,&StateWidth_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateWidth_Context::event_refresh_handler));

--- a/synfig-studio/src/gui/states/state_zoom.cpp
+++ b/synfig-studio/src/gui/states/state_zoom.cpp
@@ -94,7 +94,7 @@ public:
 /* === M E T H O D S ======================================================= */
 
 StateZoom::StateZoom():
-	Smach::state<StateZoom_Context>("zoom", N_("Zoom Tool"))
+	Smach::state<StateZoom_Context>("zoom", N_("Zoom"))
 {
 	insert(event_def(EVENT_STOP,&StateZoom_Context::event_stop_handler));
 	insert(event_def(EVENT_REFRESH,&StateZoom_Context::event_refresh_handler));


### PR DESCRIPTION
erasing word "Tool" while keeping tooltip with word "Tool"
Fix #1151