### PR TITLE
fix(MotionBlur): undefined behavior when subsample range is 0

### DIFF
--- a/synfig-core/src/synfig/layers/layer_motionblur.cpp
+++ b/synfig-core/src/synfig/layers/layer_motionblur.cpp
@@ -204,7 +204,7 @@ Layer_MotionBlur::build_rendering_task_vfunc(Context context) const
 	}
 
 	const Color::BlendMethod blend_method = no_blur_effect ? Color::BLEND_COMPOSITE : Color::BLEND_ADD_COMPOSITE;
-	const Real k = no_blur_effect ? 1.0 : (1.0/sum);
+	const Real k = no_blur_effect ? 1.0 : (approximate_zero(sum) ? 0.0 : (1.0/sum));
 
 	rendering::Task::Handle task;
 	for(int i = 0; i < samples; i++)
@@ -226,5 +226,7 @@ Layer_MotionBlur::build_rendering_task_vfunc(Context context) const
 		task = task_blend;
 	}
 
+	if (!task)
+		return context.build_rendering_task();
 	return task;
 }


### PR DESCRIPTION
For linear subsampling type, there is an undefined behavior when both subsample (start and end) amounts are 0.

Synfig version 1.0.2: *none* is drawn!
Synfig version 1.2.1: a pale gray rectangle is drawn
Synfig version 1.4.3: a black gray rectangle is drawn

Anyway, this commit fixes the case when both are 0, by drawing the context without any motion blur effect.

Note:
If they (the subsample amounts) are equal, but both nonzero, the canvas is normally drawn.
Behavior is not the same between 1.0.2 and >=1.2.1 though. The motion trail has a different number of 'echoes': 1.0.2 has less than the next releases.

fix #3345