### PR TITLE
refactor: Filesystem::remove_recursive() uses Path

### DIFF
--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -98,7 +98,7 @@ ffmpeg_trgt::~ffmpeg_trgt()
 
 	// Remove temporary sound file
 	if (FileSystemNative::instance()->is_file(sound_filename.u8string())) {
-		if(FileSystemNative::instance()->remove_recursive(sound_filename.u8string())) {
+		if (FileSystemNative::instance()->remove_recursive(sound_filename)) {
 			synfig::warning("Error deleting temporary sound file (%s).", sound_filename.u8_str());
 		}
 	}

--- a/synfig-core/src/synfig/filesystem.cpp
+++ b/synfig-core/src/synfig/filesystem.cpp
@@ -127,21 +127,21 @@ bool FileSystem::directory_create_recursive(const String &dirname) {
 		|| (directory_create_recursive(filesystem::Path::dirname(dirname)) && directory_create(dirname));
 }
 
-bool FileSystem::remove_recursive(const String &filename)
+bool FileSystem::remove_recursive(const filesystem::Path& filename)
 {
 	assert(!filename.empty());
 
 	if (filename.empty())
 		return false;
-	if (is_file(filename))
-		return file_remove(filename);
-	if (is_directory(filename))
+	if (is_file(filename.u8string()))
+		return file_remove(filename.u8string());
+	if (is_directory(filename.u8string()))
 	{
 		FileList files;
-		directory_scan(filename, files);
+		directory_scan(filename.u8string(), files);
 		bool success = true;
-		for(FileList::const_iterator i = files.begin(); i != files.end(); ++i)
-			if (!remove_recursive(filename + ETL_DIRECTORY_SEPARATOR + *i))
+		for (const auto& i : files)
+			if (!remove_recursive(filename / i))
 				success = false;
 		return success;
 	}

--- a/synfig-core/src/synfig/filesystem.h
+++ b/synfig-core/src/synfig/filesystem.h
@@ -197,7 +197,7 @@ namespace synfig
 		Identifier get_identifier(const String &filename) { return Identifier(this, filename); }
 
 		bool directory_create_recursive(const String &dirname);
-		bool remove_recursive(const String &filename);
+		bool remove_recursive(const filesystem::Path& filename);
 
 		static bool copy(Handle from_file_system, const String &from_filename, Handle to_file_system, const String &to_filename);
 		static bool copy_recursive(Handle from_file_system, const String &from_filename, Handle to_file_system, const String &to_filename);

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3899,7 +3899,7 @@ App::open_from_plugin(const filesystem::Path& filename, const std::string& impor
 			dialog_message_1b("ERROR", errors, "details", _("Close"));
 	}
 
-	FileSystemNative::instance()->remove_recursive(tmp_filename.u8string());
+	FileSystemNative::instance()->remove_recursive(tmp_filename);
 	// lock file (temp_lock.second) is auto-deleted
 }
 


### PR DESCRIPTION
`synfig::Filesystem::remove_recursive()` now uses
`synfig::filesystem::Path` instead of `synfig::String`