### PR TITLE
ci: Add CI action for OSX packaging script

### DIFF
--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+ 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
@@ -24,4 +27,4 @@ jobs:
     steps:
       - name: "Synfig Studio (OSX package)"
         run: |
-          /home/data/2-data/vm/OSX-10.9-export/actions-runner/morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF_NAME
+          /home/data/2-data/vm/OSX-10.9-export/actions-runner/morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $BRANCH_NAME

--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     runs-on: osx-10.9
-    continue-on-error: no
+    continue-on-error: false
     name: "Synfig Studio (OSX package)"
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -1,0 +1,27 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Synfig CI (Self-Hosted)
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: osx-10.9
+    continue-on-error: no
+    name: "Synfig Studio (OSX package)"
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: "Synfig Studio (OSX package)"
+        run: |
+          /home/data/2-data/vm/OSX-10.9-export/actions-runner/morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF_NAME

--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -24,4 +24,5 @@ jobs:
     steps:
       - name: "Synfig Studio (OSX package)"
         run: |
+          ls ../..
           ../../morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF

--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -24,5 +24,4 @@ jobs:
     steps:
       - name: "Synfig Studio (OSX package)"
         run: |
-          ls ../..
-          ../../morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF
+          ../../../morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF

--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -24,4 +24,4 @@ jobs:
     steps:
       - name: "Synfig Studio (OSX package)"
         run: |
-          ../morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF
+          ../../morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF

--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -24,4 +24,4 @@ jobs:
     steps:
       - name: "Synfig Studio (OSX package)"
         run: |
-          /home/data/2-data/vm/OSX-10.9-export/actions-runner/morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF
+          ../morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF

--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -14,7 +14,8 @@ on:
   workflow_dispatch:
 
 env:
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  REPO_NAME: ${{github.repository}}
  
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -27,4 +28,4 @@ jobs:
     steps:
       - name: "Synfig Studio (OSX package)"
         run: |
-          /home/data/2-data/vm/OSX-10.9-export/actions-runner/morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $BRANCH_NAME
+          /home/data/2-data/vm/OSX-10.9-export/actions-runner/morevna-builds.osx/build-synfig.sh https://github.com/$REPO_NAME $BRANCH_NAME

--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -12,10 +12,6 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-env:
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-  REPO_NAME: ${{github.repository}}
  
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -28,4 +24,4 @@ jobs:
     steps:
       - name: "Synfig Studio (OSX package)"
         run: |
-          /home/data/2-data/vm/OSX-10.9-export/actions-runner/morevna-builds.osx/build-synfig.sh https://github.com/$REPO_NAME $BRANCH_NAME
+          /home/data/2-data/vm/OSX-10.9-export/actions-runner/morevna-builds.osx/build-synfig.sh https://github.com/$GITHUB_REPOSITORY $GITHUB_REF


### PR DESCRIPTION
This PR adds CI job, which builds OSX package on our local machine (self-hosted instance for GitHub Actions).

The machine is processing tasks from 04:00 GMT till 11:00 GMT.