### PR TITLE
fix: color/gradient dialog edits the parameter that opened itself

### DIFF
--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
@@ -97,11 +97,11 @@ public:
 
 	void set_canvas_interface(const etl::loose_handle<synfigapp::CanvasInterface>& x);
 
+protected:
 	ValueBase_Entry *value_entry;
 
 	void on_value_editing_done();
 
-protected:
 	virtual void
 	render_vfunc(
 		const ::Cairo::RefPtr< ::Cairo::Context>& cr,

--- a/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
+++ b/synfig-studio/src/gui/cellrenderer/cellrenderer_value.h
@@ -36,6 +36,8 @@
 
 #include <synfig/paramdesc.h>
 #include <synfig/value.h>
+
+#include <synfigapp/canvasinterface.h>
 #include <synfigapp/value_desc.h>
 
 
@@ -68,6 +70,9 @@ class CellRenderer_ValueBase : public Gtk::CellRendererText
 	bool edit_value_done_called;
 
 	synfig::ValueBase saved_data; //Issues 659, 526, 520
+
+	etl::loose_handle<synfigapp::CanvasInterface> canvas_interface;
+
 public:
 	sigc::signal<void, const Glib::ustring&> &signal_secondary_click()
 	{return signal_secondary_click_; }
@@ -89,6 +94,8 @@ public:
 
 	CellRenderer_ValueBase();
 	~CellRenderer_ValueBase();
+
+	void set_canvas_interface(const etl::loose_handle<synfigapp::CanvasInterface>& x);
 
 	ValueBase_Entry *value_entry;
 

--- a/synfig-studio/src/gui/dialogs/dialog_color.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_color.cpp
@@ -169,5 +169,5 @@ void
 Dialog_Color::reset()
 {
 	signal_edited_.clear();
-	value_desc = synfigapp::ValueDesc();
+	set_value_desc(synfigapp::ValueDesc());
 }

--- a/synfig-studio/src/gui/dialogs/dialog_color.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_color.cpp
@@ -93,6 +93,18 @@ Dialog_Color::get_color() const
 }
 
 void
+Dialog_Color::set_value_desc(const synfigapp::ValueDesc& x)
+{
+	value_desc = x;
+}
+
+synfigapp::ValueDesc
+Dialog_Color::get_value_desc() const
+{
+	return value_desc;
+}
+
+void
 Dialog_Color::create_color_edit_widget()
 {
 	color_edit_widget = manage(new Widget_ColorEdit());
@@ -157,4 +169,5 @@ void
 Dialog_Color::reset()
 {
 	signal_edited_.clear();
+	value_desc = synfigapp::ValueDesc();
 }

--- a/synfig-studio/src/gui/dialogs/dialog_color.h
+++ b/synfig-studio/src/gui/dialogs/dialog_color.h
@@ -32,6 +32,7 @@
 
 #include <gtkmm/dialog.h>
 #include <synfig/color.h>
+#include <synfigapp/value_desc.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -48,6 +49,8 @@ class Dialog_Color : public Gtk::Dialog
 	Widget_ColorEdit* color_edit_widget;
 
 	sigc::signal<void,synfig::Color> signal_edited_;
+
+	synfigapp::ValueDesc value_desc;
 
 	void create_color_edit_widget();
 	void create_set_color_button(const char *stock_id,
@@ -68,6 +71,10 @@ public:
 
 	void set_color(const synfig::Color& x);
 	synfig::Color get_color() const;
+
+	void set_value_desc(const synfigapp::ValueDesc& x);
+	synfigapp::ValueDesc get_value_desc() const;
+
 	void reset();
 }; // END of Dialog_Color
 

--- a/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
@@ -129,6 +129,7 @@ Dialog_Gradient::reset()
 {
 	value_changed_connection.disconnect();
 	signal_edited_.clear();
+	value_desc = synfigapp::ValueDesc();
 }
 
 void
@@ -188,4 +189,16 @@ Dialog_Gradient::edit(const synfigapp::ValueDesc &x, etl::handle<synfigapp::Canv
 	);
 
 	present();
+}
+
+void
+Dialog_Gradient::set_value_desc(const synfigapp::ValueDesc& x)
+{
+	value_desc = x;
+}
+
+synfigapp::ValueDesc
+Dialog_Gradient::get_value_desc() const
+{
+	return value_desc;
 }

--- a/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_gradient.cpp
@@ -129,7 +129,7 @@ Dialog_Gradient::reset()
 {
 	value_changed_connection.disconnect();
 	signal_edited_.clear();
-	value_desc = synfigapp::ValueDesc();
+	set_value_desc(synfigapp::ValueDesc());
 }
 
 void

--- a/synfig-studio/src/gui/dialogs/dialog_gradient.h
+++ b/synfig-studio/src/gui/dialogs/dialog_gradient.h
@@ -80,6 +80,8 @@ class Dialog_Gradient : public Gtk::Dialog
 	Widget_ColorEdit* widget_color;
 	Gtk::Button *set_default_button;
 
+	synfigapp::ValueDesc value_desc;
+
 	void on_changed();
 
 public:
@@ -100,6 +102,9 @@ public:
 	//! Interface to external calls to fill in the Gradient Editor Dialog
 	//! when a Constant ValueNode or a Animated ValueNode is double cliked.
 	void edit(const synfigapp::ValueDesc &x, etl::handle<synfigapp::CanvasInterface> canvas_interface, synfig::Time time=0);
+
+	void set_value_desc(const synfigapp::ValueDesc& x);
+	synfigapp::ValueDesc get_value_desc() const;
 }; // END of Dialog_Gradient
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -626,6 +626,8 @@ LayerTree::set_model(Glib::RefPtr<LayerTreeStore> layer_tree_store)
 	if(cellrenderer_time_track && layer_tree_store_ && layer_tree_store_->canvas_interface())
 		cellrenderer_time_track->set_canvas_interface(layer_tree_store_->canvas_interface());
 #endif	// TIMETRACK_IN_PARAMS_PANEL
+
+	cellrenderer_value->set_canvas_interface(layer_tree_store_->canvas_interface());
 }
 
 void


### PR DESCRIPTION
Here we prevent to emit signal_edited_ for Color and Gradient dialog
windows when presented by Parameter Panel.

Those dialogs may be opened by a cell and try to update the parameter
value related to another one, as it just remembered its parameter tree
path.

Reproducible steps:
1. Create a region layer
2. Create an outline layer
3. Click on color parameter to edit it
4. Without closing color dialog, select the region layer instead
5. Try to edit the color in dialog
6. Error Message appears

fix #3288