### PR TITLE
chore: don't pollute synfig.pc with unneeded flags

### DIFF
--- a/synfig-core/configure.ac
+++ b/synfig-core/configure.ac
@@ -123,7 +123,6 @@ if test $with_magickpp = "yes" ; then {
 	PKG_CHECK_MODULES(MAGICKPP, Magick++ >= 6.4.2,[
 		with_magickpp="yes"
 		AM_CONDITIONAL(HAVE_LIBMAGICKPP,true)
-		CONFIG_DEPS="$CONFIG_DEPS Magick++"
 	],[
 		with_magickpp="no"
 		AC_MSG_ERROR([ *** Unable to find Magick++])
@@ -177,8 +176,8 @@ AC_ARG_WITH(libavcodec,
 
 if test $with_libavcodec != "no" ; then {
 	PKG_CHECK_MODULES(LIBAVCODEC, [libavcodec >= 57.0 libavformat >= 57.0 libavutil >= 55.0 libswscale >= 4.0],
-		[CONFIG_DEPS="$CONFIG_DEPS libavcodec libavformat libswscale"],
-		[echo no; with_libavcodec="no"])
+		[with_libavcodec="yes"],
+		[with_libavcodec="no"])
 } ; fi
 if test $with_libavcodec = "yes" ; then {
 	AC_DEFINE(WITH_LIBAVCODEC,[],[enable libavcodec support])
@@ -219,7 +218,6 @@ AC_ARG_WITH(freetype,
 if test $with_freetype != "no" ; then {
 	PKG_CHECK_MODULES(FREETYPE, freetype2,[
 		with_freetype="yes"
-		CONFIG_DEPS="$CONFIG_DEPS freetype2"
 	],[
 		PKG_CHECK_MODULES(FREETYPE, xft,[
 			with_freetype="yes"
@@ -242,7 +240,6 @@ AC_ARG_WITH(fontconfig,
 if test $with_fontconfig != "no" ; then {
 	PKG_CHECK_MODULES(FONTCONFIG, fontconfig,[
 		with_fontconfig="yes"
-		CONFIG_DEPS="$CONFIG_DEPS fontconfig"
 	],[
 		with_fontconfig="no"
 	])
@@ -294,9 +291,7 @@ AC_ARG_WITH(openexr,
 	with_openexr="yes"
 ])
 if test $with_openexr = "yes" ; then {
-	PKG_CHECK_MODULES(OPENEXR, OpenEXR,[
-		CONFIG_DEPS="$CONFIG_DEPS OpenEXR"
-	],
+	PKG_CHECK_MODULES(OPENEXR, OpenEXR,,
 	[
 		with_openexr="no"
 	])
@@ -389,9 +384,7 @@ if test $with_opengl != "no" ; then {
 		;;
 		*)
 			PKG_CHECK_MODULES(LIBGL, gl, [
-				CONFIG_DEPS="$CONFIG_DEPS gl"
 				LIBGL_CFLAGS="$LIBGL_CFLAGS -DGL_GLEXT_PROTOTYPES"
-				CONFIG_CFLAGS="$CONFIG_CFLAGS -DWITH_OPENGL"
 				with_opengl="yes"
 			],[
 				AC_MSG_RESULT([ ** Cannot find gl.pc. OpenGL disabled.])
@@ -411,7 +404,6 @@ AC_ARG_WITH(opencl,
 if test $with_opencl != "no" ; then {
 	AC_CHECK_HEADER(CL/opencl.h,,AC_MSG_ERROR([ ** You need to install opencl-headers package.]))
 	PKG_CHECK_MODULES(LIBCL, OpenCL,[
-		CONFIG_DEPS="$CONFIG_DEPS OpenCL"
 		with_opencl="yes"
 	],[
 		AC_MSG_ERROR([ ** You need to install OpenCL.])
@@ -424,14 +416,9 @@ AM_CONDITIONAL(WITH_OPENCL, test $with_opencl = yes)
 PKG_CHECK_MODULES(LIBFFTW, fftw3,,[
 	AC_MSG_ERROR([ ** You need to install FFTW 3.])
 ])
-CONFIG_DEPS="$CONFIG_DEPS fftw3"
 
-PKG_CHECK_MODULES(MLTPP, mlt++-7,[
-	CONFIG_DEPS="$CONFIG_DEPS mlt++-7"
-],[
-	PKG_CHECK_MODULES(MLTPP, mlt++,[
-		CONFIG_DEPS="$CONFIG_DEPS mlt++"
-	],[
+PKG_CHECK_MODULES(MLTPP, mlt++-7,,[
+	PKG_CHECK_MODULES(MLTPP, mlt++,,[
 		AC_MSG_ERROR([ ** You need to install mlt++.])
 	])
 ])

--- a/synfig-studio/configure.ac
+++ b/synfig-studio/configure.ac
@@ -183,7 +183,6 @@ AC_ARG_WITH(fontconfig,
 if test $with_fontconfig != "no" ; then {
 	PKG_CHECK_MODULES(FONTCONFIG, fontconfig,[
 		with_fontconfig="yes"
-		CONFIG_DEPS="$CONFIG_DEPS fontconfig"
 	],[
 		with_fontconfig="no"
 	])
@@ -195,7 +194,18 @@ if test $with_fontconfig = "yes" ; then {
 } else {
 	AM_CONDITIONAL(WITH_FONTCONFIG,false)
 } ; fi
+AC_SUBST(FONTCONFIG_CFLAGS)
+AC_SUBST(FONTCONFIG_LIBS)
 
+# MLT++ CHECK-------------------------
+
+PKG_CHECK_MODULES(MLTPP, mlt++-7,,[
+	PKG_CHECK_MODULES(MLTPP, mlt++,,[
+		AC_MSG_ERROR([ ** You need to install mlt++.])
+	])
+])
+AC_SUBST(MLTPP_CFLAGS)
+AC_SUBST(MLTPP_LIBS)
 
 AC_CONFIG_FILES([
     Makefile
@@ -250,6 +260,7 @@ Profiling Mode -------------------> $profiling
 Optimizations --------------------> $optimization
 JACK Enabled ---------------------> $enable_jack
 Build images ---------------------> $with_images
+FontConfig Enabled ---------------> $with_fontconfig
 
 "'$'"CXX ------------------------------> '$CXX'
 "'$'"CXXFLAGS -------------------------> '$CXXFLAGS'
@@ -260,4 +271,8 @@ Build images ---------------------> $with_images
 "'$'"GTKMM_LIBS -----------------------> '$GTKMM_LIBS'
 "'$'"JACK_CFLAGS ----------------------> '$JACK_CFLAGS'
 "'$'"JACK_LIBS ------------------------> '$JACK_LIBS'
+"'$'"FONTCONFIG_CFLAGS ----------------> '$FONTCONFIG_CFLAGS'
+"'$'"FONTCONFIG_LIBS ------------------> '$FONTCONFIG_LIBS'
+"'$'"MLTPP_CFLAGS ---------------------> '$MLTPP_CFLAGS'
+"'$'"MLTPP_LIBS -----------------------> '$MLTPP_LIBS'
 "

--- a/synfig-studio/src/gui/Makefile.am
+++ b/synfig-studio/src/gui/Makefile.am
@@ -118,7 +118,9 @@ synfigstudio_LDADD = \
 	../synfigapp/libsynfigapp.la \
 	@SYNFIG_LIBS@ \
 	@GTKMM_LIBS@ \
-	@JACK_LIBS@
+	@JACK_LIBS@ \
+	@MLTPP_LIBS@ \
+	@FONTCONFIG_LIBS@
 
 synfigstudio_LDFLAGS = \
 	-dlopen self
@@ -127,6 +129,8 @@ synfigstudio_CXXFLAGS = \
 	@SYNFIG_CFLAGS@ \
 	@GTKMM_CFLAGS@ \
 	@JACK_CFLAGS@ \
+	@MLTPP_CFLAGS@ \
+	@FONTCONFIG_CFLAGS@ \
 	-DIMAGE_EXT=\"$(imageext)\" \
 	-DSYNFIG_DATADIR=\"$(synfig_datadir)\" \
 	-DLOCALEDIR=\"${LOCALEDIR}\"


### PR DESCRIPTION
it only should point what is need to link to it

Plus: in synfig-studio, use MLT++ and fontconfig flags for GUI only, not synfigapp