### PR TITLE
refactor: clean up Bevel layer

### DIFF
--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -38,17 +38,8 @@
 #include <synfig/localization.h>
 #include <synfig/general.h>
 
-#include <synfig/string.h>
-#include <synfig/time.h>
+#include <synfig/blur.h>
 #include <synfig/context.h>
-#include <synfig/misc.h>
-#include <synfig/paramdesc.h>
-#include <synfig/renddesc.h>
-#include <synfig/surface.h>
-#include <synfig/value.h>
-#include <synfig/valuenode.h>
-
-#include <cstring>
 
 #endif
 

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -198,7 +198,8 @@ Layer_Bevel::get_sub_renddesc_vfunc(const RendDesc &renddesc) const
 		case Blur::CROSS:
 		case Blur::FASTGAUSSIAN:
 		{
-			workdesc.set_subwindow(-std::max(1,halfsizex),-std::max(1,halfsizey),offset_w+2*std::max(1,halfsizex),offset_h+2*std::max(1,halfsizey));
+			halfsizex = std::max(1, halfsizex);
+			halfsizey = std::max(1, halfsizey);
 			break;
 		}
 		case Blur::GAUSSIAN:
@@ -215,12 +216,11 @@ Layer_Bevel::get_sub_renddesc_vfunc(const RendDesc &renddesc) const
 
 			halfsizex = (halfsizex + 1)/2;
 			halfsizey = (halfsizey + 1)/2;
-			workdesc.set_subwindow( -halfsizex, -halfsizey, offset_w+2*halfsizex, offset_h+2*halfsizey );
-
 			break;
 		}
 	}
 
+	workdesc.set_subwindow( -halfsizex, -halfsizey, offset_w + 2*halfsizex, offset_h + 2*halfsizey );
 	return workdesc;
 }
 

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -208,14 +208,14 @@ Layer_Bevel::get_sub_renddesc_vfunc(const RendDesc &renddesc) const
 		case Blur::GAUSSIAN:
 		{
 		#define GAUSSIAN_ADJUSTMENT		(0.05)
-			Real	pw = (Real)workdesc.get_w()/(workdesc.get_br()[0]-workdesc.get_tl()[0]);
-			Real 	ph = (Real)workdesc.get_h()/(workdesc.get_br()[1]-workdesc.get_tl()[1]);
+			Real pw = workdesc.get_pw();
+			Real ph = workdesc.get_ph();
 
-			pw=pw*pw;
-			ph=ph*ph;
+			Real pw2 = pw * pw;
+			Real ph2 = ph * ph;
 
-			halfsizex = (int)(std::fabs(pw)*size[0]*GAUSSIAN_ADJUSTMENT+0.5);
-			halfsizey = (int)(std::fabs(ph)*size[1]*GAUSSIAN_ADJUSTMENT+0.5);
+			halfsizex = (int)(size[0]*GAUSSIAN_ADJUSTMENT/std::fabs(pw2) + 0.5);
+			halfsizey = (int)(size[1]*GAUSSIAN_ADJUSTMENT/std::fabs(ph2) + 0.5);
 
 			halfsizex = (halfsizex + 1)/2;
 			halfsizey = (halfsizey + 1)/2;
@@ -281,14 +281,14 @@ Layer_Bevel::accelerated_render(Context context,Surface *surface,int quality, co
 	{
 		case Blur::GAUSSIAN:
 		{
-			Real pw = (Real)workdesc.get_w()/(workdesc.get_br()[0]-workdesc.get_tl()[0]);
-			Real ph = (Real)workdesc.get_h()/(workdesc.get_br()[1]-workdesc.get_tl()[1]);
+			Real pw = workdesc.get_pw();
+			Real ph = workdesc.get_ph();
 
-			pw=pw*pw;
-			ph=ph*ph;
+			Real pw2 = pw * pw;
+			Real ph2 = ph * ph;
 
-			halfsizex = (int)(std::fabs(pw)*size[0]*GAUSSIAN_ADJUSTMENT+0.5);
-			halfsizey = (int)(std::fabs(ph)*size[1]*GAUSSIAN_ADJUSTMENT+0.5);
+			halfsizex = (int)(size[0]*GAUSSIAN_ADJUSTMENT/std::fabs(pw2) + 0.5);
+			halfsizey = (int)(size[1]*GAUSSIAN_ADJUSTMENT/std::fabs(ph2) + 0.5);
 
 			halfsizex = (halfsizex + 1)/2;
 			halfsizey = (halfsizey + 1)/2;

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -47,15 +47,6 @@ using namespace synfig;
 using namespace modules;
 using namespace lyr_std;
 
-/*#define TYPE_BOX			0
-#define TYPE_FASTGUASSIAN	1
-#define TYPE_FASTGAUSSIAN	1
-#define TYPE_CROSS			2
-#define TYPE_GUASSIAN		3
-#define TYPE_GAUSSIAN		3
-#define TYPE_DISC			4
-*/
-
 /* -- G L O B A L S --------------------------------------------------------- */
 
 SYNFIG_LAYER_INIT(Layer_Bevel);
@@ -65,12 +56,6 @@ SYNFIG_LAYER_SET_CATEGORY(Layer_Bevel,N_("Stylize"));
 SYNFIG_LAYER_SET_VERSION(Layer_Bevel,"0.2");
 
 /* -- F U N C T I O N S ----------------------------------------------------- */
-
-inline void clamp(Vector &v)
-{
-	if(v[0]<0.0)v[0]=0.0;
-	if(v[1]<0.0)v[1]=0.0;
-}
 
 Layer_Bevel::Layer_Bevel():
 	Layer_CompositeFork(0.75,Color::BLEND_ONTO),

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -196,10 +196,6 @@ Layer_Bevel::get_sub_renddesc_vfunc(const RendDesc &renddesc) const
 		case Blur::DISC:
 		case Blur::BOX:
 		case Blur::CROSS:
-		{
-			workdesc.set_subwindow(-std::max(1,halfsizex),-std::max(1,halfsizey),offset_w+2*std::max(1,halfsizex),offset_h+2*std::max(1,halfsizey));
-			break;
-		}
 		case Blur::FASTGAUSSIAN:
 		{
 			workdesc.set_subwindow(-std::max(1,halfsizex),-std::max(1,halfsizey),offset_w+2*std::max(1,halfsizex),offset_h+2*std::max(1,halfsizey));

--- a/synfig-core/src/modules/lyr_std/bevel.h
+++ b/synfig-core/src/modules/lyr_std/bevel.h
@@ -70,21 +70,21 @@ private:
 public:
 	Layer_Bevel();
 
-	virtual bool set_param(const String &param, const ValueBase &value);
+	bool set_param(const String& param, const ValueBase& value) override;
 
-	virtual ValueBase get_param(const String &param)const;
+	ValueBase get_param(const String& param) const override;
 
-	virtual Color get_color(Context context, const Point &pos)const;
+	Color get_color(Context context, const Point& pos) const override;
 
-	virtual bool accelerated_render(Context context,Surface *surface,int quality, const RendDesc &renddesc, ProgressCallback *cb)const;
+	bool accelerated_render(Context context, Surface* surface, int quality, const RendDesc& renddesc, ProgressCallback* cb) const override;
 
-	virtual Rect get_full_bounding_rect(Context context)const;
-	virtual Vocab get_param_vocab()const;
-	virtual bool reads_context()const { return true; }
+	Rect get_full_bounding_rect(Context context) const override;
+	Vocab get_param_vocab() const override;
+	bool reads_context() const override { return true; }
 
 protected:
-	virtual RendDesc get_sub_renddesc_vfunc(const RendDesc &renddesc) const;
-	virtual rendering::Task::Handle build_rendering_task_vfunc(Context context) const;
+	RendDesc get_sub_renddesc_vfunc(const RendDesc& renddesc) const override;
+	rendering::Task::Handle build_rendering_task_vfunc(Context context) const override;
 }; // END of class Layer_Bevel
 
 }; // END of namespace lyr_std

--- a/synfig-core/src/modules/lyr_std/bevel.h
+++ b/synfig-core/src/modules/lyr_std/bevel.h
@@ -33,10 +33,6 @@
 /* -- H E A D E R S --------------------------------------------------------- */
 
 #include <synfig/layers/layer_composite_fork.h>
-#include <synfig/color.h>
-#include <synfig/vector.h>
-#include <synfig/blur.h>
-#include <synfig/angle.h>
 
 namespace synfig
 {

--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -35,7 +35,7 @@
 
 #include "blur.h"
 
-#include <stdexcept>
+#include <vector>
 
 #include <synfig/blur/boxblur.h>
 #include <synfig/blur/gaussian.h>
@@ -513,19 +513,15 @@ bool Blur::operator()(const Surface &surface,
 			int bh = (int)(std::fabs(ph)*size[1]*GAUSSIAN_ADJUSTMENT+0.5);
 			int max=bw+bh;
 
-			Color* SC0=new Color[w+2];
-			Color* SC1=new Color[w+2];
-			Color* SC2=new Color[w+2];
-			Color* SC3=new Color[w+2];
+			std::vector<Color> SC(4*(w+2));
+			Color* SC0 = &SC[0*(w+2)];
+			Color* SC1 = &SC[1*(w+2)];
+			Color* SC2 = &SC[2*(w+2)];
+			Color* SC3 = &SC[3*(w+2)];
 
 			while(bw&&bh)
 			{
 				if(!blurcall.amount_complete(max-(bw+bh),max)) {
-					delete [] SC0;
-					delete [] SC1;
-					delete [] SC2;
-					delete [] SC3;
-
 					return false;
 				}
 
@@ -550,10 +546,6 @@ bool Blur::operator()(const Surface &surface,
 			while(bw)
 			{
 				if(!blurcall.amount_complete(max-(bw+bh),max)) {
-					delete [] SC0;
-					delete [] SC1;
-					delete [] SC2;
-					delete [] SC3;
 					return false;
 				}
 				if(bw>=2)
@@ -571,10 +563,6 @@ bool Blur::operator()(const Surface &surface,
 			while(bh)
 			{
 				if(!blurcall.amount_complete(max-(bw+bh),max)) {
-					delete [] SC0;
-					delete [] SC1;
-					delete [] SC2;
-					delete [] SC3;
 					return false;
 				}
 				if(bh>=2)
@@ -589,11 +577,6 @@ bool Blur::operator()(const Surface &surface,
 					bh--;
 				}
 			}
-
-			delete [] SC0;
-			delete [] SC1;
-			delete [] SC2;
-			delete [] SC3;
 		}
 		break;
 
@@ -859,19 +842,15 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			int bh = (int)(std::fabs(ph)*size[1]*GAUSSIAN_ADJUSTMENT+0.5);
 			int max=bw+bh;
 
-			float *SC0=new float[w+2];
-			float *SC1=new float[w+2];
-			float *SC2=new float[w+2];
-			float *SC3=new float[w+2];
+			std::vector<float> SC(4*(w+2));
+			float* SC0 = &SC[0*(w+2)];
+			float* SC1 = &SC[1*(w+2)];
+			float* SC2 = &SC[2*(w+2)];
+			float* SC3 = &SC[3*(w+2)];
 
 			while(bw&&bh)
 			{
 				if (!blurcall.amount_complete(max-(bw+bh),max)) {
-					delete [] SC0;
-					delete [] SC1;
-					delete [] SC2;
-					delete [] SC3;
-
 					return false;
 				}
 
@@ -897,11 +876,6 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			while(bw)
 			{
 				if (!blurcall.amount_complete(max-(bw+bh),max)) {
-					delete [] SC0;
-					delete [] SC1;
-					delete [] SC2;
-					delete [] SC3;
-
 					return false;
 				}
 				if(bw>=2)
@@ -920,11 +894,6 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			while(bh)
 			{
 				if (!blurcall.amount_complete(max-(bw+bh),max)) {
-					delete [] SC0;
-					delete [] SC1;
-					delete [] SC2;
-					delete [] SC3;
-
 					return false;
 				}
 				if(bh>=2)
@@ -939,12 +908,6 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 					bh--;
 				}
 			}
-
-			delete [] SC0;
-			delete [] SC1;
-			delete [] SC2;
-			delete [] SC3;
-
 		}
 		break;
 

--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -287,8 +287,8 @@ bool Blur::operator()(const Surface &surface,
 	const Real pw = resolution[0] / w;
 	const Real ph = resolution[1] / h;
 
-	int	halfsizex = (int) (std::fabs(size[0] * 0.5 / pw) + 1),
-		halfsizey = (int) (std::fabs(size[1] * 0.5 / ph) + 1);
+	const Real halfsizex = std::fabs(size[0] * 0.5 / pw) + 1;
+	const Real halfsizey = std::fabs(size[1] * 0.5 / ph) + 1;
 
 	SuperCallback blurcall(cb,0,5000,5000);
 
@@ -317,8 +317,8 @@ bool Blur::operator()(const Surface &surface,
 	switch(parsed_type) {
 	case Blur::DISC:	// D I S C ----------------------------------------------------------
 		{
-			int bw = halfsizex;
-			int bh = halfsizey;
+			int bw = int(halfsizex);
+			int bh = int(halfsizey);
 
 			if(size[0] && size[1] && w*h>2)
 			{
@@ -376,8 +376,7 @@ bool Blur::operator()(const Surface &surface,
 
 			if(size[0])
 			{
-				int length = halfsizex;
-				length=std::max(1,length);
+				int length = std::max(1.0, halfsizex);
 
 				hbox_blur(worksurface.begin(),worksurface.end(),length,temp_surface.begin());
 			}
@@ -385,8 +384,7 @@ bool Blur::operator()(const Surface &surface,
 
 			if(size[1])
 			{
-				int length = halfsizey;
-				length = std::max(1,length);
+				int length = std::max(1.0, halfsizey);
 
 				vbox_blur(temp_surface.begin(),temp_surface.end(),length,worksurface.begin());
 			}
@@ -409,8 +407,7 @@ bool Blur::operator()(const Surface &surface,
 			//horizontal part
 			if(size[0])
 			{
-				Real length = size[0]*0.5/std::fabs(pw) + 1;
-				length=std::max(1.0,length);
+				Real length = std::max(1.0, halfsizex);
 
 				//two box blurs produces: 1 2 1
 				hbox_blur(worksurface.begin(),w,h,(int)(length*3/4),temp_surface.begin());
@@ -420,8 +417,7 @@ bool Blur::operator()(const Surface &surface,
 			//vertical part
 			if(size[1])
 			{
-				Real length = size[1]*0.5/std::fabs(ph) + 1;
-				length=std::max(1.0,length);
+				Real length = std::max(1.0, halfsizey);
 
 				//two box blurs produces: 1 2 1 on the horizontal 1 2 1
 				vbox_blur(worksurface.begin(),w,h,(int)(length*3/4),temp_surface.begin());
@@ -438,8 +434,7 @@ bool Blur::operator()(const Surface &surface,
 
 			if(size[0])
 			{
-				int length = halfsizex;
-				length = std::max(1,length);
+				int length = std::max(1.0, halfsizex);
 
 				hbox_blur(worksurface.begin(),worksurface.end(),length,temp_surface.begin());
 			}
@@ -451,8 +446,7 @@ bool Blur::operator()(const Surface &surface,
 
 			if(size[1])
 			{
-				int length = halfsizey;
-				length = std::max(1,length);
+				int length = std::max(1.0, halfsizey);
 
 				vbox_blur(worksurface.begin(),worksurface.end(),length,temp_surface2.begin());
 			}
@@ -610,8 +604,8 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 	const Real pw = resolution[0] / w;
 	const Real ph = resolution[1] / h;
 
-	int	halfsizex = (int) (std::fabs(size[0] * 0.5 / pw) + 1),
-		halfsizey = (int) (std::fabs(size[1] * 0.5 / ph) + 1);
+	const Real halfsizex = std::fabs(size[0] * 0.5 / pw) + 1;
+	const Real halfsizey = std::fabs(size[1] * 0.5 / ph) + 1;
 
 	SuperCallback blurcall(cb,0,5000,5000);
 
@@ -630,8 +624,8 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 	switch (parsed_type) {
 	case Blur::DISC:	// D I S C ----------------------------------------------------------
 		{
-			int bw = halfsizex;
-			int bh = halfsizey;
+			int bw = int(halfsizex);
+			int bh = int(halfsizey);
 
 			if(size[0] && size[1] && w*h>2)
 			{
@@ -687,8 +681,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 
 			if(size[0])
 			{
-				int length = halfsizex;
-				length=std::max(1,length);
+				int length = std::max(1.0, halfsizex);
 
 				hbox_blur(surface.begin(), surface.end(), length, temp_surface.begin());
 			}
@@ -696,8 +689,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 
 			if(size[1])
 			{
-				int length = halfsizey;
-				length = std::max(1,length);
+				int length = std::max(1.0, halfsizey);
 				vbox_blur(temp_surface.begin(), temp_surface.end(), length, out.begin());
 			}
 			else out = temp_surface;
@@ -719,8 +711,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			//horizontal part
 			if(size[0])
 			{
-				Real length = size[0] * 0.5 / std::fabs(pw) + 1;
-				length=std::max(1.0,length);
+				Real length = std::max(1.0, halfsizex);
 
 				//two box blurs produces: 1 2 1
 				hbox_blur(out.begin(), w, h, (int)(length*3/4), temp_surface.begin());
@@ -730,8 +721,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			//vertical part
 			if(size[1])
 			{
-				Real length = size[1] * 0.5 / std::fabs(ph) + 1;
-				length=std::max(1.0,length);
+				Real length = std::max(1.0, halfsizey);
 
 				//two box blurs produces: 1 2 1 on the horizontal 1 2 1
 				vbox_blur(out.begin(), w, h, (int)(length*3/4), temp_surface.begin());
@@ -748,8 +738,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 
 			if(size[0])
 			{
-				int length = halfsizex;
-				length = std::max(1,length);
+				int length = std::max(1.0, halfsizex);
 
 				temp_surface.set_wh(w, h);
 				hbox_blur(out.begin(), out.end(), length, temp_surface.begin());
@@ -762,8 +751,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 
 			if(size[1])
 			{
-				int length = halfsizey;
-				length = std::max(1,length);
+				int length = std::max(1.0, halfsizey);
 
 				temp_surface2.set_wh(w, h);
 				vbox_blur(out.begin(), out.end(), length, temp_surface2.begin());

--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -284,11 +284,11 @@ bool Blur::operator()(const Surface &surface,
 
 	if(w == 0 || h == 0 || resolution[0] == 0 || resolution[1] == 0) return false;
 
-	const Real	pw = resolution[0]/w,
-				ph = resolution[1]/h;
+	const Real pw = resolution[0] / w;
+	const Real ph = resolution[1] / h;
 
-	int	halfsizex = (int) (std::fabs(size[0]*.5/pw) + 1),
-		halfsizey = (int) (std::fabs(size[1]*.5/ph) + 1);
+	int	halfsizex = (int) (std::fabs(size[0] * 0.5 / pw) + 1),
+		halfsizey = (int) (std::fabs(size[1] * 0.5 / ph) + 1);
 
 	SuperCallback blurcall(cb,0,5000,5000);
 
@@ -409,7 +409,7 @@ bool Blur::operator()(const Surface &surface,
 			//horizontal part
 			if(size[0])
 			{
-				Real length=std::fabs((float)w/(resolution[0]))*size[0]*0.5+1;
+				Real length = size[0]*0.5/std::fabs(pw) + 1;
 				length=std::max(1.0,length);
 
 				//two box blurs produces: 1 2 1
@@ -420,7 +420,7 @@ bool Blur::operator()(const Surface &surface,
 			//vertical part
 			if(size[1])
 			{
-				Real length=std::fabs((float)h/(resolution[1]))*size[1]*0.5+1;
+				Real length = size[1]*0.5/std::fabs(ph) + 1;
 				length=std::max(1.0,length);
 
 				//two box blurs produces: 1 2 1 on the horizontal 1 2 1
@@ -474,9 +474,6 @@ bool Blur::operator()(const Surface &surface,
 			#define GAUSSIAN_ADJUSTMENT		(0.05)
 			#endif
 
-			Real	pw = (Real)w/(resolution[0]);
-			Real 	ph = (Real)h/(resolution[1]);
-
 			Surface temp_surface;
 			Surface *gauss_surface;
 
@@ -490,11 +487,11 @@ bool Blur::operator()(const Surface &surface,
 			   squares our rendertime.
 			   There has got to be a faster way...
 			*/
-			pw=pw*pw;
-			ph=ph*ph;
+			const Real pw2 = pw*pw;
+			const Real ph2 = ph*ph;
 
-			int bw = (int)(std::fabs(pw)*size[0]*GAUSSIAN_ADJUSTMENT+0.5);
-			int bh = (int)(std::fabs(ph)*size[1]*GAUSSIAN_ADJUSTMENT+0.5);
+			int bw = (int)(size[0]*GAUSSIAN_ADJUSTMENT/std::fabs(pw2) + 0.5);
+			int bh = (int)(size[1]*GAUSSIAN_ADJUSTMENT/std::fabs(ph2) + 0.5);
 			int max=bw+bh;
 
 			std::vector<Color> SC(4*(w+2));
@@ -610,11 +607,11 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 
 	if(w == 0 || h == 0 || resolution[0] == 0 || resolution[1] == 0) return false;
 
-	const Real	pw = resolution[0]/w,
-				ph = resolution[1]/h;
+	const Real pw = resolution[0] / w;
+	const Real ph = resolution[1] / h;
 
-	int	halfsizex = (int) (std::fabs(size[0]*.5/pw) + 1),
-		halfsizey = (int) (std::fabs(size[1]*.5/ph) + 1);
+	int	halfsizex = (int) (std::fabs(size[0] * 0.5 / pw) + 1),
+		halfsizey = (int) (std::fabs(size[1] * 0.5 / ph) + 1);
 
 	SuperCallback blurcall(cb,0,5000,5000);
 
@@ -722,7 +719,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			//horizontal part
 			if(size[0])
 			{
-				Real length=std::fabs((float)w/(resolution[0]))*size[0]*0.5+1;
+				Real length = size[0] * 0.5 / std::fabs(pw) + 1;
 				length=std::max(1.0,length);
 
 				//two box blurs produces: 1 2 1
@@ -733,7 +730,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			//vertical part
 			if(size[1])
 			{
-				Real length=std::fabs((float)h/(resolution[1]))*size[1]*0.5+1;
+				Real length = size[1] * 0.5 / std::fabs(ph) + 1;
 				length=std::max(1.0,length);
 
 				//two box blurs produces: 1 2 1 on the horizontal 1 2 1
@@ -789,9 +786,6 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			#define GAUSSIAN_ADJUSTMENT		(0.05)
 			#endif
 
-			Real	pw = (Real)w/(resolution[0]);
-			Real 	ph = (Real)h/(resolution[1]);
-
 			synfig::surface<float> *gauss_surface;
 
 			gauss_surface = &out;
@@ -804,11 +798,11 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			   squares our rendertime.
 			   There has got to be a faster way...
 			*/
-			pw=pw*pw;
-			ph=ph*ph;
+			const Real pw2 = pw*pw;
+			const Real ph2 = ph*ph;
 
-			int bw = (int)(std::fabs(pw)*size[0]*GAUSSIAN_ADJUSTMENT+0.5);
-			int bh = (int)(std::fabs(ph)*size[1]*GAUSSIAN_ADJUSTMENT+0.5);
+			int bw = (int)(size[0]*GAUSSIAN_ADJUSTMENT/std::fabs(pw2) + 0.5);
+			int bh = (int)(size[1]*GAUSSIAN_ADJUSTMENT/std::fabs(ph2) + 0.5);
 			int max=bw+bh;
 
 			std::vector<float> SC(4*(w+2));

--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -709,7 +709,7 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 								if( v >= h ) v = h-1;
 
 								//accumulate the color, and # of pixels added in
-								a += out[v][u];
+								a += surface[v][u];
 								total++;
 							}
 						}

--- a/synfig-core/src/synfig/blur.cpp
+++ b/synfig-core/src/synfig/blur.cpp
@@ -290,17 +290,13 @@ bool Blur::operator()(const Surface &surface,
 	int	halfsizex = (int) (std::fabs(size[0]*.5/pw) + 1),
 		halfsizey = (int) (std::fabs(size[1]*.5/ph) + 1);
 
-	int x,y;
-
 	SuperCallback blurcall(cb,0,5000,5000);
 
 	Surface worksurface(w,h);
 
 	// Premultiply the alpha
-	for(y=0;y<h;y++)
-	{
-		for(x=0;x<w;x++)
-		{
+	for (int y = 0; y < h; y++) {
+		for (int x = 0; x < w; x++) {
 			Color a = surface[y][x];
 			float aa = a.get_a();
 			a.set_r(a.get_r()*aa);
@@ -328,11 +324,9 @@ bool Blur::operator()(const Surface &surface,
 			{
 				int x2,y2;
 				Surface tmp_surface(worksurface);
-
-				for(y=0;y<h;y++)
-				{
-					for(x=0;x<w;x++)
-					{
+				
+				for (int y = 0; y < h; y++) {
+					for (int x = 0; x < w; x++) {
 						//accumulate all the pixels in an ellipse of w,h about the current pixel
 						Color color=Color::alpha();
 						int total=0;
@@ -352,14 +346,8 @@ bool Blur::operator()(const Surface &surface,
 									continue;
 
 								//cap the pixel indices to inside the surface
-								int u= x+x2,
-									v= y+y2;
-
-								if( u < 0 )					u = 0;
-								if( u >= w ) u = w-1;
-
-								if( v < 0 ) 				v = 0;
-								if( v >= h ) v = h-1;
+								int u = synfig::clamp(x+x2, 0, w-1);
+								int v = synfig::clamp(y+y2, 0, h-1);
 
 								//accumulate the color, and # of pixels added in
 								color += tmp_surface[v][u];
@@ -471,12 +459,8 @@ bool Blur::operator()(const Surface &surface,
 			else temp_surface2 = worksurface;
 
 			//blend the two together
-			int x,y;
-
-			for(y=0;y<h;y++)
-			{
-				for(x=0;x<w;x++)
-				{
+			for (int y = 0; y < h; y++) {
+				for (int x = 0; x < w; x++) {
 					worksurface[y][x] = (temp_surface[y][x]+temp_surface2[y][x])/2;//Color::blend((temp_surface[y][x]+temp_surface2[y][x])/2,worksurface[y][x],get_amount(),get_blend_method());
 				}
 			}
@@ -590,10 +574,8 @@ bool Blur::operator()(const Surface &surface,
 	out.set_wh(w,h);
 
 	//divide out the alpha
-	for(y=0;y<h;y++)
-	{
-		for(x=0;x<w;x++)
-		{
+	for (int y = 0; y < h; y++) {
+		for (int x = 0; x < w; x++) {
 			Color a = worksurface[y][x];
 			if(a.get_a())
 			{
@@ -633,7 +615,6 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 
 	int	halfsizex = (int) (std::fabs(size[0]*.5/pw) + 1),
 		halfsizey = (int) (std::fabs(size[1]*.5/ph) + 1);
-	int x,y;
 
 	SuperCallback blurcall(cb,0,5000,5000);
 
@@ -658,11 +639,9 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			if(size[0] && size[1] && w*h>2)
 			{
 				int x2,y2;
-
-				for(y=0;y<h;y++)
-				{
-					for(x=0;x<w;x++)
-					{
+			
+				for (int y = 0; y < h; y++) {
+					for (int x = 0; x < w; x++) {
 						//accumulate all the pixels in an ellipse of w,h about the current pixel
 						float a = 0;
 						int total=0;
@@ -682,14 +661,8 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 									continue;
 
 								//cap the pixel indices to inside the surface
-								int u= x+x2,
-									v= y+y2;
-
-								if( u < 0 )					u = 0;
-								if( u >= w ) u = w-1;
-
-								if( v < 0 ) 				v = 0;
-								if( v >= h ) v = h-1;
+								int u = synfig::clamp(x+x2, 0, w-1);
+								int v = synfig::clamp(y+y2, 0, h-1);
 
 								//accumulate the color, and # of pixels added in
 								a += surface[v][u];
@@ -801,12 +774,8 @@ bool Blur::operator()(const synfig::surface<float> &surface,
 			else v_surface = out;
 
 			//blend the two together
-			int x,y;
-
-			for(y=0;y<h;y++)
-			{
-				for(x=0;x<w;x++)
-				{
+			for (int y = 0; y < h; y++) {
+				for (int x = 0; x < w; x++) {
 					out[y][x] = (h_surface[y][x] + v_surface[y][x]) / 2;
 				}
 			}


### PR DESCRIPTION
Maybe a minor performance improvement because it now does a single memory allocation (instead of 4) per Blur call.