### PR TITLE
build: fix macOS build

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_ANALYTICS: 1
-        run: ./1-setup-osx-brew.sh
+        run: brew update && ./1-setup-osx-brew.sh
 
       - name: Install dependencies (apt)
         if: runner.os == 'Linux'

--- a/1-setup-osx-brew.sh
+++ b/1-setup-osx-brew.sh
@@ -72,6 +72,8 @@ do
     brew info "$pkg" | grep 'Not installed' >/dev/null && brew install "$pkg"
 done
 
+brew reinstall libtool
+
 
 # Do not install lxml for GitHub Actions
 if [[ -z "${CI}" ]]; then


### PR DESCRIPTION
Currently it fails with following errors:
```
glibtoolize: copying file 'libltdl/COPYING.LIB'
glibtoolize:   error: creating 'libltdl/Makefile.am' from '/usr/local/Cellar/libtool/2.4.7/share/libtool/Makefile.am' failed
glibtoolize: copying file 'libltdl/README'
glibtoolize:   error: creating 'libltdl/configure.ac' from '/usr/local/Cellar/libtool/2.4.7/share/libtool/configure.ac' failed
glibtoolize: copying file 'libltdl/aclocal.m4'
glibtoolize:   error: creating 'libltdl/Makefile.in' from '/usr/local/Cellar/libtool/2.4.7/share/libtool/Makefile.in' failed
glibtoolize: copying file 'libltdl/config-h.in'
glibtoolize:   error: creating 'libltdl/configure' from '/usr/local/Cellar/libtool/2.4.7/share/libtool/configure' failed
```