### PR TITLE
chore: fix #3398 - Missing install-sh script on macOS

### DIFF
--- a/synfig-core/bootstrap.sh
+++ b/synfig-core/bootstrap.sh
@@ -50,4 +50,9 @@ sed 's/itlocaledir = $(prefix)\/$(DATADIRNAME)\/locale/itlocaledir = $(datarootd
 # -- force didn't work under MacOS
 mv -f po/Makefile.in.in.tmp po/Makefile.in.in
 
+# Fix https://github.com/synfig/synfig/issues/3398
+# For compatibility with MacOS we have to make sure "sh" binary 
+# is found in "/bin/sh", not "/usr/bin/sh"
+sed -i "s|#!/usr/bin/sh|#!/bin/sh|" config/install-sh
+
 echo "Done! Please run ./configure now."

--- a/synfig-core/bootstrap.sh
+++ b/synfig-core/bootstrap.sh
@@ -53,6 +53,8 @@ mv -f po/Makefile.in.in.tmp po/Makefile.in.in
 # Fix https://github.com/synfig/synfig/issues/3398
 # For compatibility with MacOS we have to make sure "sh" binary 
 # is found in "/bin/sh", not "/usr/bin/sh"
-sed -i "s|#!/usr/bin/sh|#!/bin/sh|" config/install-sh
+sed "s|#!/usr/bin/sh|#!/bin/sh|" < config/install-sh > config/install-sh.tmp
+mv -f config/install-sh.tmp config/install-sh
+chmod +x config/install-sh
 
 echo "Done! Please run ./configure now."

--- a/synfig-studio/bootstrap.sh
+++ b/synfig-studio/bootstrap.sh
@@ -34,4 +34,9 @@ sed 's/itlocaledir = $(prefix)\/$(DATADIRNAME)\/locale/itlocaledir = $(datarootd
 # -- force didn't work under MacOS
 mv -f po/Makefile.in.in.tmp po/Makefile.in.in
 
+# Fix https://github.com/synfig/synfig/issues/3398
+# For compatibility with MacOS we have to make sure "sh" binary 
+# is found in "/bin/sh", not "/usr/bin/sh"
+sed -i "s|#!/usr/bin/sh|#!/bin/sh|" config/install-sh
+
 echo "Done! Please run ./configure now."

--- a/synfig-studio/bootstrap.sh
+++ b/synfig-studio/bootstrap.sh
@@ -37,6 +37,8 @@ mv -f po/Makefile.in.in.tmp po/Makefile.in.in
 # Fix https://github.com/synfig/synfig/issues/3398
 # For compatibility with MacOS we have to make sure "sh" binary 
 # is found in "/bin/sh", not "/usr/bin/sh"
-sed -i "s|#!/usr/bin/sh|#!/bin/sh|" config/install-sh
+sed "s|#!/usr/bin/sh|#!/bin/sh|" < config/install-sh > config/install-sh.tmp
+mv -f config/install-sh.tmp config/install-sh
+chmod +x config/install-sh
 
 echo "Done! Please run ./configure now."


### PR DESCRIPTION
For compatibility with MacOS we have to make sure "sh" binary is found in "/bin/sh", not "/usr/bin/sh"