### PR TITLE
fix: convert.exe directory and missing extension

### DIFF
--- a/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/mptr_imagemagick.cpp
@@ -104,7 +104,7 @@ imagemagick_mptr::get_frame(synfig::Surface &surface, const synfig::RendDesc &re
 	std::vector<std::pair<std::string, std::string>> binaries {
 		{"magick", "convert"}, // ImageMagick 7 with legacy syntax
 #ifdef _WIN32
-		{synfig::OS::get_binary_path().append("convert").u8string(), ""}, // legacy (version < 7) - Avoid Windows system "convert.exe"
+		{synfig::OS::get_binary_path().parent_path().append("convert.exe").u8string(), ""}, // legacy (version < 7) - Avoid Windows system "convert.exe"
 #else
 		{"convert", ""}, // legacy (version < 7)
 #endif

--- a/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
+++ b/synfig-core/src/modules/mod_imagemagick/trgt_imagemagick.cpp
@@ -114,7 +114,7 @@ imagemagick_trgt::start_frame(synfig::ProgressCallback *cb)
 	std::vector<std::pair<std::string, std::string>> binaries {
 		{"magick", "convert"}, // ImageMagick 7 with legacy syntax
 #ifdef _WIN32
-		{synfig::OS::get_binary_path().append("convert").u8string(), ""}, // legacy (version < 7) - Avoid Windows system "convert.exe"
+		{synfig::OS::get_binary_path().parent_path().append("convert.exe").u8string(), ""}, // legacy (version < 7) - Avoid Windows system "convert.exe"
 #else
 		{"convert", ""}, // legacy (version < 7)
 #endif


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw

> If the file name does not contain an extension, .exe is appended.
> Therefore, if the file name extension is .com, this parameter must
> include the .com extension.
> If the file name ends in a period (.) with no extension, or if the
> file name contains a path, .exe is not appended.