### PR TITLE
refactor: avoid macro in header file of ValueNode_Composite

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.h
@@ -35,14 +35,13 @@
 
 /* === M A C R O S ========================================================= */
 
-#define MAX_LINKS 8
-
 /* === C L A S S E S & S T R U C T S ======================================= */
 
 namespace synfig {
 
 class ValueNode_Composite : public LinkableValueNode
 {
+	static constexpr unsigned int MAX_LINKS = 8;
 	ValueNode::RHandle components[MAX_LINKS];
 
 	ValueNode_Composite(const ValueBase &value, etl::loose_handle<Canvas> canvas = 0);

--- a/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_radialcomposite.h
@@ -41,7 +41,8 @@ namespace synfig {
 
 class ValueNode_RadialComposite : public LinkableValueNode
 {
-	ValueNode::RHandle components[6];
+	static constexpr unsigned int MAX_LINKS = 6;
+	ValueNode::RHandle components[MAX_LINKS];
 
 	ValueNode_RadialComposite(const ValueBase &value);
 


### PR DESCRIPTION
It's for internal use only.