### PR TITLE
ci(Github Actions): bump macOS version (12 Monterey -> 13 Ventura)

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -24,13 +24,13 @@ jobs:
         include:
         # includes a new variable of npm with a value of 2
         # for the matrix leg matching the os and version
-        - os: macos-12
-          name: macOS 12 Monterey (Autotools)
+        - os: macos-13
+          name: macOS 13 Ventura (Autotools)
           toolchain: autotools
           allow_failures: false
 
-        - os: macos-12
-          name: macOS 12 Monterey (CMake+Ninja)
+        - os: macos-13
+          name: macOS 13 Ventura (CMake+Ninja)
           toolchain: cmake-ninja
           allow_failures: true
 


### PR DESCRIPTION
Homebrew has stopped building Monterey bottles (https://github.com/Homebrew/brew/pull/18314)