### PR TITLE
Upgraded MLT version from '7.2.0' to '7.28.0' under MSYS2 environment

### DIFF
--- a/autobuild/build.sh
+++ b/autobuild/build.sh
@@ -90,7 +90,7 @@ if [[ `uname` == "MINGW"* ]]; then # MacOS doesn't support `uname -o` flag
 	# copy MLT
 	MLT_REV=1   # Change this when something is changed inside of if block below
 	if [ ! -f "${PREFIX}/mlt-${VERSION_MLT}-${MLT_REV}.done" ]; then
-		VERSION_MLT="7.2.0"
+		VERSION_MLT="7.28.0"
 		cp -rf /opt/mlt-${VERSION_MLT}/*.dll "${PREFIX}/bin/"
 		cp -rf /opt/mlt-${VERSION_MLT}/*.exe "${PREFIX}/bin/"
 		cp -rf /opt/mlt-${VERSION_MLT}/share "${PREFIX}/bin/"

--- a/autobuild/msys2/build_mlt.sh
+++ b/autobuild/msys2/build_mlt.sh
@@ -4,7 +4,7 @@
 # -------------------------------------------------------------------------------
 set -e # exit on error
 
-VERSION_MLT="7.2.0"
+VERSION_MLT="7.28.0"
 # CMake cannot invoke `ccache` binaries in MSYS2 because they are just
 # bash scripts so it ends up with "invalid Win32 application" error
 # PATH="${MINGW_PREFIX}/lib/ccache/bin:${PATH}"


### PR DESCRIPTION
This PR upgrades the MLT framework from 7.2.0 to 7.28.0. This update addresses issue #3026.