### PR TITLE
fix: Upgraded MLT version from '7.2.0' to '7.28.0' under MSYS2 environment

### DIFF
--- a/2-build-cmake.sh
+++ b/2-build-cmake.sh
@@ -10,7 +10,7 @@ BUILDDIR=cmake-build
 
 if [[ "$(uname -s)" =~ ^MSYS_NT.* ]] || [[ "$(uname -s)" =~ Msys$ ]]
 then
-export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.2.0/lib/pkgconfig"
+export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/opt/mlt-7.28.0/lib/pkgconfig"
 fi
 
 mkdir -p "${BUILDDIR}" && cd "${BUILDDIR}"

--- a/autobuild/build.sh
+++ b/autobuild/build.sh
@@ -90,7 +90,7 @@ if [[ `uname` == "MINGW"* ]]; then # MacOS doesn't support `uname -o` flag
 	# copy MLT
 	MLT_REV=1   # Change this when something is changed inside of if block below
 	if [ ! -f "${PREFIX}/mlt-${VERSION_MLT}-${MLT_REV}.done" ]; then
-		VERSION_MLT="7.2.0"
+		VERSION_MLT="7.28.0"
 		cp -rf /opt/mlt-${VERSION_MLT}/*.dll "${PREFIX}/bin/"
 		cp -rf /opt/mlt-${VERSION_MLT}/*.exe "${PREFIX}/bin/"
 		cp -rf /opt/mlt-${VERSION_MLT}/share "${PREFIX}/bin/"

--- a/autobuild/msys2/build_mlt.sh
+++ b/autobuild/msys2/build_mlt.sh
@@ -4,7 +4,7 @@
 # -------------------------------------------------------------------------------
 set -e # exit on error
 
-VERSION_MLT="7.2.0"
+VERSION_MLT="7.28.0"
 # CMake cannot invoke `ccache` binaries in MSYS2 because they are just
 # bash scripts so it ends up with "invalid Win32 application" error
 # PATH="${MINGW_PREFIX}/lib/ccache/bin:${PATH}"

--- a/autobuild/synfigstudio-release.sh
+++ b/autobuild/synfigstudio-release.sh
@@ -42,7 +42,7 @@ NC='\033[0m' # No Color
 
 if [[ `uname` == "MINGW"* ]]; then # MacOS doesn't support `uname -o` flag
 	PATH="${MINGW_PREFIX}/lib/ccache/bin:${PATH}"
-	PKG_CONFIG_PATH="/opt/mlt-7.2.0/lib/pkgconfig:${PKG_CONFIG_PATH}"
+	PKG_CONFIG_PATH="/opt/mlt-7.28.0/lib/pkgconfig:${PKG_CONFIG_PATH}"
 	echo "ccache enabled"
 fi
 

--- a/cmake/InstallMSYS2.cmake
+++ b/cmake/InstallMSYS2.cmake
@@ -96,7 +96,7 @@ install(FILES ${MINGW_LIBS} DESTINATION bin)
 
 find_program(CYGPATH_EXECUTABLE cygpath ${MINGW_PATH}/../usr/bin/)
 if(CYGPATH_EXECUTABLE)
-    set(MLT_PATH "/opt/mlt-7.2.0")
+    set(MLT_PATH "/opt/mlt-7.28.0")
     execute_process(
 		    COMMAND ${CYGPATH_EXECUTABLE} -m ${MLT_PATH}
 		    OUTPUT_VARIABLE MLT_DIRECTORY
@@ -106,7 +106,7 @@ if(CYGPATH_EXECUTABLE)
     message(${MLT_DIRECTORY})
 else()
     message(WARNING "-- cygpath tool not found, using relative path for MLT.")
-    set(MLT_DIRECTORY "${MINGW_PATH}/../opt/mlt-7.2.0")
+    set(MLT_DIRECTORY "${MINGW_PATH}/../opt/mlt-7.28.0")
 endif()
 
 file(GLOB MLT_FILES


### PR DESCRIPTION
This PR upgrades the MLT framework from 7.2.0 to 7.28.0 in the MSYS2 environment. This update addresses issue #3026 where the MLT framework fails to build in the MSYS2 environment.