### PR TITLE
fix: clang build (and bump macOS version)

### DIFF
--- a/.github/workflows/synfig-ci.yml
+++ b/.github/workflows/synfig-ci.yml
@@ -24,13 +24,13 @@ jobs:
         include:
         # includes a new variable of npm with a value of 2
         # for the matrix leg matching the os and version
-        - os: macos-12
-          name: macOS 12 Monterey (Autotools)
+        - os: macos-13
+          name: macOS 13 Ventura (Autotools)
           toolchain: autotools
           allow_failures: false
 
-        - os: macos-12
-          name: macOS 12 Monterey (CMake+Ninja)
+        - os: macos-13
+          name: macOS 13 Ventura (CMake+Ninja)
           toolchain: cmake-ninja
           allow_failures: true
 

--- a/synfig-core/test/test_base.h
+++ b/synfig-core/test/test_base.h
@@ -52,9 +52,19 @@ std::ostream& operator<<(std::ostream& os, const synfig::Vector& v)
 	return os;
 }
 
-// remove this operator after switch to c++17 (it is already implemented in c++17)
-#if !defined(__APPLE__) && !defined(__clang__) || __clang_major__ == 6
-// macOS Clang toolchain has already defined this operator for all c++ versions
+/*
+In Clang, the `operator<<(nullptr_t)` was added in version 9 without the corresponding C++ version guard.
+This behavior was fixed in version 15 (commit: https://github.com/llvm/llvm-project/commit/50cfb76)
+
+todo: After switching to C++17, this workaround should be removed.
+
+P.S. As an alternative solution that does not depend on the compiler, the following code can be used:
+```
+#define NULLPTR_HELPER(out, val) (std::is_same<decltype(val), nullptr_t>::value ? (out << "null") : (out << val))
+oss << "\t - expected "; NULLPTR_HELPER(oss, a) << ", but got "; NULLPTR_HELPER(oss, b) << std::endl;
+```
+*/
+#if !defined(__clang__) || (__clang_major__  < 9 || __clang_major__ > 14)
 std::ostream& operator<<(std::ostream& os, std::nullptr_t)
 {
 	os << "null";


### PR DESCRIPTION
In macOS 13, Apple updated clang to version 15, which caused Synfig to stop building.

P.S. GitHub macOS 12 deprecation notice: https://github.com/actions/runner-images/issues/10721