### PR TITLE
chore: fix various typos

### DIFF
--- a/perf/scripts/test_render_all_perf.py
+++ b/perf/scripts/test_render_all_perf.py
@@ -11,7 +11,7 @@
 # 3. Don't have any applications running at the same time.  It can mess with the
 #    performance measurements.
 #
-# It can take an extremely long time to run (.e.g 25 mintues right now).  Before
+# It can take an extremely long time to run (eg. 25 minutes right now).  Before
 # trying to do any perf tweaking in the rendering code, make sure you generate
 # a reference/baseline to go off from.  This should be the latest commit on
 # `master`.  Don't forget to copy this CSV file to another location in case you

--- a/synfig-core/bootstrap.sh
+++ b/synfig-core/bootstrap.sh
@@ -42,7 +42,7 @@ AUTOPOINT='intltoolize --automake --copy' autoreconf --force --install --verbose
 # for a bug in intltool.  
 # See https://launchpad.net/bugs/398571 and https://bugs.launchpad.net/bugs/992047
 #
-# TODO: Drop this hack, and bump our intltool version requiement once the issue
+# TODO: Drop this hack, and bump our intltool version requirement once the issue
 #       is fixed in intltool
 
 echo "patching po/Makefile.in.in..."

--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.h
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.h
@@ -60,7 +60,7 @@ private:
 	synfig::ValueBase param_style;
 	//!Parameter: (int) weight used in the font
 	synfig::ValueBase param_weight;
-	//!Parameter: (int) diretion of the text
+	//!Parameter: (int) direction of the text
 	synfig::ValueBase param_direction;
 	//!Parameter: (synfig::Real) horizontal spacing
 	synfig::ValueBase param_compress;

--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -82,7 +82,7 @@ target_sources(libsynfig
         "${CMAKE_CURRENT_LIST_DIR}/curve.cpp"
 )
 
-## these were added seprately in autotools build, preserving this for now
+## these were added separately in autotools build, preserving this for now
 ## TODO: either merge with main list or create new target
 target_sources(libsynfig
     PRIVATE

--- a/synfig-core/src/synfig/blur/boxblur.h
+++ b/synfig-core/src/synfig/blur/boxblur.h
@@ -42,7 +42,7 @@ namespace synfig {
 /**
  * Blur every row of a sample block based only on the samples of the same horizontal line.
  *
- * The formula for a blured sample is: ?
+ * The formula for a blurred sample is: ?
  *
  * @param pen the initial point of the sample block
  * @param w the block width
@@ -88,7 +88,7 @@ hbox_blur(T1 pen,int w, int h, int length, T2 outpen)
 /**
  * Blur every column of a sample block based only on the samples of the same vertical line.
  *
- * The formula for a blured sample is: ?
+ * The formula for a blurred sample is: ?
  *
  * @param pen the initial point of the sample block
  * @param w the block width

--- a/synfig-core/src/synfig/filesystem_path.h
+++ b/synfig-core/src/synfig/filesystem_path.h
@@ -328,7 +328,7 @@ void swap(synfig::filesystem::Path& lhs, synfig::filesystem::Path& rhs) noexcept
  * Returns the current path, also known as current working directory.
  *
  * It just calls the synfig::OS::get_current_working_directory().
- * It is defined here for convinience and to imitate the C++17 filesystem namespace.
+ * It is defined here for convenience and to imitate the C++17 filesystem namespace.
  *
  * @return the current working directory
  */

--- a/synfig-core/src/synfig/os.cpp
+++ b/synfig-core/src/synfig/os.cpp
@@ -505,7 +505,7 @@ public:
 			return false;
 		}
 
-		// pipe to comunicate error to parent process
+		// pipe to communicate error to parent process
 		int error_message_pipe[2];
 		if (pipe(error_message_pipe)) {
 			synfig::error(_("Unable to open exec error pipes to %s (no pipe)"), binary_path.u8_str());

--- a/synfig-core/src/synfig/pen.h
+++ b/synfig-core/src/synfig/pen.h
@@ -45,7 +45,7 @@ namespace synfig {
 /**
  * A 2D surface row iterator: access surface samples of a single row.
  *
- * You can get or set a sample value with operator[] or the current sample by derefencing the iterator.
+ * You can get or set a sample value with operator[] or the current sample by dereferencing the iterator.
  *
  * Check if iterator is valid by casting it to bool.
  *

--- a/synfig-core/src/synfig/rendering/task.h
+++ b/synfig-core/src/synfig/rendering/task.h
@@ -143,7 +143,7 @@ public:
 	class Token;
 
 	/// Special values for OptimizerPass
-	///   For optimzation purposes, some tasks may not be run itself,
+	///   For optimization purposes, some tasks may not be run itself,
 	///   but delegates to (a single) one of its subtasks.
 	/// These values indicates no delegation to a subtask: they are special cases
 	/// \sa get_pass_subtask_index()

--- a/synfig-core/src/synfig/synfig_iterations.h
+++ b/synfig-core/src/synfig/synfig_iterations.h
@@ -81,7 +81,7 @@ enum TraverseCallbackAction {
 /// Walks into valuenode tree performing valuenode_callback() on each valuenode
 /// If value_node is LinkableValueNode, runs on each of its links too, according to return of the valuenode_callback (see TraverseCallbackAction)
 ///
-/// \param value_node The starting point to scannning
+/// \param value_node The starting point to scanning
 /// \param valuenode_callback A functor called at each valuenode found
 void traverse_valuenodes(ValueNode::Handle value_node, std::function<TraverseCallbackAction(ValueNode::Handle)> valuenode_callback);
 

--- a/synfig-studio/bootstrap.sh
+++ b/synfig-studio/bootstrap.sh
@@ -26,7 +26,7 @@ AUTOPOINT='intltoolize --automake --copy' autoreconf --force --install --verbose
 # for a bug in intltool.  
 # See https://launchpad.net/bugs/398571 and https://bugs.launchpad.net/bugs/992047
 #
-# TODO: Drop this hack, and bump our intltool version requiement once the issue
+# TODO: Drop this hack, and bump our intltool version requirement once the issue
 #       is fixed in intltool
 
 echo "patching po/Makefile.in.in..."

--- a/synfig-studio/docs/bones_gui.txt
+++ b/synfig-studio/docs/bones_gui.txt
@@ -140,7 +140,7 @@ always valid)
 SETUP AND ANIMATED SKELETONS
 ----------------------------
 
-By using the ALT-7 keyboard combintation the user sees the setup or the
+By using the ALT-7 keyboard combination the user sees the setup or the
 non setup skeletons.
 When the user is creating the skeleton and is modifying it in non
 animation mode then the setuo and the non setup skeletons should be the

--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2345,7 +2345,7 @@ App::dialog_open_file_ext(const std::string& title, std::vector<synfig::filesyst
 	filter_supported->add_pattern("*.tsv");
 	filter_supported->add_pattern("*.xml");
 
-	// Sub fileters
+	// Sub filters
 	// 1 Synfig documents. sfg is not supported to import
 	Glib::RefPtr<Gtk::FileFilter> filter_synfig = Gtk::FileFilter::create();
 	filter_synfig->set_name(_("Synfig files (*.sif, *.sifz)"));

--- a/synfig-studio/src/gui/dialogs/dialog_spritesheetparam.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_spritesheetparam.cpp
@@ -55,7 +55,7 @@ Dialog_SpriteSheetParam::Dialog_SpriteSheetParam(Gtk::Window &parent):
 	offset_y_label->set_valign(Gtk::ALIGN_CENTER);
 	offset_y_box = Gtk::manage(new Gtk::SpinButton(Gtk::Adjustment::create(0.0, 0.0,10000.0)));
 
-	//Dirrection
+	//Direction
 	Gtk::Label* direction_label(manage(new Gtk::Label(_("Direction:"))));
 	direction_label->set_halign(Gtk::ALIGN_START);
 	direction_label->set_valign(Gtk::ALIGN_CENTER);

--- a/synfig-studio/src/gui/docks/dock_navigator.cpp
+++ b/synfig-studio/src/gui/docks/dock_navigator.cpp
@@ -1,6 +1,6 @@
 /* === S Y N F I G ========================================================= */
 /*!	\file dock_navigator.cpp
-**	\brief Dock Nagivator File
+**	\brief Dock Navigator File
 **
 **	\legal
 **	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley

--- a/synfig-studio/src/gui/states/state_circle.cpp
+++ b/synfig-studio/src/gui/states/state_circle.cpp
@@ -1372,7 +1372,7 @@ StateCircle_Context::toggle_layer_creation()
 		feather_dist.set_sensitive(false);
 	}
 
-	// orign is at center
+	// origin is at center
 	if (get_layer_region_flag() ||
 		get_layer_outline_flag() ||
 		get_layer_advanced_outline_flag() ||

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -981,7 +981,7 @@ StateDraw_Context::process_stroke(StrokeData stroke_data, WidthData width_data, 
 		for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter)
 			iter->set_position(hom_to_std(ValueBase::List(bline.begin(), bline.end()), iter->get_position(), false, false));
 	}
-	// print out resutls
+	// print out results
 	//synfig::info("-----------widths");
 	//for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter) {
 		//if(!iter->get_dash())

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -908,7 +908,7 @@ StateLasso_Context::process_stroke(StrokeData stroke_data, WidthData width_data,
 		for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter)
 			iter->set_position(hom_to_std(ValueBase::List(bline.begin(), bline.end()), iter->get_position(), false, false));
 	}
-	// print out resutls
+	// print out results
 	//synfig::info("-----------widths");
 	//for (std::list<synfig::WidthPoint>::iterator iter = wplist.begin(); iter != wplist.end(); ++iter) {
 		//if(!iter->get_dash())

--- a/synfig-studio/src/synfigapp/actions/waypointsetsmart.cpp
+++ b/synfig-studio/src/synfigapp/actions/waypointsetsmart.cpp
@@ -182,7 +182,7 @@ Action::WaypointSetSmart::set_param(const synfig::String& name, const Action::Pa
 bool
 Action::WaypointSetSmart::is_ready()const
 {
-	//we either need a valuedesc for the inital waypoint added
+	//we either need a valuedesc for the initial waypoint added
 	//or a valuenode to add more waypoints to the parameter
 	if(!value_desc && !value_node){
 		synfig::error(_("Either value_desc or value_node must be set"));

--- a/synfig-studio/src/synfigapp/blineconvert.cpp
+++ b/synfig-studio/src/synfigapp/blineconvert.cpp
@@ -615,7 +615,7 @@ synfigapp::BLineConverter::operator()(std::list<synfig::BLinePoint>  &blinepoint
 			deriv.resize(size);
 
 			// Wondering whether the modification of the deriv vector
-			// using a char* pointer and pointer arithmetric was safe,
+			// using a char* pointer and pointer arithmetic was safe,
 			// I looked it up...
 			//
 			// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2369.pdf tells me:

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -616,7 +616,7 @@ Instance::save_as(const synfig::String &file_name)
 		new_canvas_filesystem = CanvasFileNaming::make_filesystem(new_container);
 		if (!new_canvas_filesystem)
 		{
-			warning("Cannot create canvas filesysem for: %s", new_canvas_filename.c_str());
+			warning("Cannot create canvas filesystem for: %s", new_canvas_filename.c_str());
 			return false;
 		}
 

--- a/synfig-studio/src/synfigapp/vectorizer/centerlineskeletonizer.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlineskeletonizer.cpp
@@ -205,7 +205,7 @@ void IndexTable::build(ContourFamily &family) {
   for (i = 0; i < m_columns.size(); ++i) {
     m_identifiers[i] = i;
     m_columns[i].push_back(&family[i][0]);
-    // Each node referenced in the Table is signed as 'head' of the cirular
+    // Each node referenced in the Table is signed as 'head' of the circular
     // list.
     family[i][0].setAttribute(ContourNode::HEAD);
   }


### PR DESCRIPTION
Found via `codespell -q 3 -L aline,ang,apendices,ba,bu,childs,dout,eiter,existant,forse,objext,pard,parms,pevent,propertyst,rin,ro,sectionin,shouldbe,textin,thru,uint,unselect,vertexes -S "./.git,*.patch,./synfig-studio/po,./synfig-core/po,/synfig-core/m4,./synfig-osx/,./gtkmm-osx,./bugs,.*.eps,*.sif,./synfig-studio/plugins/lottie-exporter"`