### PR TITLE
feat: Color Palette Improvements.

### DIFF
--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -106,6 +106,7 @@ class Dock_Canvases;
 
 class Dock_Keyframes;
 class Dock_Params;
+class Dock_PalEdit;
 class Dock_Layers;
 class Dock_MetaData;
 class Dock_Children;
@@ -176,6 +177,9 @@ private:
 
 	static int jack_locks_;
 
+	// Mouse Bindings:
+	static std::map<synfig::String, std::pair<GdkModifierType, int>> mouse_bindings_;
+
 //	static std::list< etl::handle< Module > > module_list_;
 
 	static std::string icon_theme_name;
@@ -206,6 +210,7 @@ public:
 	static About *about;
 	static MainWindow *main_window;
 	static Dock_Toolbox *dock_toolbox;
+	static Dock_PalEdit *dock_paledit;
 
 	static std::list<etl::handle<Instance> > instance_list;
 
@@ -341,8 +346,15 @@ public:
 	static bool load_settings(const synfig::String& key_filter = "");
 	static void load_accel_map();
 	static void save_accel_map();
+
 	/// \param[out] map Maps AccelKey to Action
 	static const std::map<const char*, const char*>& get_default_accel_map();
+	
+	static const std::map<synfig::String, std::pair<GdkModifierType, int>>& get_default_mouse_binding_map();
+	static const std::map<synfig::String, std::pair<GdkModifierType, int>>& get_current_mouse_binding_map() { return mouse_bindings_; }
+
+	static void set_mouse_binding(const synfig::String& action, const std::pair<GdkModifierType, int>& binding);
+	
 	static void load_recent_files();
 	static void load_language_settings();
 	static void apply_gtk_settings();

--- a/synfig-studio/src/gui/dialogs/dialog_setup.h
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.h
@@ -195,11 +195,21 @@ class Dialog_Setup : public Dialog_Template
 	PrefsBrushPath prefs_brushpath;
 
 	Gtk::CellRendererAccel renderer_accel;
+	Gtk::CellRendererAccel renderer_mouse_accel;
+
 	Gtk::TreeView *treeview_accels;
+	Gtk::TreeView *treeview_mouse_accels;
 
 	void on_accel_edited(const Glib::ustring& path_string, guint accel_key, Gdk::ModifierType accel_mods, guint hardware_keycode);
 	void on_accel_cleared(const Glib::ustring& path_string);
 	void on_restore_default_accels_pressed();
+
+	// Signal handler for mouse shortcut editing
+	bool on_mouse_shortcut_clicked(GdkEventButton* event);
+
+	bool capturing_mouse_shortcut = false; // Flag for capturing mode
+	Gtk::TreeModel::Row current_row_for_mouse_binding;
+
 public:
 	/*
  -- ** -- S I G N A L S -------------------------------------------------------

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -408,7 +408,7 @@ Dock_PalEdit::refresh()
 				i
 			)
 		);
-		widget_color->signal_middle_click().connect(
+		widget_color->signal_activate_with_modifier(GDK_SHIFT_MASK).connect(
 			sigc::bind(
 				sigc::mem_fun(*this,&studio::Dock_PalEdit::select_outline_color),
 				i

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -402,21 +402,35 @@ Dock_PalEdit::refresh()
 		Widget_Color* widget_color(manage(new Widget_Color()));
 		widget_color->set_value(get_color(i));
 		widget_color->set_size_request(12,12);
-		widget_color->signal_activate().connect(
+
+		synfig::String color_palette = "Color Palette";
+		
+		for(auto&& mouse_binding : App::get_current_mouse_binding_map()) {
+			synfig::String mouse_binding_full_action = mouse_binding.first;
+			std::pair<GdkModifierType, int> mouse_binding_shortcut = mouse_binding.second;
+
+			if(mouse_binding_full_action.find(color_palette) == 0) {
+				// color_palette.size() + 1 to account for the '/' character.
+				widget_color->push_mouse_binding(mouse_binding_full_action.substr(color_palette.size() + 1), mouse_binding_shortcut);
+			}
+		}
+
+		widget_color->signal_mouse_binding("Select Fill Color").connect(
 			sigc::bind(
-				sigc::mem_fun(*this,&studio::Dock_PalEdit::select_fill_color),
+				sigc::mem_fun(*this, &studio::Dock_PalEdit::select_fill_color),
 				i
 			)
 		);
-		widget_color->signal_activate_with_modifier(GDK_SHIFT_MASK).connect(
+		widget_color->signal_mouse_binding("Select Outline Color").connect(
 			sigc::bind(
-				sigc::mem_fun(*this,&studio::Dock_PalEdit::select_outline_color),
+				sigc::mem_fun(*this, &studio::Dock_PalEdit::select_outline_color),
 				i
 			)
 		);
+
 		widget_color->signal_right_click().connect(
 			sigc::bind(
-				sigc::mem_fun(*this,&studio::Dock_PalEdit::show_menu),
+				sigc::mem_fun(*this, &studio::Dock_PalEdit::show_menu),
 				i
 			)
 		);

--- a/synfig-studio/src/gui/modules/mod_palette/mod_palette.h
+++ b/synfig-studio/src/gui/modules/mod_palette/mod_palette.h
@@ -57,6 +57,9 @@ protected:
 
 public:
 	virtual ~ModPalette() { stop(); }
+
+	Dock_PalEdit*   get_pal_edit()   { return dock_pal_edit; }
+	Dock_PalBrowse* get_pal_browse() { return dock_pal_browse; }
 };
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/widgets/widget_color.cpp
+++ b/synfig-studio/src/gui/widgets/widget_color.cpp
@@ -157,6 +157,12 @@ Widget_Color::on_event(GdkEvent *event)
 	case GDK_BUTTON_PRESS:
 		if(event->button.button==1)
 		{
+			if(event->button.state & state_flags)
+			{
+				signal_activate_with_modifier_();
+				return true;
+			}
+
 			signal_activate_();
 			return true;
 		}

--- a/synfig-studio/src/gui/widgets/widget_color.h
+++ b/synfig-studio/src/gui/widgets/widget_color.h
@@ -58,6 +58,10 @@ private:
 	GdkModifierType state_flags;
 	sigc::signal<void> signal_activate_with_modifier_;
 
+	// Used for mouse binding:
+	std::map<synfig::String, std::pair<GdkModifierType, int>> widget_mouse_bindings_;
+	std::map<synfig::String, sigc::signal<void>> widget_mouse_binding_signals_;
+
 public:
 	sigc::signal<void>& signal_activate() { return signal_activate_; }
 	sigc::signal<void>& signal_clicked() { return signal_activate_; }
@@ -65,6 +69,9 @@ public:
 	sigc::signal<void>& signal_right_click() { return signal_right_click_; }
 
 	sigc::signal<void>& signal_activate_with_modifier(GdkModifierType flags) { state_flags = flags; return signal_activate_with_modifier_; } 
+
+	void push_mouse_binding(const synfig::String& action, const std::pair<GdkModifierType, int>& mouse_binding);
+	sigc::signal<void>& signal_mouse_binding(const synfig::String& action) { return widget_mouse_binding_signals_[action]; } 
 
 	const synfig::Color& get_value() const;
 	void set_value(const synfig::Color &x);

--- a/synfig-studio/src/gui/widgets/widget_color.h
+++ b/synfig-studio/src/gui/widgets/widget_color.h
@@ -31,6 +31,8 @@
 /* === H E A D E R S ======================================================= */
 
 #include <gtkmm/drawingarea.h>
+#include <gdk/gdktypes.h>
+
 #include <synfig/color.h>
 
 /* === M A C R O S ========================================================= */
@@ -53,11 +55,16 @@ private:
 	sigc::signal<void> signal_middle_click_;
 	sigc::signal<void> signal_right_click_;
 
+	GdkModifierType state_flags;
+	sigc::signal<void> signal_activate_with_modifier_;
+
 public:
 	sigc::signal<void>& signal_activate() { return signal_activate_; }
 	sigc::signal<void>& signal_clicked() { return signal_activate_; }
 	sigc::signal<void>& signal_middle_click() { return signal_middle_click_; }
 	sigc::signal<void>& signal_right_click() { return signal_right_click_; }
+
+	sigc::signal<void>& signal_activate_with_modifier(GdkModifierType flags) { state_flags = flags; return signal_activate_with_modifier_; } 
 
 	const synfig::Color& get_value() const;
 	void set_value(const synfig::Color &x);


### PR DESCRIPTION
## Description

Earlier, the shortcut for selecting the outline color from the palette was middle click, which is unintuitive. Therefore the binding is changed to shift click instead of middle click. This is also customizable via **Edit->Preferences->Shortcuts** as shown below:

![Mouse Shortcuts](https://github.com/user-attachments/assets/e4e19383-ca59-42db-ba4b-d2b1968248f1)

This PR addresses the issue #3292 

## Features Implemented in Code
A seperate tree view that displays mouse bindings similar to keyboard shortcuts is implemented with the ability of modifying mouse shortcuts.