### PR TITLE
ci: Resolve error when build dir cannot be removed after previous (failed) run

### DIFF
--- a/.github/workflows/synfig-ci-self-hosted.yml
+++ b/.github/workflows/synfig-ci-self-hosted.yml
@@ -32,6 +32,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: "Fix permissions on build folder"
+        run: |
+          chmod -R u+w ./
       - uses: actions/checkout@v4
       - name: "Synfig Studio (source tarballs)"
         run: |


### PR DESCRIPTION
If previous build was terminated due to hard reset, then build dir remains in read-only state, which prevents next runs of CI jobs.
This is attempt to fix such situation.