### PR TITLE
fix(ci): show-pr-change-note not working with prs from forks

### DIFF
--- a/.github/workflows/show-pr-change-note.yml
+++ b/.github/workflows/show-pr-change-note.yml
@@ -1,7 +1,7 @@
 name: Show Pull Request Change Note
 
 on: 
-  pull_request:
+  pull_request_target:
       types: [opened, edited]
 
 jobs:


### PR DESCRIPTION
This fixes the issue where contributors weren't automatically shown how their pull requests affect the release notes if the pull request was created from a forked repository. This is crucial because (as I understand) Synfig’s contribution mechanism relies entirely on forking.

The change uses the GitHub Actions event pull_request_target instead of pull_request, which:

1. Solves the above permissions issue.
2. Maintains security since it only uses the workflow defined in the main branch of the official Synfig repository, avoiding execution of untrusted code from the fork.

For more details on the difference between pull_request and pull_request_target, check [this](https://stackoverflow.com/a/74959635/12263075)