### PR TITLE
refactor: cleanup Layer::get_sub_renddesc*() methods

### DIFF
--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -859,23 +859,15 @@ Layer::accelerated_render(Context context,Surface *surface,int quality, const Re
 
 
 RendDesc
-Layer::get_sub_renddesc_vfunc(const RendDesc &renddesc) const
+Layer::get_sub_renddesc_vfunc(const RendDesc& renddesc) const
 {
 	return renddesc;
 }
 
-void
-Layer::get_sub_renddesc(const RendDesc &renddesc, std::vector<RendDesc> &out_descs) const
-{
-	out_descs.push_back(get_sub_renddesc_vfunc(renddesc));
-}
-
 RendDesc
-Layer::get_sub_renddesc(const RendDesc &renddesc) const
+Layer::get_sub_renddesc(const RendDesc& renddesc) const
 {
-	std::vector<RendDesc> descs;
-	get_sub_renddesc(renddesc, descs);
-	return descs[0];
+	return get_sub_renddesc_vfunc(renddesc);
 }
 
 rendering::Task::Handle

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -871,11 +871,11 @@ Layer::get_sub_renddesc(const RendDesc &renddesc, std::vector<RendDesc> &out_des
 }
 
 RendDesc
-Layer::get_sub_renddesc(const RendDesc &renddesc, int index) const
+Layer::get_sub_renddesc(const RendDesc &renddesc) const
 {
 	std::vector<RendDesc> descs;
 	get_sub_renddesc(renddesc, descs);
-	return index >=0 && index < (int)descs.size() ? descs[index] : RendDesc::zero();
+	return descs[0];
 }
 
 rendering::Task::Handle

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -865,15 +865,9 @@ Layer::get_sub_renddesc_vfunc(const RendDesc &renddesc) const
 }
 
 void
-Layer::get_sub_renddesc_vfunc(const RendDesc &renddesc, std::vector<RendDesc> &out_descs) const
-{
-	out_descs.push_back( get_sub_renddesc_vfunc(renddesc) );
-}
-
-void
 Layer::get_sub_renddesc(const RendDesc &renddesc, std::vector<RendDesc> &out_descs) const
 {
-	get_sub_renddesc_vfunc(renddesc, out_descs);
+	out_descs.push_back(get_sub_renddesc_vfunc(renddesc));
 }
 
 RendDesc

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -612,7 +612,7 @@ protected:
 
 public:
 	void get_sub_renddesc(const RendDesc &renddesc, std::vector<RendDesc> &out_descs) const;
-	RendDesc get_sub_renddesc(const RendDesc &renddesc, int index = 0) const;
+	RendDesc get_sub_renddesc(const RendDesc &renddesc) const;
 
 	//! Returns rendering task for context
 	/*!	\param context		Context iterator referring to next Layer.

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -609,7 +609,6 @@ protected:
 	virtual rendering::Task::Handle build_rendering_task_vfunc(Context context) const;
 
 	virtual RendDesc get_sub_renddesc_vfunc(const RendDesc &renddesc) const;
-	virtual void get_sub_renddesc_vfunc(const RendDesc &renddesc, std::vector<RendDesc> &out_descs) const;
 
 public:
 	void get_sub_renddesc(const RendDesc &renddesc, std::vector<RendDesc> &out_descs) const;

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -611,7 +611,6 @@ protected:
 	virtual RendDesc get_sub_renddesc_vfunc(const RendDesc &renddesc) const;
 
 public:
-	void get_sub_renddesc(const RendDesc &renddesc, std::vector<RendDesc> &out_descs) const;
 	RendDesc get_sub_renddesc(const RendDesc &renddesc) const;
 
 	//! Returns rendering task for context

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -608,9 +608,20 @@ protected:
 	virtual void set_outline_grow_vfunc(IndependentContext context, Real outline_grow);
 	virtual rendering::Task::Handle build_rendering_task_vfunc(Context context) const;
 
+	//! \see Layer::get_sub_renddesc()
 	virtual RendDesc get_sub_renddesc_vfunc(const RendDesc &renddesc) const;
 
 public:
+	//! Get the needed renddesc for context layers.
+	/*!
+	 * For the given renddesc argument, returns the computed
+	 * neeed renddesc for the underlying layer.
+	 * It basically sets the vector rectangle coordinates of
+	 * the context/underlying layer.
+	 *
+	 * \param renddesc The required rend_desc for this layer
+	 * \return the needed RendDesc for the underlying layer
+	 */
 	RendDesc get_sub_renddesc(const RendDesc &renddesc) const;
 
 	//! Returns rendering task for context

--- a/synfig-core/src/synfig/rendering/common/task/tasklayer.cpp
+++ b/synfig-core/src/synfig/rendering/common/task/tasklayer.cpp
@@ -73,10 +73,6 @@ TaskLayer::calc_bounds() const
 	return context.get_full_bounding_rect();
 }
 
-bool
-TaskLayer::renddesc_less(const RendDesc &a, const RendDesc &b)
-	{ return fabs(a.get_pw()*a.get_ph()) > fabs(b.get_pw()*b.get_ph()); }
-
 void
 TaskLayer::set_coords_sub_tasks()
 {
@@ -92,43 +88,38 @@ TaskLayer::set_coords_sub_tasks()
 	desc.set_tl(source_rect.get_min());
 	desc.set_br(source_rect.get_max());
 
-	std::vector<RendDesc> descs;
-	layer->get_sub_renddesc(desc, descs);
-	sort(descs.begin(), descs.end(), renddesc_less);
+	RendDesc sub_desc = layer->get_sub_renddesc(desc);
 
 	Task::Handle task = sub_task();
 	sub_tasks.clear();
 
-	for(const auto& sub_desc : descs)
-	{
-		if (sub_desc.get_w() <= 0 || sub_desc.get_h() <= 0)
-			continue;
+	if (sub_desc.get_w() <= 0 || sub_desc.get_h() <= 0)
+		return;
 
-		Point lt = sub_desc.get_tl(), rb = sub_desc.get_br();
-		Rect rect(lt, rb);
-		if (!rect.is_valid())
-			continue;
+	Point lt = sub_desc.get_tl(), rb = sub_desc.get_br();
+	Rect rect(lt, rb);
+	if (!rect.is_valid())
+		return;
 
-		Matrix matrix;
-		if (approximate_less(rb[0], lt[0]))
-			{ matrix.m00 = -1.0; matrix.m20 = rb[0] - lt[0]; }
-		if (approximate_less(rb[1], lt[1]))
-			{ matrix.m11 = -1.0; matrix.m20 = rb[1] - lt[1]; }
-		matrix = sub_desc.get_transformation_matrix() * matrix;
-		if (!matrix.is_invertible())
-			continue;
+	Matrix matrix;
+	if (approximate_less(rb[0], lt[0]))
+		{ matrix.m00 = -1.0; matrix.m20 = rb[0] - lt[0]; }
+	if (approximate_less(rb[1], lt[1]))
+		{ matrix.m11 = -1.0; matrix.m20 = rb[1] - lt[1]; }
+	matrix = sub_desc.get_transformation_matrix() * matrix;
+	if (!matrix.is_invertible())
+		return;
 
-		Task::Handle t = task->clone();
-		if (!matrix.is_identity()) {
-			TaskTransformationAffine::Handle ta = new TaskTransformationAffine();
-			ta->transformation->matrix = matrix;
-			ta->sub_task() = t;
-			t = ta;
-		}
-
-		sub_tasks.push_back(t);
-		t->set_coords(rect, VectorInt(sub_desc.get_w(), sub_desc.get_h()));
+	Task::Handle t = task->clone();
+	if (!matrix.is_identity()) {
+		TaskTransformationAffine::Handle ta = new TaskTransformationAffine();
+		ta->transformation->matrix = matrix;
+		ta->sub_task() = t;
+		t = ta;
 	}
+
+	sub_tasks.push_back(t);
+	t->set_coords(rect, VectorInt(sub_desc.get_w(), sub_desc.get_h()));
 }
 
 /* === E N T R Y P O I N T ================================================= */

--- a/synfig-core/src/synfig/rendering/common/task/tasklayer.cpp
+++ b/synfig-core/src/synfig/rendering/common/task/tasklayer.cpp
@@ -99,12 +99,12 @@ TaskLayer::set_coords_sub_tasks()
 	Task::Handle task = sub_task();
 	sub_tasks.clear();
 
-	for(std::vector<RendDesc>::const_iterator i = descs.begin(); i != descs.end(); ++i)
+	for(const auto& sub_desc : descs)
 	{
-		if (i->get_w() <= 0 || i->get_h() <= 0)
+		if (sub_desc.get_w() <= 0 || sub_desc.get_h() <= 0)
 			continue;
 
-		Point lt = i->get_tl(), rb = i->get_br();
+		Point lt = sub_desc.get_tl(), rb = sub_desc.get_br();
 		Rect rect(lt, rb);
 		if (!rect.is_valid())
 			continue;
@@ -114,7 +114,7 @@ TaskLayer::set_coords_sub_tasks()
 			{ matrix.m00 = -1.0; matrix.m20 = rb[0] - lt[0]; }
 		if (approximate_less(rb[1], lt[1]))
 			{ matrix.m11 = -1.0; matrix.m20 = rb[1] - lt[1]; }
-		matrix = i->get_transformation_matrix() * matrix;
+		matrix = sub_desc.get_transformation_matrix() * matrix;
 		if (!matrix.is_invertible())
 			continue;
 
@@ -127,7 +127,7 @@ TaskLayer::set_coords_sub_tasks()
 		}
 
 		sub_tasks.push_back(t);
-		t->set_coords(rect, VectorInt(i->get_w(), i->get_h()));
+		t->set_coords(rect, VectorInt(sub_desc.get_w(), sub_desc.get_h()));
 	}
 }
 

--- a/synfig-core/src/synfig/rendering/common/task/tasklayer.h
+++ b/synfig-core/src/synfig/rendering/common/task/tasklayer.h
@@ -59,9 +59,6 @@ public:
 
 	virtual Rect calc_bounds() const;
 	virtual void set_coords_sub_tasks();
-
-private:
-	static bool renddesc_less(const RendDesc &a, const RendDesc &b);
 };
 
 } /* end namespace rendering */


### PR DESCRIPTION
Some were not override, other have useless parameters.