### PR TITLE
fix: prevent potential null pointer dereference in ValueDescDisconnect action

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuedescdisconnect.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescdisconnect.cpp
@@ -119,7 +119,7 @@ Action::ValueDescDisconnect::is_candidate(const ParamList &x)
 	// don't allow the Index parameter of the Duplicate layer to be disconnected
 	if(value_desc.parent_is_layer() && value_desc.get_layer()->get_name() == "duplicate" && value_desc.get_param_name() == "index")
 		return false;
-	if(!value_desc.parent_is_canvas() && value_desc.is_value_node() && value_desc.get_value_node()->rcount()>1)
+	if(!value_desc.parent_is_canvas() && value_desc.is_value_node() && value_desc.get_value_node() && value_desc.get_value_node()->rcount()>1)
 		return true;
 	if(value_desc.is_const())
 		return false;


### PR DESCRIPTION
Also this fixes MSYS2 MinGW warning:

```bash
/synfig-studio/src/synfigapp/actions/valuedescdisconnect.cpp:122:104:
C:/msys64/mingw64/include/c++/14.2.0/bits/atomic_base.h:501:31: warning: 'unsigned int __atomic_load_4(const volatile void*, int)' writing 4 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
  501 |         return __atomic_load_n(&_M_i, int(__m));
      |                ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
In static member function 'static bool synfigapp::Action::ValueDescDisconnect::is_candidate(const synfigapp::Action::ParamList&)':
cc1plus.exe: note: destination object is likely at address zero
```