### PR TITLE
fix: resolve issue with toolbar space remaining visible after hiding

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3644,4 +3644,5 @@ CanvasView::set_show_toolbars(bool show)
 {
 	top_toolbar->set_visible(show);
 	right_toolbar->set_visible(show);
+	stopbutton->set_visible(show);
 };


### PR DESCRIPTION
And so hiding toolbars was basically useless.

### Visible Toolbars
![Captura de ecrã de 2024-11-29 06-38-23](https://github.com/user-attachments/assets/6052a692-7919-436a-9a68-0b653c2c1328)

### Hidden Toolbars (v. 1.5.3)
![Captura de ecrã de 2024-11-29 06-40-08](https://github.com/user-attachments/assets/7acc9f62-4304-40f4-b825-a127d1636c5c)

### Hidden Toolbars (now)
![Captura de ecrã de 2024-11-29 06-38-38](https://github.com/user-attachments/assets/97b3a2dc-211c-46f1-a1dd-bdb64b9325a0)
