### PR TITLE
fix: inverted interpolation of gradient since 1.3.11

### DIFF
--- a/synfig-core/src/modules/lyr_std/mandelbrot.cpp
+++ b/synfig-core/src/modules/lyr_std/mandelbrot.cpp
@@ -59,7 +59,7 @@ SYNFIG_LAYER_INIT(Mandelbrot);
 SYNFIG_LAYER_SET_NAME(Mandelbrot,"mandelbrot");
 SYNFIG_LAYER_SET_LOCAL_NAME(Mandelbrot,N_("Mandelbrot Set"));
 SYNFIG_LAYER_SET_CATEGORY(Mandelbrot,N_("Fractals"));
-SYNFIG_LAYER_SET_VERSION(Mandelbrot,"0.2");
+SYNFIG_LAYER_SET_VERSION(Mandelbrot,"0.3");
 
 /* === P R O C E D U R E S ================================================= */
 
@@ -103,7 +103,8 @@ Mandelbrot::Mandelbrot():
 	param_gradient_loop_inside(ValueBase(true)),
 	param_gradient_outside(ValueBase(Gradient(Color::alpha(),Color::black()))),
 	param_gradient_offset_outside(ValueBase(Real(0.0))),
-	param_gradient_scale_outside(ValueBase(Real(1.0)))
+	param_gradient_scale_outside(ValueBase(Real(1.0))),
+	param_broken_gradient(ValueBase(bool(false)))
 {
 	param_iterations=ValueBase(int(32));
 
@@ -173,6 +174,7 @@ Mandelbrot::set_param(const String & param, const ValueBase &value)
 	  }
 	  );
 
+	IMPORT_VALUE(param_broken_gradient);
 	return false;
 }
 
@@ -206,6 +208,7 @@ Mandelbrot::get_param(const String & param)const
 		ret.set(sqrt(param_bailout.get(Real())));
 		return ret;
 	}
+	EXPORT_VALUE(param_broken_gradient);
 	EXPORT_NAME();
 	EXPORT_VERSION();
 
@@ -279,6 +282,12 @@ Mandelbrot::get_param_vocab()const
 		.set_local_name(_("Scale Outside"))
 	);
 
+	ret.push_back(ParamDesc("broken_gradient")
+		.set_local_name(_("Broken Gradient"))
+		.set_description(_("Support wrong implementation of gradient in Synfig versions from 1.3.11 to 1.5.5"))
+		.hidden()
+	);
+
 	return ret;
 }
 
@@ -295,6 +304,7 @@ Mandelbrot::get_sub_renddesc_vfunc(const RendDesc &renddesc) const
 Color
 Mandelbrot::get_color(Context context, const Point &pos)const
 {
+	const bool invert_gradient_to_fix = param_broken_gradient.get(bool());
 	int iterations=param_iterations.get(int());
 	Real bailout=param_bailout.get(Real());
 	bool broken=param_broken.get(bool());
@@ -304,6 +314,8 @@ Mandelbrot::get_color(Context context, const Point &pos)const
 	bool solid_inside=param_solid_inside.get(bool());
 	bool invert_inside=param_invert_inside.get(bool());
 	Gradient gradient_inside=param_gradient_inside.get(Gradient());
+	if (invert_gradient_to_fix)
+		gradient_inside = Gradient::from_bad_version(gradient_inside);
 	Real gradient_offset_inside=param_gradient_offset_inside.get(Real());
 	bool gradient_loop_inside=param_gradient_loop_inside.get(bool());
 
@@ -312,6 +324,8 @@ Mandelbrot::get_color(Context context, const Point &pos)const
 	bool solid_outside=param_solid_outside.get(bool());
 	bool invert_outside=param_invert_outside.get(bool());
 	Gradient gradient_outside=param_gradient_outside.get(Gradient());
+	if (invert_gradient_to_fix)
+		gradient_outside = Gradient::from_bad_version(gradient_outside);
 	bool smooth_outside=param_smooth_outside.get(bool());
 	Real gradient_offset_outside=param_gradient_offset_outside.get(Real());
 	Real gradient_scale_outside=param_gradient_scale_outside.get(Real());
@@ -407,4 +421,14 @@ Mandelbrot::get_color(Context context, const Point &pos)const
 	}
 
 	return ret;
+}
+
+bool
+Mandelbrot::set_version(const String &ver)
+{
+	if (ver == "0.2-problematic-gradient") {
+		param_broken_gradient = true;
+	}
+
+	return true;
 }

--- a/synfig-core/src/modules/lyr_std/mandelbrot.h
+++ b/synfig-core/src/modules/lyr_std/mandelbrot.h
@@ -91,6 +91,8 @@ private:
 	ValueBase param_gradient_offset_outside;
 	//!Parameter: (Real)
 	ValueBase param_gradient_scale_outside;
+	//!Parameter: (bool) wrong implementation of gradient in Synfig versions from 1.3.11 to 1.5.5
+	synfig::ValueBase param_broken_gradient;
 
 public:
 	Mandelbrot();
@@ -99,6 +101,8 @@ public:
 	virtual ValueBase get_param(const String &param)const;
 	virtual Color get_color(Context context, const Point &pos)const;
 	virtual Vocab get_param_vocab()const;
+
+	virtual bool set_version(const synfig::String& ver);
 
 protected:
 	virtual RendDesc get_sub_renddesc_vfunc(const RendDesc &renddesc) const;

--- a/synfig-core/src/modules/mod_example/metaballs.cpp
+++ b/synfig-core/src/modules/mod_example/metaballs.cpp
@@ -55,7 +55,7 @@ SYNFIG_LAYER_INIT(Metaballs);
 SYNFIG_LAYER_SET_NAME(Metaballs,"metaballs");
 SYNFIG_LAYER_SET_LOCAL_NAME(Metaballs,N_("Metaballs"));
 SYNFIG_LAYER_SET_CATEGORY(Metaballs,N_("Example"));
-SYNFIG_LAYER_SET_VERSION(Metaballs,"0.1");
+SYNFIG_LAYER_SET_VERSION(Metaballs,"0.2");
 
 /* === P R O C E D U R E S ================================================= */
 
@@ -141,7 +141,8 @@ Metaballs::Metaballs():
 	param_weights(ValueBase(std::vector<synfig::Real>())),
 	param_threshold(ValueBase(Real(0))),
 	param_threshold2(ValueBase(Real(1))),
-	param_positive(ValueBase(false))
+	param_positive(ValueBase(false)),
+	param_broken_gradient(ValueBase(false))
 {
 	std::vector<synfig::Point> centers;
 	std::vector<synfig::Real> radii;
@@ -167,6 +168,7 @@ Metaballs::set_param(const String & param, const ValueBase &value)
 	IMPORT_VALUE(param_threshold);
 	IMPORT_VALUE(param_threshold2);
 	IMPORT_VALUE(param_positive);
+	IMPORT_VALUE(param_broken_gradient);
 
 	return Layer_Composite::set_param(param,value);
 }
@@ -181,6 +183,7 @@ Metaballs::get_param(const String &param)const
 	EXPORT_VALUE(param_threshold);
 	EXPORT_VALUE(param_threshold2);
 	EXPORT_VALUE(param_positive);
+	EXPORT_VALUE(param_broken_gradient);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
@@ -221,7 +224,23 @@ Metaballs::get_param_vocab()const
 		.set_local_name(_("Positive Only"))
 	);
 
+	ret.push_back(ParamDesc("broken_gradient")
+		.set_local_name(_("Broken Gradient"))
+		.set_description(_("Support wrong implementation of gradient in Synfig versions from 1.3.11 to 1.5.5"))
+		.hidden()
+	);
+
 	return ret;
+}
+
+bool
+Metaballs::set_version(const String &ver)
+{
+	if (ver == "0.1-problematic-gradient") {
+		param_broken_gradient = true;
+	}
+
+	return true;
 }
 
 synfig::Layer::Handle
@@ -302,6 +321,8 @@ Metaballs::build_composite_task_vfunc(ContextParams /*context_params*/) const
 	task->threshold = param_threshold.get(Real());
 	task->threshold2 = param_threshold2.get(Real());
 	task->gradient = param_gradient.get(Gradient());
+	if (param_broken_gradient.get(bool()))
+		task->gradient = Gradient::from_bad_version(task->gradient);
 	task->positive = param_positive.get(bool());
 
 	return task;

--- a/synfig-core/src/modules/mod_example/metaballs.h
+++ b/synfig-core/src/modules/mod_example/metaballs.h
@@ -61,6 +61,8 @@ private:
 	synfig::ValueBase param_threshold2;
 	//! Parameter: (bool)
 	synfig::ValueBase param_positive;
+	//!Parameter: (bool) wrong implementation of gradient in Synfig versions from 1.3.11 to 1.5.5
+	synfig::ValueBase param_broken_gradient;
 
 	synfig::Real densityfunc(const synfig::Point &p, const synfig::Point &c, synfig::Real R)const;
 
@@ -79,6 +81,8 @@ public:
 	virtual Vocab get_param_vocab()const;
 
 	virtual synfig::Layer::Handle hit_check(synfig::Context context, const synfig::Point &point)const;
+
+	virtual bool set_version(const synfig::String& ver);
 
 protected:
 	synfig::rendering::Task::Handle build_composite_task_vfunc(synfig::ContextParams /*context_params*/) const;

--- a/synfig-core/src/modules/mod_particle/plant.cpp
+++ b/synfig-core/src/modules/mod_particle/plant.cpp
@@ -55,7 +55,7 @@ SYNFIG_LAYER_INIT(Plant);
 SYNFIG_LAYER_SET_NAME(Plant,"plant");
 SYNFIG_LAYER_SET_LOCAL_NAME(Plant,N_("Plant"));
 SYNFIG_LAYER_SET_CATEGORY(Plant,N_("Other"));
-SYNFIG_LAYER_SET_VERSION(Plant,"0.2");
+SYNFIG_LAYER_SET_VERSION(Plant,"0.3");
 
 /* === P R O C E D U R E S ================================================= */
 
@@ -79,6 +79,7 @@ Plant::Plant():
 	param_random_factor(ValueBase(Real(0.2))),
 	param_drag(ValueBase(Real(0.1))),
 	param_use_width(ValueBase(true)),
+	param_broken_gradient(ValueBase(false)),
 	bline_loop(true),
 	bounding_rect(Rect::zero()),
 	mass(0.5),
@@ -118,6 +119,10 @@ Plant::branch(int n,int depth,float t, float stunt_growth, synfig::Point positio
 	Vector gravity=param_gravity.get(Vector());
 	Real drag=param_drag.get(Real());
 	Gradient gradient=param_gradient.get(Gradient());
+	const bool invert_gradient = param_broken_gradient.get(bool());
+	if (invert_gradient)
+		gradient = Gradient::from_bad_version(gradient);
+
 	Angle split_angle=param_split_angle.get(Angle());
 	Real random_factor=param_random_factor.get(Real());
 	Random random;
@@ -196,6 +201,10 @@ Plant::sync()const
 	std::vector<BLinePoint> bline(param_bline.get_list_of(BLinePoint()));
 	Real step_=param_step.get(Real());
 	Gradient gradient=param_gradient.get(Gradient());
+	const bool invert_gradient = param_broken_gradient.get(bool());
+	if (invert_gradient)
+		gradient = Gradient::from_bad_version(gradient);
+
 	Real random_factor=param_random_factor.get(Real());
 	Random random;
 	random.set_seed(param_random.get(int()));
@@ -204,7 +213,7 @@ Plant::sync()const
 	Real perp_velocity=param_perp_velocity.get(Real());
 	int splits=param_splits.get(int());
 	bool use_width=param_use_width.get(bool());
-	
+
 	std::lock_guard<std::mutex> lock(mutex);
 	if (!needs_sync_) return;
 	time_t start_time; time(&start_time);
@@ -334,6 +343,7 @@ Plant::set_param(const String & param, const ValueBase &value)
 	IMPORT_VALUE(param_size_as_alpha);
 	IMPORT_VALUE(param_reverse);
 	IMPORT_VALUE(param_use_width);
+	IMPORT_VALUE(param_broken_gradient);
 
 	if(param=="offset")
 		return set_param("origin", value);
@@ -366,6 +376,7 @@ Plant::get_param(const String& param)const
 	EXPORT_VALUE(param_reverse);
 	EXPORT_VALUE(param_use_width);
 	EXPORT_VALUE(param_random);
+	EXPORT_VALUE(param_broken_gradient);
 
 	EXPORT_NAME();
 
@@ -470,6 +481,12 @@ Plant::get_param_vocab()const
 		.set_description(_("Scale the velocity by the spline's width"))
 	);
 
+	ret.push_back(ParamDesc("broken_gradient")
+		.set_local_name(_("Broken Gradient"))
+		.set_description(_("Support wrong implementation of gradient in Synfig versions from 1.3.11 to 1.5.5"))
+		.hidden()
+	);
+
 	return ret;
 }
 
@@ -480,8 +497,17 @@ Plant::set_version(const String &ver)
 
 	if (version == "0.1")
 		param_use_width.set(false);
+	else if (version == "0.2-problematic-gradient") {
+		param_broken_gradient = true;
+	}
 
 	return true;
+}
+
+void
+Plant::reset_version()
+{
+	version = get_register_version();
 }
 
 bool

--- a/synfig-core/src/modules/mod_particle/plant.h
+++ b/synfig-core/src/modules/mod_particle/plant.h
@@ -86,6 +86,8 @@ private:
 	ValueBase param_drag;
 	//!Parameter: (bool)
 	ValueBase param_use_width;
+	//!Parameter: (bool) wrong implementation of gradient in Synfig versions from 1.3.11 to 1.5.5
+	ValueBase param_broken_gradient;
 
 	bool bline_loop;
 
@@ -121,6 +123,7 @@ public:
 	virtual ValueBase get_param(const String & param)const;
 
 	virtual bool set_version(const String &ver);
+	virtual void reset_version();
 
 	virtual Vocab get_param_vocab()const;
 

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -37,13 +37,6 @@
 #include "gradient.h"
 
 #include <algorithm>
-#include <stdexcept>
-
-#include "general.h"
-#include <synfig/localization.h>
-#include <synfig/real.h>
-
-#include "exception.h"
 
 #endif
 

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -194,11 +194,11 @@ Gradient::operator() (Real x) const
 	Gradient::const_iterator j = i--;
 
 	Real d = j->pos - i->pos;
-	if (d <= real_high_precision<Real>()) return i->color;
+	if (approximate_zero_hp(d)) return i->color;
 
 	// operator+() also contains the same calculations
 	ColorReal amount = (x - i->pos)/d;
-	return Color::blend(i->color, j->color, amount, Color::BLEND_STRAIGHT);
+	return Color::blend(j->color, i->color, amount, Color::BLEND_STRAIGHT);
 }
 
 Real
@@ -215,6 +215,27 @@ Gradient::mag() const
 		sum += v*v;
 	}
 	return sqrt(sum);
+}
+
+Gradient
+Gradient::from_bad_version(const Gradient& wrong_gradient)
+{
+	if (wrong_gradient.size() <= 1)
+		return wrong_gradient;
+
+	Gradient gradient;
+	gradient.push_back(*wrong_gradient.begin());
+
+	auto it = wrong_gradient.begin();
+	auto previous_it = it++;
+	for (; it != wrong_gradient.end(); ++it, ++previous_it) {
+		gradient.push_back(CPoint(previous_it->pos, it->color));
+		gradient.push_back(CPoint(it->pos, previous_it->color));
+	}
+
+	gradient.push_back(*wrong_gradient.rbegin());
+
+	return gradient;
 }
 
 Gradient::iterator

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -178,7 +178,7 @@ Gradient::operator*=(const ColorReal &rhs)
 
 //! Returns color of point x
 Color
-Gradient::operator() (const Real &x) const
+Gradient::operator() (Real x) const
 {
 	if (cpoints.empty())
 		return Color();
@@ -219,7 +219,7 @@ Gradient::mag() const
 }
 
 Gradient::iterator
-Gradient::proximity(const Real &x)
+Gradient::proximity(Real x)
 {
 	// This algorithm requires a sorted list.
 	iterator iter;

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -72,6 +72,12 @@ Gradient::Gradient(const Color &c1, const Color &c2, const Color &c3)
 	push_back(CPoint(1.0,c3));
 }
 
+void
+Gradient::sync()
+{
+	stable_sort(begin(), end());
+}
+
 // both input gradients should be already sorted
 Gradient
 Gradient::operator+(const Gradient &rhs) const
@@ -245,12 +251,24 @@ Gradient::proximity(Real x)
 	return iter;
 }
 
+Gradient::const_iterator
+Gradient::proximity(Real x) const
+{
+	return const_cast<Gradient*>(this)->proximity(x);
+}
+
 Gradient::iterator
 Gradient::find(const UniqueID &id)
 {
 	for (iterator i = begin(); i != end(); ++i)
 		if (id == *i) return i;
 	return end();
+}
+
+Gradient::const_iterator
+Gradient::find(const UniqueID& id) const
+{
+	return const_cast<Gradient*>(this)->find(id);
 }
 
 
@@ -270,7 +288,6 @@ CompiledGradient::Entry::Entry(const Accumulator &prev_sum, const GradientCPoint
 		next_sum = prev_sum + (next_color + prev_color)*(0.5*dp);
 	}
 }
-
 
 CompiledGradient::CompiledGradient():
 	is_empty(true), repeat(false), zigzag(false)

--- a/synfig-core/src/synfig/gradient.h
+++ b/synfig-core/src/synfig/gradient.h
@@ -152,6 +152,13 @@ public:
 
 	iterator find(const UniqueID& id);
 	const_iterator find(const UniqueID& id) const;
+
+	/**
+	 * Create a Gradient with correct interpolation from
+	 * a bad one created with Synfig versions between 1.3.11 and 1.5.3.
+	 * Please avoid use this trick unless for fixing this issue.
+	 */
+	static Gradient from_bad_version(const Gradient& wrong_gradient);
 }; // END of class Gradient
 
 

--- a/synfig-core/src/synfig/gradient.h
+++ b/synfig-core/src/synfig/gradient.h
@@ -121,17 +121,17 @@ public:
 
 	void push_back(const CPoint& cpoint) { cpoints.push_back(cpoint); }
 	iterator erase(iterator iter) { return cpoints.erase(iter); }
-	bool empty() const { return cpoints.empty(); }
-	size_t size() const { return cpoints.size(); }
+	bool empty() const noexcept { return cpoints.empty(); }
+	size_t size() const noexcept { return cpoints.size(); }
 
-	iterator begin() { return cpoints.begin(); }
-	iterator end() { return cpoints.end(); }
-	reverse_iterator rbegin() { return cpoints.rbegin(); }
-	reverse_iterator rend() { return cpoints.rend(); }
-	const_iterator begin() const { return cpoints.begin(); }
-	const_iterator end() const { return cpoints.end(); }
-	const_reverse_iterator rbegin() const { return cpoints.rbegin(); }
-	const_reverse_iterator rend() const { return cpoints.rend(); }
+	iterator begin() noexcept { return cpoints.begin(); }
+	iterator end() noexcept { return cpoints.end(); }
+	reverse_iterator rbegin() noexcept { return cpoints.rbegin(); }
+	reverse_iterator rend() noexcept { return cpoints.rend(); }
+	const_iterator begin() const noexcept { return cpoints.begin(); }
+	const_iterator end() const noexcept { return cpoints.end(); }
+	const_reverse_iterator rbegin() const noexcept { return cpoints.rbegin(); }
+	const_reverse_iterator rend() const noexcept { return cpoints.rend(); }
 
 	Gradient& operator+=(const Gradient& rhs) { return *this = *this + rhs; }
 	Gradient& operator*=(const ColorReal& rhs);

--- a/synfig-core/src/synfig/gradient.h
+++ b/synfig-core/src/synfig/gradient.h
@@ -33,7 +33,6 @@
 /* === H E A D E R S ======================================================= */
 
 #include <vector>
-#include <algorithm>
 
 #include "real.h"
 #include "color.h"
@@ -114,10 +113,7 @@ public:
 	Gradient(const Color& c1, const Color& c2, const Color& c3);
 
 	/** You should call this function after changing stuff. */
-	void sort() { stable_sort(begin(), end()); }
-
-	/** Alias for sort (Implemented for consistency) */
-	void sync() { sort(); }
+	void sync();
 
 	void push_back(const CPoint& cpoint) { cpoints.push_back(cpoint); }
 	iterator erase(iterator iter) { return cpoints.erase(iter); }
@@ -152,12 +148,10 @@ public:
 	/** Returns the iterator of the CPoint closest to position @a x */
 	iterator proximity(Real x);
 	/** Returns the iterator of the CPoint closest to position @a x */
-	const_iterator proximity(Real x) const
-		{ return const_cast<Gradient*>(this)->proximity(x); }
+	const_iterator proximity(Real x) const;
 
 	iterator find(const UniqueID& id);
-	const_iterator find(const UniqueID& id) const
-		{ return const_cast<Gradient*>(this)->find(id); }
+	const_iterator find(const UniqueID& id) const;
 }; // END of class Gradient
 
 

--- a/synfig-core/src/synfig/gradient.h
+++ b/synfig-core/src/synfig/gradient.h
@@ -47,8 +47,11 @@
 
 namespace synfig {
 
-//! \struct GradientCPoint
-//! \brief Gradient color point
+/**
+ * Gradient Color point.
+ * A gradient is an ordered list of Color points,
+ * and each one has describes a color and a position in the gradient.
+ */
 struct GradientCPoint : public UniqueID
 {
 	Real pos;
@@ -63,13 +66,31 @@ struct GradientCPoint : public UniqueID
 	GradientCPoint(const Real &pos, const Color &color):pos(pos),color(color) { }
 }; // END of class GradientCPoint
 
-// for use in std::upper_bound, std::lower_bound, etc
-// must be inline to avoid 'multiple definition' linker error
+/**
+ * For use in std::upper_bound, std::lower_bound, etc.
+ * It must be inline to avoid 'multiple definition' linker error
+ */
 inline bool operator<(const Real &a, const GradientCPoint &b)
 	{ return a < b.pos; }
 
-//! \class Gradient
-//! \brief Color Gradient Class
+/**
+ * Color Gradient class.
+ * A Gradient is an ordered list of color points (GradientCPoint).
+ *
+ * There are convenient constructors for two or three color points.
+ * You can add any number of points you want by using push_back() method.
+ *
+ * Please note that the color points must be sorted by position in order
+ * to get correct interpolation. This requirement is due implementation
+ * decision for performance reasons.
+ * Therefore, you shall call sync() after you add the batch of color points
+ * or edit the position of the existent ones.
+ *
+ * For fetching the interpolated color, use the function call operator,
+ * i.e. operator() passing the desired intermediate point as argument.
+ *
+ * @see GradientCPoint
+ */
 class Gradient
 {
 public:
@@ -86,19 +107,19 @@ private:
 public:
 	Gradient() { }
 
-	//! Two-Tone Color Gradient Convenience Constructor
+	/** Two-Tone Color Gradient Convenience Constructor */
 	Gradient(const Color &c1, const Color &c2);
 
-	//! Three-Tone Color Gradient Convenience Constructor
+	/** Three-Tone Color Gradient Convenience Constructor */
 	Gradient(const Color &c1, const Color &c2, const Color &c3);
 
-	//! You should call this function after changing stuff.
+	/** You should call this function after changing stuff. */
 	void sort() { stable_sort(begin(), end()); }
 
-	//! Alias for sort (Implemented for consistency)
+	/** Alias for sort (Implemented for consistency) */
 	void sync() { sort(); }
 
-	void push_back(const CPoint cpoint) { cpoints.push_back(cpoint); }
+	void push_back(const CPoint& cpoint) { cpoints.push_back(cpoint); }
 	iterator erase(iterator iter) { return cpoints.erase(iter); }
 	bool empty()const { return cpoints.empty(); }
 	size_t size()const { return cpoints.size(); }
@@ -122,13 +143,15 @@ public:
 	Gradient operator*(const ColorReal &rhs) const { return Gradient(*this)*=rhs; }
 	Gradient operator/(const ColorReal &rhs) const { return Gradient(*this)/=rhs; }
 
+	/** Fetch the interpolated Color for a given position @a x */
 	Color operator() (const Real &x) const;
 
-	//! Returns average luminance of gradient
+	/** Returns average luminance of gradient */
 	Real mag() const;
 
-	//! Returns the iterator of the CPoint closest to \a x
+	/** Returns the iterator of the CPoint closest to position @a x */
 	iterator proximity(const Real &x);
+	/** Returns the iterator of the CPoint closest to position @a x */
 	const_iterator proximity(const Real &x)const
 		{ return const_cast<Gradient*>(this)->proximity(x); }
 
@@ -138,9 +161,10 @@ public:
 }; // END of class Gradient
 
 
-//! \class CompiledGradient
-//! \brief Compiled gradient can quickly calculate color of specified color
-//!        and average color of specified range
+/**
+ * Compiled gradient can quickly calculate color of specified color
+ * and average color of specified range.
+ */
 class CompiledGradient {
 public:
 	// High precision color accumulator, alpha premulted

--- a/synfig-core/src/synfig/gradient.h
+++ b/synfig-core/src/synfig/gradient.h
@@ -59,18 +59,18 @@ struct GradientCPoint : public UniqueID
 
 	bool operator< (const GradientCPoint& rhs) const
 		{ return pos < rhs.pos; }
-	bool operator< (const Real& rhs) const
+	bool operator< (Real rhs) const
 		{ return pos < rhs; }
 
 	GradientCPoint() : pos() { }
-	GradientCPoint(const Real& pos, const Color& color) : pos(pos), color(color) { }
+	GradientCPoint(Real pos, const Color& color) : pos(pos), color(color) { }
 }; // END of class GradientCPoint
 
 /**
  * For use in std::upper_bound, std::lower_bound, etc.
  * It must be inline to avoid 'multiple definition' linker error
  */
-inline bool operator<(const Real& a, const GradientCPoint& b)
+inline bool operator<(Real a, const GradientCPoint& b)
 	{ return a < b.pos; }
 
 /**
@@ -144,15 +144,15 @@ public:
 	Gradient operator/(const ColorReal& rhs) const { return Gradient(*this)/=rhs; }
 
 	/** Fetch the interpolated Color for a given position @a x */
-	Color operator() (const Real& x) const;
+	Color operator() (Real x) const;
 
 	/** Returns average luminance of gradient */
 	Real mag() const;
 
 	/** Returns the iterator of the CPoint closest to position @a x */
-	iterator proximity(const Real& x);
+	iterator proximity(Real x);
 	/** Returns the iterator of the CPoint closest to position @a x */
-	const_iterator proximity(const Real& x) const
+	const_iterator proximity(Real x) const
 		{ return const_cast<Gradient*>(this)->proximity(x); }
 
 	iterator find(const UniqueID& id);
@@ -243,7 +243,7 @@ public:
 
 		Entry(const Accumulator& prev_sum, const GradientCPoint& prev, const GradientCPoint& next);
 
-		inline bool operator< (const Real& x) const
+		inline bool operator< (Real x) const
 			{ return next_pos < x; } // to easy search by std::upper_bound and std::lower_bound
 
 		inline Color color(Real x) const {

--- a/synfig-core/src/synfig/gradient.h
+++ b/synfig-core/src/synfig/gradient.h
@@ -27,8 +27,8 @@
 
 /* === S T A R T =========================================================== */
 
-#ifndef __SYNFIG_GRADIENT_H
-#define __SYNFIG_GRADIENT_H
+#ifndef SYNFIG_GRADIENT_H
+#define SYNFIG_GRADIENT_H
 
 /* === H E A D E R S ======================================================= */
 
@@ -57,20 +57,20 @@ struct GradientCPoint : public UniqueID
 	Real pos;
 	Color color;
 
-	bool operator< (const GradientCPoint &rhs) const
+	bool operator< (const GradientCPoint& rhs) const
 		{ return pos < rhs.pos; }
-	bool operator< (const Real &rhs) const
+	bool operator< (const Real& rhs) const
 		{ return pos < rhs; }
 
-	GradientCPoint(): pos() { }
-	GradientCPoint(const Real &pos, const Color &color):pos(pos),color(color) { }
+	GradientCPoint() : pos() { }
+	GradientCPoint(const Real& pos, const Color& color) : pos(pos), color(color) { }
 }; // END of class GradientCPoint
 
 /**
  * For use in std::upper_bound, std::lower_bound, etc.
  * It must be inline to avoid 'multiple definition' linker error
  */
-inline bool operator<(const Real &a, const GradientCPoint &b)
+inline bool operator<(const Real& a, const GradientCPoint& b)
 	{ return a < b.pos; }
 
 /**
@@ -108,10 +108,10 @@ public:
 	Gradient() { }
 
 	/** Two-Tone Color Gradient Convenience Constructor */
-	Gradient(const Color &c1, const Color &c2);
+	Gradient(const Color& c1, const Color& c2);
 
 	/** Three-Tone Color Gradient Convenience Constructor */
-	Gradient(const Color &c1, const Color &c2, const Color &c3);
+	Gradient(const Color& c1, const Color& c2, const Color& c3);
 
 	/** You should call this function after changing stuff. */
 	void sort() { stable_sort(begin(), end()); }
@@ -121,42 +121,42 @@ public:
 
 	void push_back(const CPoint& cpoint) { cpoints.push_back(cpoint); }
 	iterator erase(iterator iter) { return cpoints.erase(iter); }
-	bool empty()const { return cpoints.empty(); }
-	size_t size()const { return cpoints.size(); }
+	bool empty() const { return cpoints.empty(); }
+	size_t size() const { return cpoints.size(); }
 
 	iterator begin() { return cpoints.begin(); }
 	iterator end() { return cpoints.end(); }
 	reverse_iterator rbegin() { return cpoints.rbegin(); }
 	reverse_iterator rend() { return cpoints.rend(); }
-	const_iterator begin()const { return cpoints.begin(); }
-	const_iterator end()const { return cpoints.end(); }
-	const_reverse_iterator rbegin()const { return cpoints.rbegin(); }
-	const_reverse_iterator rend()const { return cpoints.rend(); }
+	const_iterator begin() const { return cpoints.begin(); }
+	const_iterator end() const { return cpoints.end(); }
+	const_reverse_iterator rbegin() const { return cpoints.rbegin(); }
+	const_reverse_iterator rend() const { return cpoints.rend(); }
 
-	Gradient &operator+=(const Gradient  &rhs) { return *this = *this + rhs; }
-	Gradient &operator*=(const ColorReal &rhs);
-	Gradient &operator-=(const Gradient  &rhs) { return *this = *this + rhs*ColorReal(-1); }
-	Gradient &operator/=(const ColorReal &rhs) { return *this *= ColorReal(1)/rhs; }
+	Gradient& operator+=(const Gradient& rhs) { return *this = *this + rhs; }
+	Gradient& operator*=(const ColorReal& rhs);
+	Gradient& operator-=(const Gradient& rhs) { return *this = *this + rhs*ColorReal(-1); }
+	Gradient& operator/=(const ColorReal& rhs) { return *this *= ColorReal(1)/rhs; }
 
-	Gradient operator+(const Gradient  &rhs) const;
-	Gradient operator-(const Gradient  &rhs) const { return *this + rhs*ColorReal(-1); }
-	Gradient operator*(const ColorReal &rhs) const { return Gradient(*this)*=rhs; }
-	Gradient operator/(const ColorReal &rhs) const { return Gradient(*this)/=rhs; }
+	Gradient operator+(const Gradient& rhs) const;
+	Gradient operator-(const Gradient& rhs) const { return *this + rhs*ColorReal(-1); }
+	Gradient operator*(const ColorReal& rhs) const { return Gradient(*this)*=rhs; }
+	Gradient operator/(const ColorReal& rhs) const { return Gradient(*this)/=rhs; }
 
 	/** Fetch the interpolated Color for a given position @a x */
-	Color operator() (const Real &x) const;
+	Color operator() (const Real& x) const;
 
 	/** Returns average luminance of gradient */
 	Real mag() const;
 
 	/** Returns the iterator of the CPoint closest to position @a x */
-	iterator proximity(const Real &x);
+	iterator proximity(const Real& x);
 	/** Returns the iterator of the CPoint closest to position @a x */
-	const_iterator proximity(const Real &x)const
+	const_iterator proximity(const Real& x) const
 		{ return const_cast<Gradient*>(this)->proximity(x); }
 
-	iterator find(const UniqueID &id);
-	const_iterator find(const UniqueID &id)const
+	iterator find(const UniqueID& id);
+	const_iterator find(const UniqueID& id) const
 		{ return const_cast<Gradient*>(this)->find(id); }
 }; // END of class Gradient
 
@@ -180,7 +180,7 @@ public:
 		Accumulator(Real r, Real g, Real b, Real a):
 			r(r), g(g), b(b), a(a) { }
 
-		Accumulator(const Color &color)
+		Accumulator(const Color& color)
 		{
 			// premult alpha
 			a = (Real)color.get_a();
@@ -197,27 +197,27 @@ public:
 			return Color((ColorReal)(k*r), (ColorReal)(k*g), (ColorReal)(k*b), (ColorReal)a);
 		}
 
-		bool operator== (const Accumulator &x) const
+		bool operator== (const Accumulator& x) const
 			{ return r == x.r && g == x.g && b == x.b && a == x.a; }
 
-		Accumulator operator+ (const Accumulator &x) const
+		Accumulator operator+ (const Accumulator& x) const
 			{ return Accumulator( r+x.r, g+x.g, b+x.b, a+x.a ); }
-		Accumulator operator- (const Accumulator &x) const
+		Accumulator operator- (const Accumulator& x) const
 			{ return Accumulator( r-x.r, g-x.g, b-x.b, a-x.a ); }
 		Accumulator operator- () const
 			{ return Accumulator( -r, -g, -b, -a ); }
-		Accumulator operator* (const Accumulator &x) const
+		Accumulator operator* (const Accumulator& x) const
 			{ return Accumulator( r*x.r, g*x.g, b*x.b, a*x.a ); }
 		Accumulator operator* (Real x) const
 			{ return Accumulator( r*x, g*x, b*x, a*x ); }
 		Accumulator operator/ (Real x) const
 			{ return *this * (1.0/x); }
 
-		Accumulator& operator+= (const Accumulator &x)
+		Accumulator& operator+= (const Accumulator& x)
 			{ r+=x.r; g+=x.g; b+=x.b; a+=x.a; return *this; }
-		Accumulator& operator-= (const Accumulator &x)
+		Accumulator& operator-= (const Accumulator& x)
 			{ r-=x.r; g-=x.g; b-=x.b; a-=x.a; return *this; }
-		Accumulator& operator*= (const Accumulator &x)
+		Accumulator& operator*= (const Accumulator& x)
 			{ r*=x.r; g*=x.g; b*=x.b; a*=x.a; return *this; }
 		Accumulator& operator*= (Real x)
 			{ r*=x; g*=x; b*=x; a*=x; return *this; }
@@ -241,9 +241,9 @@ public:
 
 		Entry(): prev_pos(), next_pos() { }
 
-		Entry(const Accumulator &prev_sum, const GradientCPoint &prev, const GradientCPoint &next);
+		Entry(const Accumulator& prev_sum, const GradientCPoint& prev, const GradientCPoint& next);
 
-		inline bool operator< (const Real &x) const
+		inline bool operator< (const Real& x) const
 			{ return next_pos < x; } // to easy search by std::upper_bound and std::lower_bound
 
 		inline Color color(Real x) const {
@@ -272,11 +272,11 @@ private:
 
 public:
 	CompiledGradient();
-	explicit CompiledGradient(const Color &color);
-	explicit CompiledGradient(const Gradient &gradient, bool repeat = false, bool zigzag = false);
+	explicit CompiledGradient(const Color& color);
+	explicit CompiledGradient(const Gradient& gradient, bool repeat = false, bool zigzag = false);
 
-	void set(const Color &color);
-	void set(const Gradient &gradient, bool repeat = false, bool zigzag = false);
+	void set(const Color& color);
+	void set(const Gradient& gradient, bool repeat = false, bool zigzag = false);
 	void reset() { set(Color()); }
 
 	bool empty() const { return is_empty; }

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -538,7 +538,7 @@ CanvasParser::parse_gradient(xmlpp::Element *node)
 			ret.push_back(cpoint);
 		}
 	}
-	ret.sort();
+	ret.sync();
 	return ret;
 }
 

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -3133,6 +3133,16 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 		layer->set_param("blend_method", Color::BLEND_STRAIGHT);
 	}
 
+	// Possible issue with Gradient parameters:
+	if (canvas->get_version() == "1.1" || canvas->get_version() == "1.2") {
+		if (layer->get_name() == "plant" && version == "0.2")
+			layer->set_version("0.2-problematic-gradient");
+		else if (layer->get_name() == "mandelbrot" && version == "0.2")
+			layer->set_version("0.2-problematic-gradient");
+		else if (layer->get_name() == "metaballs" && version == "0.1")
+			layer->set_version("0.1-problematic-gradient");
+	}
+
 	layer->reset_version();
 	return layer;
 }

--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -248,7 +248,7 @@ xmlpp::Element* encode_dash_item(xmlpp::Element* root, DashItem dash_item)
 xmlpp::Element* encode_gradient(xmlpp::Element* root,Gradient x)
 {
 	root->set_name("gradient");
-	x.sort();
+	x.sync();
 	for (Gradient::const_iterator iter = x.begin(); iter != x.end(); ++iter) {
 		xmlpp::Element *cpoint(encode_color(root->add_child("color"),iter->color));
 		cpoint->set_attribute("pos",strprintf("%f",iter->pos));

--- a/synfig-core/test/CMakeLists.txt
+++ b/synfig-core/test/CMakeLists.txt
@@ -29,6 +29,10 @@ add_executable(test_synfig_filesystem_path filesystem_path.cpp)
 target_link_libraries(test_synfig_filesystem_path PRIVATE libsynfig)
 add_test(NAME test_synfig_filesystem_path COMMAND test_synfig_filesystem_path)
 
+add_executable(test_synfig_gradient gradient.cpp)
+target_link_libraries(test_synfig_gradient PRIVATE libsynfig)
+add_test(NAME test_synfig_gradient COMMAND test_synfig_gradient)
+
 add_executable(test_synfig_handle handle.cpp)
 target_link_libraries(test_synfig_handle PRIVATE libsynfig)
 add_test(NAME test_synfig_handle COMMAND test_synfig_handle)

--- a/synfig-core/test/Makefile.am
+++ b/synfig-core/test/Makefile.am
@@ -14,6 +14,7 @@ TESTS = \
 	test_synfig_bone \
 	test_synfig_clock \
 	test_synfig_filesystem_path \
+	test_synfig_gradient \
 	test_synfig_handle \
 	test_synfig_keyframe \
 	test_synfig_node \
@@ -36,6 +37,8 @@ test_synfig_bline_SOURCES=bline.cpp
 test_synfig_clock_SOURCES=clock.cpp
 
 test_synfig_filesystem_path_SOURCES=filesystem_path.cpp
+
+test_synfig_gradient_SOURCES=gradient.cpp
 
 test_synfig_handle_SOURCES=handle.cpp
 

--- a/synfig-core/test/gradient.cpp
+++ b/synfig-core/test/gradient.cpp
@@ -1,0 +1,381 @@
+/* === S Y N F I G ========================================================= */
+/*! \file angle.cpp
+**  \brief Test Angle class
+**
+** Copyright (c) 2002 Robert B. Quattlebaum Jr.
+** Copyright (c) 2025 Synfig Contributors
+**
+** This file is part of Synfig.
+**
+** Synfig is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 2 of the License, or
+** (at your option) any later version.
+**
+** Synfig is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**
+** ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#include <synfig/gradient.h>
+
+#include "test_base.h"
+
+/* === M A C R O S ========================================================= */
+
+using namespace synfig;
+
+/* === C L A S S E S ======================================================= */
+
+void
+test_gradient_base_constructor_is_empty()
+{
+	Gradient g;
+	ASSERT(g.empty());
+	ASSERT_EQUAL(0, g.size());
+	ASSERT(g.begin() == g.end());
+	ASSERT(g.rbegin() == g.rend());
+}
+
+void
+test_gradient_constructor_two_colors_keeps_the_order()
+{
+	Gradient g(Color::black(), Color::green());
+	ASSERT_FALSE(g.empty());
+	ASSERT_EQUAL(2, g.size());
+	ASSERT(g.begin() != g.end());
+	ASSERT(g.rbegin() != g.rend());
+
+	ASSERT(Color::black() == g.begin()->color);
+	ASSERT(Color::green() == (g.end()-1)->color);
+	ASSERT_EQUAL(0., g.begin()->pos);
+	ASSERT_EQUAL(1., (g.end()-1)->pos);
+
+	g.sync();
+
+	ASSERT(Color::black() == g.begin()->color);
+	ASSERT(Color::green() == (g.end()-1)->color);
+	ASSERT_EQUAL(0., g.begin()->pos);
+	ASSERT_EQUAL(1., (g.end()-1)->pos);
+}
+
+void
+test_gradient_constructor_three_colors_keeps_the_order()
+{
+	Gradient g(Color::black(), Color::green(), Color::red());
+	ASSERT_FALSE(g.empty());
+	ASSERT_EQUAL(3, g.size());
+	ASSERT(g.begin() != g.end());
+	ASSERT(g.rbegin() != g.rend());
+
+	ASSERT(Color::black() == g.begin()->color);
+	ASSERT(Color::red() == (g.end()-1)->color);
+	ASSERT_EQUAL(0., g.begin()->pos);
+	ASSERT_EQUAL(1., (g.end()-1)->pos);
+
+	g.sync();
+
+	ASSERT(Color::black() == g.begin()->color);
+	ASSERT(Color::red() == (g.end()-1)->color);
+	ASSERT_EQUAL(0., g.begin()->pos);
+	ASSERT_EQUAL(1., (g.end()-1)->pos);
+}
+
+void
+test_gradient_constructor_three_colors_let_the_second_in_the_middle()
+{
+	Gradient g(Color::black(), Color::green(), Color::red());
+	ASSERT(Color::green() == (g.end()-2)->color);
+	ASSERT_EQUAL(.5, (g.end()-2)->pos);
+
+	g.sync();
+
+	ASSERT(Color::green() == (g.end()-2)->color);
+	ASSERT_EQUAL(.5, (g.end()-2)->pos);
+}
+
+void
+test_gradient_0_color_fetches_the_empty_color_no_matter_position()
+{
+	Gradient g;
+	ASSERT(Color() == g(0.0));
+	ASSERT(Color() == g(0.3));
+	ASSERT(Color() == g(0.6));
+	ASSERT(Color() == g(1.0));
+
+	ASSERT(Color() == g(-8.0));
+	ASSERT(Color() == g(+8.0));
+}
+
+void
+test_gradient_1_color_fetches_the_same_color_no_matter_position()
+{
+	{
+		Gradient g1;
+		g1.push_back({0.0, Color::red()});
+		ASSERT(Color::red() == g1(0.0));
+		ASSERT(Color::red() == g1(0.3));
+		ASSERT(Color::red() == g1(0.6));
+		ASSERT(Color::red() == g1(1.0));
+
+		ASSERT(Color::red() == g1(-8.0));
+		ASSERT(Color::red() == g1(+8.0));
+	}
+
+	{
+		Gradient g2;
+		g2.push_back({0.55, Color::cyan()});
+		ASSERT(Color::cyan() == g2(0.0));
+		ASSERT(Color::cyan() == g2(0.3));
+		ASSERT(Color::cyan() == g2(0.6));
+		ASSERT(Color::cyan() == g2(1.0));
+
+		ASSERT(Color::cyan() == g2(-8.0));
+		ASSERT(Color::cyan() == g2(+8.0));
+	}
+}
+
+void
+test_gradient_2_colors_fetches_the_first_color_even_if_before_first_position()
+{
+	{
+		Gradient g1(Color::red(), Color::blue());
+		ASSERT(Color::red() == g1(-0.3));
+		ASSERT(Color::red() == g1(-0.6));
+		ASSERT(Color::red() == g1(-1.0));
+		ASSERT(Color::red() == g1(-8.0));
+	}
+
+	{
+		Gradient g2;
+		g2.push_back({-2.0, Color::red()});
+		g2.push_back({+3.0, Color::blue()});
+		ASSERT_FALSE(Color::red() == g2(-0.3));
+		ASSERT_FALSE(Color::red() == g2(-0.6));
+		ASSERT_FALSE(Color::red() == g2(-1.0));
+		ASSERT(Color::red() == g2(-8.0));
+	}
+}
+
+void
+test_gradient_2_colors_fetches_the_last_color_even_if_after_last_position()
+{
+	{
+		Gradient g1(Color::red(), Color::blue());
+		ASSERT(Color::blue() == g1(+1.3));
+		ASSERT(Color::blue() == g1(+1.6));
+		ASSERT(Color::blue() == g1(+2.0));
+		ASSERT(Color::blue() == g1(+8.0));
+	}
+
+	{
+		Gradient g2;
+		g2.push_back({-2.0, Color::red()});
+		g2.push_back({+3.0, Color::blue()});
+		ASSERT_FALSE(Color::blue() == g2(+1.3));
+		ASSERT_FALSE(Color::blue() == g2(+1.6));
+		ASSERT_FALSE(Color::blue() == g2(+2.0));
+		ASSERT(Color::blue() == g2(+8.0));
+	}
+}
+
+void
+test_gradient_2_colors_fetches_the_first_color_for_the_exact_first_position()
+{
+	{
+		Gradient g1(Color::red(), Color::blue());
+		ASSERT(Color::red() == g1(0.0));
+	}
+
+	{
+		Gradient g2;
+		g2.push_back({-2.0, Color::red()});
+		g2.push_back({+3.0, Color::blue()});
+		ASSERT(Color::red() == g2(-2.0));
+	}
+}
+
+void
+test_gradient_2_colors_fetches_the_last_color_for_the_exact_last_position()
+{
+	{
+		Gradient g1(Color::red(), Color::blue());
+		ASSERT(Color::blue() == g1(+1.0));
+	}
+
+	{
+		Gradient g2;
+		g2.push_back({-2.0, Color::red()});
+		g2.push_back({+3.0, Color::blue()});
+		ASSERT(Color::blue() == g2(+3.0));
+	}
+}
+
+void
+test_gradient_2_colors_fetches_the_middle_color_for_the_exact_middle_position()
+{
+	{
+		Gradient g1(Color::red(), Color::blue());
+		ASSERT(Color(.5, 0., .5, 1.) == g1(0.5));
+	}
+
+	{
+		Gradient g2;
+		g2.push_back({-2.0, Color::red()});
+		g2.push_back({+2.0, Color::blue()});
+		ASSERT(Color(.5, 0., .5, 1.) == g2(0.0));
+	}
+}
+
+void
+test_gradient_2_colors_fetches_similar_to_the_first_color_for_position_near_to_the_first_position()
+{
+	{
+		Gradient g1(Color::red(), Color::blue());
+		ASSERT(Color(.7, 0., .3, 1.) == g1(0.3));
+	}
+
+	{
+		Gradient g2;
+		g2.push_back({-2.0, Color::red()});
+		g2.push_back({+2.0, Color::blue()});
+		ASSERT(Color(.75, 0., .25, 1.) == g2(-1.0));
+	}
+}
+
+void
+test_gradient_2_colors_fetches_similar_to_the_last_color_for_position_near_to_the_last_position()
+{
+	{
+		Gradient g1(Color::red(), Color::blue());
+		ASSERT(Color(.3, 0, .7, 1.) == g1(0.7));
+	}
+
+	{
+		Gradient g2;
+		g2.push_back({-2.0, Color::red()});
+		g2.push_back({+2.0, Color::blue()});
+		ASSERT(Color(.25, 0., .75, 1.) == g2(+1.0));
+	}
+}
+
+void
+test_gradient_3_colors_fetches_the_first_color_even_if_before_first_position()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT(Color::red() == g1(-0.3));
+	ASSERT(Color::red() == g1(-0.6));
+	ASSERT(Color::red() == g1(-1.0));
+	ASSERT(Color::red() == g1(-8.0));
+}
+
+void
+test_gradient_3_colors_fetches_the_last_color_even_if_after_last_position()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT(Color::blue() == g1(+1.3));
+	ASSERT(Color::blue() == g1(+1.6));
+	ASSERT(Color::blue() == g1(+2.0));
+	ASSERT(Color::blue() == g1(+8.0));
+}
+
+void
+test_gradient_3_colors_fetches_the_first_color_for_the_exact_first_position()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT(Color::red() == g1(0.0));
+}
+
+void
+test_gradient_3_colors_fetches_the_last_color_for_the_exact_last_position()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT(Color::blue() == g1(+1.0));
+}
+
+void
+test_gradient_3_colors_fetches_the_middle_color_for_the_exact_middle_position()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT(Color::green() == g1(0.5));
+}
+
+void
+test_gradient_3_colors_fetches_similar_to_the_first_color_for_position_near_to_the_first_position()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT_APPROX_EQUAL(0.8f, g1(0.1).get_r());
+	ASSERT_APPROX_EQUAL(0.2f, g1(0.1).get_g());
+	ASSERT_APPROX_EQUAL(0.0f, g1(0.1).get_b());
+	// ASSERT(Color(.8, .2, 0., 1.) == g1(0.1));
+}
+
+void
+test_gradient_3_colors_fetches_similar_to_the_last_color_for_position_near_to_the_last_position()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT_APPROX_EQUAL(0.0f, g1(0.9).get_r());
+	ASSERT_APPROX_EQUAL_MICRO(0.2f, g1(0.9).get_g());
+	ASSERT_APPROX_EQUAL(0.8f, g1(0.9).get_b());
+}
+
+void
+test_gradient_3_colors_fetches_similar_to_the_middle_color_for_position_near_to_the_middle_position_from_left()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT_APPROX_EQUAL_MICRO(0.2f, g1(0.4).get_r());
+	ASSERT_APPROX_EQUAL(0.8f, g1(0.4).get_g());
+	ASSERT_APPROX_EQUAL(0.f, g1(0.4).get_b());
+	// ASSERT(Color(.2, .8, 0., 1.) == g1(0.4));
+}
+
+void
+test_gradient_3_colors_fetches_similar_to_the_middle_color_for_position_near_to_the_middle_position_from_right()
+{
+	Gradient g1(Color::red(), Color::green(), Color::blue());
+	ASSERT_APPROX_EQUAL(0.0f, g1(0.6).get_r());
+	ASSERT_APPROX_EQUAL(0.8f, g1(0.6).get_g());
+	ASSERT_APPROX_EQUAL(0.2f, g1(0.6).get_b());
+	// ASSERT(Color(0, .2, .8, 1.) == g1(0.6));
+}
+
+/* === E N T R Y P O I N T ================================================= */
+
+int main() {
+
+	TEST_SUITE_BEGIN()
+	TEST_FUNCTION(test_gradient_base_constructor_is_empty)
+	TEST_FUNCTION(test_gradient_constructor_two_colors_keeps_the_order)
+	TEST_FUNCTION(test_gradient_constructor_three_colors_keeps_the_order)
+	TEST_FUNCTION(test_gradient_constructor_three_colors_let_the_second_in_the_middle)
+	TEST_FUNCTION(test_gradient_0_color_fetches_the_empty_color_no_matter_position)
+	TEST_FUNCTION(test_gradient_1_color_fetches_the_same_color_no_matter_position)
+
+	TEST_FUNCTION(test_gradient_2_colors_fetches_the_first_color_even_if_before_first_position)
+	TEST_FUNCTION(test_gradient_2_colors_fetches_the_last_color_even_if_after_last_position)
+	TEST_FUNCTION(test_gradient_2_colors_fetches_the_first_color_for_the_exact_first_position)
+	TEST_FUNCTION(test_gradient_2_colors_fetches_the_last_color_for_the_exact_last_position)
+	TEST_FUNCTION(test_gradient_2_colors_fetches_the_middle_color_for_the_exact_middle_position)
+	TEST_FUNCTION(test_gradient_2_colors_fetches_similar_to_the_first_color_for_position_near_to_the_first_position)
+	TEST_FUNCTION(test_gradient_2_colors_fetches_similar_to_the_last_color_for_position_near_to_the_last_position)
+
+	TEST_FUNCTION(test_gradient_3_colors_fetches_the_first_color_even_if_before_first_position)
+	TEST_FUNCTION(test_gradient_3_colors_fetches_the_last_color_even_if_after_last_position)
+	TEST_FUNCTION(test_gradient_3_colors_fetches_the_first_color_for_the_exact_first_position)
+	TEST_FUNCTION(test_gradient_3_colors_fetches_the_last_color_for_the_exact_last_position)
+	TEST_FUNCTION(test_gradient_3_colors_fetches_the_middle_color_for_the_exact_middle_position)
+	TEST_FUNCTION(test_gradient_3_colors_fetches_similar_to_the_first_color_for_position_near_to_the_first_position)
+	TEST_FUNCTION(test_gradient_3_colors_fetches_similar_to_the_last_color_for_position_near_to_the_last_position)
+	TEST_FUNCTION(test_gradient_3_colors_fetches_similar_to_the_middle_color_for_position_near_to_the_middle_position_from_left)
+	TEST_FUNCTION(test_gradient_3_colors_fetches_similar_to_the_middle_color_for_position_near_to_the_middle_position_from_right)
+	TEST_SUITE_END()
+
+	return tst_exit_status;
+}

--- a/synfig-studio/src/gui/widgets/widget_gradient.cpp
+++ b/synfig-studio/src/gui/widgets/widget_gradient.cpp
@@ -181,8 +181,7 @@ Widget_Gradient::insert_cpoint(float x)
 	new_cpoint.pos=x;
 	new_cpoint.color=gradient_(x);
 	gradient_.push_back(new_cpoint);
-	gradient_.sort();
-	gradient_.sort();
+	gradient_.sync();
 	set_selected_cpoint(new_cpoint);
 	queue_draw();
 }
@@ -253,7 +252,7 @@ Widget_Gradient::update_cpoint(const synfig::Gradient::CPoint &x)
 	if (iter != gradient_.end()) {
 		iter->pos=x.pos;
 		iter->color=x.color;
-		gradient_.sort();
+		gradient_.sync();
 		queue_draw();
 	}
 }
@@ -304,7 +303,7 @@ Widget_Gradient::on_event(GdkEvent *event)
 				else
 				{
 					iter->pos=pos;
-					gradient_.sort();
+					gradient_.sync();
 				}
 
 //				signal_value_changed_();


### PR DESCRIPTION
AFAIK it only affects Plant, Mandelbrot and Metaballs layers.
All the others use CompiledGradient, that doesn't suffer the issue.

Gradient::operator() was getting the values in wrong direction
(except for the gradient start and end positions)
@ 0.0 - first color (OK)
@ 1.0 - last color (OK)
@ 0.3 - closer to last color instead of first one
          (it looks like how it should be if position was 0.7)
@ 0.7 - closer to last color instead of first one
          (it looks like how it should be if position was 0.3)

For 3-or-more-color gradients, each interval is reversed,
but the start and end color are correct...

So the solution was to create an intermediate gradients that
keep the start and end color points, but create swapped color
points for each pair of them.

Consider a 3-color gradient like this:

Color A @0.0 -> Color B @0.3 -> Color C @1.0

, where @ means the color point position.

It is transformed to:

Color A @0.0 -> Color B @0.0 -> Color A @0.3 -> Color C @0.3 -> Color B @1.0 -> Color C @1.0

And it works fine.

Tests were created to check this inversion.

Layer versions were bumped, so it won't depend anymore about the Canvas version on load.