### PR TITLE
fix: crash when trying to link to polygon instead of spline

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -185,8 +185,10 @@ synfig::find_closest_point(const ValueBase &bline, const Point &pos, Real radius
 	synfig::Point best_point;
 
 	const ValueBase::List &list = bline.get_list();
-	int size = (int)list.size();
-	int count = loop ? size : size - 1;
+	const int size = (int)list.size();
+	if (size == 0)
+		return 0;
+	const int count = loop ? size : size - 1;
 	
 	for(int i0 = 0; i0 < count; ++i0) {
 		int i1 = (i0 + 1) % size;
@@ -238,6 +240,8 @@ synfig::std_to_hom(const ValueBase &bline, Real pos, bool index_loop, bool bline
 
 	const std::vector<BLinePoint> list(bline.get_list_of(BLinePoint()));
 	size_t size = list.size();
+	if (size == 0)
+		return loops;
 	size_t count = bline_loop? size : size - 1;
 	if (count < 1)
 		return loops + pos;
@@ -282,6 +286,8 @@ synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline
 
 	const std::vector<BLinePoint> list(bline.get_list_of(BLinePoint()));
 	size_t size = list.size();
+	if (size == 0)
+		return loops;
 	size_t count = bline_loop? size : size - 1;
 	if (count < 1)
 		return loops + pos;

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalctangent.cpp
@@ -104,8 +104,10 @@ ValueNode_BLineCalcTangent::operator()(Time t, Real amount)const
 	const ValueBase bline_value_node = (*bline_)(t);
 
 	const bool looped = bline_value_node.get_loop();
-	int size = (int)bline.size();
-	int count = looped ? size : size - 1;
+	const int size = (int)bline.size();
+	if (size == 0)
+		return ValueBase();
+	const int count = looped ? size : size - 1;
 	if (count < 1)
 	{
 		Type &type(get_type());

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
@@ -101,8 +101,10 @@ ValueNode_BLineCalcVertex::operator()(Time t)const
 	const ValueBase bline_value_node = (*bline_)(t);
 
 	const bool looped = bline_value_node.get_loop();
-	int size = (int)bline.size();
-	int count = looped ? size : size - 1;
+	const int size = (int)bline.size();
+	if (size == 0)
+		return Vector();
+	const int count = looped ? size : size - 1;
 	if (count < 1) return Vector();
 
 	bool loop = (*loop_)(t).get(bool());

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcwidth.cpp
@@ -102,8 +102,10 @@ ValueNode_BLineCalcWidth::operator()(Time t, Real amount)const
 	const ValueBase bline_value_node = (*bline_)(t);
 
 	const bool looped = bline_value_node.get_loop();
-	int size = (int)bline.size();
-	int count = looped ? size : size - 1;
+	const int size = (int)bline.size();
+	if (size == 0)
+		return ValueBase();
+	const int count = looped ? size : size - 1;
 	if (count < 1) return Real();
 
 	bool loop         = (*loop_)(t).get(bool());

--- a/synfig-studio/src/synfigapp/actions/valuedescblinelink.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescblinelink.cpp
@@ -115,8 +115,12 @@ Action::ValueDescBLineLink::is_candidate(const ParamList &x)
 
 	// We need a dynamic list.
 	ValueNode::Handle value_desc_valuenode = value_desc.get_parent_value_node();
-	if (!ValueNode_DynamicList::Handle::cast_dynamic(value_desc_valuenode))
+	if (auto dynamic_list = ValueNode_DynamicList::Handle::cast_dynamic(value_desc_valuenode)) {
+		if (dynamic_list->get_contained_type() != type_bline_point)
+			return false;
+	} else {
 		return false;
+	}
 
 	// if any of the selected valuedesc belongs to the spline, can't link.
 	const auto range = x.equal_range("selected_value_desc");


### PR DESCRIPTION
The action "Link to Spline", when used to link to a Polygon, crashes Synfig Studio.

Another commit/PR should support it.
For now, it just doesn't show the option for the user in this forbidden case anymore.

Problem backs to 1.0.2 at least.

Fix #3480