### PR TITLE
refactor: remove unused CanvasInterface::auto_export() method

### DIFF
--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -3541,20 +3541,6 @@ CanvasParser::parse_from_file_as(const FileSystem::Identifier &identifier,const 
 				if (!canvas) return canvas;
 				register_canvas_in_map(canvas, as);
 
-				const ValueNodeList& value_node_list(canvas->value_node_list());
-
-				again:
-				ValueNodeList::const_iterator iter;
-				for(iter=value_node_list.begin();iter!=value_node_list.end();++iter)
-				{
-					ValueNode::Handle value_node(*iter);
-					if(value_node->is_exported() && value_node->get_id().find("Unnamed")==0)
-					{
-						canvas->remove_value_node(value_node, true);
-						goto again;
-					}
-				}
-
 				return canvas;
 			}
 		} else {
@@ -3597,24 +3583,7 @@ CanvasParser::parse_as(xmlpp::Element* node,String &errors)
 		total_warnings_=0;
 		if(node)
 		{
-			Canvas::Handle canvas(parse_canvas(node,0,false,FileSystemNative::instance()->get_identifier(std::string()),""));
-			if (!canvas) return canvas;
-
-			const ValueNodeList& value_node_list(canvas->value_node_list());
-
-			again:
-			ValueNodeList::const_iterator iter;
-			for(iter=value_node_list.begin();iter!=value_node_list.end();++iter)
-			{
-				ValueNode::Handle value_node(*iter);
-				if(value_node->is_exported() && value_node->get_id().find("Unnamed")==0)
-				{
-					canvas->remove_value_node(value_node, false); // \todo verify false here
-					goto again;
-				}
-			}
-
-			return canvas;
+			return parse_canvas(node, nullptr, false, FileSystemNative::instance()->get_identifier(""), "");
 		}
 	}
 	catch(Exception::BadLinkName&) { synfig::error("BadLinkName Thrown"); }

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -1170,7 +1170,6 @@ StateDraw_Context::new_bline(std::list<synfig::BLinePoint> bline,std::list<synfi
 				{
 					shift_origin = true;
 					shift_origin_vector = start_duck->get_origin();
-					get_canvas_interface()->auto_export(start_duck_value_desc);
 					if (extend_finish)
 						if(start_duck_value_node_bline&&start_duck_value_node_bline==finish_duck_value_node_bline)
 							extend_finish_join_same=true;
@@ -1194,7 +1193,6 @@ StateDraw_Context::new_bline(std::list<synfig::BLinePoint> bline,std::list<synfi
 				{
 					shift_origin = true;
 					shift_origin_vector = finish_duck->get_origin();
-					get_canvas_interface()->auto_export(finish_duck_value_desc);
 					if(extend_start)
 						if(finish_duck_value_node_bline&&start_duck_value_node_bline==finish_duck_value_node_bline)
 							extend_start_join_same=true;
@@ -2132,7 +2130,6 @@ StateDraw_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real 
 								value_node->set_link("t2",value_node_next->get_link("t2"));
 								value_node->set_link("split",ValueNode_Const::create(true));
 
-								// get_canvas_interface()->auto_export(value_node);
 								printf("exporting\n");
 								get_canvas_interface()->add_value_node(value_node,value_node->get_id() + strprintf("foo %d", rand()));
 
@@ -2213,17 +2210,11 @@ StateDraw_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real 
 		std::list<synfigapp::ValueDesc>::iterator iter;
 		for(iter=vertex_list.begin();iter!=vertex_list.end();++iter)
 		{
-			// Ensure that the vertex is exported.
-			get_canvas_interface()->auto_export(*iter);
-
 			value_node_bline->add(iter->get_value_node());
-			//value_node_bline->add(ValueNode_BLine::ListEntry(iter->get_value_node()));
 		}
 
 		value_node_bline->set_loop(true);
 	}
-
-	get_canvas_interface()->auto_export(value_node_bline);
 
 	// Now we create the region layer
 	// Create the layer
@@ -2727,8 +2718,6 @@ StateDraw_Context::fill_last_stroke_and_unselect_other_layers()
 	synfigapp::Action::PassiveGrouper group(get_canvas_interface()->get_instance().get(),_("Fill Stroke"));
 
 	Layer::Handle layer;
-
-	get_canvas_interface()->auto_export(last_stroke);
 
 	synfigapp::PushMode push_mode(get_canvas_interface(),synfigapp::MODE_NORMAL);
 

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -1086,7 +1086,6 @@ StateLasso_Context::new_bline(std::list<synfig::BLinePoint> bline,std::list<synf
 				{
 					shift_origin = true;
 					shift_origin_vector = start_duck->get_origin();
-					get_canvas_interface()->auto_export(start_duck_value_desc);
 					if (extend_finish)
 						if(start_duck_value_node_bline&&start_duck_value_node_bline==finish_duck_value_node_bline)
 							extend_finish_join_same=true;
@@ -1110,7 +1109,6 @@ StateLasso_Context::new_bline(std::list<synfig::BLinePoint> bline,std::list<synf
 				{
 					shift_origin = true;
 					shift_origin_vector = finish_duck->get_origin();
-					get_canvas_interface()->auto_export(finish_duck_value_desc);
 					if(extend_start)
 						if(finish_duck_value_node_bline&&start_duck_value_node_bline==finish_duck_value_node_bline)
 							extend_start_join_same=true;
@@ -2055,7 +2053,6 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 								value_node->set_link("t2",value_node_next->get_link("t2"));
 								value_node->set_link("split",ValueNode_Const::create(true));
 
-								// get_canvas_interface()->auto_export(value_node);
 								printf("exporting\n");
 								get_canvas_interface()->add_value_node(value_node,value_node->get_id() + strprintf("foo %d", rand()));
 
@@ -2135,17 +2132,11 @@ StateLasso_Context::new_region(std::list<synfig::BLinePoint> bline, synfig::Real
 
 		std::list<synfigapp::ValueDesc>::iterator iter;
 		for (iter = vertex_list.begin(); iter != vertex_list.end(); ++iter) {
-			// Ensure that the vertex is exported.
-			get_canvas_interface()->auto_export(*iter);
-
 			value_node_bline->add(iter->get_value_node());
-			//value_node_bline->add(ValueNode_BLine::ListEntry(iter->get_value_node()));
 		}
 
 		value_node_bline->set_loop(true);
 	}
-
-	get_canvas_interface()->auto_export(value_node_bline);
 
 	// Now we create the region layer
 	// Create the layer
@@ -2616,8 +2607,6 @@ StateLasso_Context::fill_last_stroke_and_unselect_other_layers()
 	synfigapp::Action::PassiveGrouper group(get_canvas_interface()->get_instance().get(),_("Fill Stroke"));
 
 	Layer::Handle layer;
-
-	get_canvas_interface()->auto_export(last_stroke);
 
 	synfigapp::PushMode push_mode(get_canvas_interface(),synfigapp::MODE_NORMAL);
 

--- a/synfig-studio/src/gui/trees/childrentreestore.cpp
+++ b/synfig-studio/src/gui/trees/childrentreestore.cpp
@@ -218,11 +218,7 @@ ChildrenTreeStore::on_canvas_removed(synfig::Canvas::Handle /*canvas*/)
 void
 ChildrenTreeStore::on_value_node_added(synfig::ValueNode::Handle value_node)
 {
-//	if(value_node->get_id().find("Unnamed")!=String::npos)
-//		return;
-
 	Gtk::TreeRow row = *prepend(value_node_row.children());
-
 	set_row(row,synfigapp::ValueDesc(canvas_interface()->get_canvas(),value_node->get_id()),false);
 }
 

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -1189,60 +1189,6 @@ CanvasInterface::waypoint_remove(ValueNode::Handle value_node,synfig::Waypoint w
 		get_ui_interface()->error(_("Action Failed."));
 }
 
-
-void
-CanvasInterface::auto_export(synfig::ValueNode::Handle /*value_node*/)
-{
-/*
-	// Check to see if we are already exported.
-	if(value_node->is_exported())
-		return;
-
-	Action::Handle 	action(Action::create("ValueNodeAdd"));
-
-	assert(action);
-	if(!action)
-		return;
-
-	String name(strprintf(_("Unnamed%08d"),synfig::UniqueID().get_uid()));
-
-	action->set_param("canvas",get_canvas());
-	action->set_param("canvas_interface",etl::loose_handle<CanvasInterface>(this));
-	action->set_param("new",value_node);
-	action->set_param("name",name);
-
-	if(!get_instance()->perform_action(action))
-		get_ui_interface()->error(_("Action Failed."));
-*/
-}
-
-void
-CanvasInterface::auto_export(const ValueDesc& /*value_desc*/)
-{
-	// THIS FUNCTION IS DEPRECATED, AND IS NOW A STUB.
-#if 0
-	// Check to see if we are already exported.
-	if(value_desc.is_exported())
-		return;
-
-	Action::Handle 	action(Action::create("ValueDescExport"));
-
-	assert(action);
-	if(!action)
-		return;
-
-	String name(strprintf(_("Unnamed%08d"),synfig::UniqueID().get_uid()));
-
-	action->set_param("canvas",get_canvas());
-	action->set_param("canvas_interface",etl::loose_handle<CanvasInterface>(this));
-	action->set_param("value_desc",value_desc);
-	action->set_param("name",name);
-
-	if(!get_instance()->perform_action(action))
-		get_ui_interface()->error(_("Action Failed."));
-#endif
-}
-
 bool
 CanvasInterface::change_value(synfigapp::ValueDesc value_desc,synfig::ValueBase new_value,bool lock_animation)
 {

--- a/synfig-studio/src/synfigapp/canvasinterface.h
+++ b/synfig-studio/src/synfigapp/canvasinterface.h
@@ -212,10 +212,6 @@ public:	// Signal Interface
 
 public:
 
-	void auto_export(const ValueDesc& value_desc);
-
-	void auto_export(synfig::ValueNode::Handle value_node);
-
 	void set_meta_data(const synfig::String& key,const synfig::String& data);
 
 	void erase_meta_data(const synfig::String& key);


### PR DESCRIPTION
It is commented-out since initial commit in 2005.

It also removes the code on loading canvas that automatically deletes exported Value Nodes whose ID starts with "Unnamed". It can be safely removed because:
1. this code slice also dates back 2005
2. by using `git grep Unnamed`, it can be seen the only place that sets a valuenode ID as "Unnamed..." is the commented-out CanvasInterface::auto_export() this PR deletes.