### PR TITLE
fix: crash with positive sound delay for MLT >= 7.20

### DIFF
--- a/synfig-core/src/synfig/soundprocessor.cpp
+++ b/synfig-core/src/synfig/soundprocessor.cpp
@@ -149,7 +149,7 @@ void SoundProcessor::addSound(const PlayOptions &playOptions, const Sound &sound
 		track->set_in_and_out(-delay, -1);
 	} else
 	if (delay > 0) {
-		Mlt::Playlist *playlist = new Mlt::Playlist();
+		Mlt::Playlist *playlist = new Mlt::Playlist(internal->profile);
 		playlist->blank(delay);
 		playlist->append(*track);
 		delete track;


### PR DESCRIPTION
The MLT framework we use as our audio backend for
Sound layer changed how it creates blank audio: since version 7.20 it has a MLT producer for blank. [1]

So now we have to provide a profile to our playlist producer; otherwise, synfig crashes with this error log message:

```
[mlt_producer 0x55555897c070] <playlist>
    Playlist can not create blank producer without profile
```

Reported-by: Lae82 in Synfig Forums [2]

[1] https://www.mltframework.org/blog/v7.20.0_released/
[2] https://forums.synfig.org/t/setting-audio-delay-parameter-for-audio-layer-with-a-positive-value-crashes-synfig/16223