### PR TITLE
fix: DeviceTracker segfaults with bogus null libgtkmm devices

### DIFF
--- a/synfig-studio/src/gui/devicetracker.cpp
+++ b/synfig-studio/src/gui/devicetracker.cpp
@@ -100,6 +100,8 @@ DeviceTracker::DeviceTracker()
 	list_devices(devices);
 	for(DeviceList::const_iterator i = devices.begin(); i != devices.end(); ++i) {
 		const Glib::RefPtr<Gdk::Device> &device = *i;
+		if(!device)
+		        continue;
 
 		bool unknown_type = false;
 		InputDevice::Type type = InputDevice::TYPE_MOUSE;
@@ -198,6 +200,8 @@ DeviceTracker::load_preferences()
 	list_devices(devices);
 	for(DeviceList::const_iterator i = devices.begin(); i != devices.end(); ++i) {
 		const Glib::RefPtr<Gdk::Device> &device = *i;
+		if(!device)
+			continue;
 
 		InputDevice::Handle synfig_device = synfigapp::Main::find_input_device(device->get_name());
 		if (!synfig_device)

--- a/synfig-studio/src/gui/dialogs/dialog_input.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_input.cpp
@@ -133,7 +133,7 @@ void Dialog_Input::take_options()
 	for(DeviceList::const_iterator i = devices.begin(); i != devices.end(); ++i) {
 		const Glib::RefPtr<Gdk::Device> &device = *i;
 
-		if (!synfigapp::Main::find_input_device(device->get_name()))
+		if (!device || !synfigapp::Main::find_input_device(device->get_name()))
 			continue;
 
 		options->devices.push_back(DeviceOptions::Device());


### PR DESCRIPTION
Fixes the startup crashes with gtkmm3.0 (3.24.9 for me) reporting NULL devices.

```
0x00007f88573e35e4 in Gdk::Device::get_source() const () at /lib64/libgdkmm-3.0.so.1
0x00000000004d9879 in studio::DeviceTracker::DeviceTracker (this=0x0) at /synfig/synfig-studio/src/gui/devicetracker.cpp:108
0x00000000004336b1 in studio::App::init (this=0xbd34920, rootpath="/synfig/synfig/build/output/Debug")
    at /home/fcartegn/synfig/synfig/synfig-studio/src/gui/app.cpp:1666
0x0000000000409bfd in operator() (__closure=0xbf8cf10) at /synfig/synfig-studio/src/gui/main.cpp:85
0x000000000040abac in sigc::adaptor_functor<main(int, char**)::<lambda()> >::operator()(void) const (this=0xbf8cf10)
    at /usr/include/sigc++-2.0/sigc++/adaptors/adaptor_trait.h:256
 0x000000000040aa5f in sigc::internal::slot_call0<main(int, char**)::<lambda()>, void>::call_it(sigc::internal::slot_rep *) (rep=0xbf8cee0)
    at /usr/include/sigc++-2.0/sigc++/functors/slot.h:136
0x00007f8855aa8af4 in Glib::SignalProxyNormal::slot0_void_callback(_GObject*, void*) () at /lib64/libglibmm-2.4.so.1
0x00007f88559e97da in g_closure_invoke () at /lib64/libgobject-2.0.so.0
0x00007f8855a19c4d in signal_emit_unlocked_R.isra.0 () at /lib64/libgobject-2.0.so.0
0x00007f8855a0a3e9 in signal_emit_valist_unlocked () at /lib64/libgobject-2.0.so.0
0x00007f8855a0a671 in g_signal_emit_valist () at /lib64/libgobject-2.0.so.0
0x00007f8855a0a733 in g_signal_emit () at /lib64/libgobject-2.0.so.0
0x00007f88544fa472 in g_application_register () at /lib64/libgio-2.0.so.0
0x00007f8854707bea in Gio::Application::register_application() () at /lib64/libgiomm-2.4.so.1
0x0000000000409ff9 in main (argc=1, argv=0x7fff1d9e0728) at /synfig/synfig-studio/src/gui/main.cpp:88
```