### PR TITLE
refactor: reduce visibility of internal variable members of Layer_Bitmap

### DIFF
--- a/synfig-core/src/synfig/layers/layer_bitmap.h
+++ b/synfig-core/src/synfig/layers/layer_bitmap.h
@@ -57,18 +57,21 @@ class Layer_Bitmap : public Layer_Composite, public Layer_NoDeform
 public:
 	typedef etl::handle<Layer_Bitmap> Handle;
 
+private:
 	ValueBase param_tl;
 	ValueBase param_br;
 	ValueBase param_c;
 	ValueBase param_gamma_adjust;
 
-	mutable std::mutex mutex;
 	mutable rendering::software::PackedSurface::Reader reader;
+public:
+	mutable std::mutex mutex;
 	mutable rendering::SurfaceResource::Handle rendering_surface;
+private:
 	mutable bool trimmed;
 	mutable unsigned int left, top, width, height;
 
-
+public:
 	Layer_Bitmap();
 
 	GUID get_surface_modification_id() const

--- a/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
+++ b/synfig-studio/src/synfigapp/vectorizer/centerlinetostrokes.cpp
@@ -944,8 +944,8 @@ void studio::conversionToStrokes(std::vector<synfig::Layer::Handle>& strokes, Ve
   max_thickness_zero                      = !g.currConfig->m_maxThickness; // if any value then false otherwise 0 then true
   unsigned int i, j, k;
 
-  synfig::Point topleft = image->param_tl.get(synfig::Point());
-  synfig::Point bottomright = image->param_br.get(synfig::Point());
+  synfig::Point topleft = image->get_param("tl").get(synfig::Point());
+  synfig::Point bottomright = image->get_param("br").get(synfig::Point());
   bottomleft[0] = topleft[0];
   bottomleft[1] = bottomright[1];
 


### PR DESCRIPTION
more should be done, but that's better than current situation