### PR TITLE
ci: enable ccache compression for AppVeyor build

### DIFF
--- a/2-build-cmake.sh
+++ b/2-build-cmake.sh
@@ -21,10 +21,19 @@ then
 mode=$1
 fi
 
+# AppVeyor cache size limit:
+# https://www.appveyor.com/docs/build-cache/#cache-size-beta
+ccache --set-config compression_level=5
+ccache --max-size=1G
+ccache --show-config
+
 cmake -GNinja -DENABLE_TESTS=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE="${mode}" ..
 cmake --build .
 cmake --install . >/dev/null
 ctest --output-on-failure
+
+ccache --show-stats
+ccache --show-compression
 
 echo
 echo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build_script:
 # scripts to run after build (working directory and environment changes are persisted from the previous steps)
 after_build:
   - cmd: set SYNFIG_ID="%APPVEYOR_REPO_COMMIT_TIMESTAMP:~0,10%-win%MSYSTEM:~-2%-%APPVEYOR_REPO_COMMIT:~0,5%"
-  - cmd: call 7z a "SynfigStudio-1.5.2-testing-%SYNFIG_ID%.zip" %APPVEYOR_BUILD_FOLDER%\cmake-build\install\*
+  - cmd: call 7z a "SynfigStudio-1.5.4-testing-%SYNFIG_ID%.zip" %APPVEYOR_BUILD_FOLDER%\cmake-build\install\*
 
 artifacts:
   - path: "SynfigStudio-*.zip"


### PR DESCRIPTION
AppVeyor cache size is only 1Gb:
https://www.appveyor.com/docs/build-cache/#cache-size-beta