### PR TITLE
fix: search for ffmpeg binary in env paths on MS Windows

### DIFF
--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -46,7 +46,7 @@
 #endif
 
 #ifdef _WIN32
-    #include <windows.h>
+#include <windows.h>
 #endif
 
 /* === M A C R O S ========================================================= */
@@ -65,62 +65,62 @@ SYNFIG_TARGET_SET_VERSION(ffmpeg_trgt,"0.1");
 bool
 ffmpeg_trgt::does_video_codec_support_alpha_channel(const synfig::String &video_codec) const
 {
-	const std::vector<const char*> valid_codecs = {
-		"libvpx-vp8", "libvpx-vp9", "hap"
-	};
-	return std::find(valid_codecs.begin(), valid_codecs.end(), video_codec) != valid_codecs.end();
+    const std::vector<const char*> valid_codecs = {
+        "libvpx-vp8", "libvpx-vp9", "hap"
+    };
+    return std::find(valid_codecs.begin(), valid_codecs.end(), video_codec) != valid_codecs.end();
 }
 
 ffmpeg_trgt::ffmpeg_trgt(const synfig::filesystem::Path& Filename, const synfig::TargetParam &params):
-	imagecount(0),
-	multi_image(false),
-	filename(Filename),
-	bitrate()
+    imagecount(0),
+    multi_image(false),
+    filename(Filename),
+    bitrate()
 {
-	// Set default video codec and bitrate if they weren't given.
-	if (params.video_codec == "none")
-		video_codec = "mpeg1video";
-	else
-		video_codec = params.video_codec;
+    // Set default video codec and bitrate if they weren't given.
+    if (params.video_codec == "none")
+        video_codec = "mpeg1video";
+    else
+        video_codec = params.video_codec;
 
-	if (params.bitrate == -1)
-		bitrate = 200;
-	else
-		bitrate = params.bitrate;
+    if (params.bitrate == -1)
+        bitrate = 200;
+    else
+        bitrate = params.bitrate;
 
-	if (does_video_codec_support_alpha_channel(video_codec))
-		set_alpha_mode(TARGET_ALPHA_MODE_KEEP);
-	else
-		set_alpha_mode(TARGET_ALPHA_MODE_FILL);
+    if (does_video_codec_support_alpha_channel(video_codec))
+        set_alpha_mode(TARGET_ALPHA_MODE_KEEP);
+    else
+        set_alpha_mode(TARGET_ALPHA_MODE_FILL);
 }
 
 ffmpeg_trgt::~ffmpeg_trgt()
 {
-	if(pipe)
-	{
-		pipe->close();
-	}
-	pipe = nullptr;
+    if(pipe)
+    {
+        pipe->close();
+    }
+    pipe = nullptr;
 
-	// Remove temporary sound file
-	if (FileSystemNative::instance()->is_file(sound_filename.u8string())) {
-		if (!FileSystemNative::instance()->remove_recursive(sound_filename)) {
-			synfig::warning("Error deleting temporary sound file (%s).", sound_filename.u8_str());
-		}
-	}
+    // Remove temporary sound file
+    if (FileSystemNative::instance()->is_file(sound_filename.u8string())) {
+        if (!FileSystemNative::instance()->remove_recursive(sound_filename)) {
+            synfig::warning("Error deleting temporary sound file (%s).", sound_filename.u8_str());
+        }
+    }
 }
 
 bool
 ffmpeg_trgt::set_rend_desc(RendDesc *given_desc)
 {
-	//given_desc->set_pixel_format(PF_RGB);
+    //given_desc->set_pixel_format(PF_RGB);
 
-	// Make sure that the width and height
-	// are multiples of 8
-	given_desc->set_w((given_desc->get_w()+4)/8*8);
-	given_desc->set_h((given_desc->get_h()+4)/8*8);
+    // Make sure that the width and height
+    // are multiples of 8
+    given_desc->set_w((given_desc->get_w()+4)/8*8);
+    given_desc->set_h((given_desc->get_h()+4)/8*8);
 
-	/*
+    /*
 	// Valid framerates:
 	// 23.976, 24, 25, 29.97, 30, 50 ,59.94, 60
 	float fps=given_desc->get_frame_rate();
@@ -142,42 +142,42 @@ ffmpeg_trgt::set_rend_desc(RendDesc *given_desc)
 		given_desc->set_frame_rate(59.94);
 	*/
 
-	desc=*given_desc;
+    desc=*given_desc;
 
-	return true;
+    return true;
 }
 
 bool
 ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 {
-	bool with_sound = true;
-	const std::string extension = filename.extension().u8string();
-	const std::vector<const char*> image_only_extensions{".gif", ".mng"};
-	const bool does_file_format_support_audio = std::find(image_only_extensions.begin(), image_only_extensions.end(), extension) == image_only_extensions.end();
+    bool with_sound = true;
+    const std::string extension = filename.extension().u8string();
+    const std::vector<const char*> image_only_extensions{".gif", ".mng"};
+    const bool does_file_format_support_audio = std::find(image_only_extensions.begin(), image_only_extensions.end(), extension) == image_only_extensions.end();
 
-	if (!does_file_format_support_audio) {
-		with_sound = false;
-	} else if(!SoundProcessor::subsys_init()) {
-		if (cb) cb->error(_("Unable to initialize Sound subsystem"));
-		with_sound = false;
-	} else {
-		auto& fs = FileSystemNative::instance();
-		synfig::SoundProcessor soundProcessor;
-		soundProcessor.set_infinite(false);
-		get_canvas()->fill_sound_processor(soundProcessor);
-		// Generate random filename here
-		do {
-			synfig::GUID guid;
-			sound_filename = filename;
-			sound_filename.replace_extension("." + guid.get_string().substr(0,8) + ".wav");
-		} while (fs->is_exists(sound_filename.u8string()));
+    if (!does_file_format_support_audio) {
+        with_sound = false;
+    } else if(!SoundProcessor::subsys_init()) {
+        if (cb) cb->error(_("Unable to initialize Sound subsystem"));
+        with_sound = false;
+    } else {
+        auto& fs = FileSystemNative::instance();
+        synfig::SoundProcessor soundProcessor;
+        soundProcessor.set_infinite(false);
+        get_canvas()->fill_sound_processor(soundProcessor);
+        // Generate random filename here
+        do {
+            synfig::GUID guid;
+            sound_filename = filename;
+            sound_filename.replace_extension("." + guid.get_string().substr(0,8) + ".wav");
+        } while (fs->is_exists(sound_filename.u8string()));
 
-		soundProcessor.do_export(sound_filename.u8string());
+        soundProcessor.do_export(sound_filename.u8string());
 
-		if (!fs->is_exists(sound_filename.u8string())) {
-			with_sound = false;
-		}
-	}
+        if (!fs->is_exists(sound_filename.u8string())) {
+            with_sound = false;
+        }
+    }
 
     synfig::filesystem::Path ffmpeg_binary_path;
 #ifdef _WIN32
@@ -231,170 +231,170 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 
 
 #else
-	// Some Linux OS may have `avconv` instead of `ffmpeg`, so let's check both
-	const std::vector<std::string> binary_choices = {"ffmpeg", "avconv"};
-	for (const auto& bin_name : binary_choices) {
-		OS::RunArgs args;
-		args.push_back(bin_name);
-		OS::RunPipe::Handle pipe = OS::run_async({"which"}, args, OS::RUN_MODE_READ);
-		if (!pipe) {
-			synfig::error(_("%s: Internal error: couldn't run 'which' async"), "trgt_ffmpeg");
-			continue;
-		}
-		std::string result = pipe->read_contents();
-		int status = pipe->close();
-		synfig::info("which %s -> [%i] %s", args.get_string().c_str(), status, result.c_str());
-		if (status == 0) {
-			ffmpeg_binary_path = bin_name; // we can use `result` value here, but in this case we need to remove trailing `\n`
-			break;
-		}
-	}
+    // Some Linux OS may have `avconv` instead of `ffmpeg`, so let's check both
+    const std::vector<std::string> binary_choices = {"ffmpeg", "avconv"};
+    for (const auto& bin_name : binary_choices) {
+        OS::RunArgs args;
+        args.push_back(bin_name);
+        OS::RunPipe::Handle pipe = OS::run_async({"which"}, args, OS::RUN_MODE_READ);
+        if (!pipe) {
+            synfig::error(_("%s: Internal error: couldn't run 'which' async"), "trgt_ffmpeg");
+            continue;
+        }
+        std::string result = pipe->read_contents();
+        int status = pipe->close();
+        synfig::info("which %s -> [%i] %s", args.get_string().c_str(), status, result.c_str());
+        if (status == 0) {
+            ffmpeg_binary_path = bin_name; // we can use `result` value here, but in this case we need to remove trailing `\n`
+            break;
+        }
+    }
 #endif
 
-	if (ffmpeg_binary_path.empty()) {
-		if (cb) cb->error(_("Error: No FFmpeg binary found.\n\nPlease install \"ffmpeg\" or \"avconv\" (libav-tools package)."));
-		return false;
-	}
+    if (ffmpeg_binary_path.empty()) {
+        if (cb) cb->error(_("Error: No FFmpeg binary found.\n\nPlease install \"ffmpeg\" or \"avconv\" (libav-tools package)."));
+        return false;
+    }
 
-	imagecount=desc.get_frame_start();
-	if(desc.get_frame_end()-desc.get_frame_start()>0)
-		multi_image=true;
+    imagecount=desc.get_frame_start();
+    if(desc.get_frame_end()-desc.get_frame_start()>0)
+        multi_image=true;
 
-	const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
+    const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
 
-	std::string video_codec_real = (video_codec == "libx264-lossless" ? "libx264" : video_codec);
+    std::string video_codec_real = (video_codec == "libx264-lossless" ? "libx264" : video_codec);
 
-	OS::RunArgs vargs;
-	if (with_sound) {
-		vargs.push_back("-i");
-		vargs.push_back(sound_filename);
-	}
-	vargs.push_back("-f");
-	vargs.push_back("image2pipe");
-	vargs.push_back("-vcodec");
-	vargs.push_back(use_alpha ? "pam" : "ppm");
-	vargs.push_back("-r");
-	{
-		// this should avoid conflicts with locale settings
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		vargs.push_back(strprintf("%f", desc.get_frame_rate()));
-	}
-	vargs.push_back("-i");
-	vargs.push_back("pipe:");
-	vargs.push_back("-metadata");
-	vargs.push_back(strprintf("title=\"%s\"", get_canvas()->get_name().c_str()));
-	vargs.push_back("-vcodec");
-	vargs.push_back(video_codec_real);
-	vargs.push_back("-b:v");
-	vargs.push_back(strprintf("%ik", bitrate));
-	if (video_codec == "libx264-lossless") {
-		vargs.push_back("-tune");
-		vargs.push_back("fastdecode");
-		vargs.push_back("-pix_fmt");
-		vargs.push_back(use_alpha ? "yuva420p" : "yuv420p");
-		vargs.push_back("-qp");
-		vargs.push_back("0");
-	} else if (use_alpha){
-		if (video_codec == "hap") {
-			vargs.push_back("-format");
-			vargs.push_back("hap_alpha");
-		}
-		vargs.push_back("-pix_fmt");
-		vargs.push_back("yuva420p");
-	}
-	if (with_sound) {
-		vargs.push_back("-acodec");
-		// MPEG-1 cannot work with 'le' audio, it requires 'be'
-		vargs.push_back(video_codec == "mpeg1video" ? "pcm_s16be" : "pcm_s16le");
-	}
-	vargs.push_back("-y");
-	vargs.push_back("-t");
-	{
-		// this should avoid conflicts with locale settings
-		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-		vargs.push_back(desc.get_duration().get_string(Time::Format::FORMAT_VIDEO));
-	}
-	// We need "--" to separate filename from arguments (for the case when filename starts with "-")
-	if ( filename.u8string().substr(0,1) == "-" )
-		vargs.push_back("--");
+    OS::RunArgs vargs;
+    if (with_sound) {
+        vargs.push_back("-i");
+        vargs.push_back(sound_filename);
+    }
+    vargs.push_back("-f");
+    vargs.push_back("image2pipe");
+    vargs.push_back("-vcodec");
+    vargs.push_back(use_alpha ? "pam" : "ppm");
+    vargs.push_back("-r");
+    {
+        // this should avoid conflicts with locale settings
+        synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
+        vargs.push_back(strprintf("%f", desc.get_frame_rate()));
+    }
+    vargs.push_back("-i");
+    vargs.push_back("pipe:");
+    vargs.push_back("-metadata");
+    vargs.push_back(strprintf("title=\"%s\"", get_canvas()->get_name().c_str()));
+    vargs.push_back("-vcodec");
+    vargs.push_back(video_codec_real);
+    vargs.push_back("-b:v");
+    vargs.push_back(strprintf("%ik", bitrate));
+    if (video_codec == "libx264-lossless") {
+        vargs.push_back("-tune");
+        vargs.push_back("fastdecode");
+        vargs.push_back("-pix_fmt");
+        vargs.push_back(use_alpha ? "yuva420p" : "yuv420p");
+        vargs.push_back("-qp");
+        vargs.push_back("0");
+    } else if (use_alpha){
+        if (video_codec == "hap") {
+            vargs.push_back("-format");
+            vargs.push_back("hap_alpha");
+        }
+        vargs.push_back("-pix_fmt");
+        vargs.push_back("yuva420p");
+    }
+    if (with_sound) {
+        vargs.push_back("-acodec");
+        // MPEG-1 cannot work with 'le' audio, it requires 'be'
+        vargs.push_back(video_codec == "mpeg1video" ? "pcm_s16be" : "pcm_s16le");
+    }
+    vargs.push_back("-y");
+    vargs.push_back("-t");
+    {
+        // this should avoid conflicts with locale settings
+        synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
+        vargs.push_back(desc.get_duration().get_string(Time::Format::FORMAT_VIDEO));
+    }
+    // We need "--" to separate filename from arguments (for the case when filename starts with "-")
+    if ( filename.u8string().substr(0,1) == "-" )
+        vargs.push_back("--");
 
-	vargs.push_back(filename);
+    vargs.push_back(filename);
 
-	pipe = OS::run_async(ffmpeg_binary_path, vargs, OS::RUN_MODE_WRITE);
+    pipe = OS::run_async(ffmpeg_binary_path, vargs, OS::RUN_MODE_WRITE);
 
-	if(!pipe || !pipe->is_writable())
-	{
-		synfig::error(_("Unable to open pipe to ffmpeg (no file)"));
-		if (pipe) {
-			pipe->close();
-			pipe = nullptr;
-		}
-		return false;
-	}
+    if(!pipe || !pipe->is_writable())
+    {
+        synfig::error(_("Unable to open pipe to ffmpeg (no file)"));
+        if (pipe) {
+            pipe->close();
+            pipe = nullptr;
+        }
+        return false;
+    }
 
-	synfig::info(_("Running async command: %s"), pipe->get_command().c_str());
+    synfig::info(_("Running async command: %s"), pipe->get_command().c_str());
 
-	return true;
+    return true;
 }
 
 void
 ffmpeg_trgt::end_frame()
 {
-	//pipe->print(" ");
-	pipe->flush();
-	imagecount++;
+    //pipe->print(" ");
+    pipe->flush();
+    imagecount++;
 }
 
 bool
 ffmpeg_trgt::start_frame(synfig::ProgressCallback */*callback*/)
 {
-	std::size_t w=desc.get_w(),h=desc.get_h();
+    std::size_t w=desc.get_w(),h=desc.get_h();
 
-	if(!pipe || !pipe->is_writable())
-		return false;
+    if(!pipe || !pipe->is_writable())
+        return false;
 
-	const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
+    const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
 
-	if (!use_alpha) {
-		pipe->printf("P6\n");
-		pipe->printf("%zu %zu\n", w, h);
-		pipe->printf("%d\n", 255);
-	} else {
-		pipe->printf("P7\n");
-		pipe->printf("WIDTH %zu\n", w);
-		pipe->printf("HEIGHT %zu\n", h);
-		pipe->printf("DEPTH 4\n");
-		pipe->printf("MAXVAL %d\n", 255);
-		pipe->printf("TUPLTYPE RGB_ALPHA\n");
-		pipe->printf("ENDHDR\n");
-	}
+    if (!use_alpha) {
+        pipe->printf("P6\n");
+        pipe->printf("%zu %zu\n", w, h);
+        pipe->printf("%d\n", 255);
+    } else {
+        pipe->printf("P7\n");
+        pipe->printf("WIDTH %zu\n", w);
+        pipe->printf("HEIGHT %zu\n", h);
+        pipe->printf("DEPTH 4\n");
+        pipe->printf("MAXVAL %d\n", 255);
+        pipe->printf("TUPLTYPE RGB_ALPHA\n");
+        pipe->printf("ENDHDR\n");
+    }
 
-	buffer.resize(w * (use_alpha ? 4 : 3));
-	color_buffer.resize(w);
+    buffer.resize(w * (use_alpha ? 4 : 3));
+    color_buffer.resize(w);
 
-	return true;
+    return true;
 }
 
 Color *
 ffmpeg_trgt::start_scanline(int /*scanline*/)
 {
-	return color_buffer.empty() ? nullptr : color_buffer.data();
+    return color_buffer.empty() ? nullptr : color_buffer.data();
 }
 
 bool
 ffmpeg_trgt::end_scanline()
 {
-	if(!pipe)
-		return false;
+    if(!pipe)
+        return false;
 
-	PixelFormat format = PF_RGB;
-	if(get_alpha_mode() == TARGET_ALPHA_MODE_KEEP)
-		format |= PF_A;
+    PixelFormat format = PF_RGB;
+    if(get_alpha_mode() == TARGET_ALPHA_MODE_KEEP)
+        format |= PF_A;
 
-	color_to_pixelformat(buffer.data(), color_buffer.data(), format, 0, desc.get_w());
+    color_to_pixelformat(buffer.data(), color_buffer.data(), format, 0, desc.get_w());
 
-	if(!pipe->write(buffer.data(),1,buffer.size()))
-		return false;
+    if(!pipe->write(buffer.data(),1,buffer.size()))
+        return false;
 
-	return true;
+    return true;
 }

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -36,17 +36,11 @@
 
 #include "trgt_ffmpeg.h"
 
-
-
 #include <synfig/filesystemnative.h>
 #include <synfig/general.h>
 #include <synfig/localization.h>
 #include <synfig/soundprocessor.h>
 
-#endif
-
-#ifdef _WIN32
-#include <windows.h>
 #endif
 
 /* === M A C R O S ========================================================= */
@@ -65,62 +59,62 @@ SYNFIG_TARGET_SET_VERSION(ffmpeg_trgt,"0.1");
 bool
 ffmpeg_trgt::does_video_codec_support_alpha_channel(const synfig::String &video_codec) const
 {
-    const std::vector<const char*> valid_codecs = {
-        "libvpx-vp8", "libvpx-vp9", "hap"
-    };
-    return std::find(valid_codecs.begin(), valid_codecs.end(), video_codec) != valid_codecs.end();
+	const std::vector<const char*> valid_codecs = {
+		"libvpx-vp8", "libvpx-vp9", "hap"
+	};
+	return std::find(valid_codecs.begin(), valid_codecs.end(), video_codec) != valid_codecs.end();
 }
 
 ffmpeg_trgt::ffmpeg_trgt(const synfig::filesystem::Path& Filename, const synfig::TargetParam &params):
-    imagecount(0),
-    multi_image(false),
-    filename(Filename),
-    bitrate()
+	imagecount(0),
+	multi_image(false),
+	filename(Filename),
+	bitrate()
 {
-    // Set default video codec and bitrate if they weren't given.
-    if (params.video_codec == "none")
-        video_codec = "mpeg1video";
-    else
-        video_codec = params.video_codec;
+	// Set default video codec and bitrate if they weren't given.
+	if (params.video_codec == "none")
+		video_codec = "mpeg1video";
+	else
+		video_codec = params.video_codec;
 
-    if (params.bitrate == -1)
-        bitrate = 200;
-    else
-        bitrate = params.bitrate;
+	if (params.bitrate == -1)
+		bitrate = 200;
+	else
+		bitrate = params.bitrate;
 
-    if (does_video_codec_support_alpha_channel(video_codec))
-        set_alpha_mode(TARGET_ALPHA_MODE_KEEP);
-    else
-        set_alpha_mode(TARGET_ALPHA_MODE_FILL);
+	if (does_video_codec_support_alpha_channel(video_codec))
+		set_alpha_mode(TARGET_ALPHA_MODE_KEEP);
+	else
+		set_alpha_mode(TARGET_ALPHA_MODE_FILL);
 }
 
 ffmpeg_trgt::~ffmpeg_trgt()
 {
-    if(pipe)
-    {
-        pipe->close();
-    }
-    pipe = nullptr;
+	if(pipe)
+	{
+		pipe->close();
+	}
+	pipe = nullptr;
 
-    // Remove temporary sound file
-    if (FileSystemNative::instance()->is_file(sound_filename.u8string())) {
-        if (!FileSystemNative::instance()->remove_recursive(sound_filename)) {
-            synfig::warning("Error deleting temporary sound file (%s).", sound_filename.u8_str());
-        }
-    }
+	// Remove temporary sound file
+	if (FileSystemNative::instance()->is_file(sound_filename.u8string())) {
+		if (!FileSystemNative::instance()->remove_recursive(sound_filename)) {
+			synfig::warning("Error deleting temporary sound file (%s).", sound_filename.u8_str());
+		}
+	}
 }
 
 bool
 ffmpeg_trgt::set_rend_desc(RendDesc *given_desc)
 {
-    //given_desc->set_pixel_format(PF_RGB);
+	//given_desc->set_pixel_format(PF_RGB);
 
-    // Make sure that the width and height
-    // are multiples of 8
-    given_desc->set_w((given_desc->get_w()+4)/8*8);
-    given_desc->set_h((given_desc->get_h()+4)/8*8);
+	// Make sure that the width and height
+	// are multiples of 8
+	given_desc->set_w((given_desc->get_w()+4)/8*8);
+	given_desc->set_h((given_desc->get_h()+4)/8*8);
 
-    /*
+	/*
 	// Valid framerates:
 	// 23.976, 24, 25, 29.97, 30, 50 ,59.94, 60
 	float fps=given_desc->get_frame_rate();
@@ -142,259 +136,239 @@ ffmpeg_trgt::set_rend_desc(RendDesc *given_desc)
 		given_desc->set_frame_rate(59.94);
 	*/
 
-    desc=*given_desc;
+	desc=*given_desc;
 
-    return true;
+	return true;
 }
 
 bool
 ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 {
-    bool with_sound = true;
-    const std::string extension = filename.extension().u8string();
-    const std::vector<const char*> image_only_extensions{".gif", ".mng"};
-    const bool does_file_format_support_audio = std::find(image_only_extensions.begin(), image_only_extensions.end(), extension) == image_only_extensions.end();
+	bool with_sound = true;
+	const std::string extension = filename.extension().u8string();
+	const std::vector<const char*> image_only_extensions{".gif", ".mng"};
+	const bool does_file_format_support_audio = std::find(image_only_extensions.begin(), image_only_extensions.end(), extension) == image_only_extensions.end();
 
-    if (!does_file_format_support_audio) {
-        with_sound = false;
-    } else if(!SoundProcessor::subsys_init()) {
-        if (cb) cb->error(_("Unable to initialize Sound subsystem"));
-        with_sound = false;
-    } else {
-        auto& fs = FileSystemNative::instance();
-        synfig::SoundProcessor soundProcessor;
-        soundProcessor.set_infinite(false);
-        get_canvas()->fill_sound_processor(soundProcessor);
-        // Generate random filename here
-        do {
-            synfig::GUID guid;
-            sound_filename = filename;
-            sound_filename.replace_extension("." + guid.get_string().substr(0,8) + ".wav");
-        } while (fs->is_exists(sound_filename.u8string()));
+	if (!does_file_format_support_audio) {
+		with_sound = false;
+	} else if(!SoundProcessor::subsys_init()) {
+		if (cb) cb->error(_("Unable to initialize Sound subsystem"));
+		with_sound = false;
+	} else {
+		auto& fs = FileSystemNative::instance();
+		synfig::SoundProcessor soundProcessor;
+		soundProcessor.set_infinite(false);
+		get_canvas()->fill_sound_processor(soundProcessor);
+		// Generate random filename here
+		do {
+			synfig::GUID guid;
+			sound_filename = filename;
+			sound_filename.replace_extension("." + guid.get_string().substr(0,8) + ".wav");
+		} while (fs->is_exists(sound_filename.u8string()));
 
-        soundProcessor.do_export(sound_filename.u8string());
+		soundProcessor.do_export(sound_filename.u8string());
 
-        if (!fs->is_exists(sound_filename.u8string())) {
-            with_sound = false;
-        }
-    }
+		if (!fs->is_exists(sound_filename.u8string())) {
+			with_sound = false;
+		}
+	}
 
-    synfig::filesystem::Path ffmpeg_binary_path;
+	synfig::filesystem::Path ffmpeg_binary_path;
 #ifdef _WIN32
-    // Windows always have ffmpeg
-    ffmpeg_binary_path = synfig::OS::get_binary_path().parent_path() / filesystem::Path("ffmpeg.exe");
-    if (!FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
-        synfig::warning("FFmpeg binary not found at expected path: %s, application will try to look at other paths", ffmpeg_binary_path.u8_str());
-        ffmpeg_binary_path.clear();
-    }
+	// Windows always have ffmpeg
+	ffmpeg_binary_path = synfig::OS::get_binary_path().parent_path() / filesystem::Path("ffmpeg.exe");
+	if (!FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
+        synfig::error("Expected FFmpeg binary not found at expected path: %s, application will try to look at other paths", ffmpeg_binary_path.u8_str());
+		ffmpeg_binary_path.clear();
+	}
 
-    if (ffmpeg_binary_path.empty()) {
-
-        DWORD size = GetEnvironmentVariableW(L"PATH", nullptr, 0);
-        if (size != 0) {
-
-            std::vector<wchar_t> pathBuffer(size);
-            GetEnvironmentVariableW(L"PATH", pathBuffer.data(), size); // filling pathBuffer with the value of "PATH" ENVIRONMENT variable
-
-            // Convert buffer to std::wstring
-            std::wstring pathVariable(pathBuffer.data());
-
-            std::wstringstream ws(pathVariable);
-            std::wstring dir;
-            constexpr wchar_t ENV_PATH_SEPARATOR = ';';
-            while (std::getline(ws, dir, ENV_PATH_SEPARATOR)) { //iterating over all the paths in ENVIRONMENT variable  "PATH"
-
-                // Convert UTF-16 (wchar_t) to UTF-8
-                int size_needed = WideCharToMultiByte(CP_UTF8, 0, dir.c_str(), -1, nullptr, 0, nullptr, nullptr);
-                if (size_needed == 0) {
-                    synfig::error("Failed to convert UTF-16 string  %s to UTF-8 string ",dir.c_str());
-                    continue;
-                }
-
-                std::vector<char> buffer(size_needed);
-                WideCharToMultiByte(CP_UTF8, 0, dir.c_str(), -1, buffer.data(), size_needed, nullptr, nullptr);
-
-
-                ffmpeg_binary_path = filesystem::Path::from_native(dir) / filesystem::Path("ffmpeg.exe");
-                synfig::info("searching for ffmpeg exe in -> %s",ffmpeg_binary_path.u8_str());
-
+    const char* path_env = std::getenv("PATH"); // fetching all the path from the ENVIRONMENT path variable
+    std::vector<std::string> paths;
+    if(ffmpeg_binary_path.empty()){
+        if (path_env) {
+            std::stringstream ss(path_env);
+            std::string dir;
+            char PATH_SEPARATOR = ';';
+            while (std::getline(ss, dir, PATH_SEPARATOR)) { // trying to seach ffmpeg in al
+                synfig::info("searching for ffmpeg exe in -> %s",dir.c_str());
+                ffmpeg_binary_path = filesystem::Path(dir) + filesystem::Path("\\ffmpeg.exe");
                 if (FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
                     synfig::info("Expected FFmpeg binary found: at %s", ffmpeg_binary_path.u8_str());
                     break;
-                } else {
+                }
+                else{
                     ffmpeg_binary_path.clear();
                 }
             }
         }
-
     }
 
 
 #else
-    // Some Linux OS may have `avconv` instead of `ffmpeg`, so let's check both
-    const std::vector<std::string> binary_choices = {"ffmpeg", "avconv"};
-    for (const auto& bin_name : binary_choices) {
-        OS::RunArgs args;
-        args.push_back(bin_name);
-        OS::RunPipe::Handle pipe = OS::run_async({"which"}, args, OS::RUN_MODE_READ);
-        if (!pipe) {
-            synfig::error(_("%s: Internal error: couldn't run 'which' async"), "trgt_ffmpeg");
-            continue;
-        }
-        std::string result = pipe->read_contents();
-        int status = pipe->close();
-        synfig::info("which %s -> [%i] %s", args.get_string().c_str(), status, result.c_str());
-        if (status == 0) {
-            ffmpeg_binary_path = bin_name; // we can use `result` value here, but in this case we need to remove trailing `\n`
-            break;
-        }
-    }
+	// Some Linux OS may have `avconv` instead of `ffmpeg`, so let's check both
+	const std::vector<std::string> binary_choices = {"ffmpeg", "avconv"};
+	for (const auto& bin_name : binary_choices) {
+		OS::RunArgs args;
+		args.push_back(bin_name);
+		OS::RunPipe::Handle pipe = OS::run_async({"which"}, args, OS::RUN_MODE_READ);
+		if (!pipe) {
+			synfig::error(_("%s: Internal error: couldn't run 'which' async"), "trgt_ffmpeg");
+			continue;
+		}
+		std::string result = pipe->read_contents();
+		int status = pipe->close();
+		synfig::info("which %s -> [%i] %s", args.get_string().c_str(), status, result.c_str());
+		if (status == 0) {
+			ffmpeg_binary_path = bin_name; // we can use `result` value here, but in this case we need to remove trailing `\n`
+			break;
+		}
+	}
 #endif
 
-    if (ffmpeg_binary_path.empty()) {
-        if (cb) cb->error(_("Error: No FFmpeg binary found.\n\nPlease install \"ffmpeg\" or \"avconv\" (libav-tools package)."));
-        return false;
-    }
+	if (ffmpeg_binary_path.empty()) {
+		if (cb) cb->error(_("Error: No FFmpeg binary found.\n\nPlease install \"ffmpeg\" or \"avconv\" (libav-tools package)."));
+		return false;
+	}
 
-    imagecount=desc.get_frame_start();
-    if(desc.get_frame_end()-desc.get_frame_start()>0)
-        multi_image=true;
+	imagecount=desc.get_frame_start();
+	if(desc.get_frame_end()-desc.get_frame_start()>0)
+		multi_image=true;
 
-    const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
+	const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
 
-    std::string video_codec_real = (video_codec == "libx264-lossless" ? "libx264" : video_codec);
+	std::string video_codec_real = (video_codec == "libx264-lossless" ? "libx264" : video_codec);
 
-    OS::RunArgs vargs;
-    if (with_sound) {
-        vargs.push_back("-i");
-        vargs.push_back(sound_filename);
-    }
-    vargs.push_back("-f");
-    vargs.push_back("image2pipe");
-    vargs.push_back("-vcodec");
-    vargs.push_back(use_alpha ? "pam" : "ppm");
-    vargs.push_back("-r");
-    {
-        // this should avoid conflicts with locale settings
-        synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-        vargs.push_back(strprintf("%f", desc.get_frame_rate()));
-    }
-    vargs.push_back("-i");
-    vargs.push_back("pipe:");
-    vargs.push_back("-metadata");
-    vargs.push_back(strprintf("title=\"%s\"", get_canvas()->get_name().c_str()));
-    vargs.push_back("-vcodec");
-    vargs.push_back(video_codec_real);
-    vargs.push_back("-b:v");
-    vargs.push_back(strprintf("%ik", bitrate));
-    if (video_codec == "libx264-lossless") {
-        vargs.push_back("-tune");
-        vargs.push_back("fastdecode");
-        vargs.push_back("-pix_fmt");
-        vargs.push_back(use_alpha ? "yuva420p" : "yuv420p");
-        vargs.push_back("-qp");
-        vargs.push_back("0");
-    } else if (use_alpha){
-        if (video_codec == "hap") {
-            vargs.push_back("-format");
-            vargs.push_back("hap_alpha");
-        }
-        vargs.push_back("-pix_fmt");
-        vargs.push_back("yuva420p");
-    }
-    if (with_sound) {
-        vargs.push_back("-acodec");
-        // MPEG-1 cannot work with 'le' audio, it requires 'be'
-        vargs.push_back(video_codec == "mpeg1video" ? "pcm_s16be" : "pcm_s16le");
-    }
-    vargs.push_back("-y");
-    vargs.push_back("-t");
-    {
-        // this should avoid conflicts with locale settings
-        synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
-        vargs.push_back(desc.get_duration().get_string(Time::Format::FORMAT_VIDEO));
-    }
-    // We need "--" to separate filename from arguments (for the case when filename starts with "-")
-    if ( filename.u8string().substr(0,1) == "-" )
-        vargs.push_back("--");
+	OS::RunArgs vargs;
+	if (with_sound) {
+		vargs.push_back("-i");
+		vargs.push_back(sound_filename);
+	}
+	vargs.push_back("-f");
+	vargs.push_back("image2pipe");
+	vargs.push_back("-vcodec");
+	vargs.push_back(use_alpha ? "pam" : "ppm");
+	vargs.push_back("-r");
+	{
+		// this should avoid conflicts with locale settings
+		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
+		vargs.push_back(strprintf("%f", desc.get_frame_rate()));
+	}
+	vargs.push_back("-i");
+	vargs.push_back("pipe:");
+	vargs.push_back("-metadata");
+	vargs.push_back(strprintf("title=\"%s\"", get_canvas()->get_name().c_str()));
+	vargs.push_back("-vcodec");
+	vargs.push_back(video_codec_real);
+	vargs.push_back("-b:v");
+	vargs.push_back(strprintf("%ik", bitrate));
+	if (video_codec == "libx264-lossless") {
+		vargs.push_back("-tune");
+		vargs.push_back("fastdecode");
+		vargs.push_back("-pix_fmt");
+		vargs.push_back(use_alpha ? "yuva420p" : "yuv420p");
+		vargs.push_back("-qp");
+		vargs.push_back("0");
+	} else if (use_alpha){
+		if (video_codec == "hap") {
+			vargs.push_back("-format");
+			vargs.push_back("hap_alpha");
+		}
+		vargs.push_back("-pix_fmt");
+		vargs.push_back("yuva420p");
+	}
+	if (with_sound) {
+		vargs.push_back("-acodec");
+		// MPEG-1 cannot work with 'le' audio, it requires 'be'
+		vargs.push_back(video_codec == "mpeg1video" ? "pcm_s16be" : "pcm_s16le");
+	}
+	vargs.push_back("-y");
+	vargs.push_back("-t");
+	{
+		// this should avoid conflicts with locale settings
+		synfig::ChangeLocale change_locale(LC_NUMERIC, "C");
+		vargs.push_back(desc.get_duration().get_string(Time::Format::FORMAT_VIDEO));
+	}
+	// We need "--" to separate filename from arguments (for the case when filename starts with "-")
+	if ( filename.u8string().substr(0,1) == "-" )
+		vargs.push_back("--");
 
-    vargs.push_back(filename);
+	vargs.push_back(filename);
 
-    pipe = OS::run_async(ffmpeg_binary_path, vargs, OS::RUN_MODE_WRITE);
+	pipe = OS::run_async(ffmpeg_binary_path, vargs, OS::RUN_MODE_WRITE);
 
-    if(!pipe || !pipe->is_writable())
-    {
-        synfig::error(_("Unable to open pipe to ffmpeg (no file)"));
-        if (pipe) {
-            pipe->close();
-            pipe = nullptr;
-        }
-        return false;
-    }
+	if(!pipe || !pipe->is_writable())
+	{
+		synfig::error(_("Unable to open pipe to ffmpeg (no file)"));
+		if (pipe) {
+			pipe->close();
+			pipe = nullptr;
+		}
+		return false;
+	}
 
-    synfig::info(_("Running async command: %s"), pipe->get_command().c_str());
+	synfig::info(_("Running async command: %s"), pipe->get_command().c_str());
 
-    return true;
+	return true;
 }
 
 void
 ffmpeg_trgt::end_frame()
 {
-    //pipe->print(" ");
-    pipe->flush();
-    imagecount++;
+	//pipe->print(" ");
+	pipe->flush();
+	imagecount++;
 }
 
 bool
 ffmpeg_trgt::start_frame(synfig::ProgressCallback */*callback*/)
 {
-    std::size_t w=desc.get_w(),h=desc.get_h();
+	std::size_t w=desc.get_w(),h=desc.get_h();
 
-    if(!pipe || !pipe->is_writable())
-        return false;
+	if(!pipe || !pipe->is_writable())
+		return false;
 
-    const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
+	const bool use_alpha = get_alpha_mode() == TARGET_ALPHA_MODE_KEEP;
 
-    if (!use_alpha) {
-        pipe->printf("P6\n");
-        pipe->printf("%zu %zu\n", w, h);
-        pipe->printf("%d\n", 255);
-    } else {
-        pipe->printf("P7\n");
-        pipe->printf("WIDTH %zu\n", w);
-        pipe->printf("HEIGHT %zu\n", h);
-        pipe->printf("DEPTH 4\n");
-        pipe->printf("MAXVAL %d\n", 255);
-        pipe->printf("TUPLTYPE RGB_ALPHA\n");
-        pipe->printf("ENDHDR\n");
-    }
+	if (!use_alpha) {
+		pipe->printf("P6\n");
+		pipe->printf("%zu %zu\n", w, h);
+		pipe->printf("%d\n", 255);
+	} else {
+		pipe->printf("P7\n");
+		pipe->printf("WIDTH %zu\n", w);
+		pipe->printf("HEIGHT %zu\n", h);
+		pipe->printf("DEPTH 4\n");
+		pipe->printf("MAXVAL %d\n", 255);
+		pipe->printf("TUPLTYPE RGB_ALPHA\n");
+		pipe->printf("ENDHDR\n");
+	}
 
-    buffer.resize(w * (use_alpha ? 4 : 3));
-    color_buffer.resize(w);
+	buffer.resize(w * (use_alpha ? 4 : 3));
+	color_buffer.resize(w);
 
-    return true;
+	return true;
 }
 
 Color *
 ffmpeg_trgt::start_scanline(int /*scanline*/)
 {
-    return color_buffer.empty() ? nullptr : color_buffer.data();
+	return color_buffer.empty() ? nullptr : color_buffer.data();
 }
 
 bool
 ffmpeg_trgt::end_scanline()
 {
-    if(!pipe)
-        return false;
+	if(!pipe)
+		return false;
 
-    PixelFormat format = PF_RGB;
-    if(get_alpha_mode() == TARGET_ALPHA_MODE_KEEP)
-        format |= PF_A;
+	PixelFormat format = PF_RGB;
+	if(get_alpha_mode() == TARGET_ALPHA_MODE_KEEP)
+		format |= PF_A;
 
-    color_to_pixelformat(buffer.data(), color_buffer.data(), format, 0, desc.get_w());
+	color_to_pixelformat(buffer.data(), color_buffer.data(), format, 0, desc.get_w());
 
-    if(!pipe->write(buffer.data(),1,buffer.size()))
-        return false;
+	if(!pipe->write(buffer.data(),1,buffer.size()))
+		return false;
 
-    return true;
+	return true;
 }

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -179,9 +179,9 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 		}
 	}
 
-	synfig::filesystem::Path ffmpeg_binary_path;
+    synfig::filesystem::Path ffmpeg_binary_path;
 #ifdef _WIN32
-	// Windows always have ffmpeg
+    // Windows always have ffmpeg
     ffmpeg_binary_path = synfig::OS::get_binary_path().parent_path() / filesystem::Path("ffmpeg.exe");
     if (!FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
         synfig::warning("FFmpeg binary not found at expected path: %s, application will try to look at other paths", ffmpeg_binary_path.u8_str());
@@ -202,7 +202,7 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
             std::wstringstream ws(pathVariable);
             std::wstring dir;
             constexpr wchar_t ENV_PATH_SEPARATOR = ';';
-            while (std::getline(ws, dir, ENV_PATH_SEPARATOR)) { //iterating over all the paths in ENVIRONMENT variable "PATH"
+            while (std::getline(ws, dir, ENV_PATH_SEPARATOR)) { //iterating over all the paths in ENVIRONMENT variable  "PATH"
 
                 // Convert UTF-16 (wchar_t) to UTF-8
                 int size_needed = WideCharToMultiByte(CP_UTF8, 0, dir.c_str(), -1, nullptr, 0, nullptr, nullptr);

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -178,9 +178,28 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 	// Windows always have ffmpeg
 	ffmpeg_binary_path = synfig::OS::get_binary_path().parent_path() / filesystem::Path("ffmpeg.exe");
 	if (!FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
-		synfig::error("Expected FFmpeg binary not found: %s", ffmpeg_binary_path.u8_str());
+        synfig::error("Expected FFmpeg binary not found at expected path: %s, application will try to look at other paths", ffmpeg_binary_path.u8_str());
 		ffmpeg_binary_path.clear();
 	}
+    const char* path_env = std::getenv("PATH");
+    std::vector<std::string> paths;
+    if(ffmpeg_binary_path.empty()){
+        if (path_env) {
+            std::stringstream ss(path_env);
+            std::string dir;
+            char PATH_SEPARATOR = ';';
+            while (std::getline(ss, dir, PATH_SEPARATOR)) {
+                std::cout<<"dir "<<dir<<std::endl;
+                ffmpeg_binary_path = filesystem::Path(dir) + filesystem::Path("\\ffmpeg.exe");
+                if (FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
+                    synfig::info("Expected FFmpeg binary found: at %s", ffmpeg_binary_path.u8_str());
+                    break;
+                }
+            }
+        }
+    }
+
+
 #else
 	// Some Linux OS may have `avconv` instead of `ffmpeg`, so let's check both
 	const std::vector<std::string> binary_choices = {"ffmpeg", "avconv"};

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -36,11 +36,17 @@
 
 #include "trgt_ffmpeg.h"
 
+
+
 #include <synfig/filesystemnative.h>
 #include <synfig/general.h>
 #include <synfig/localization.h>
 #include <synfig/soundprocessor.h>
 
+#endif
+
+#ifdef _WIN32
+    #include <windows.h>
 #endif
 
 /* === M A C R O S ========================================================= */
@@ -178,30 +184,49 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
 	// Windows always have ffmpeg
 	ffmpeg_binary_path = synfig::OS::get_binary_path().parent_path() / filesystem::Path("ffmpeg.exe");
 	if (!FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
-        synfig::error("Expected FFmpeg binary not found at expected path: %s, application will try to look at other paths", ffmpeg_binary_path.u8_str());
-		ffmpeg_binary_path.clear();
-	}
+        	synfig::warning("FFmpeg binary not found at expected path: %s, application will try to look at other paths", ffmpeg_binary_path.u8_str());
+        	ffmpeg_binary_path.clear();
+    	}
 
-    const char* path_env = std::getenv("PATH"); // fetching all the path from the ENVIRONMENT path variable
-    std::vector<std::string> paths;
-    if(ffmpeg_binary_path.empty()){
-        if (path_env) {
-            std::stringstream ss(path_env);
-            std::string dir;
-            char PATH_SEPARATOR = ';';
-            while (std::getline(ss, dir, PATH_SEPARATOR)) { // trying to seach ffmpeg in al
-                synfig::info("searching for ffmpeg exe in -> %s",dir.c_str());
-                ffmpeg_binary_path = filesystem::Path(dir) + filesystem::Path("\\ffmpeg.exe");
-                if (FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
-                    synfig::info("Expected FFmpeg binary found: at %s", ffmpeg_binary_path.u8_str());
-                    break;
-                }
-                else{
-                    ffmpeg_binary_path.clear();
-                }
-            }
-        }
-    }
+	if (ffmpeg_binary_path.empty()) {
+
+        	DWORD size = GetEnvironmentVariableW(L"PATH", nullptr, 0);
+        	if (size != 0) {
+
+            		std::vector<wchar_t> pathBuffer(size);
+            		GetEnvironmentVariableW(L"PATH", pathBuffer.data(), size); // filling pathBuffer with the value of "PATH" ENVIRONMENT variable
+
+            		// Convert buffer to std::wstring
+            		std::wstring pathVariable(pathBuffer.data());
+
+            		std::wstringstream ws(pathVariable);
+            		std::wstring dir;
+            		constexpr wchar_t ENV_PATH_SEPARATOR = ';';
+            		while (std::getline(ws, dir, ENV_PATH_SEPARATOR)) { //iterating over all the paths in ENVIRONMENT variable "PATH"
+
+		                int size_needed = WideCharToMultiByte(CP_UTF8, 0, dir.c_str(), -1, nullptr, 0, nullptr, nullptr);
+		                if (size_needed == 0) {
+		                	synfig::error("Failed to convert UTF-16 string  %s to UTF-8 string ",dir.c_str());
+		                	continue;
+		                }
+		                // Convert UTF-16 (wchar_t) to UTF-8
+		                std::vector<char> buffer(size_needed);
+		                WideCharToMultiByte(CP_UTF8, 0, dir.c_str(), -1, buffer.data(), size_needed, nullptr, nullptr);
+		
+		
+		                ffmpeg_binary_path = filesystem::Path::from_native(dir) / filesystem::Path("ffmpeg.exe");
+		                synfig::info("searching for ffmpeg exe in -> %s",ffmpeg_binary_path.u8_str());
+		
+		                if (FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
+		                	synfig::info("Expected FFmpeg binary found: at %s", ffmpeg_binary_path.u8_str());
+		                    	break;
+		                } else {
+		                    	ffmpeg_binary_path.clear();
+		                }
+            		}
+        	}
+
+    	}
 
 
 #else

--- a/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
+++ b/synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp
@@ -181,19 +181,23 @@ ffmpeg_trgt::init(ProgressCallback* cb = nullptr)
         synfig::error("Expected FFmpeg binary not found at expected path: %s, application will try to look at other paths", ffmpeg_binary_path.u8_str());
 		ffmpeg_binary_path.clear();
 	}
-    const char* path_env = std::getenv("PATH");
+
+    const char* path_env = std::getenv("PATH"); // fetching all the path from the ENVIRONMENT path variable
     std::vector<std::string> paths;
     if(ffmpeg_binary_path.empty()){
         if (path_env) {
             std::stringstream ss(path_env);
             std::string dir;
             char PATH_SEPARATOR = ';';
-            while (std::getline(ss, dir, PATH_SEPARATOR)) {
-                std::cout<<"dir "<<dir<<std::endl;
+            while (std::getline(ss, dir, PATH_SEPARATOR)) { // trying to seach ffmpeg in al
+                synfig::info("searching for ffmpeg exe in -> %s",dir.c_str());
                 ffmpeg_binary_path = filesystem::Path(dir) + filesystem::Path("\\ffmpeg.exe");
                 if (FileSystemNative::instance()->is_file(ffmpeg_binary_path.u8string())) {
                     synfig::info("Expected FFmpeg binary found: at %s", ffmpeg_binary_path.u8_str());
                     break;
+                }
+                else{
+                    ffmpeg_binary_path.clear();
                 }
             }
         }


### PR DESCRIPTION
If ffmpeg binary is not found on the expected path on Windows, it'll search for it in the paths set in PATH environment variable.

It allows to use the synfig binaries from AppVeyor CI without having to copy ffmpeg binaries if it is installed on the Windows machine.

fix https://github.com/synfig/synfig/issues/3509
