### PR TITLE
fix(ValueNode_Subtract): Add inversion logic to ValueNode_Subtract for LHS adjustment

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
@@ -234,3 +234,40 @@ ValueNode_Subtract::get_children_vocab_vfunc()const
 
 	return ret;
 }
+
+LinkableValueNode::InvertibleStatus
+ValueNode_Subtract::is_invertible(const Time& t, const ValueBase& target_value, int* link_index) const
+{
+	if (!t.is_valid())
+		return INVERSE_ERROR_BAD_TIME;
+	if (approximate_zero((*scalar)(t).get(Real()))) {
+		if (link_index)
+			*link_index = get_link_index_from_name("scalar");
+		return INVERSE_ERROR_BAD_PARAMETER;
+	}
+	const Type& type = target_value.get_type();
+	if (type != type_real && type != type_angle && type != type_vector)
+		return INVERSE_ERROR_BAD_TYPE;
+	if (link_index)
+		*link_index = get_link_index_from_name("lhs");
+	return INVERSE_OK;
+}
+
+ValueBase
+ValueNode_Subtract::get_inverse(const Time& t, const ValueBase& target_value) const
+{
+	Real scalar_value = (*scalar)(t).get(Real());
+
+	if (approximate_zero(scalar_value))
+		throw std::runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Scalar is zero")));
+
+	const Type& type = target_value.get_type();
+	if (type == type_real)
+		return target_value.get(Real()) / scalar_value + (*ref_b)(t).get(Real());
+	if (type == type_angle)
+		return target_value.get(Angle()) / scalar_value + (*ref_b)(t).get(Angle());
+	if (type == type_vector)
+		return target_value.get(Vector()) / scalar_value + (*ref_b)(t).get(Vector());
+	throw std::runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Invalid value type")));
+	
+}

--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.h
@@ -61,6 +61,12 @@ public:
 
 	virtual ValueBase operator()(Time t) const override;
 
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse()
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
+	//! Returns the modified Link to match the target value at time t
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const override;
+
 protected:
 	LinkableValueNode* create_new() const override;
 

--- a/synfig-studio/plugins/lottie-exporter/sources/image.py
+++ b/synfig-studio/plugins/lottie-exporter/sources/image.py
@@ -96,12 +96,13 @@ def add_image_asset(lottie, layer):
     head, tail = os.path.split(file_path)
     new_image_path = os.path.join(images_dir, tail)
 
-    # using shutil to make a copy of the image
-    shutil.copy(src, new_image_path)
-
-    # copy meta-data of the file
-    shutil.copystat(src, new_image_path)
-
+    try:
+        # using shutil to make a copy of the image
+        shutil.copy(src, new_image_path)
+        # copy meta-data of the file
+        shutil.copystat(src, new_image_path)
+    except shutil.SameFileError:
+        pass
     lottie["u"] = "images/"
     lottie["p"] = tail
     return st


### PR DESCRIPTION
This PR adds inversion logic to the ValueNode_Subtract class, enabling automatic adjustment of the LHS when the RHS has nested converters. This behavior matches the existing functionality in ValueNode_Add
Changes:
Added is_invertible and get_inverse methods to ValueNode_Subtract.
Fixes #3513 