### PR TITLE
Draft: feat: replacing toolbar from toolbox and dock history bar (#2188)

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -217,6 +217,8 @@ int	 App::Busy::count;
 bool App::shutdown_in_progress;
 
 Glib::RefPtr<studio::UIManager>	App::ui_manager_;
+Glib::RefPtr<Gtk::Builder> App::ui_builder_;
+Glib::RefPtr<Gio::SimpleActionGroup> App::history_action_group;
 
 int        App::jack_locks_ = 0;
 synfig::Distance::System  App::distance_system;
@@ -1573,6 +1575,7 @@ void App::init(const synfig::String& rootpath)
 
 		studio_init_cb.task(_("Init UI Manager..."));
 		App::ui_manager_=studio::UIManager::create();
+		ui_builder_ = Gtk::Builder::create();
 		init_ui_manager();
 
 		studio_init_cb.task(_("Init Dock Manager..."));
@@ -1853,6 +1856,8 @@ App::on_shutdown()
 	delete dock_manager;
 
 	instance_list.clear();
+
+	ui_builder_.reset();
 
 	if (sound_render_done) delete sound_render_done;
 	sound_render_done = nullptr;
@@ -4127,4 +4132,16 @@ studio::App::check_python_version(const std::string& path)
 	}
 	synfig::warning(err_msg, (std_out + '\n' + std_err).c_str());
 	return false;
+}
+
+Glib::RefPtr<Gio::SimpleActionGroup> 
+App::get_history_action_group() 
+{
+    return history_action_group;
+}
+
+void
+App::set_history_action_group(Glib::RefPtr<Gio::SimpleActionGroup> action_group) 
+{
+    history_action_group = action_group;
 }

--- a/synfig-studio/src/gui/app.h
+++ b/synfig-studio/src/gui/app.h
@@ -35,6 +35,8 @@
 
 #include <gtkmm/box.h>
 #include <gtkmm/uimanager.h>
+#include <gtkmm/builder.h>
+#include <giomm/simpleactiongroup.h>
 
 #include <gui/iconcontroller.h>
 #include <gui/mainwindow.h>
@@ -173,6 +175,8 @@ private:
 	static etl::handle<CanvasView> selected_canvas_view;
 
 	static Glib::RefPtr<UIManager>	ui_manager_;
+	static Glib::RefPtr<Gtk::Builder> ui_builder_;
+	static Glib::RefPtr<Gio::SimpleActionGroup> history_action_group;
 
 	static int jack_locks_;
 
@@ -331,6 +335,9 @@ public:
 	static StateManager* get_state_manager();
 
 	static Glib::RefPtr<UIManager>& ui_manager() { return ui_manager_; }
+	static Glib::RefPtr<Gtk::Builder> ui_builder() { return ui_builder_; }
+	static Glib::RefPtr<Gio::SimpleActionGroup> get_history_action_group();
+    static void set_history_action_group(Glib::RefPtr<Gio::SimpleActionGroup> action_group);
 
 	static void add_recent_file(const etl::handle<Instance> instance);
 

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1011,10 +1011,41 @@ CanvasView::create_work_area()
 Gtk::ToolButton*
 CanvasView::create_action_toolbutton(const Glib::RefPtr<Gtk::Action> &action)
 {
-	Gtk::ToolButton *button = Gtk::manage(new Gtk::ToolButton());
-	button->set_related_action(action);
-	button->show();
-	return button;
+    Gtk::ToolButton *button = Gtk::manage(new Gtk::ToolButton());
+    button->set_related_action(action);
+    button->show();
+    return button;
+}
+Gtk::ToolButton*
+CanvasView::create_action_toolbutton(
+    const Glib::RefPtr<Gio::Action>& action, const Glib::ustring& icon_name)
+{
+    Gtk::ToolButton* button = Gtk::manage(new Gtk::ToolButton());
+    button->signal_clicked().connect([action]() {
+        if (action && action->get_enabled()) {
+            action->activate();
+        }
+    });
+
+    // Set icon
+    if (!icon_name.empty()) {
+        button->set_icon_name(icon_name);  
+        auto image = Gtk::manage(new Gtk::Image(icon_name, Gtk::ICON_SIZE_SMALL_TOOLBAR));
+        image->set_pixel_size(16);
+        button->set_icon_widget(*image); 
+    }
+
+    if (action) {
+        button->set_sensitive(action->get_enabled());
+        action->property_enabled().signal_changed().connect( 
+            [button, action]() {
+                button->set_sensitive(action->get_enabled());
+            }
+        );
+    }
+
+    button->show();
+    return button;
 }
 
 Gtk::SeparatorToolItem*
@@ -1033,31 +1064,36 @@ void CanvasView::toggle_render_combobox()
 	App::setup_changed();
 }
 
-Gtk::Widget*
+Gtk::Widget* 
 CanvasView::create_top_toolbar()
 {
-	top_toolbar = manage(new Gtk::Toolbar());
-	top_toolbar->set_icon_size(Gtk::IconSize::from_name("synfig-small_icon_16x16"));
-	top_toolbar->set_toolbar_style(Gtk::TOOLBAR_BOTH_HORIZ);
-
+	top_toolbar = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL,0));
 	// File buttons
 	if (App::show_file_toolbar) {
-		top_toolbar->append(*create_action_toolbutton(App::ui_manager()->get_action("/toolbar-main/new")));
-		top_toolbar->append(*create_action_toolbutton(App::ui_manager()->get_action("/toolbar-main/open")));
-		top_toolbar->append(*create_action_toolbutton(action_group->get_action("save")));
-		top_toolbar->append(*create_action_toolbutton(action_group->get_action("save-as")));
-		top_toolbar->append(*create_action_toolbutton(App::ui_manager()->get_action("/toolbar-main/save-all")));
+		top_toolbar->pack_start(*create_action_toolbutton(App::ui_manager()->get_action("/toolbar-main/new")), Gtk::PACK_SHRINK);
+		top_toolbar->pack_start(*create_action_toolbutton(App::ui_manager()->get_action("/toolbar-main/open")), Gtk::PACK_SHRINK);
+		top_toolbar->pack_start(*create_action_toolbutton(action_group->get_action("save")), Gtk::PACK_SHRINK);
+		top_toolbar->pack_start(*create_action_toolbutton(action_group->get_action("save-as")), Gtk::PACK_SHRINK);
+		top_toolbar->pack_start(*create_action_toolbutton(App::ui_manager()->get_action("/toolbar-main/save-all")), Gtk::PACK_SHRINK);
 
 		// Separator
-		top_toolbar->append( *create_tool_separator() );
+		top_toolbar->pack_start( *create_tool_separator() , Gtk::PACK_SHRINK);
 	}
 
-	// Undo/Redo buttons
-	top_toolbar->append(*create_action_toolbutton(App::ui_manager()->get_action("/toolbar-main/undo")));
-	top_toolbar->append(*create_action_toolbutton(App::ui_manager()->get_action("/toolbar-main/redo")));
+	// Retrieve the action group
+	auto action_group = Glib::RefPtr<Gio::SimpleActionGroup>::cast_dynamic(
+		App::get_history_action_group());
+	top_toolbar->pack_start(*create_action_toolbutton(action_group->lookup_action("undo"), "action_doc_undo_icon"), Gtk::PACK_SHRINK);
+	top_toolbar->pack_start(*create_action_toolbutton(action_group->lookup_action("redo"), "action_doc_redo_icon"), Gtk::PACK_SHRINK);
+		
+
+
+
+
+	
 
 	// Separator
-	top_toolbar->append(*create_tool_separator());
+	top_toolbar->pack_start(*create_tool_separator(), Gtk::PACK_SHRINK);
 
 	{ // Preview Settings dialog button
 		preview_options_button = Gtk::manage(new Gtk::ToolButton());
@@ -1068,7 +1104,7 @@ CanvasView::create_top_toolbar()
 		preview_options_button->set_tooltip_text(_("Shows the Preview Settings Dialog"));
 		preview_options_button->show();
 
-		top_toolbar->append(*preview_options_button);
+		top_toolbar->pack_start(*preview_options_button, Gtk::PACK_SHRINK);
 	}
 
 	{ // Render Settings dialog button
@@ -1080,11 +1116,11 @@ CanvasView::create_top_toolbar()
 		render_options_button->set_tooltip_text(_("Shows the Render Settings Dialog"));
 		render_options_button->show();
 
-		top_toolbar->append(*render_options_button);
+		top_toolbar->pack_start(*render_options_button, Gtk::PACK_SHRINK);
 	}
 
 	// Separator
-	top_toolbar->append(*create_tool_separator());
+	top_toolbar->pack_start(*create_tool_separator(), Gtk::PACK_SHRINK);
 
 	{ // Refresh button
 		refreshbutton = Gtk::manage(new Gtk::ToolButton());
@@ -1094,7 +1130,7 @@ CanvasView::create_top_toolbar()
 		refreshbutton->set_tooltip_text( _("Refresh workarea"));
 		refreshbutton->show();
 
-		top_toolbar->append(*refreshbutton);
+		top_toolbar->pack_start(*refreshbutton, Gtk::PACK_SHRINK);
 	}
 
 	{ // Rendering mode ComboBox
@@ -1112,7 +1148,7 @@ CanvasView::create_top_toolbar()
 		container->add(*render_combobox);
 
 		container->show();
-		top_toolbar->add(*container);
+		top_toolbar->pack_start(*container, Gtk::PACK_SHRINK);
 	}
 
 	{ // Background rendering button
@@ -1125,11 +1161,11 @@ CanvasView::create_top_toolbar()
 		background_rendering_button->set_tooltip_text(_("Render future and past frames in background when enabled"));
 		background_rendering_button->show();
 
-		top_toolbar->append(*background_rendering_button);
+		top_toolbar->pack_start(*background_rendering_button, Gtk::PACK_SHRINK);
 	}
 
 	// Separator
-	top_toolbar->append(*create_tool_separator());
+	top_toolbar->pack_start(*create_tool_separator(), Gtk::PACK_SHRINK);
 
 	// ResolutionDial widget
 	resolutiondial_->update_lowres(work_area->get_low_resolution_flag());
@@ -1142,7 +1178,7 @@ CanvasView::create_top_toolbar()
 	resolutiondial_->insert_to_toolbar(*top_toolbar);
 
 	// Separator
-	top_toolbar->append(*create_tool_separator());
+	top_toolbar->pack_start(*create_tool_separator(), Gtk::PACK_SHRINK);
 
 	{ // Onion skin toggle button
 		onion_skin = Gtk::manage(new Gtk::ToggleToolButton());
@@ -1154,7 +1190,7 @@ CanvasView::create_top_toolbar()
 		onion_skin->set_tooltip_text(_("Show Onion Skin when enabled"));
 		onion_skin->show();
 
-		top_toolbar->append(*onion_skin);
+		top_toolbar->pack_start(*onion_skin, Gtk::PACK_SHRINK);
 	}
 
 	{ // Past onion skin spin button
@@ -1170,7 +1206,7 @@ CanvasView::create_top_toolbar()
 		toolitem->set_is_important(true);
 		toolitem->show();
 
-		top_toolbar->append(*toolitem);
+		top_toolbar->pack_start(*toolitem, Gtk::PACK_SHRINK);
 	}
 
 	{ // Future onion skin spin button
@@ -1186,7 +1222,7 @@ CanvasView::create_top_toolbar()
 		toolitem->set_is_important(true);
 		toolitem->show();
 
-		top_toolbar->append(*toolitem);
+		top_toolbar->pack_start(*toolitem, Gtk::PACK_SHRINK);
 	}
 
 	{ // Onion skin on Keyframes/Frames toggle button
@@ -1199,8 +1235,23 @@ CanvasView::create_top_toolbar()
 		onion_skin_keyframes->set_tooltip_text(_("Show Onion Skin on Keyframes when enabled, on Frames when disabled"));
 		onion_skin_keyframes->show();
 
-		top_toolbar->append(*onion_skin_keyframes);
+		top_toolbar->pack_start(*onion_skin_keyframes , Gtk::PACK_SHRINK);
 	}
+
+	for (auto child : top_toolbar->get_children()) {
+		if (auto tool_button = dynamic_cast<Gtk::ToolButton*>(child)) {	
+			if (!tool_button->get_icon_name().empty()) {
+				auto image = Gtk::make_managed<Gtk::Image>(tool_button->get_icon_name(), Gtk::ICON_SIZE_MENU);
+				image->set_pixel_size(16);
+				tool_button->set_icon_widget(*image);
+				tool_button->show_all();
+			}
+		}
+	}
+	
+	//padding can be done by css
+	top_toolbar->set_margin_top(5);
+	top_toolbar->set_margin_bottom(5);
 
 	if(App::enable_mainwin_toolbar)
 		top_toolbar->show();
@@ -1228,10 +1279,7 @@ CanvasView::create_stop_button()
 Gtk::Widget*
 CanvasView::create_right_toolbar()
 {
-	right_toolbar = manage(new Gtk::Toolbar());
-	right_toolbar->set_icon_size(Gtk::IconSize::from_name("synfig-small_icon_16x16"));
-	right_toolbar->set_toolbar_style(Gtk::TOOLBAR_ICONS);
-	right_toolbar->set_property("orientation", Gtk::ORIENTATION_VERTICAL);
+	right_toolbar = manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL,0));
 
 	{ // Show grid toggle button
 		show_grid = Gtk::manage(new Gtk::ToggleToolButton());
@@ -1243,7 +1291,7 @@ CanvasView::create_right_toolbar()
 		show_grid->set_tooltip_text(_("Show Grid when enabled"));
 		show_grid->show();
 
-		right_toolbar->append(*show_grid);
+		right_toolbar->pack_start(*show_grid, Gtk::PACK_SHRINK);
 	}
 
 	{ // Snap to grid toggle button
@@ -1256,7 +1304,7 @@ CanvasView::create_right_toolbar()
 		snap_grid->set_tooltip_text(_("Snap to Grid when enabled"));
 		snap_grid->show();
 
-		right_toolbar->append(*snap_grid);
+		right_toolbar->pack_start(*snap_grid, Gtk::PACK_SHRINK);
 	}
 
 	{ // Show guide toggle button
@@ -1269,7 +1317,7 @@ CanvasView::create_right_toolbar()
 		show_guides->set_tooltip_text(_("Show Guides when enabled"));
 		show_guides->show();
 
-		right_toolbar->append(*show_guides);
+		right_toolbar->pack_start(*show_guides, Gtk::PACK_SHRINK);
 	}
 
 	{ // Snap to guides toggle button
@@ -1282,11 +1330,11 @@ CanvasView::create_right_toolbar()
 		snap_guides->set_tooltip_text(_("Snap to Guides when enabled"));
 		snap_guides->show();
 
-		right_toolbar->append(*snap_guides);
+		right_toolbar->pack_start(*snap_guides, Gtk::PACK_SHRINK);
 	}
 
 	// Separator
-	right_toolbar->append(*create_tool_separator());
+	right_toolbar->pack_start(*create_tool_separator(), Gtk::PACK_SHRINK);
 
 	// ToggleDuckDial widget
 	Duck::Type m = work_area->get_type_mask();
@@ -1304,6 +1352,18 @@ CanvasView::create_right_toolbar()
 	toggleducksdial.signal_ducks_angle().connect(
 		sigc::bind(sigc::mem_fun(*this, &CanvasView::toggle_duck_mask),Duck::TYPE_ANGLE));
 	toggleducksdial.insert_to_toolbar(*right_toolbar);
+	//setting icon size 16*16
+	for (auto child : right_toolbar->get_children()) {
+		if (auto tool_button = dynamic_cast<Gtk::ToolButton*>(child)) {			
+			auto image = Gtk::make_managed<Gtk::Image>(tool_button->get_icon_name(), Gtk::ICON_SIZE_MENU);
+			image->set_pixel_size(16);
+			tool_button->set_icon_widget(*image);
+			tool_button->show_all(); 
+		}
+	}
+	//padding can be done by css
+	right_toolbar->set_margin_start(5);
+	right_toolbar->set_margin_end(5);
 
 	right_toolbar->show();
 

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -54,9 +54,10 @@
 #include <gtkmm/statusbar.h>
 #include <gtkmm/toggleaction.h>
 #include <gtkmm/toggletoolbutton.h>
-#include <gtkmm/toolbar.h>
 #include <gtkmm/toolbutton.h>
 #include <gtkmm/uimanager.h>
+#include <gtkmm/box.h>
+#include <giomm/simpleactiongroup.h>
 
 #include <synfig/canvas.h>
 #include <synfig/clock.h>
@@ -282,8 +283,8 @@ private:
 	Gtk::ToolButton *refreshbutton;
 	Gtk::ComboBoxText *render_combobox;
 	Gtk::Grid *timebar;
-	Gtk::Toolbar *top_toolbar;
-	Gtk::Toolbar *right_toolbar;
+	Gtk::Box *top_toolbar;
+	Gtk::Box *right_toolbar;
 	Widget_Enum *widget_interpolation;
 	Gtk::ToggleButton *animatebutton;
 	Gtk::ToggleButton *timetrackbutton;
@@ -440,6 +441,7 @@ private:
 	Gtk::Widget *create_time_bar();
 
 	Gtk::ToolButton* create_action_toolbutton(const Glib::RefPtr<Gtk::Action> &action);
+	Gtk::ToolButton* create_action_toolbutton(const Glib::RefPtr<Gio::Action>& action, const Glib::ustring &icon_name);
 	Gtk::SeparatorToolItem* create_tool_separator();
 	Gtk::Widget* create_top_toolbar();
 	Gtk::Widget* create_stop_button();

--- a/synfig-studio/src/gui/dials/resolutiondial.cpp
+++ b/synfig-studio/src/gui/dials/resolutiondial.cpp
@@ -81,18 +81,23 @@ ResolutionDial::ResolutionDial()
 }
 
 void
-ResolutionDial::insert_to_toolbar(Gtk::Toolbar &toolbar, int index)
+ResolutionDial::insert_to_toolbar(Gtk::Box &toolbar, int index)
 {
-	if (index < 0) index = toolbar.get_n_items();
+	if (index < 0) index = toolbar.get_children().size();
+	
+    // Add widgets to the toolbar
+    toolbar.pack_start(increase_resolution, Gtk::PACK_SHRINK);
+    toolbar.pack_start(use_low_resolution, Gtk::PACK_SHRINK);
+    toolbar.pack_start(decrease_resolution, Gtk::PACK_SHRINK);
 
-	// reverse order
-	toolbar.insert(increase_resolution, index);
-	toolbar.insert(use_low_resolution,  index);
-	toolbar.insert(decrease_resolution, index);
+    // Reorder widgets to the specified index
+    toolbar.reorder_child(increase_resolution, index);
+    toolbar.reorder_child(use_low_resolution,  index + 1);
+    toolbar.reorder_child(decrease_resolution, index + 2);
 }
 
 void
-ResolutionDial::remove_from_toolbar(Gtk::Toolbar &toolbar)
+ResolutionDial::remove_from_toolbar(Gtk::Box &toolbar)
 {
 	toolbar.remove(decrease_resolution);
 	toolbar.remove(use_low_resolution);

--- a/synfig-studio/src/gui/dials/resolutiondial.h
+++ b/synfig-studio/src/gui/dials/resolutiondial.h
@@ -33,7 +33,7 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <gtkmm/toolbar.h>
+#include <gtkmm/box.h>
 #include <gtkmm/toolbutton.h>
 #include <gtkmm/toggletoolbutton.h>
 
@@ -55,8 +55,8 @@ class ResolutionDial
 public:
 	ResolutionDial();
 
-	void insert_to_toolbar(Gtk::Toolbar &toolbar, int index = -1);
-	void remove_from_toolbar(Gtk::Toolbar &toolbar);
+	void insert_to_toolbar(Gtk::Box &toolbar, int index = -1);
+	void remove_from_toolbar(Gtk::Box &toolbar);
 
 	void update_lowres(bool flag);
 	Glib::SignalProxy0<void> signal_increase_resolution()  { return increase_resolution.signal_clicked(); }

--- a/synfig-studio/src/gui/dials/toggleducksdial.cpp
+++ b/synfig-studio/src/gui/dials/toggleducksdial.cpp
@@ -70,21 +70,38 @@ ToggleDucksDial::ToggleDucksDial(const Gtk::IconSize &size)
 }
 
 void
-ToggleDucksDial::insert_to_toolbar(Gtk::Toolbar &toolbar, int index)
+ToggleDucksDial::insert_to_toolbar(Gtk::Box &toolbar, int index)
 {
-	if (index < 0) index = toolbar.get_n_items();
+    auto children = toolbar.get_children();
+    int num_children = children.size();
 
-	// reverse order
-	toolbar.insert(ducks_angle,    index);
-	toolbar.insert(ducks_width,    index);
-	toolbar.insert(ducks_radius,   index);
-	toolbar.insert(ducks_tangent,  index);
-	toolbar.insert(ducks_vertex,   index);
-	toolbar.insert(ducks_position, index);
+    // If index is negative or exceeds the number of children, append at the end
+    if (index < 0 || index > num_children) {
+        index = num_children;
+    }
+
+    // Insert widgets in reverse order after the determined sibling
+    toolbar.pack_start(ducks_position, Gtk::PACK_SHRINK);
+    toolbar.reorder_child(ducks_position, index);
+
+    toolbar.pack_start(ducks_vertex, Gtk::PACK_SHRINK);
+    toolbar.reorder_child(ducks_vertex, index + 1);
+
+    toolbar.pack_start(ducks_tangent, Gtk::PACK_SHRINK);
+    toolbar.reorder_child(ducks_tangent,  index + 2);
+
+    toolbar.pack_start(ducks_radius, Gtk::PACK_SHRINK);
+    toolbar.reorder_child(ducks_radius, index + 3);
+
+    toolbar.pack_start(ducks_width, Gtk::PACK_SHRINK);
+    toolbar.reorder_child(ducks_width, index + 4);
+
+    toolbar.pack_start(ducks_angle, Gtk::PACK_SHRINK);
+    toolbar.reorder_child(ducks_angle, index + 5);
 }
 
 void
-ToggleDucksDial::remove_from_toolbar(Gtk::Toolbar &toolbar)
+ToggleDucksDial::remove_from_toolbar(Gtk::Box &toolbar)
 {
 	toolbar.remove(ducks_position);
 	toolbar.remove(ducks_vertex);

--- a/synfig-studio/src/gui/dials/toggleducksdial.h
+++ b/synfig-studio/src/gui/dials/toggleducksdial.h
@@ -33,7 +33,7 @@
 
 /* === H E A D E R S ======================================================= */
 
-#include <gtkmm/toolbar.h>
+#include <gtkmm/box.h>
 #include <gtkmm/toggletoolbutton.h>
 
 #include <gui/duckmatic.h>
@@ -62,8 +62,8 @@ public:
 	ToggleDucksDial(const Gtk::IconSize &size);
 	void update_toggles(Duck::Type mask);
 
-	void insert_to_toolbar(Gtk::Toolbar &toolbar, int index = -1);
-	void remove_from_toolbar(Gtk::Toolbar &toolbar);
+	void insert_to_toolbar(Gtk::Box &toolbar, int index = -1);
+	void remove_from_toolbar(Gtk::Box &toolbar);
 
 	Glib::SignalProxy0<void> signal_ducks_position()  { return ducks_position.signal_toggled(); }
 	Glib::SignalProxy0<void> signal_ducks_vertex()    { return ducks_vertex.  signal_toggled(); }

--- a/synfig-studio/src/gui/docks/dock_history.cpp
+++ b/synfig-studio/src/gui/docks/dock_history.cpp
@@ -64,88 +64,136 @@ using namespace studio;
 /* === M E T H O D S ======================================================= */
 
 Dock_History::Dock_History():
-	Dock_CanvasSpecific("history",_("History"),"history_icon"),
-	action_group(Gtk::ActionGroup::create("action_group_dock_history"))
+ 	Dock_CanvasSpecific("history",_("History"),"history_icon"),
+    action_group(Gio::SimpleActionGroup::create())
 {
-	// Make History toolbar small for space efficiency
-	get_style_context()->add_class("synfigstudio-efficient-workspace");
+    // Make History toolbar small for space efficiency
+    get_style_context()->add_class("synfigstudio-efficient-workspace");
 
 	App::signal_instance_deleted().connect(sigc::mem_fun(*this,&studio::Dock_History::delete_instance));
 	App::signal_instance_selected().connect(sigc::mem_fun(*this,&studio::Dock_History::set_selected_instance_signal));
 
-	action_group->add(Gtk::Action::create_with_icon_name(
-		"clear-undo",
-		"clear_undo_icon",
-		_("Clear Undo Stack"),
-		_("Clear the undo stack")
-	),
-		sigc::mem_fun(
-			*this,
-			&Dock_History::clear_undo
-		)
+	action_group->add_action("undo", 
+			[]() { studio::App::undo(); } 
 	);
-	action_group->add(Gtk::Action::create_with_icon_name(
-		"clear-redo",
-		"clear_redo_icon",
-		_("Clear Redo Stack"),
-		_("Clear the redo stack")
-	),
-		sigc::mem_fun(
-			*this,
-			&Dock_History::clear_redo
-		)
+	action_group->add_action("redo", 
+			[]() { studio::App::redo(); }
 	);
-	action_group->add(Gtk::Action::create_with_icon_name(
-		"clear-undo-and-redo",
-		"edit-clear",
-		_("Clear Undo and Redo Stacks"),
-		_("Clear the undo and redo stacks")
-	),
-		sigc::mem_fun(
-			*this,
-			&Dock_History::clear_undo_and_redo
-		)
+	action_group->add_action("clear-undo", 
+			sigc::mem_fun(*this, &Dock_History::clear_undo)
 	);
-	action_group->add(Gtk::Action::create_with_icon_name(
-		"undo",
-		"action_doc_undo_icon",
-		_("Undo"),
-		_("Undo the previous action")
-	),
-		sigc::ptr_fun(studio::App::undo)
+	action_group->add_action("clear-redo", 
+			sigc::mem_fun(*this, &Dock_History::clear_redo)
 	);
-	action_group->add(Gtk::Action::create_with_icon_name(
-		"redo",
-		"action_doc_redo_icon",
-		_("Redo"),
-		_("Redo the previously undone action")
-	),
-		sigc::ptr_fun(studio::App::redo)
+	action_group->add_action("clear-undo-and-redo", 
+			sigc::mem_fun(*this, &Dock_History::clear_undo_and_redo)
 	);
+	const char* ui_xml = R"(
+	<?xml version="1.0" encoding="UTF-8"?>
+	<interface>
+	<object class="GtkBox" id="toolbar-history">
+		<property name="orientation">horizontal</property>
+		<property name="spacing">4</property>
+		<property name="visible">true</property>
 
-	action_group->add( Gtk::Action::create("toolbar-history", _("History")) );
-	App::ui_manager()->insert_action_group(action_group);
+		<!-- Undo Button -->
+		<child>
+		<object class="GtkToolButton" id="undo-toolbutton">
+			<property name="visible">true</property>
+			<property name="action-name">action_group_dock_history.undo</property>
+			<property name="tooltip-text" translatable="yes">Undo the previous action</property>
+			<property name="icon-name">action_doc_undo_icon</property>
+		</object>
+		<packing>
+			<property name="expand">false</property>
+		</packing>
+		</child>
 
-	Glib::ustring ui_info =
-	"<ui>"
-	"	<toolbar action='toolbar-history'>"
-	"	<toolitem action='undo' />"
-	"	<toolitem action='redo' />"
-	"	<toolitem action='clear-undo' />"
-	"	<toolitem action='clear-redo' />"
-	"	<toolitem action='clear-undo-and-redo' />"
-	"	</toolbar>"
-	"</ui>"
+		<!-- Redo Button -->
+		<child>
+		<object class="GtkToolButton" id="redo-toolbutton">
+			<property name="visible">true</property>
+			<property name="action-name">action_group_dock_history.redo</property>
+			<property name="tooltip-text" translatable="yes">Redo the previously undone action</property>
+			<property name="icon-name">action_doc_redo_icon</property>
+		</object>
+		<packing>
+			<property name="expand">false</property>
+		</packing>
+		</child>
+
+		<!-- Clear Undo Stack Button -->
+		<child>
+		<object class="GtkToolButton" id="clear-undo-toolbutton">
+			<property name="visible">true</property>
+			<property name="action-name">action_group_dock_history.clear-undo</property>
+			<property name="tooltip-text" translatable="yes">Clear the undo stack</property>
+			<property name="icon-name">clear_undo_icon</property>
+		</object>
+		<packing>
+			<property name="expand">false</property>
+		</packing>
+
+		</child>
+		<!-- Clear Redo Stack Button -->
+		<child>
+		<object class="GtkToolButton" id="clear-redo-toolbutton">
+			<property name="visible">true</property>
+			<property name="action-name">action_group_dock_history.clear-redo</property>
+			<property name="tooltip-text" translatable="yes">Clear the redo stack</property>
+			<property name="icon-name">clear_redo_icon</property>
+		</object>
+		<packing>
+			<property name="expand">false</property>
+		</packing>
+		</child>
+
+		<!-- Clear Undo and Redo Stacks Button -->
+		<child>
+		<object class="GtkToolButton" id="clear-undo-redo-toolbutton">
+			<property name="visible">true</property>
+			<property name="action-name">action_group_dock_history.clear-undo-and-redo</property>
+			<property name="tooltip-text" translatable="yes">Clear the undo and redo stacks</property>
+			<property name="icon-name">edit-clear</property>
+		</object>
+		<packing>
+			<property name="expand">false</property>
+		</packing>
+		</child>
+
+	</object>
+	</interface>
+		)"
 	;
-
-	App::ui_manager()->add_ui_from_string(ui_info);
-
-	action_group->set_sensitive(false);
-
-	if (Gtk::Toolbar* toolbar = dynamic_cast<Gtk::Toolbar*>(App::ui_manager()->get_widget("/toolbar-history"))) {
-		set_toolbar(*toolbar);
+	
+	App::ui_builder()->add_from_string(ui_xml);
+	Gtk::Box* toolbar_box = nullptr;
+	App::ui_builder()->get_widget("toolbar-history", toolbar_box);
+	if (toolbar_box) {
+		toolbar_box->get_style_context()->add_class("synfigstudio-efficient-workspace");
+		toolbar_box->insert_action_group("action_group_dock_history", action_group);
+		set_toolbar(*toolbar_box);
+		App::set_history_action_group(action_group);
+		// try to set size 16*16
+		for (auto child : toolbar_box->get_children()) {
+			if (auto tool_button = dynamic_cast<Gtk::ToolButton*>(child)) {			
+				auto image = Gtk::make_managed<Gtk::Image>(tool_button->get_icon_name(), Gtk::ICON_SIZE_MENU);
+				image->set_pixel_size(16);
+				tool_button->set_icon_widget(*image);
+				tool_button->show_all(); 
+			}
+		}
 	}
-	add(*create_action_tree());
+	// Set initial sensitivity
+	const std::vector<Glib::ustring> actions = {
+		"undo", "redo", "clear-undo", "clear-redo", "clear-undo-and-redo"
+	};
+	
+	for(const auto& action : actions) {
+		action_group->action_enabled_changed(
+			"action_group_dock_history." + action, false);
+	}
+    add(*create_action_tree());
 }
 
 Dock_History::~Dock_History()
@@ -299,15 +347,39 @@ Dock_History::clear_undo_and_redo()
 void
 Dock_History::update_undo_redo()
 {
-	etl::handle<Instance> instance=App::get_selected_instance();
-	if(instance)
-	{
-		action_group->get_action("undo")->set_sensitive(instance->get_undo_status());
-		action_group->get_action("clear-undo")->set_sensitive(instance->get_undo_status());
-		action_group->get_action("redo")->set_sensitive(instance->get_redo_status());
-		action_group->get_action("clear-redo")->set_sensitive(instance->get_redo_status());
-		action_group->get_action("clear-undo-and-redo")->set_sensitive(instance->get_undo_status() || instance->get_redo_status());
-	}
+    etl::handle<Instance> instance = App::get_selected_instance();
+    const bool has_instance = static_cast<bool>(instance);
+
+    // Helper function to safely set action states
+    auto set_action_state = [&](const char* action_name, bool state) {
+        if (auto action = action_group->lookup_action(action_name)) {
+            if (auto simple_action = Glib::RefPtr<Gio::SimpleAction>::cast_dynamic(action)) {
+                simple_action->set_enabled(has_instance && state);
+            }
+        }
+    };
+
+    if (instance) {
+        set_action_state("undo", instance->get_undo_status());
+        set_action_state("redo", instance->get_redo_status());
+        set_action_state("clear-undo", instance->get_undo_status());
+        set_action_state("clear-redo", instance->get_redo_status());
+        set_action_state("clear-undo-and-redo", 
+            instance->get_undo_status() || instance->get_redo_status());
+    } else {
+        // Explicitly disable all actions when no instance exists
+        const char* actions[] = {
+            "undo", "redo", "clear-undo", "clear-redo", "clear-undo-and-redo"
+        };
+        
+        for (const auto& action : actions) {
+            if (auto act = action_group->lookup_action(action)) {
+                if (auto simple_act = Glib::RefPtr<Gio::SimpleAction>::cast_dynamic(act)) {
+                    simple_act->set_enabled(false);
+                }
+            }
+        }
+    }
 }
 
 void
@@ -341,29 +413,40 @@ Dock_History::on_undo_tree_changed()
 void
 Dock_History::set_selected_instance_(etl::handle<studio::Instance> instance)
 {
-	if(studio::App::shutdown_in_progress)
-		return;
+    if(studio::App::shutdown_in_progress)
+        return;
 
-	if (on_undo_tree_changed_connection)
-		on_undo_tree_changed_connection.disconnect();
+    if (on_undo_tree_changed_connection)
+        on_undo_tree_changed_connection.disconnect();
 
-	selected_instance=instance;
-	if(instance)
-	{
-		on_undo_tree_changed_connection = selected_instance->history_tree_store()->signal_undo_tree_changed().connect(
-			sigc::mem_fun(*this,&Dock_History::on_undo_tree_changed));
+    selected_instance=instance;
+    if(instance)
+    {
+        on_undo_tree_changed_connection = selected_instance->history_tree_store()->signal_undo_tree_changed().connect(
+            sigc::mem_fun(*this,&Dock_History::on_undo_tree_changed));
 
-		action_tree->set_model(instance->history_tree_store());
-		action_tree->show();
-		update_undo_redo();
-		action_group->set_sensitive(true);
-	}
-	else
-	{
-		action_tree->set_model(Glib::RefPtr< Gtk::TreeModel >());
-		action_tree->hide();
-		action_group->set_sensitive(false);
-	}
+        action_tree->set_model(instance->history_tree_store());
+        action_tree->show();
+        update_undo_redo();
+    }
+    else
+    {
+        action_tree->set_model(Glib::RefPtr< Gtk::TreeModel >());
+        action_tree->hide();
+        
+        // Disable all actions when no instance exists
+        const std::vector<Glib::ustring> actions = {
+            "undo", "redo", "clear-undo", "clear-redo", "clear-undo-and-redo"
+        };
+        
+        for(const auto& action : actions) {
+            if(auto act = action_group->lookup_action(action)) {
+                if(auto simple_act = Glib::RefPtr<Gio::SimpleAction>::cast_dynamic(act)) {
+                    simple_act->set_enabled(false);
+                }
+            }
+        }
+    }
 }
 
 void

--- a/synfig-studio/src/gui/docks/dock_history.h
+++ b/synfig-studio/src/gui/docks/dock_history.h
@@ -31,6 +31,9 @@
 /* === H E A D E R S ======================================================= */
 
 #include <gtkmm/actiongroup.h>
+#include <gtkmm/box.h>
+#include <gtkmm/image.h>
+#include <giomm/simpleactiongroup.h>
 #include <gtkmm/treeview.h>
 #include <gui/instance.h>
 #include <gui/docks/dock_canvasspecific.h>
@@ -45,7 +48,7 @@ namespace studio {
 
 class Dock_History : public Dock_CanvasSpecific
 {
-	Glib::RefPtr<Gtk::ActionGroup> action_group;
+	Glib::RefPtr<Gio::SimpleActionGroup> action_group;
 	Gtk::TreeView *action_tree;
 
 	etl::loose_handle<studio::Instance>	selected_instance;

--- a/synfig-studio/src/gui/docks/dockable.cpp
+++ b/synfig-studio/src/gui/docks/dockable.cpp
@@ -208,6 +208,17 @@ Dockable::set_toolbar(Gtk::Toolbar& toolbar)
 	toolbar_container->add(toolbar);
 }
 
+void
+Dockable::set_toolbar(Gtk::Box& box)
+{
+    reset_toolbar();
+    box.set_spacing(4);
+    box.set_hexpand(true);
+    box.set_vexpand(false);
+    box.show_all();
+    toolbar_container->add(box);
+}
+
 Gtk::ToolButton*
 Dockable::add_button(const std::string& icon_name, const synfig::String& tooltip)
 {

--- a/synfig-studio/src/gui/docks/dockable.h
+++ b/synfig-studio/src/gui/docks/dockable.h
@@ -32,6 +32,7 @@
 
 #include <gtkmm/eventbox.h>
 #include <gtkmm/grid.h>
+#include <gtkmm/box.h>
 #include <gtkmm/scrolledwindow.h>
 #include <gtkmm/toolbar.h>
 #include <gtkmm/toolbutton.h>
@@ -87,6 +88,7 @@ public:
 
 	void add(Gtk::Widget& x);
 	void set_toolbar(Gtk::Toolbar& toolbar);
+	void set_toolbar(Gtk::Box& box);
 	Gtk::ToolButton* add_button(const std::string& icon_name, const synfig::String& tooltip = synfig::String());
 
 	void reset_container();


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/413eea9e-3109-41c6-aba2-a648bf4158f9)
* I have converted the two toolbox (right and top) and the dock history toolbar.
* I wonder if this is the best practice or if there's a better approach.
just to continue in the rest of deprecated bars.


