### PR TITLE
feat(ValueNode_Subtract): Add inversion logic for LHS adjustment

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.cpp
@@ -234,3 +234,39 @@ ValueNode_Subtract::get_children_vocab_vfunc()const
 
 	return ret;
 }
+
+LinkableValueNode::InvertibleStatus
+ValueNode_Subtract::is_invertible(const Time& t, const ValueBase& target_value, int* link_index) const
+{
+	if (!t.is_valid())
+		return INVERSE_ERROR_BAD_TIME;
+	if (approximate_zero((*scalar)(t).get(Real()))) {
+		if (link_index)
+			*link_index = get_link_index_from_name("scalar");
+		return INVERSE_ERROR_BAD_PARAMETER;
+	}
+	const Type& type = target_value.get_type();
+	if (type != type_real && type != type_angle && type != type_vector)
+		return INVERSE_ERROR_BAD_TYPE;
+	if (link_index)
+		*link_index = get_link_index_from_name("lhs");
+	return INVERSE_OK;
+}
+
+ValueBase
+ValueNode_Subtract::get_inverse(const Time& t, const ValueBase& target_value) const
+{
+	Real scalar_value = (*scalar)(t).get(Real());
+
+	if (approximate_zero(scalar_value))
+		throw std::runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Scalar is zero")));
+
+	const Type& type = target_value.get_type();
+	if (type == type_real)
+		return target_value.get(Real()) / scalar_value + (*ref_b)(t).get(Real());
+	if (type == type_angle)
+		return target_value.get(Angle()) / scalar_value + (*ref_b)(t).get(Angle());
+	if (type == type_vector)
+		return target_value.get(Vector()) / scalar_value + (*ref_b)(t).get(Vector());
+	throw std::runtime_error(strprintf("ValueNode_%s: %s: %s",get_name().c_str(),_("Attempting to get the inverse of a non invertible Valuenode"),_("Invalid value type")));
+}

--- a/synfig-core/src/synfig/valuenodes/valuenode_subtract.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_subtract.h
@@ -61,6 +61,12 @@ public:
 
 	virtual ValueBase operator()(Time t) const override;
 
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse()
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
+	//! Returns the modified Link to match the target value at time t
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase& target_value) const override;
+
 protected:
 	LinkableValueNode* create_new() const override;
 

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -48,6 +48,7 @@
 #include <synfig/filesystemnative.h>
 #include <synfig/filesystemtemporary.h>
 #include <synfig/valuenodes/valuenode_add.h>
+#include <synfig/valuenodes/valuenode_subtract.h>
 #include <synfig/valuenodes/valuenode_composite.h>
 #include <synfig/valuenodes/valuenode_const.h>
 #include <synfig/valuenodes/valuenode_radialcomposite.h>
@@ -99,6 +100,7 @@ synfigapp::is_editable(synfig::ValueNode::Handle value_node)
 	if(ValueNode_Const::Handle::cast_dynamic(value_node)
 		|| ValueNode_Animated::Handle::cast_dynamic(value_node)
 		|| ValueNode_Add::Handle::cast_dynamic(value_node)
+		|| ValueNode_Subtract::Handle::cast_dynamic(value_node)
 		|| ValueNode_Composite::Handle::cast_dynamic(value_node)
 		|| ValueNode_RadialComposite::Handle::cast_dynamic(value_node)
 		||(ValueNode_Reference::Handle::cast_dynamic(value_node) && !ValueNode_Greyed::Handle::cast_dynamic(value_node))


### PR DESCRIPTION
This PR adds inversion logic to the ValueNode_Subtract class, enabling automatic adjustment of the LHS when the RHS has nested converters. This behavior matches the existing functionality in ValueNode_Add
Changes:
Added is_invertible and get_inverse methods to ValueNode_Subtract.

Fix #3513