### PR TITLE
feat(dialog): add Enter key support to accept user choice

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3453,7 +3453,7 @@ App::dialog_sets_entry(const std::string &action, const std::string &content, st
 	dialog.add_button(button2, Gtk::RESPONSE_OK);
 
 	dialog.set_default_response(Gtk::RESPONSE_OK);
-	//entry->signal_activate().connect(sigc::bind(sigc::mem_fun(dialog,&Gtk::Dialog::response),Gtk::RESPONSE_OK));
+	combo_entry->get_entry()->signal_activate().connect(sigc::bind(sigc::mem_fun(dialog, &Gtk::Dialog::response), Gtk::RESPONSE_OK));
 	dialog.show();
 
 	if(dialog.run()!=Gtk::RESPONSE_OK)


### PR DESCRIPTION
fixes : #3519
Previously, hitting the Enter key in the dialog did nothing. This update allows the Enter key to accept the user choice as if the "Add" button was clicked.