### PR TITLE
fix: History panel didn't show sub-actions anymore

### DIFF
--- a/synfig-studio/src/gui/trees/historytreestore.cpp
+++ b/synfig-studio/src/gui/trees/historytreestore.cpp
@@ -129,10 +129,7 @@ HistoryTreeStore::insert_action(Gtk::TreeRow row, synfigapp::Action::Undoable::H
 		row[model.canvas_id] = specific_action->get_canvas()->get_id();
 	}
 
-	synfigapp::Action::Group::Handle group;
-	synfigapp::Action::Group::Handle::cast_dynamic(action);
-	if(group)
-	{
+	if (auto group = synfigapp::Action::Group::Handle::cast_dynamic(action)) {
 		synfigapp::Action::ActionList::const_iterator iter;
 		for(iter=group->action_list().begin();iter!=group->action_list().end();++iter)
 		{


### PR DESCRIPTION
missing assignment to a variable after a mistake in commit b76be9e5e42018e1570aa73a1558b4db68edc398