### PR TITLE
fix: FileSystem::remove_recursive() removes the directory itself too

### DIFF
--- a/synfig-core/src/synfig/filesystem.cpp
+++ b/synfig-core/src/synfig/filesystem.cpp
@@ -143,6 +143,8 @@ bool FileSystem::remove_recursive(const filesystem::Path& filename)
 		for (const auto& i : files)
 			if (!remove_recursive(filename / i))
 				success = false;
+		if (success)
+			success = file_remove(filename.u8string());
 		return success;
 	}
 	return true;


### PR DESCRIPTION
Before this commit, `FileSystem::remove_recursive()` removes:
- a single file, if the path points to one
- all directory contents, if the path points to a directory

After this commit, the path itself will be removed if it is a directory (and its subdirs, of course).

Currently, this method is only used in three places as shown by the following `git grep` output:
```
synfig-core/src/modules/mod_ffmpeg/trgt_ffmpeg.cpp:             if (!FileSystemNative::instance()->remove_recursive(sound_filename)) {
synfig-core/src/synfig/filesystem.cpp:bool FileSystem::remove_recursive(const filesystem::Path& filename)
synfig-core/src/synfig/filesystem.cpp:                  if (!remove_recursive(filename / i))
synfig-core/src/synfig/filesystem.h:            bool remove_recursive(const filesystem::Path& filename);
synfig-studio/src/gui/app.cpp:  FileSystemNative::instance()->remove_recursive(tmp_filename);
synfig-studio/src/synfigapp/instance.cpp:                       //new_canvas_filesystem->remove_recursive(CanvasFileNaming::container_prefix);
synfig-studio/src/synfigapp/instance.cpp:       //new_canvas_filesystem->remove_recursive(CanvasFileNaming::container_prefix);
```

- In Target FFmpeg, it is used to delete a single (temporary) audio file while exporting the animation;
- In FileSystem itself, because it is a recursive method
- In `studio::App::open_from_plugin()`, to remove a temp file that a plugin changes

Therefore, all current cases call this method to remove a single file only, and that is the reason the issue was not detected.