### PR TITLE
fix: shift in TaskBlur due to resampling

### DIFF
--- a/synfig-core/src/synfig/rendering/common/task/taskblur.h
+++ b/synfig-core/src/synfig/rendering/common/task/taskblur.h
@@ -32,6 +32,7 @@
 
 #include "../../task.h"
 #include "../../primitive/blur.h"
+#include "./tasktransformation.h"
 
 /* === M A C R O S ========================================================= */
 
@@ -44,7 +45,9 @@ namespace synfig
 namespace rendering
 {
 
-class TaskBlur: public Task
+// Blur works identically after or before transformation, so we make it a
+// member of TaskInterfaceTransformationPass to avoid unnecessarily resampling
+class TaskBlur: public Task, public TaskInterfaceTransformationPass
 {
 public:
 	typedef etl::handle<TaskBlur> Handle;


### PR DESCRIPTION
Fixes https://github.com/synfig/synfig/issues/3472
The above link also contains a detailed explanation of the problem.

This commit affects rendering of all layers that utilize blur, so a lot (almost everything in "geometry" category, Shade, etc.). I did some tests on my own and everything seems fine. but if you have some heavy works with a lot of blur/feathering I urge you to test this branch yourself before merging.