### PR TITLE
Add Spine JSON export feature for Synfig skeleton animations

### DIFF
--- a/synfig-studio/src/synfigapp/Makefile.am
+++ b/synfig-studio/src/synfigapp/Makefile.am
@@ -14,6 +14,7 @@ LAYER_ACTION_HH = \
 	actions/layerembed.h \
 	actions/layerencapsulate.h \
 	actions/layerencapsulatefilter.h \
+	actions/spine_export.h \
 	actions/layerencapsulateswitch.h \
 	actions/layerextract.h \
 	actions/layerfit.h \
@@ -44,6 +45,7 @@ LAYER_ACTION_CC = \
 	actions/layerembed.cpp \
 	actions/layerencapsulate.cpp \
 	actions/layerencapsulatefilter.cpp \
+	actions/spine_export.cpp \
 	actions/layerencapsulateswitch.cpp \
 	actions/layerextract.cpp \
 	actions/layerfit.cpp \

--- a/synfig-studio/src/synfigapp/action.cpp
+++ b/synfig-studio/src/synfigapp/action.cpp
@@ -56,6 +56,7 @@
 #include "actions/layerparamdisconnect.h"
 #include "actions/layerencapsulate.h"
 #include "actions/layerencapsulatefilter.h"
+#include "actions/spine_export.h"
 #include "actions/layerencapsulateswitch.h"
 #include "actions/layerduplicate.h"
 #include "actions/layersetdesc.h"
@@ -214,6 +215,7 @@ Action::Main::Main()
 	ADD_ACTION(Action::LayerParamDisconnect);
 	ADD_ACTION(Action::LayerEncapsulate);
 	ADD_ACTION(Action::LayerEncapsulateFilter);
+	ADD_ACTION(Action::SpineExport);
 	ADD_ACTION(Action::LayerEncapsulateSwitch);
 	ADD_ACTION(Action::LayerDuplicate);
 	ADD_ACTION(Action::LayerSetDesc);

--- a/synfig-studio/src/synfigapp/actions/CMakeLists.txt
+++ b/synfig-studio/src/synfigapp/actions/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(synfigapp
         "${CMAKE_CURRENT_LIST_DIR}/layerembed.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layerencapsulate.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layerencapsulatefilter.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/spine_export.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layerencapsulateswitch.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layerextract.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layerfit.cpp"

--- a/synfig-studio/src/synfigapp/actions/spine_export.cpp
+++ b/synfig-studio/src/synfigapp/actions/spine_export.cpp
@@ -2,8 +2,6 @@
 /*! \file spine_export.cpp
 ** \brief Spine Export Implementation
 **
-** \legal
-** Copyright (c) 2025 Ayush Satpathy
 **
 ** This file is part of Synfig.
 **

--- a/synfig-studio/src/synfigapp/actions/spine_export.cpp
+++ b/synfig-studio/src/synfigapp/actions/spine_export.cpp
@@ -1,0 +1,115 @@
+/* === S Y N F I G ========================================================= */
+/*! \file spine_export.cpp
+** \brief Spine Export Implementation
+**
+** \legal
+** Copyright (c) 2025 Ayush Satpathy
+**
+** This file is part of Synfig.
+**
+** Synfig is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 2 of the License, or
+** (at your option) any later version.
+**
+** Synfig is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Synfig. If not, see <https://www.gnu.org/licenses/>.
+** \endlegal
+*/
+/* ========================================================================= */
+
+#include "spine_export.h"
+#include <synfig/general.h>
+#include <fstream>
+#include <synfig/localization.h>
+#include <synfig/canvas.h>
+#include <synfig/layers/layer_skeleton.h>
+#include <json/json.h>
+
+using namespace synfig;
+using namespace synfigapp;
+using namespace Action;
+
+/* === M A C R O S ========================================================= */
+
+ACTION_INIT_NO_GET_LOCAL_NAME(Action::SpineExport);
+ACTION_SET_NAME(Action::SpineExport, "SpineExport");
+ACTION_SET_LOCAL_NAME(Action::SpineExport, ("Export to Spine JSON"));
+ACTION_SET_TASK(Action::SpineExport, "export");
+ACTION_SET_CATEGORY(Action::SpineExport, Action::CATEGORY_OTHER);
+ACTION_SET_PRIORITY(Action::SpineExport, 0);
+ACTION_SET_VERSION(Action::SpineExport, "0.1");
+
+/* === M E T H O D S ======================================================= */
+
+Action::SpineExport::SpineExport() {}
+
+synfig::String Action::SpineExport::get_local_name() const {
+    return ("Export to Spine JSON");
+}
+
+Action::ParamVocab Action::SpineExport::get_param_vocab() {
+    ParamVocab ret;
+    ret.push_back(ParamDesc("canvas", Param::TYPE_CANVAS)
+        .set_local_name(_("Canvas"))
+        .set_desc(_("Canvas to be exported")));
+    return ret;
+}
+
+bool Action::SpineExport::is_candidate(const ParamList &x) {
+    return candidate_check(get_param_vocab(), x);
+}
+
+bool Action::SpineExport::set_param(const synfig::String& name, const Action::Param &param) {
+    if (name == "canvas" && param.get_type() == Param::TYPE_CANVAS) {
+        canvas_ = param.get_canvas();
+        return true;
+    }
+    return false;
+}
+
+bool Action::SpineExport::is_ready() const {
+    return canvas_.operator bool();
+}
+
+void Action::SpineExport::prepare() {
+    if (!first_time()) return;
+    
+    if (!canvas_) {
+        throw Error(("No valid canvas to export"));
+    }
+    
+    export_to_spine_json(canvas_, "spine_export.json");
+}
+
+void synfigapp::Action::SpineExport::export_to_spine_json(const synfig::Canvas::Handle&, const synfig::String& filename) {
+    // Hardcoded JSON structure for Spine export
+    synfig::String spine_json = R"(
+    {
+        "skeleton": { "hash": "123456", "spine": "4.0", "width": 500, "height": 500 },
+        "bones": [
+            { "name": "root" },
+            { "name": "bone1", "parent": "root", "length": 100, "x": 50, "y": 0, "rotation": 0 }
+        ],
+        "slots": [
+            { "name": "slot1", "bone": "bone1", "attachment": "default" }
+        ],
+        "skins": { "default": { "slot1": { "default": { "width": 100, "height": 100 } } } },
+        "animations": { "idle": { "bones": { "bone1": { "rotate": [{ "time": 0, "angle": 10 }, { "time": 1, "angle": -10 }] } } } }
+    })";
+
+    // Write to file
+    std::ofstream out(filename);
+    if (out) {
+        out << spine_json;
+        out.close();
+        std::cout << "Exported Spine JSON to " << filename << std::endl;
+    } else {
+        std::cerr << "Failed to write JSON file: " << filename << std::endl;
+    }
+}

--- a/synfig-studio/src/synfigapp/actions/spine_export.h
+++ b/synfig-studio/src/synfigapp/actions/spine_export.h
@@ -2,9 +2,6 @@
 /*! \file spine_export.h
 ** \brief Spine JSON Export Header File
 **
-** \legal
-** Copyright (c) 2025 Ayush Satpathy
-**
 ** This file is part of Synfig.
 **
 ** Synfig is free software: you can redistribute it and/or modify

--- a/synfig-studio/src/synfigapp/actions/spine_export.h
+++ b/synfig-studio/src/synfigapp/actions/spine_export.h
@@ -1,0 +1,66 @@
+/* === S Y N F I G ========================================================= */
+/*! \file spine_export.h
+** \brief Spine JSON Export Header File
+**
+** \legal
+** Copyright (c) 2025 Ayush Satpathy
+**
+** This file is part of Synfig.
+**
+** Synfig is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 2 of the License, or
+** (at your option) any later version.
+**
+** Synfig is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+** \endlegal
+*/
+/* ========================================================================= */
+
+#ifndef __SYNFIG_APP_ACTION_SPINEEXPORT_H
+#define __SYNFIG_APP_ACTION_SPINEEXPORT_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <synfig/layer.h>
+#include <synfigapp/action.h>
+#include <synfig/canvas.h>
+#include <synfig/string.h>
+#include <fstream>
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace synfigapp {
+
+namespace Action {
+
+class SpineExport : public Super {
+private:
+    synfig::Canvas::Handle canvas_;
+    synfig::String export_path_;
+
+    void export_to_spine_json(const synfig::Canvas::Handle& canvas, const synfig::String& filename);
+
+public:
+    SpineExport();
+
+    static ParamVocab get_param_vocab();
+    static bool is_candidate(const ParamList &x);
+
+    virtual bool set_param(const synfig::String& name, const Param &);
+    virtual bool is_ready() const;
+    virtual void prepare();
+
+    ACTION_MODULE_EXT
+};
+
+}; // END of namespace Action
+}; // END of namespace synfigapp
+
+#endif


### PR DESCRIPTION
This PR introduces a new menu option, "Export to Spine JSON", in Synfig Studio. Currently, this is a basic hardcoded implementation that allows downloading a hardcoded JSON file when the menu option is clicked. The feature is still in its early stages, and I am structuring it to enable exporting Synfig skeleton animations to the Spine JSON format.

Implementation Details

- Added a new menu entry for "Export to Spine JSON".
- Created a basic structure for handling the export logic in : spine_export.h and spine_export.cpp
- The current implementation generates and downloads a hardcoded JSON file when the option is selected(still in progress).

Next Steps

I will proceed with:
- Implementing the logic to extract skeleton animation data from Synfig.
- Formatting the extracted data into the Spine JSON format.
- Ensuring compatibility with Spine for  import.

Request for Feedback
I would love some insights and guidance as I move forward with implementing this feature in this PR. Any suggestions on the best approach for structuring the export and structuring the functionality would be of great help!
![Screenshot 2025-03-21 040707](https://github.com/user-attachments/assets/38754146-22d7-4d4a-9c2e-621ef2e79491)
