### PR TITLE
feat: added a way to easily access the rendered file

### DIFF
--- a/synfig-studio/src/gui/docks/dock_info.cpp
+++ b/synfig-studio/src/gui/docks/dock_info.cpp
@@ -40,6 +40,8 @@
 #include <gui/localization.h>
 #include <gui/workarea.h>
 
+#include "synfig/os.h"
+
 #endif
 
 /* === U S I N G =========================================================== */
@@ -157,6 +159,9 @@ studio::Dock_Info::Dock_Info()
 
 	Gtk::Label *separator2 = manage(new Gtk::Label(" "));
 	grid->attach(*separator2, 0, 4, 8, 1);
+	grid->attach(*separator2, 0, 4, 8, 1);
+	Gtk::Label *separator3 = manage(new Gtk::Label(" "));
+	grid->attach(*separator3, 0, 8, 8, 1);
 
 	// Render Progress Bar
 	Gtk::Box *render_box = manage(new Gtk::Box());
@@ -182,16 +187,23 @@ studio::Dock_Info::Dock_Info()
 	stop_button.set_valign(Gtk::ALIGN_CENTER);
 	stop_button.signal_clicked().connect(sigc::mem_fun(*this, &studio::Dock_Info::on_stop_button_clicked));
 
+	open_button.set_label("Open Rendered File");
+	open_button.set_halign(Gtk::ALIGN_START);
+	open_button.signal_clicked().connect(sigc::mem_fun(*this,&studio::Dock_Info::on_open_button_clicked));
+
 	render_box->pack_start(*overlay, true, true, 0);
 	render_box->pack_start(stop_button, false, false, 0);
 	grid->attach_next_to(*render_progress_label, *separator2, Gtk::POS_BOTTOM, 8, 1);
 	grid->attach_next_to(*render_box, *render_progress_label, Gtk::POS_BOTTOM, 7, 1);
+	grid->attach_next_to(open_button, *separator3, Gtk::POS_BOTTOM, 8, 1);
 
 	grid->set_margin_start(5);
 	grid->set_margin_end(5);
 	grid->set_margin_top(5);
 	grid->set_margin_bottom(5);
 	grid->show_all();
+
+	open_button.hide();
 
 	add(*grid);
 
@@ -205,6 +217,11 @@ studio::Dock_Info::Dock_Info()
 
 studio::Dock_Info::~Dock_Info()
 {
+}
+
+void studio::Dock_Info::on_open_button_clicked()
+{
+    synfig::OS::launch_file_async(output_target);    
 }
 
 void studio::Dock_Info::on_stop_button_clicked()
@@ -262,4 +279,15 @@ void studio::Dock_Info::set_render_progress(float value)
 		stop_button.set_sensitive(true);
 	else
 		stop_button.set_sensitive(false);
+}
+
+void studio::Dock_Info::hide_open_button()
+{
+    open_button.hide();
+}
+
+void studio::Dock_Info::set_open_button(std::string output_path)
+{
+    output_target = output_path;
+    open_button.show();
 }

--- a/synfig-studio/src/gui/docks/dock_info.h
+++ b/synfig-studio/src/gui/docks/dock_info.h
@@ -53,6 +53,9 @@ class Dock_Info : public Dock_CanvasSpecific
 	Gtk::ProgressBar render_progress;
 	Gtk::Label       render_percentage;
 	Gtk::Button      stop_button;
+	Gtk::Button   open_button;
+
+	std::string   output_target;
 
 	etl::handle<AsyncRenderer> async_renderer;
 
@@ -65,6 +68,7 @@ class Dock_Info : public Dock_CanvasSpecific
 
 	void on_mouse_move();
 	void on_stop_button_clicked();
+	void on_open_button_clicked();
 
 public:
 	Dock_Info();
@@ -78,6 +82,8 @@ public:
 	void set_render_progress   (float value);
 	void set_n_passes_requested(int   value);
 	void set_n_passes_pending  (int   value);
+	void set_open_button(std::string output_path);
+	void hide_open_button();
 };
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/render.cpp
+++ b/synfig-studio/src/gui/render.cpp
@@ -364,6 +364,7 @@ RenderSettings::on_render_pressed()
 	App::dock_info_->set_n_passes_requested(render_passes.size());
 	App::dock_info_->set_n_passes_pending(render_passes.size());
 	App::dock_info_->set_render_progress(0.0);
+	App::dock_info_->hide_open_button();
 	App::dock_manager->find_dockable("info").present(); //Bring Dock_Info to front
 
 	progress_logger->clear();
@@ -576,6 +577,19 @@ RenderSettings::on_finished(std::string error_message)
 			App::sound_render_done->set_position(Time());
 			App::sound_render_done->set_playing(true);
 		}
+
+		filesystem::Path filename(entry_filename.get_text());
+		std::list<std::string> ext_mult = {{".bmp"}, {".png"},
+				{".jpg"},{".exr"},{".ppm"}};		
+		
+		bool ext_multi_file = !toggle_single_frame.get_active() 
+		        && (find(ext_mult.begin(), ext_mult.end(),
+				filename.extension()) != ext_mult.end());		
+		
+		if (ext_multi_file)
+		  App::dock_info_->set_open_button(filesystem::Path::dirname(filename.c_str()).c_str());
+		else 
+		  App::dock_info_->set_open_button(filename.c_str());
 		App::dock_info_->set_render_progress(1.0);
 	}
 


### PR DESCRIPTION
Feature : #3533 
above issue contains the description of the feature

let me know if there are any bad practices in my code based on synfig's code style

- i have created "Open Rendered File" button in dock_info which opens rendered file
- file is opened based on output. folder is opened in case of multiple outputs


![Screenshot from 2025-03-30 08-58-22](https://github.com/user-attachments/assets/5822a3f7-3751-455b-928c-1991f6dacd62)
