### PR TITLE
feat: Add atan2 support for value type Real

### DIFF
--- a/synfig-core/src/synfig/filesystem.cpp
+++ b/synfig-core/src/synfig/filesystem.cpp
@@ -143,6 +143,8 @@ bool FileSystem::remove_recursive(const filesystem::Path& filename)
 		for (const auto& i : files)
 			if (!remove_recursive(filename / i))
 				success = false;
+		if (success)
+			success = file_remove(filename.u8string());
 		return success;
 	}
 	return true;

--- a/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
@@ -61,12 +61,21 @@ ValueNode_Atan2::ValueNode_Atan2(const ValueBase &value):
 {
 	init_children_vocab();
 	//Type type = value.get_type();
-	if (value.get_type() == type_angle || value.get_type() == type_real) {
-		Angle angle = value.get(Angle());
-		set_link("x", ValueNode_Const::create(Angle::cos(angle).get()));
-		set_link("y", ValueNode_Const::create(Angle::sin(angle).get()));
-	} else {
-		//throw Exception::BadType(type.description.local_name);
+	if (value.get_type() == type_angle)
+	{
+		set_link("x",ValueNode_Const::create(Angle::cos(value.get(Angle())).get()));
+		set_link("y",ValueNode_Const::create(Angle::sin(value.get(Angle())).get()));
+	}
+	else if (value.get_type() == type_real)
+	{
+		double degrees = value.get(Real());
+		double pi = 3.14159265358979323846;
+		double radians = degrees * (pi / 180.0);
+		set_link("x", ValueNode_Const::create(std::cos(radians)));
+		set_link("y", ValueNode_Const::create(std::sin(radians)));
+	}
+	else
+	{
 		throw Exception::BadType(value.get_type().description.local_name);
 	}
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_atan2.cpp
@@ -60,13 +60,13 @@ ValueNode_Atan2::ValueNode_Atan2(const ValueBase &value):
 	LinkableValueNode(value.get_type())
 {
 	init_children_vocab();
-	if (value.get_type() == type_angle)
-	{
-		set_link("x",ValueNode_Const::create(Angle::cos(value.get(Angle())).get()));
-		set_link("y",ValueNode_Const::create(Angle::sin(value.get(Angle())).get()));
-	}
-	else
-	{
+	//Type type = value.get_type();
+	if (value.get_type() == type_angle || value.get_type() == type_real) {
+		Angle angle = value.get(Angle());
+		set_link("x", ValueNode_Const::create(Angle::cos(angle).get()));
+		set_link("y", ValueNode_Const::create(Angle::sin(angle).get()));
+	} else {
+		//throw Exception::BadType(type.description.local_name);
 		throw Exception::BadType(value.get_type().description.local_name);
 	}
 }
@@ -94,8 +94,11 @@ ValueNode_Atan2::operator()(Time t)const
 	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
 		"%s:%d operator()\n", __FILE__, __LINE__);
 
-	return Angle::tan((*y_)(t).get(Real()),
-					  (*x_)(t).get(Real()));
+	if (get_type() == type_angle)
+		return Angle::tan((*y_)(t).get(Real()),
+						(*x_)(t).get(Real()));
+	else
+		return std::atan2((*y_)(t).get(Real()), (*x_)(t).get(Real()));
 }
 
 
@@ -104,7 +107,7 @@ ValueNode_Atan2::operator()(Time t)const
 bool
 ValueNode_Atan2::check_type(Type &type)
 {
-	return type==type_angle;
+	return type == type_angle || type == type_real;
 }
 
 bool


### PR DESCRIPTION
The value type "Real" doesn't have atan2 as a convert type. This PR introduces atan2 conversion of "Real" values, so that the Bone Angle → Real → Angle  conversion can be achieved as requested in the issue #3528 .
Fixes #3528 