### PR TITLE
fix: naming system for duplicated layers

### DIFF
--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -462,7 +462,7 @@ Layer::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid) const
 
 	ret->group_=group_;
 	//ret->set_canvas(get_canvas());
-	ret->set_description(get_description());
+	ret->set_description(get_description()+"#");
 	ret->set_active(active());
 	ret->set_optimized(optimized());
 	ret->set_exclude_from_rendering(get_exclude_from_rendering());

--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -453,7 +453,7 @@ Layer::simple_clone()const
 }
 
 Layer::Handle
-Layer::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid) const
+Layer::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid , bool flag) const
 {
 	if(!book().count(get_name())) return 0;
 
@@ -462,7 +462,11 @@ Layer::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid) const
 
 	ret->group_=group_;
 	//ret->set_canvas(get_canvas());
-	ret->set_description(get_description()+"#");
+	if (flag) {
+			ret->set_description(get_description()+"#");  // Add "#" if flag is 1
+		} else {
+			ret->set_description(get_description());  // No "#" if flag is 0
+	}
 	ret->set_active(active());
 	ret->set_optimized(optimized());
 	ret->set_exclude_from_rendering(get_exclude_from_rendering());

--- a/synfig-core/src/synfig/layer.h
+++ b/synfig-core/src/synfig/layer.h
@@ -641,7 +641,7 @@ public:
 	virtual Handle hit_check(Context context, const Point &point)const;
 
 	//! Duplicates the Layer
-	virtual Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
+	virtual Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID(), bool flag=true)const;
 
 	//! Returns true if the layer needs to be able to examine its context.
 	/*! context to render itself, other than for simple blending.  For

--- a/synfig-core/src/synfig/layers/layer_duplicate.cpp
+++ b/synfig-core/src/synfig/layers/layer_duplicate.cpp
@@ -77,7 +77,7 @@ Layer_Duplicate::Layer_Duplicate():
 }
 
 Layer::Handle
-Layer_Duplicate::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid)const
+Layer_Duplicate::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid ,bool flag)const
 {
 	Layer::Handle ret = (Layer::Handle)Layer_Composite::clone(canvas, deriv_guid);
 

--- a/synfig-core/src/synfig/layers/layer_duplicate.h
+++ b/synfig-core/src/synfig/layers/layer_duplicate.h
@@ -52,7 +52,7 @@ public:
 	Layer_Duplicate();
 
 	//! Duplicates the Layer
-	virtual Layer::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID())const;
+	virtual Layer::Handle clone(etl::loose_handle<Canvas> canvas, const GUID& deriv_guid=GUID(),bool flag=true)const;
 	virtual bool set_param(const String & param, const synfig::ValueBase &value);
 	virtual ValueBase get_param(const String & param)const;
 	virtual Color get_color(Context context, const Point &pos)const;

--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -536,7 +536,7 @@ LayerActionManager::paste()
 
 	for(std::list<synfig::Layer::Handle>::iterator iter=clipboard_.begin();iter!=clipboard_.end();++iter)
 	{
-		layer=(*iter)->clone(canvas, guid);
+		layer=(*iter)->clone(canvas, guid,false);
 		layer_selection.push_back(layer);
 
 		replace_exported_value_nodes(layer, valuenode_replacements);


### PR DESCRIPTION
# Improve Layer Duplication Naming

## Background

Currently in Synfig:
![default](https://github.com/user-attachments/assets/01191119-1a07-4fda-bd9d-de1ca6458e16)

- **Duplicate Layer**  
  - You duplicate “circle003” → you get another “circle003” (no suffix)  
  - Duplicate again → still “circle003”  
- **Copy‑Paste Layer**  
  - You copy “circle003” and paste → you get “circle003”
  - Paste again → “circle003”  

This differs from common tools (e.g. After Effects), which append increasing numbers:

- **After Effects**  
  - “Layer1” → “Layer1 2” → “Layer1 3” → …  

## What’s Wrong

1. **Duplicate adds no suffix**  
   - Makes it impossible to distinguish original vs. duplicate at a glance, plus designer will need to rename which maybe slows him.
2. **Copy‑Paste adds double `##`**  
   - Because `clone()` (which appends `#`) is called twice in the copy‑paste flow.  
   - Results in “Layer##” instead of “Layer#”.

## Changes in This PR
![image](https://github.com/user-attachments/assets/0172cee4-057d-4d70-acff-a2032d7129de)


- **Duplicate Layer** now appends a single `#` on each duplicate, e.g.:  
  - First duplicate → `Layer#`  
  - Second duplicate → `Layer##`  
- **Copy‑Paste Layer** behavior is unchanged for now, but i have identified why it adds `##` twice, as Layer::clone() indirectly is called twice.

## Remaining Issues & Next Steps

1. **Copy‑Paste still double‑hashes**    
2. **Adopt numbered suffixes (optional)**  
   - Consider switching from `#` to numbered suffixes (`Layer1 2`, `Layer1 3`, …) to match others.  

## Call for Feedback

- do you agree naming needs refine just wanted to check before working?

Thank you!  
