### PR TITLE
feat: Add inverse manipulation of switch converter

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.cpp
@@ -161,3 +161,33 @@ ValueNode_Switch::get_children_vocab_vfunc()const
 
 	return ret;
 }
+
+// Add these two methods to the ValueNode_Switch class definition in the header file,
+// then implement them in the .cpp file as shown below.
+
+LinkableValueNode::InvertibleStatus
+ValueNode_Switch::is_invertible(const Time& t, const ValueBase& target_value, int* link_index) const
+{
+	if (!t.is_valid())
+		return INVERSE_ERROR_BAD_TIME;
+
+	if (target_value.get_type() != get_type())
+		return INVERSE_ERROR_BAD_TYPE;
+
+	const bool switch_state = (*switch_)(t).get(bool());
+
+	if (link_index)
+		*link_index = switch_state ? 1 : 0; // 1=link_on, 0=link_off
+
+	return INVERSE_OK;
+}
+
+ValueBase
+ValueNode_Switch::get_inverse(const Time& t, const ValueBase& target_value) const
+{
+	const bool switch_state = (*switch_)(t).get(bool());
+
+	// The active link's value directly equals the output when the switch is in its current state.
+	// To invert, return the target value for the active link.
+	return target_value;
+}

--- a/synfig-core/src/synfig/valuenodes/valuenode_switch.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_switch.h
@@ -62,6 +62,12 @@ public:
 
 	virtual ValueBase operator()(Time t) const override;
 
+	//! Checks if it is possible to call get_inverse() for target_value at time t.
+	//! If so, return the link_index related to the return value provided by get_inverse()
+	virtual InvertibleStatus is_invertible(const Time& t, const ValueBase& target_value, int* link_index = nullptr) const override;
+	//! Returns the modified Link to match the target value at time t
+	virtual ValueBase get_inverse(const Time& t, const synfig::ValueBase &target_value) const override;
+
 protected:
 	LinkableValueNode* create_new() const override;
 

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -66,6 +66,7 @@
 #include <synfig/valuenodes/valuenode_average.h>
 #include <synfig/valuenodes/valuenode_weightedaverage.h>
 #include <synfig/valuenodes/valuenode_timeloop.h>
+#include <synfig/valuenodes/valuenode_switch.h>
 #include <synfig/layers/layer_pastecanvas.h>
 #include <synfig/layers/layer_bitmap.h>
 #include <synfig/rendering/software/surfacesw.h>
@@ -114,6 +115,7 @@ synfigapp::is_editable(synfig::ValueNode::Handle value_node)
 		|| ValueNode_Average::Handle::cast_dynamic(value_node)
 		|| ValueNode_WeightedAverage::Handle::cast_dynamic(value_node)
 		|| ValueNode_TimeLoop::Handle::cast_dynamic(value_node)
+		|| ValueNode_Switch::Handle::cast_dynamic(value_node)
 	)
 		return true;
 	return false;


### PR DESCRIPTION
Inverse manipulation of switch converter is required in order to edit switch converter from canvas. 
Changes: Added is_invertible and get_inverse methods to ValueNode_switch
Closes: #3549 