### PR TITLE
fix: bypass font caching for Devanagari MT and Devanagari Sangam MN

### DIFF
--- a/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
+++ b/synfig-core/src/modules/lyr_freetype/lyr_freetype.cpp
@@ -578,6 +578,14 @@ Layer_Freetype::new_font(const synfig::String &family, int style, int weight)
 		new_font_("sans serif",TEXT_STYLE_NORMAL,TEXT_WEIGHT_NORMAL);
 }
 
+bool should_bypass_cache(const synfig::String& font_family) {
+    const std::vector<synfig::String> bypass_fonts = {
+        "Devanagari MT",
+        "Devanagari Sangam MN"
+    };
+    return std::find(bypass_fonts.begin(), bypass_fonts.end(), font_family) != bypass_fonts.end();
+}
+
 bool
 Layer_Freetype::new_font_(const synfig::String &font_fam_, int style, int weight)
 {
@@ -585,7 +593,10 @@ Layer_Freetype::new_font_(const synfig::String &font_fam_, int style, int weight
 	if (get_canvas())
 		meta.canvas_path = get_canvas()->get_file_path()+ETL_DIRECTORY_SEPARATOR;
 
-	{
+	// Skip cache for problematic fonts
+	bool bypass_cache = should_bypass_cache(font_fam_);
+
+	if (!bypass_cache) {
 		FT_Face tmp_face = face_cache.get(meta);
 		if (tmp_face) {
 			if (face != tmp_face)
@@ -599,6 +610,7 @@ Layer_Freetype::new_font_(const synfig::String &font_fam_, int style, int weight
 	}
 
 	auto cache_face = [&](FT_Face face) {
+		if (bypass_cache) return; // Skip caching for problematic fonts
 		if (!font_path_from_canvas)
 			meta.canvas_path.clear();
 		face_cache.put(meta, face);
@@ -718,14 +730,20 @@ Layer_Freetype::new_face(const String &newfont)
 
 	for (const std::string& path : filenames) {
 		filesystem::Path absolute_path = filesystem::absolute(path);
-		auto face_ptr = face_cache.get(absolute_path);
-		if (face_ptr) {
-			face = face_ptr;
-			break;
+		bool bypass_cache = should_bypass_cache(param_family.get(String()));
+
+		// Skip cache check for problematic fonts
+		if (!bypass_cache) {
+			auto face_ptr = face_cache.get(absolute_path);
+			if (face_ptr) {
+				face = face_ptr;
+				break;
+			}
 		}
 		error = FT_New_Face(ft_library, path.c_str(), face_index, &face);
 		if (!error) {
-			face_cache.put(absolute_path, face);
+			if (!bypass_cache) // Only cache non-problematic fonts
+				face_cache.put(absolute_path, face);
 #if HAVE_HARFBUZZ
 			this->font = hb_ft_font_create(face, nullptr);
 			FaceMetaData::add_to_face(face, path, this->font);


### PR DESCRIPTION
A caching mechanism is in place where FaceCache stores FT_Face instances. When multiple layers use the same font (same FontMeta), they share the same FT_Face.
This works well for most fonts (like Arial), however, some complex fonts (Devanagari MT and Devanagari Sangam MN) don't render correctly when cached - multiple layers using these fonts show corruption. 
I have bypassed caching for these fonts.
Fixes: #3387 