### PR TITLE
fix(advanced outline): fix rendering of width point in non-homogeneous position

### DIFF
--- a/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
@@ -94,7 +94,7 @@ namespace {
 	Real calc_position(Real p, const rendering::Bend &bend, bool homogeneous) {
 		return homogeneous
 			 ? p*bend.length1()
-			 : bend.length_by_l( p*bend.l1() );
+			 : bend.length_by_index( p*bend.l1() );
 	}
 	
 	class AdvancedPoint {

--- a/synfig-core/src/synfig/rendering/primitive/bend.h
+++ b/synfig-core/src/synfig/rendering/primitive/bend.h
@@ -72,9 +72,10 @@ public:
 		Vector tn0, tn1;
 		Mode mode;
 		bool e0, e1;
-		Real l;
+		Real index; /**< The point index in the B-line */
+		Real last_index; /**< It is different (greater) of index only if zero-length segments follow this point */
 		Real length;
-		Point(): mode(NONE), e0(), e1(), l(), length() { }
+		Point(): mode(NONE), e0(), e1(), index(), last_index(), length() { }
 	};
 
 	typedef std::vector<Point> PointList;
@@ -86,18 +87,18 @@ public:
 	void tails();
 	
 	Real l0() const
-		{ return points.empty() ? Real() : points.front().l; }
+		{ return points.empty() ? Real() : points.front().index; }
 	Real l1() const
-		{ return points.empty() ? Real() : points.back().l; }
+		{ return points.empty() ? Real() : points.back().last_index; }
 
 	Real length0() const
 		{ return points.empty() ? Real() : points.front().length; }
 	Real length1() const
 		{ return points.empty() ? Real() : points.back().length; }
 	
-	PointList::const_iterator find_by_l(Real l) const;
+	PointList::const_iterator find_by_index(Real index) const;
 	PointList::const_iterator find(Real length) const;
-	Real length_by_l(Real length) const;
+	Real length_by_index(Real index) const;
 	Point interpolate(Real length) const;
 	
 	void bend(Contour &dst, const Contour &src, const Matrix &matrix, int segments) const;

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -228,7 +228,7 @@ synfig::find_closest_point(const ValueBase &bline, const Point &pos, Real radius
 Real
 synfig::std_to_hom(const ValueBase &bline, Real pos, bool index_loop, bool bline_loop)
 {
-	Real loops = index_loop ? floor(pos) : 0.0;
+	const Real loops = index_loop ? floor(pos) : 0.0;
 	pos -= loops;
 	assert(approximate_greater_or_equal(pos, 0.0));
 
@@ -239,20 +239,20 @@ synfig::std_to_hom(const ValueBase &bline, Real pos, bool index_loop, bool bline
 		return loops + 1;
 
 	const std::vector<BLinePoint> list(bline.get_list_of(BLinePoint()));
-	size_t size = list.size();
+	const size_t size = list.size();
 	if (size == 0)
 		return loops;
-	size_t count = bline_loop? size : size - 1;
+	const size_t count = bline_loop? size : size - 1;
 	if (count < 1)
 		return loops + pos;
 
 	// Calculate the lengths and the total length
 	std::vector<Real> lengths;
-	Real bline_total_length = bline_length(list, bline_loop, &lengths);
+	const Real bline_total_length = bline_length(list, bline_loop, &lengths);
 	// If the total length of the bline is zero return pos
 	if(approximate_equal(bline_total_length, 0.0))
 		return pos;
-	size_t from_vertex = size_t(pos*count);
+	const size_t from_vertex = size_t(pos*count);
 	// Calculate the partial length until the bezier that holds the current
 	Real partial_length = 0;
 	std::vector<Real>::const_iterator length_iter(lengths.begin());
@@ -260,10 +260,10 @@ synfig::std_to_hom(const ValueBase &bline, Real pos, bool index_loop, bool bline
 		partial_length += *length_iter;
 	// Calculate the remaining length of the position over current bezier
 	// Setup the curve of the current bezier.
-	size_t next_vertex = (from_vertex + 1) % size;
-	const BLinePoint &blinepoint0 = list[from_vertex];
-	const BLinePoint &blinepoint1 = list[next_vertex];
-	hermite<Vector> curve(blinepoint0.get_vertex(),   blinepoint1.get_vertex(),
+	const size_t next_vertex = (from_vertex + 1) % size;
+	const BLinePoint& blinepoint0 = list[from_vertex];
+	const BLinePoint& blinepoint1 = list[next_vertex];
+	const hermite<Vector> curve(blinepoint0.get_vertex(), blinepoint1.get_vertex(),
 							blinepoint0.get_tangent2(), blinepoint1.get_tangent1());
 	// add the distance on the bezier we are on.
 	partial_length += curve.find_distance(0.0, pos*count - from_vertex);
@@ -274,7 +274,7 @@ synfig::std_to_hom(const ValueBase &bline, Real pos, bool index_loop, bool bline
 Real
 synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline_loop)
 {
-	Real loops = index_loop ? floor(pos) : 0.0;
+	const Real loops = index_loop ? floor(pos) : 0.0;
 	pos -= loops;
 	assert(approximate_greater_or_equal(pos, 0.0));
 
@@ -285,18 +285,18 @@ synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline
 		return loops + 1;
 
 	const std::vector<BLinePoint> list(bline.get_list_of(BLinePoint()));
-	size_t size = list.size();
+	const size_t size = list.size();
 	if (size == 0)
 		return loops;
-	size_t count = bline_loop? size : size - 1;
+	const size_t count = bline_loop? size : size - 1;
 	if (count < 1)
 		return loops + pos;
 
 	// Calculate the lengths and the total length
 	std::vector<Real> lengths;
-	Real bline_total_length=bline_length(bline, bline_loop,&lengths);
+	const Real bline_total_length = bline_length(bline, bline_loop, &lengths);
 	// Calculate the my partial length (the length where pos is)
-	Real target_length = pos * bline_total_length;
+	const Real target_length = pos * bline_total_length;
 	std::vector<Real>::const_iterator length_iter(lengths.begin());
 	// Find the previous bezier where we pos is placed and the sum
 	// of lengths to it (cumulative_length)
@@ -320,16 +320,16 @@ synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline
 		--from_vertex;
 	}
 	// set up the curve
-	const BLinePoint &blinepoint0 = list[from_vertex];
-	const BLinePoint &blinepoint1 = list[(from_vertex+1) % size];
-	hermite<Vector> curve(blinepoint0.get_vertex(),   blinepoint1.get_vertex(),
+	const BLinePoint& blinepoint0 = list[from_vertex];
+	const BLinePoint& blinepoint1 = list[(from_vertex+1) % size];
+	const hermite<Vector> curve(blinepoint0.get_vertex(),   blinepoint1.get_vertex(),
 	                           blinepoint0.get_tangent2(), blinepoint1.get_tangent1());
 	// Find the solution to which is the standard position which matches the current
 	// homogeneous position
 	// Secant method: http://en.wikipedia.org/wiki/Secant_method
 	Real sn(0.0); // the standard position on current bezier
 	Real sn1(0.0), sn2(1.0);
-	Real t0((target_length-cumulative_length)/segment_length); // the homogeneous position on the current bezier
+	const Real t0((target_length-cumulative_length)/segment_length); // the homogeneous position on the current bezier
 	int iterations=0;
 	const int max_iterations=100;
 	const Real max_error(0.00001);
@@ -360,8 +360,7 @@ synfig::bline_length(const ValueBase &bline, bool bline_loop, std::vector<Real> 
 	const std::vector<BLinePoint> list(bline.get_list_of(BLinePoint()));
 	if (list.empty())
 		return 0;
-	size_t max_vertex_index(list.size());
-	if(!bline_loop) max_vertex_index--;
+	const size_t max_vertex_index = bline_loop ? list.size() : list.size() - 1;
 	if(max_vertex_index < 1) return Real();
 
 	if (lengths)
@@ -370,12 +369,12 @@ synfig::bline_length(const ValueBase &bline, bool bline_loop, std::vector<Real> 
 	// Calculate the lengths and the total length
 	Real total_length = 0;
 	for(size_t i0 = 0; i0 < max_vertex_index; ++i0) {
-		size_t i1 = (i0 + 1)%list.size();
-		const BLinePoint &blinepoint0 = list[i0];
-		const BLinePoint &blinepoint1 = list[i1];
-		hermite<Vector> curve(blinepoint0.get_vertex(),   blinepoint1.get_vertex(),
+		const size_t i1 = (i0 + 1) % list.size();
+		const BLinePoint& blinepoint0 = list[i0];
+		const BLinePoint& blinepoint1 = list[i1];
+		const hermite<Vector> curve(blinepoint0.get_vertex(), blinepoint1.get_vertex(),
 							blinepoint0.get_tangent2(), blinepoint1.get_tangent1());
-		Real l=curve.length();
+		const Real l = curve.length();
 		if(lengths) lengths->push_back(l);
 		total_length+=l;
 	}

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -303,15 +303,17 @@ synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline
 	Real cumulative_length = 0;
 	size_t from_vertex = 0;
 	Real segment_length = 0;
-	while (target_length > cumulative_length && length_iter != lengths.end()) {
+	while (approximate_greater(target_length, cumulative_length) && length_iter != lengths.end()) {
 		segment_length = *length_iter;
 		cumulative_length += segment_length;
 
 		++length_iter;
 		++from_vertex;
 	}
-	// correct the iters and partial length in case we passed over
-	if (cumulative_length > target_length) {
+	if (approximate_equal(target_length, cumulative_length)) {
+		return loops + Real(from_vertex) / count;
+	} else {
+		// correct the iters and partial length in case we passed over
 		--length_iter;
 		cumulative_length -= *length_iter;
 		--from_vertex;

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -250,13 +250,13 @@ synfig::std_to_hom(const ValueBase &bline, Real pos, bool index_loop, bool bline
 	std::vector<Real> lengths;
 	const Real bline_total_length = bline_length(list, bline_loop, &lengths);
 	// If the total length of the bline is zero return pos
-	if(approximate_equal(bline_total_length, 0.0))
+	if (approximate_equal(bline_total_length, 0.0))
 		return pos;
 	const size_t from_vertex = size_t(pos*count);
 	// Calculate the partial length until the bezier that holds the current
 	Real partial_length = 0;
 	std::vector<Real>::const_iterator length_iter(lengths.begin());
-	for(size_t i=0; i < from_vertex; ++i, ++length_iter)
+	for (size_t i = 0; i < from_vertex; ++i, ++length_iter)
 		partial_length += *length_iter;
 	// Calculate the remaining length of the position over current bezier
 	// Setup the curve of the current bezier.
@@ -304,8 +304,7 @@ synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline
 	Real cumulative_length = 0;
 	size_t from_vertex = 0;
 	Real segment_length = 0;
-	while(target_length > cumulative_length && length_iter != lengths.end())
-	{
+	while (target_length > cumulative_length && length_iter != lengths.end()) {
 		segment_length = *length_iter;
 		cumulative_length += segment_length;
 
@@ -313,8 +312,7 @@ synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline
 		++from_vertex;
 	}
 	// correct the iters and partial length in case we passed over
-	if(cumulative_length > target_length)
-	{
+	if (cumulative_length > target_length) {
 		--length_iter;
 		cumulative_length -= *length_iter;
 		--from_vertex;
@@ -336,8 +334,7 @@ synfig::hom_to_std(const ValueBase &bline, Real pos, bool index_loop, bool bline
 	Real error;
 	Real fsn1(t0-curve.find_distance(0.0,sn1)/segment_length);
 	Real fsn2(t0-curve.find_distance(0.0,sn2)/segment_length);
-	do
-	{
+	do {
 		sn=sn1-fsn1*((sn1-sn2)/(fsn1-fsn2));
 		Real fsn=t0-curve.find_distance(0.0, sn)/segment_length;
 		sn2=sn1;
@@ -361,14 +358,15 @@ synfig::bline_length(const ValueBase &bline, bool bline_loop, std::vector<Real> 
 	if (list.empty())
 		return 0;
 	const size_t max_vertex_index = bline_loop ? list.size() : list.size() - 1;
-	if(max_vertex_index < 1) return Real();
+	if (max_vertex_index < 1)
+		return Real();
 
 	if (lengths)
 		lengths->reserve(max_vertex_index);
 
 	// Calculate the lengths and the total length
 	Real total_length = 0;
-	for(size_t i0 = 0; i0 < max_vertex_index; ++i0) {
+	for (size_t i0 = 0; i0 < max_vertex_index; ++i0) {
 		const size_t i1 = (i0 + 1) % list.size();
 		const BLinePoint& blinepoint0 = list[i0];
 		const BLinePoint& blinepoint1 = list[i1];

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -230,7 +230,6 @@ synfig::std_to_hom(const ValueBase &bline, Real pos, bool index_loop, bool bline
 {
 	const Real loops = index_loop ? floor(pos) : 0.0;
 	pos -= loops;
-	assert(approximate_greater_or_equal(pos, 0.0));
 
 	// trivial cases
 	if (approximate_less_or_equal(pos, Real(0)))

--- a/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_blinecalcvertex.cpp
@@ -105,7 +105,7 @@ ValueNode_BLineCalcVertex::operator()(Time t)const
 	if (size == 0)
 		return Vector();
 	const int count = looped ? size : size - 1;
-	if (count < 1) return Vector();
+	if (count < 1) return bline[0].get(BLinePoint()).get_vertex();
 
 	bool loop = (*loop_)(t).get(bool());
 	bool homogeneous = (*homogeneous_)(t).get(bool());

--- a/synfig-core/test/bline.cpp
+++ b/synfig-core/test/bline.cpp
@@ -38,9 +38,20 @@
 using namespace synfig;
 
 void
-fill_list(std::vector<ValueBase> &list)
+fill_list_colinear(std::vector<ValueBase> &list)
 {
 	const std::vector<Point> points {{0.0, 0.0}, {0.0, 1.0}, {0.0, 2.0}};
+	for (const auto& point : points) {
+		BLinePoint p;
+		p.set_vertex(point);
+		list.push_back(p);
+	}
+}
+
+void
+fill_list_open_rectangle(std::vector<ValueBase> &list)
+{
+	const std::vector<Point> points {{0.0, 0.0}, {0.0, 2.0}, {1.0, 2.0}, {1.0, 0.0}};
 	for (const auto& point : points) {
 		BLinePoint p;
 		p.set_vertex(point);
@@ -74,12 +85,12 @@ test_bline_length_single_vertex()
 }
 
 void
-test_bline_length()
+test_bline_length_without_loop()
 {
 	std::vector<ValueBase> list;
-	fill_list(list);
+	fill_list_colinear(list);
 
-	bool loop = false;
+	const bool loop = false;
 	std::vector<Real> lengths;
 
 	Real total_length = bline_length(list, loop, &lengths);
@@ -88,21 +99,51 @@ test_bline_length()
 	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
 	ASSERT_APPROX_EQUAL(2.0, total_length);
 
-	loop = true;
+	list.clear();
+	fill_list_open_rectangle(list);
+
 	total_length = bline_length(list, loop, &lengths);
+	ASSERT_EQUAL(3, lengths.size());
+	ASSERT_APPROX_EQUAL(2.0, lengths[0]);
+	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
+	ASSERT_APPROX_EQUAL(2.0, lengths[2]);
+	ASSERT_APPROX_EQUAL(5.0, total_length);
+}
+
+void
+test_bline_length_with_loop()
+{
+	std::vector<ValueBase> list;
+	fill_list_colinear(list);
+
+	const bool loop = true;
+	std::vector<Real> lengths;
+
+	Real total_length = bline_length(list, loop, &lengths);
 	ASSERT_EQUAL(3, lengths.size());
 	ASSERT_APPROX_EQUAL(1.0, lengths[0]);
 	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
 	ASSERT_APPROX_EQUAL(2.0, lengths[2]);
 	ASSERT_APPROX_EQUAL(4.0, total_length);
+
+	list.clear();
+	fill_list_open_rectangle(list);
+
+	total_length = bline_length(list, loop, &lengths);
+	ASSERT_EQUAL(4, lengths.size());
+	ASSERT_APPROX_EQUAL(2.0, lengths[0]);
+	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
+	ASSERT_APPROX_EQUAL(2.0, lengths[2]);
+	ASSERT_APPROX_EQUAL(1.0, lengths[3]);
+	ASSERT_APPROX_EQUAL(6.0, total_length);
 }
 
 void test_bline_std_to_hom_without_loop() {
 	std::vector<ValueBase> list;
-	fill_list(list);
+	fill_list_colinear(list);
 
 	const std::vector<Real> positions = {0.0, 0.2, 1/3., 0.5, 2/3., 0.8, 1.0};
-	std::vector<Real> expected = {0.0, 0.176000, 0.370370, 0.5, 0.629630, 0.824000, 1.0};
+	const std::vector<Real> expected = {0.0, 0.176000, 0.370370, 0.5, 0.629630, 0.824000, 1.0};
 	for (size_t i = 0; i < positions.size(); ++i) {
 		Real value = synfig::std_to_hom(list, positions[i], false, false);
 		ASSERT_APPROX_EQUAL_MICRO(expected[i], value);
@@ -124,10 +165,10 @@ void test_bline_std_to_hom_without_loop() {
 
 void test_bline_std_to_hom_with_loop() {
 	std::vector<ValueBase> list;
-	fill_list(list);
+	fill_list_colinear(list);
 
 	const std::vector<Real> positions = {0.0, 0.2, 1/3., 0.5, 2/3., 0.8, 1.0};
-	std::vector<Real> expected = {0.0, 0.162, 0.25, 0.375, 0.5, 0.676, 1.0};
+	const std::vector<Real> expected = {0.0, 0.162, 0.25, 0.375, 0.5, 0.676, 1.0};
 	for (size_t i = 0; i < positions.size(); ++i) {
 		Real value = synfig::std_to_hom(list, positions[i], false, true);
 		ASSERT_APPROX_EQUAL_MICRO(expected[i], value);
@@ -149,10 +190,10 @@ void test_bline_std_to_hom_with_loop() {
 
 void test_bline_hom_to_std_without_loop() {
 	std::vector<ValueBase> list;
-	fill_list(list);
+	fill_list_colinear(list);
 
 	const std::vector<Real> positions = {0.0, 0.2, 1/3., 0.5, 2/3., 0.8, 1.0};
-	std::vector<Real> expected = {0.0, 0.216466, 0.306518, 0.5, 0.693482, 0.783534, 1.0};
+	const std::vector<Real> expected = {0.0, 0.216466, 0.306518, 0.5, 0.693482, 0.783534, 1.0};
 	for (size_t i = 0; i < positions.size(); ++i) {
 		Real value = synfig::hom_to_std(list, positions[i], false, false);
 		ASSERT_APPROX_EQUAL_MICRO(expected[i], value);
@@ -174,10 +215,10 @@ void test_bline_hom_to_std_without_loop() {
 
 void test_bline_hom_to_std_with_loop() {
 	std::vector<ValueBase> list;
-	fill_list(list);
+	fill_list_colinear(list);
 
 	const std::vector<Real> positions = {0.0, 0.2, 1/3., 0.5, 2/3., 0.8, 1.0};
-	std::vector<Real> expected = {0.0, 0.237620, 0.462321, 0.666667, 0.795654, 0.855690, 1.0};
+	const std::vector<Real> expected = {0.0, 0.237620, 0.462321, 0.666667, 0.795654, 0.855690, 1.0};
 	for (size_t i = 0; i < positions.size(); ++i) {
 		Real value = synfig::hom_to_std(list, positions[i], false, true);
 		ASSERT_APPROX_EQUAL_MICRO(expected[i], value);
@@ -251,7 +292,8 @@ int main() {
 	TEST_SUITE_BEGIN();
 
 	TEST_FUNCTION(test_bline_length_single_vertex);
-	TEST_FUNCTION(test_bline_length);
+	TEST_FUNCTION(test_bline_length_without_loop);
+	TEST_FUNCTION(test_bline_length_with_loop);
 
 	TEST_FUNCTION(test_bline_std_to_hom_without_loop);
 	TEST_FUNCTION(test_bline_std_to_hom_with_loop);

--- a/synfig-core/test/bline.cpp
+++ b/synfig-core/test/bline.cpp
@@ -274,7 +274,8 @@ void test_bline_hom_to_std_with_loop() {
 	}
 }
 
-void test_calc_vertex() {
+void
+test_calc_vertex() {
 	std::vector<ValueBase> list;
 	BLinePoint p;
 	p.set_vertex(Point(-2.342526, -1.151789));
@@ -295,7 +296,7 @@ void test_calc_vertex() {
 	p.set_origin(0.500000);
 	list.push_back(p);
 
-	ValueNode_BLine *bline = ValueNode_BLine::create(list);
+	ValueNode_BLine* bline = ValueNode_BLine::create(list);
 	
 	bool homogeneous = true;
 
@@ -478,6 +479,340 @@ test_bline_hom_to_std_with_loop_with_two_vertices_at_same_spot() {
 	}
 }
 
+void
+test_calc_vertex_for_single_vertex_without_loop_returns_itself()
+{
+	std::vector<ValueBase> list;
+	{
+		BLinePoint p;
+		p.set_vertex({1.0, 2.0});
+		list.push_back(p);
+	}
+
+	ValueNode_BLine* bline = ValueNode_BLine::create(list);
+	ValueNode_Const* const_false = static_cast<ValueNode_Const*>(ValueNode_Const::create(false));
+	ValueNode_Const* const_true = static_cast<ValueNode_Const*>(ValueNode_Const::create(true));
+	ValueNode_Const* const_amount = static_cast<ValueNode_Const*>(ValueNode_Const::create(0.1));
+
+	ValueNode_BLineCalcVertex::Handle bline_calc_vertex(ValueNode_BLineCalcVertex::create(Vector(0,0)));
+	bline_calc_vertex->set_link("bline", bline);
+	bline_calc_vertex->set_link("loop", const_false);
+	bline_calc_vertex->set_link("homogeneous", const_true);
+	bline_calc_vertex->set_link("amount", const_amount);
+
+	const_amount->set_value(0.0);
+	Vector vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 2.0), vertex)
+
+	const_amount->set_value(0.3);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 2.0), vertex)
+
+	const_amount->set_value(0.8);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 2.0), vertex)
+
+	const_amount->set_value(1.0);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 2.0), vertex)
+}
+
+void
+test_calc_vertex_for_single_vertex_with_loop_returns_itself_on_edges()
+{
+	std::vector<ValueBase> list;
+	{
+		BLinePoint p;
+		p.set_vertex({1.0, 2.0});
+		p.set_tangent({1.0, -2.0});
+		list.push_back(p);
+	}
+
+	ValueNode_BLine* bline = ValueNode_BLine::create(list);
+	ValueNode_Const* const_false = static_cast<ValueNode_Const*>(ValueNode_Const::create(false));
+	ValueNode_Const* const_true = static_cast<ValueNode_Const*>(ValueNode_Const::create(true));
+	ValueNode_Const* const_amount = static_cast<ValueNode_Const*>(ValueNode_Const::create(0.1));
+
+	ValueNode_BLineCalcVertex::Handle bline_calc_vertex(ValueNode_BLineCalcVertex::create(Vector(0,0)));
+	bline_calc_vertex->set_link("bline", bline);
+	bline_calc_vertex->set_link("loop", const_false);
+	bline_calc_vertex->set_link("homogeneous", const_true);
+	bline_calc_vertex->set_link("amount", const_amount);
+
+	const_amount->set_value(0.0);
+	Vector vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 2.0), vertex)
+
+	const_amount->set_value(0.3);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_FALSE(synfig::approximate_not_equal(1.0, vertex[0]));
+	ASSERT_FALSE(synfig::approximate_not_equal(2.0, vertex[1]));
+
+	const_amount->set_value(0.8);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_FALSE(synfig::approximate_not_equal(1.0, vertex[0]));
+	ASSERT_FALSE(synfig::approximate_not_equal(2.0, vertex[1]));
+
+	const_amount->set_value(1.0);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 2.0), vertex)
+}
+
+void
+test_calc_vertex_for_straight_line_without_loop() {
+	std::vector<ValueBase> list;
+	fill_list_colinear(list);
+
+	ValueNode_BLine* bline = ValueNode_BLine::create(list);
+	ValueNode_Const* const_false = static_cast<ValueNode_Const*>(ValueNode_Const::create(false));
+	ValueNode_Const* const_true = static_cast<ValueNode_Const*>(ValueNode_Const::create(true));
+	ValueNode_Const* const_amount = static_cast<ValueNode_Const*>(ValueNode_Const::create(0.1));
+
+	ValueNode_BLineCalcVertex::Handle bline_calc_vertex(ValueNode_BLineCalcVertex::create(Vector(0,0)));
+	bline_calc_vertex->set_link("bline", bline);
+	bline_calc_vertex->set_link("loop", const_false);
+	bline_calc_vertex->set_link("homogeneous", const_true);
+	bline_calc_vertex->set_link("amount", const_amount);
+
+	const_amount->set_value(0.0);
+	Vector vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.0), vertex)
+
+	const_amount->set_value(0.1);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.20), vertex)
+
+	const_amount->set_value(0.25);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.50), vertex)
+
+	const_amount->set_value(0.35);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.70), vertex)
+
+	const_amount->set_value(0.50);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 1.00), vertex)
+
+	const_amount->set_value(0.80);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 1.60), vertex)
+
+	const_amount->set_value(1.00);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 2.0), vertex)
+}
+
+void
+test_calc_vertex_for_straight_line_with_loop() {
+	std::vector<ValueBase> list;
+	fill_list_colinear(list);
+
+	ValueNode_BLine* bline = ValueNode_BLine::create(list);
+	bline->set_loop(true);
+	ValueNode_Const* const_false = static_cast<ValueNode_Const*>(ValueNode_Const::create(false));
+	ValueNode_Const* const_true = static_cast<ValueNode_Const*>(ValueNode_Const::create(true));
+	ValueNode_Const* const_amount = static_cast<ValueNode_Const*>(ValueNode_Const::create(0.1));
+
+	ValueNode_BLineCalcVertex::Handle bline_calc_vertex(ValueNode_BLineCalcVertex::create(Vector(0,0)));
+	bline_calc_vertex->set_link("bline", bline);
+	bline_calc_vertex->set_link("loop", const_false);
+	bline_calc_vertex->set_link("homogeneous", const_true);
+	bline_calc_vertex->set_link("amount", const_amount);
+
+	const_amount->set_value(0.0);
+	Vector vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.0), vertex)
+
+	const_amount->set_value(0.1);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.40), vertex)
+
+	const_amount->set_value(0.25);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 1.00), vertex)
+
+	const_amount->set_value(0.35);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 1.40), vertex)
+
+	const_amount->set_value(0.50);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 2.00), vertex)
+
+	const_amount->set_value(0.75);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 1.00), vertex)
+
+	const_amount->set_value(0.80);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.80), vertex)
+
+	const_amount->set_value(1.00);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.0), vertex)
+}
+
+void
+test_calc_vertex_for_open_rectangle() {
+	std::vector<ValueBase> list;
+	fill_list_open_rectangle(list);
+
+	ValueNode_BLine* bline = ValueNode_BLine::create(list);
+	ValueNode_Const* const_false = static_cast<ValueNode_Const*>(ValueNode_Const::create(false));
+	ValueNode_Const* const_true = static_cast<ValueNode_Const*>(ValueNode_Const::create(true));
+	ValueNode_Const* const_amount = static_cast<ValueNode_Const*>(ValueNode_Const::create(0.1));
+
+	ValueNode_BLineCalcVertex::Handle bline_calc_vertex(ValueNode_BLineCalcVertex::create(Vector(0,0)));
+	bline_calc_vertex->set_link("bline", bline);
+	bline_calc_vertex->set_link("loop", const_false);
+	bline_calc_vertex->set_link("homogeneous", const_true);
+	bline_calc_vertex->set_link("amount", const_amount);
+
+	const_amount->set_value(0.0);
+	Vector vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.0), vertex)
+
+	const_amount->set_value(0.10);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.50), vertex)
+
+	const_amount->set_value(0.40);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 2.00), vertex)
+
+	const_amount->set_value(0.50);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.5, 2.00), vertex)
+
+	const_amount->set_value(0.60);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 2.00), vertex)
+
+	const_amount->set_value(0.80);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 1.00), vertex)
+
+	const_amount->set_value(1.00);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 0.0), vertex)
+}
+
+void
+test_calc_vertex_for_closed_rectangle() {
+	std::vector<ValueBase> list;
+	fill_list_open_rectangle(list);
+
+	ValueNode_BLine* bline = ValueNode_BLine::create(list);
+	bline->set_loop(true);
+	ValueNode_Const* const_false = static_cast<ValueNode_Const*>(ValueNode_Const::create(false));
+	ValueNode_Const* const_true = static_cast<ValueNode_Const*>(ValueNode_Const::create(true));
+	ValueNode_Const* const_amount = static_cast<ValueNode_Const*>(ValueNode_Const::create(0.1));
+
+	ValueNode_BLineCalcVertex::Handle bline_calc_vertex(ValueNode_BLineCalcVertex::create(Vector(0,0)));
+	bline_calc_vertex->set_link("bline", bline);
+	bline_calc_vertex->set_link("loop", const_false);
+	bline_calc_vertex->set_link("homogeneous", const_true);
+	bline_calc_vertex->set_link("amount", const_amount);
+
+	const_amount->set_value(0.0);
+	Vector vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.0), vertex)
+
+	const_amount->set_value(0.1);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.60), vertex)
+
+	const_amount->set_value(0.25);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 1.50), vertex)
+
+	const_amount->set_value(1/3.);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 2.00), vertex)
+
+	const_amount->set_value(0.40);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.4, 2.00), vertex)
+
+	const_amount->set_value(0.50);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 2.00), vertex)
+
+	const_amount->set_value(0.75);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 0.50), vertex)
+
+	const_amount->set_value(5/6.);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(1.0, 0.00), vertex)
+
+	const_amount->set_value(0.90);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.6, 0.0), vertex)
+
+	const_amount->set_value(1.00);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(Vector(0.0, 0.0), vertex)
+}
+
+void
+test_calc_vertex_on_vertex_exact_positions_for_looped_curve_with_two_vertices_on_same_coords() {
+	std::vector<ValueBase> list;
+	struct SimpleBPoint {
+		Point vertex;
+		Vector tangent1;
+		Vector tangent2;
+	};
+
+	const std::vector<SimpleBPoint> bpoints {
+		{{18.1919, 43.7512}, {0., 0.}, {0., 0.}},
+		{{20.1668, 43.8746}, {0., 0.}, {0., 0.}},
+		{{18.8027, 46.8822}, {-0.098746, -0.006174}, {0., 0.}},
+		{{18.8027, 46.8822}, {0., 0.}, {0., 0.}}
+	};
+	for (const auto& item : bpoints) {
+		BLinePoint p;
+		p.set_vertex(item.vertex);
+		p.set_tangent1(item.tangent1);
+		p.set_tangent2(item.tangent2);
+		p.set_origin(0.500000);
+		list.push_back(p);
+	}
+
+	ValueNode_BLine* bline = ValueNode_BLine::create(list);
+	bline->set_loop(true);
+	ValueNode_Const* const_false = static_cast<ValueNode_Const*>(ValueNode_Const::create(false));
+	// ValueNode_Const* const_true = static_cast<ValueNode_Const*>(ValueNode_Const::create(true));
+	ValueNode_Const* const_amount = static_cast<ValueNode_Const*>(ValueNode_Const::create(0.1));
+
+	ValueNode_BLineCalcVertex::Handle bline_calc_vertex(ValueNode_BLineCalcVertex::create(Vector(0,0)));
+	bline_calc_vertex->set_link("bline", bline);
+	bline_calc_vertex->set_link("loop", const_false);
+	bline_calc_vertex->set_link("homogeneous", const_false);
+	bline_calc_vertex->set_link("amount", const_amount);
+
+	const_amount->set_value(0.0);
+	Vector vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(bpoints[0].vertex, vertex)
+
+	const_amount->set_value(0.25);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(bpoints[1].vertex, vertex)
+
+	const_amount->set_value(0.5);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(bpoints[2].vertex, vertex)
+
+	const_amount->set_value(0.75);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(bpoints[3].vertex, vertex)
+
+	const_amount->set_value(1.0);
+	vertex = (*bline_calc_vertex)(Time()).get(Vector());
+	ASSERT_VECTOR_APPROX_EQUAL_MICRO(bpoints[0].vertex, vertex)
+}
+
 int main() {
 	Type::subsys_init();
 
@@ -502,6 +837,15 @@ int main() {
 	TEST_FUNCTION(test_bline_std_to_hom_with_loop_with_two_vertices_at_same_spot);
 	TEST_FUNCTION(test_bline_hom_to_std_without_loop_with_two_vertices_at_same_spot);
 	TEST_FUNCTION(test_bline_hom_to_std_with_loop_with_two_vertices_at_same_spot);
+
+	TEST_FUNCTION(test_calc_vertex_for_single_vertex_without_loop_returns_itself);
+	TEST_FUNCTION(test_calc_vertex_for_single_vertex_with_loop_returns_itself_on_edges);
+	TEST_FUNCTION(test_calc_vertex_for_straight_line_without_loop);
+	TEST_FUNCTION(test_calc_vertex_for_straight_line_with_loop);
+	TEST_FUNCTION(test_calc_vertex_for_open_rectangle);
+	TEST_FUNCTION(test_calc_vertex_for_closed_rectangle);
+	TEST_FUNCTION(test_calc_vertex_on_vertex_exact_positions_for_looped_curve_with_two_vertices_on_same_coords);
+
 	TEST_SUITE_END();
 
 	Type::subsys_stop();

--- a/synfig-core/test/bline.cpp
+++ b/synfig-core/test/bline.cpp
@@ -138,7 +138,43 @@ test_bline_length_with_loop()
 	ASSERT_APPROX_EQUAL(6.0, total_length);
 }
 
-void test_bline_std_to_hom_without_loop() {
+void
+test_bline_std_to_hom_without_bline_loop_without_index_loop_clamps_to_zero_for_negative_position()
+{
+	std::vector<ValueBase> list;
+	fill_list_colinear(list);
+
+	ASSERT_APPROX_EQUAL(0.0, synfig::std_to_hom(list,  0.0, false, false));
+	ASSERT_APPROX_EQUAL(0.0, synfig::std_to_hom(list, -1.0, false, false));
+	ASSERT_APPROX_EQUAL(0.0, synfig::std_to_hom(list, -0.5, false, false));
+}
+
+void
+test_bline_std_to_hom_without_bline_loop_without_index_loop_clamps_to_one_for_position_greater_than_one()
+{
+	std::vector<ValueBase> list;
+	fill_list_colinear(list);
+
+	ASSERT_APPROX_EQUAL(1.0, synfig::std_to_hom(list, 1.0, false, false));
+	ASSERT_APPROX_EQUAL(1.0, synfig::std_to_hom(list, 2.0, false, false));
+	ASSERT_APPROX_EQUAL(1.0, synfig::std_to_hom(list, 2.5, false, false));
+}
+
+void
+test_bline_std_to_hom_without_bline_loop_with_index_loop_keeps_position_for_both_edges()
+{
+	std::vector<ValueBase> list;
+	fill_list_colinear(list);
+
+	ASSERT_APPROX_EQUAL( 0.0, synfig::std_to_hom(list,  0.0, true, false));
+	ASSERT_APPROX_EQUAL(-1.0, synfig::std_to_hom(list, -1.0, true, false));
+	ASSERT_APPROX_EQUAL(1.0, synfig::std_to_hom(list, 1.0, true, false));
+	ASSERT_APPROX_EQUAL(2.0, synfig::std_to_hom(list, 2.0, true, false));
+}
+
+void
+test_bline_std_to_hom_without_loop()
+{
 	std::vector<ValueBase> list;
 	fill_list_colinear(list);
 
@@ -294,6 +330,10 @@ int main() {
 	TEST_FUNCTION(test_bline_length_single_vertex);
 	TEST_FUNCTION(test_bline_length_without_loop);
 	TEST_FUNCTION(test_bline_length_with_loop);
+
+	TEST_FUNCTION(test_bline_std_to_hom_without_bline_loop_without_index_loop_clamps_to_zero_for_negative_position);
+	TEST_FUNCTION(test_bline_std_to_hom_without_bline_loop_without_index_loop_clamps_to_one_for_position_greater_than_one);
+	TEST_FUNCTION(test_bline_std_to_hom_without_bline_loop_with_index_loop_keeps_position_for_both_edges);
 
 	TEST_FUNCTION(test_bline_std_to_hom_without_loop);
 	TEST_FUNCTION(test_bline_std_to_hom_with_loop);

--- a/synfig-core/test/bline.cpp
+++ b/synfig-core/test/bline.cpp
@@ -37,53 +37,64 @@
 
 using namespace synfig;
 
-void fill_list(std::vector<ValueBase> &list) {
-	BLinePoint p;
-	list.push_back(p);
-	p.set_vertex(Point(0.0,1.0));
-	list.push_back(p);
-	p.set_vertex(Point(0.0,2.0));
-	list.push_back(p);
+void
+fill_list(std::vector<ValueBase> &list)
+{
+	const std::vector<Point> points {{0.0, 0.0}, {0.0, 1.0}, {0.0, 2.0}};
+	for (const auto& point : points) {
+		BLinePoint p;
+		p.set_vertex(point);
+		list.push_back(p);
+	}
 }
 
-void test_bline_length() {
+void
+test_bline_length_single_vertex()
+{
 	std::vector<ValueBase> list;
-	fill_list(list);
-	
+
 	bool loop = false;
 	std::vector<Real> lengths;
-
-	Real l = bline_length(list, loop, &lengths);
-	ASSERT_EQUAL(2, lengths.size());
-	ASSERT_APPROX_EQUAL(1.0, lengths[0]);
-	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
-	ASSERT_APPROX_EQUAL(2.0, l);
-
-	loop = true;
-	l = bline_length(list, loop, &lengths);
-	ASSERT_EQUAL(3, lengths.size());
-	ASSERT_APPROX_EQUAL(1.0, lengths[0]);
-	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
-	ASSERT_APPROX_EQUAL(2.0, lengths[2]);
-	ASSERT_APPROX_EQUAL(4.0, l);
+	Real total_length;
 
 	BLinePoint p1;
 	p1.set_tangent1(Point(-1,0));
 	p1.set_tangent2(Point(1,0));
-
-	list.clear();
 	list.push_back(p1);
-	lengths.clear();
-	// single point
+
 	loop = false;
-	l = bline_length(list, loop, &lengths);
+	total_length = bline_length(list, loop, &lengths);
 	ASSERT_EQUAL(0, lengths.size());
-	ASSERT_APPROX_EQUAL(0.0, l);
+	ASSERT_APPROX_EQUAL(0.0, total_length);
 
 	loop = true;
-	l = bline_length(list, loop, &lengths);
+	total_length = bline_length(list, loop, &lengths);
 	ASSERT_EQUAL(1, lengths.size());
-	ASSERT_APPROX_EQUAL_MICRO(0.349854, l);
+	ASSERT_APPROX_EQUAL_MICRO(0.349854, total_length);
+}
+
+void
+test_bline_length()
+{
+	std::vector<ValueBase> list;
+	fill_list(list);
+
+	bool loop = false;
+	std::vector<Real> lengths;
+
+	Real total_length = bline_length(list, loop, &lengths);
+	ASSERT_EQUAL(2, lengths.size());
+	ASSERT_APPROX_EQUAL(1.0, lengths[0]);
+	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
+	ASSERT_APPROX_EQUAL(2.0, total_length);
+
+	loop = true;
+	total_length = bline_length(list, loop, &lengths);
+	ASSERT_EQUAL(3, lengths.size());
+	ASSERT_APPROX_EQUAL(1.0, lengths[0]);
+	ASSERT_APPROX_EQUAL(1.0, lengths[1]);
+	ASSERT_APPROX_EQUAL(2.0, lengths[2]);
+	ASSERT_APPROX_EQUAL(4.0, total_length);
 }
 
 void test_bline_std_to_hom_without_loop() {
@@ -237,14 +248,18 @@ void test_calc_vertex() {
 int main() {
 	Type::subsys_init();
 
-	TEST_SUITE_BEGIN()
-		TEST_FUNCTION(test_bline_length)
-		TEST_FUNCTION(test_bline_std_to_hom_without_loop)
-		TEST_FUNCTION(test_bline_std_to_hom_with_loop)
-		TEST_FUNCTION(test_bline_hom_to_std_without_loop)
-		TEST_FUNCTION(test_bline_hom_to_std_with_loop)
-		TEST_FUNCTION(test_calc_vertex)
-	TEST_SUITE_END()
+	TEST_SUITE_BEGIN();
+
+	TEST_FUNCTION(test_bline_length_single_vertex);
+	TEST_FUNCTION(test_bline_length);
+
+	TEST_FUNCTION(test_bline_std_to_hom_without_loop);
+	TEST_FUNCTION(test_bline_std_to_hom_with_loop);
+	TEST_FUNCTION(test_bline_hom_to_std_without_loop);
+	TEST_FUNCTION(test_bline_hom_to_std_with_loop);
+	TEST_FUNCTION(test_calc_vertex);
+
+	TEST_SUITE_END();
 
 	Type::subsys_stop();
 

--- a/synfig-core/test/test_base.h
+++ b/synfig-core/test/test_base.h
@@ -25,6 +25,7 @@
 #ifndef SYNFIG_TESTBASE_H
 #define SYNFIG_TESTBASE_H
 
+#include <cmath> // std::isnan
 #include <cstdlib> // std::abs
 #include <iostream> // std::cerr
 #include <sstream>
@@ -128,14 +129,15 @@ std::ostream& operator<<(std::ostream& os, std::nullptr_t)
 }
 
 #define ASSERT_APPROX_EQUAL_MICRO(expected, value) {\
-	if (std::abs(expected - value) > 1e-6) { \
+	if (std::isnan(value) != std::isnan(expected) || std::abs(expected - value) > 1e-6) { \
 		ERROR_MESSAGE_TWO_VALUES(expected, value) \
 	} \
 }
 
 #define ASSERT_VECTOR_APPROX_EQUAL_MICRO(expected, value) {\
-	if (std::abs(expected[0] - value[0]) > 2e-6 || std::abs(expected[1] - value[1]) > 2e-6) { \
-		ERROR_MESSAGE_TWO_VALUES(expected, value) \
+	if (std::isnan(value[0]) != std::isnan(expected[0]) || std::isnan(value[1]) != std::isnan(expected[1]) \
+		|| std::abs(expected[0] - value[0]) > 2e-6 || std::abs(expected[1] - value[1]) > 2e-6) { \
+			ERROR_MESSAGE_TWO_VALUES(expected, value) \
 	} \
 }
 

--- a/synfig-studio/test/test_base.h
+++ b/synfig-studio/test/test_base.h
@@ -129,14 +129,15 @@ std::ostream& operator<<(std::ostream& os, std::nullptr_t)
 }
 
 #define ASSERT_APPROX_EQUAL_MICRO(expected, value) {\
-	if (std::abs(expected - value) > 1e-6) { \
-	    ERROR_MESSAGE_TWO_VALUES(expected, value) \
+	if (std::isnan(value) != std::isnan(expected) || std::abs(expected - value) > 1e-6) { \
+			ERROR_MESSAGE_TWO_VALUES(expected, value) \
 	} \
 }
 
 #define ASSERT_VECTOR_APPROX_EQUAL_MICRO(expected, value) {\
-	if (std::abs(expected[0] - value[0]) > 2e-6 || std::abs(expected[1] - value[1]) > 2e-6) { \
-	    ERROR_MESSAGE_TWO_VALUES(expected, value) \
+	if (std::isnan(value[0]) != std::isnan(expected[0]) || std::isnan(value[1]) != std::isnan(expected[1]) \
+		|| std::abs(expected[0] - value[0]) > 2e-6 || std::abs(expected[1] - value[1]) > 2e-6) { \
+			ERROR_MESSAGE_TWO_VALUES(expected, value) \
 	} \
 }
 


### PR DESCRIPTION
Advanced outline allows user to set width along its path, not only in its vertices.
If a path has zero-length segments (possibly due to two consecutive vertices at same coordinates), the width points were placed in a wrong position.

Before:
![image](https://github.com/user-attachments/assets/b433eec9-e914-4f8e-815a-4b3d708e03ab)

Now:
![image](https://github.com/user-attachments/assets/66a5b505-cbd9-442b-9974-9b14b06ccfcf)

This PR does other stuff for improving testing, and fixing some cases of single-vertex blines I found while investigating this issue.

Reported-by: Svarov in https://forums.synfig.org/t/sonic-model-wip/16286/4