### PR TITLE
feat: change naming for duplicate layer and copied

### DIFF
--- a/synfig-core/src/synfig/layer.cpp
+++ b/synfig-core/src/synfig/layer.cpp
@@ -462,7 +462,7 @@ Layer::clone(Canvas::LooseHandle canvas, const GUID& deriv_guid) const
 
 	ret->group_=group_;
 	//ret->set_canvas(get_canvas());
-	ret->set_description(get_description());
+	ret->set_description(get_description()+"#");
 	ret->set_active(active());
 	ret->set_optimized(optimized());
 	ret->set_exclude_from_rendering(get_exclude_from_rendering());

--- a/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
+++ b/synfig-studio/src/gui/actionmanagers/layeractionmanager.cpp
@@ -537,6 +537,8 @@ LayerActionManager::paste()
 	for(std::list<synfig::Layer::Handle>::iterator iter=clipboard_.begin();iter!=clipboard_.end();++iter)
 	{
 		layer=(*iter)->clone(canvas, guid);
+		String currentDesc = layer->get_description();
+		layer->set_description(currentDesc.substr(0, currentDesc.length() - 1));
 		layer_selection.push_back(layer);
 
 		replace_exported_value_nodes(layer, valuenode_replacements);


### PR DESCRIPTION
# Improve Layer Duplication Naming

## Currently in Synfig:
![default](https://github.com/user-attachments/assets/01191119-1a07-4fda-bd9d-de1ca6458e16)

- **Duplicate Layer**  
  - You duplicate “circle003” → you get another “circle003” (no suffix)  
  - Duplicate again → still “circle003”  
- **Copy‑Paste Layer**  
  - You copy “circle003” and paste → you get “circle003”
  - Paste again → “circle003”  

This differs from common software programs (e.g. After Effects), which append increasing numbers:

- **After Effects**  
  - “Layer1” → “Layer1 2” → “Layer1 3” → …  

## What’s Wrong

1. **Duplicate adds no suffix**  
   - Makes it impossible to distinguish original vs. duplicate at a glance, plus designer will need to rename which maybe slows him.

## Changes in This PR
![image](https://github.com/user-attachments/assets/0172cee4-057d-4d70-acff-a2032d7129de)


- **Duplicate Layer** now appends a single `#` on each duplicate, e.g.:  
  - First duplicate → `Layer#`  
  - Second duplicate → `Layer##`  
- **Copy‑Paste Layer** works with same logic adds # 


Thank you!  
