### PR TITLE
fix: missing template argument : compiler in FreeBSD complained

### DIFF
--- a/synfig-core/src/synfig/rendering/software/function/array.h
+++ b/synfig-core/src/synfig/rendering/software/function/array.h
@@ -429,7 +429,7 @@ public:
 	};
 
 	void fill(const Type &x) const
-		{ for(Iterator i(*this); i; ++i) i.get_array().template fill(x); }
+		{ for(Iterator i(*this); i; ++i) i.get_array().template fill<Type>(x); }
 
 	template<typename TT>
 	void assign(const Array<TT, Rank> &x) const


### PR DESCRIPTION
Issued error message:
> error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]

fix #3557