### PR TITLE
fix(ui): rectify wayland window icon

### DIFF
--- a/synfig-studio/src/gui/main.cpp
+++ b/synfig-studio/src/gui/main.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <glibmm/convert.h>
+#include <glibmm/miscutils.h>
 
 #include <synfig/os.h>
 
@@ -84,6 +85,8 @@ int main(int argc, char **argv)
 	app->signal_startup().connect([app, rootpath]() {
 		app->init(rootpath.u8string());
 	});
+
+	Glib::set_prgname("org.synfig.SynfigStudio");
 
 	app->register_application();
 	if (app->is_remote()) {


### PR DESCRIPTION
Before: 

![image](https://github.com/user-attachments/assets/ab4dbe97-55aa-433a-8690-b54d540c5211)


After: 

![image](https://github.com/user-attachments/assets/053bea1a-0eda-4afe-876a-bb84c4598d22)
