### PR TITLE
fix: enable 'Width' Parameter in Advanced Outlines to Function as Expected

### DIFF
--- a/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.cpp
@@ -492,7 +492,8 @@ Advanced_Outline::Advanced_Outline():
 	param_smoothness(ValueBase(Real(1))),
 	param_homogeneous(ValueBase(false)),
 	param_dash_offset(ValueBase(Real(0))),
-	param_dash_enabled(ValueBase(false))
+	param_dash_enabled(ValueBase(false)),
+	param_use_vertex_widths(ValueBase(false))
 {
 	clear();
 
@@ -569,7 +570,7 @@ Advanced_Outline::sync_vfunc()
 		const Real gv = exp(get_outline_grow_mark());
 		const Real wk = 0.5*gv*width;
 		const Real we = gv*expand;
-		const bool use_bline_width = wplist.empty();
+		const bool use_bline_width = wplist.empty() || param_use_vertex_widths.get(bool());
 		
 		// build bend
 		rendering::Bend bend;
@@ -712,6 +713,7 @@ Advanced_Outline::set_shape_param(const String & param, const ValueBase &value)
 	IMPORT_VALUE(param_homogeneous);
 	IMPORT_VALUE(param_dash_offset);
 	IMPORT_VALUE(param_dash_enabled);
+	IMPORT_VALUE(param_use_vertex_widths); 
 
 	// Skip polygon parameters
 	return Layer_Shape::set_shape_param(param,value);
@@ -732,6 +734,7 @@ Advanced_Outline::get_param(const String& param)const
 	EXPORT_VALUE(param_homogeneous);
 	EXPORT_VALUE(param_dash_offset);
 	EXPORT_VALUE(param_dash_enabled);
+	EXPORT_VALUE(param_use_vertex_widths);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
@@ -823,6 +826,11 @@ Advanced_Outline::get_param_vocab()const
 		.set_is_distance()
 		.set_description(_("Distance to Offset the Dash Items"))
 	);
+	ret.push_back(ParamDesc("use_vertex_widths")
+		.set_local_name(_("Use Vertex Widths"))
+		.set_description(_("When checked, uses the Width value of each vertex point (from the Spline) instead of the Width Points list"))
+		.set_hint("bool")
+	);
 	return ret;
 }
 
@@ -876,4 +884,9 @@ Advanced_Outline::connect_bline_to_wplist(ValueNode::LooseHandle x)
 		return false;
 	wplist->set_bline(ValueNode::Handle(x));
 	return true;
+}
+
+bool 
+Advanced_Outline::get_use_vertex_widths() const {
+    return param_use_vertex_widths.get(bool());
 }

--- a/synfig-core/src/modules/mod_geometry/advanced_outline.h
+++ b/synfig-core/src/modules/mod_geometry/advanced_outline.h
@@ -67,7 +67,8 @@ private:
 	synfig::ValueBase param_dash_offset;
 	//! Parameter: (bool)
 	synfig::ValueBase param_dash_enabled;
-
+	//! Parameter: (bool)
+	synfig::ValueBase param_use_vertex_widths;
 public:
 	enum CuspType
 	{
@@ -85,6 +86,7 @@ public:
 
 	//! Connects the parameter to another Value Node. Implementation for this layer
 	virtual bool connect_dynamic_param(const synfig::String& param, synfig::ValueNode::LooseHandle x );
+	bool get_use_vertex_widths() const;
 
 private:
 	bool connect_bline_to_wplist(synfig::ValueNode::LooseHandle x);


### PR DESCRIPTION
This PR addresses an issue (#3427) with the "Width" parameter in the Advanced Outline layer, which was previously non-functional. In the Normal Outline layer, the "Width" parameter adjusts the width of the outline based on vertex point widths, and this behavior was expected to carry over to Advanced Outlines. However, in Advanced Outlines, the parameter did not have any effect, even though it was visible.

How the Bug is Being Rectified:
The "Use Vertex Widths" parameter has been introduced for Advanced Outlines, enabling the use of per-vertex width values in the outline layer. This change ensures that the width of individual vertex points will now properly affect the overall width of the outline, similar to the behavior seen in Normal Outlines. The "Width" parameter is now functional within the Advanced Outline layer, allowing users to adjust the vertex width and see the corresponding changes in the outline width, just like in the Normal Outline.
![ss1](https://github.com/user-attachments/assets/e6c16252-0a8d-4f12-adf5-3d699546229f)
![ss2](https://github.com/user-attachments/assets/de109b3a-afc8-4a7a-a5bb-3bf1b90ad479)


In the first image, we can see that in the Advanced Outline layer, setting the vertex width to 1000 has no effect on the outline, even though the "Width" parameter is present and adjustable. This is the bug.

Fix:
In the second image, after enabling the new "Use Vertex Widths" toggle button, the Advanced Outline layer now responds as expected. The vertex width is applied correctly, without changing the behavior of the Width Points List (or wplist), ensuring that previous functionality remains intact.