### PR TITLE
refactor: rename pre_run() parameters of TaskPaintPixelSW and TaskFilterPixelSW and fix code style

### DIFF
--- a/synfig-core/src/modules/mod_filter/halftone2.cpp
+++ b/synfig-core/src/modules/mod_filter/halftone2.cpp
@@ -89,7 +89,7 @@ public:
 	SYNFIG_EXPORT static Token token;
 	Token::Handle get_token() const override { return token.handle(); }
 
-	void pre_run(const Matrix3& /*matrix*/) const override
+	void pre_run(const Matrix3& /*raster_to_world*/) const override
 	{
 		supersample_size = 1/std::fabs(get_pixels_per_unit()[0]*(halftone.param_size.get(Vector())).mag());
 		inverted_transformation = transformation->create_inverted();

--- a/synfig-core/src/modules/mod_filter/halftone3.cpp
+++ b/synfig-core/src/modules/mod_filter/halftone3.cpp
@@ -89,7 +89,7 @@ public:
 	SYNFIG_EXPORT static Token token;
 	Token::Handle get_token() const override { return token.handle(); }
 
-	void pre_run(const Matrix3& /*matrix*/) const override
+	void pre_run(const Matrix3& /*raster_to_world*/) const override
 	{
 		supersample = 1/std::fabs(get_pixels_per_unit()[0]*(tone[0].param_size.get(Vector())).mag());
 		inverted_transformation = transformation->create_inverted();

--- a/synfig-core/src/modules/mod_geometry/checkerboard.cpp
+++ b/synfig-core/src/modules/mod_geometry/checkerboard.cpp
@@ -136,10 +136,10 @@ public:
 		return (this->*selected_get_color_method)(p);
 	}
 
-	void pre_run(const Matrix3& matrix, const Matrix3& /*inverse_matrix*/) const override
+	void pre_run(const Matrix3& world_to_raster, const Matrix3& /*raster_to_world*/) const override
 	{
-		kx = matrix.axis_x().mag()*0.5;
-		ky = matrix.axis_y().mag()*0.5;
+		kx = world_to_raster.axis_x().mag()*0.5;
+		ky = world_to_raster.axis_y().mag()*0.5;
 		selected_get_color_method = antialias ? &TaskCheckerBoardSW::get_color_antialias : &TaskCheckerBoardSW::get_color_simple;
 	}
 

--- a/synfig-core/src/modules/mod_gradient/lineargradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/lineargradient.cpp
@@ -85,7 +85,7 @@ public:
 
 	mutable Real supersample = 0.;
 
-	void pre_run(const Matrix3& /*matrix*/, const Matrix3& /*inverse_matrix*/) const override
+	void pre_run(const Matrix3& /*world_to_raster*/, const Matrix3& /*raster_to_world*/) const override
 	{
 		supersample = get_units_per_pixel()[0]*.1;
 	}

--- a/synfig-core/src/modules/mod_gradient/radialgradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/radialgradient.cpp
@@ -90,7 +90,7 @@ public:
 
 	mutable Real supersample = 0.;
 
-	void pre_run(const Matrix3& /*matrix*/, const Matrix3& /*inverse_matrix*/) const override
+	void pre_run(const Matrix3& /*world_to_raster*/, const Matrix3& /*raster_to_world*/) const override
 	{
 		supersample = 1.2*get_units_per_pixel()[0]/radius;
 		supersample *= 0.5;

--- a/synfig-core/src/synfig/rendering/software/task/taskpaintpixelsw.cpp
+++ b/synfig-core/src/synfig/rendering/software/task/taskpaintpixelsw.cpp
@@ -80,15 +80,16 @@ synfig::rendering::TaskPaintPixelSW::run_task() const
 	if (!task->is_valid())
 		return true;
 
-	Vector ppu = task->get_pixels_per_unit();
-
 	const synfig::RectInt& target_rect = task->target_rect;
 
 	Matrix world_to_raster;
-	world_to_raster.m00 = ppu[0];
-	world_to_raster.m11 = ppu[1];
-	world_to_raster.m20 = target_rect.minx - ppu[0]*task->source_rect.minx;
-	world_to_raster.m21 = target_rect.miny - ppu[1]*task->source_rect.miny;
+	{
+		const Vector ppu = task->get_pixels_per_unit();
+		world_to_raster.m00 = ppu[0];
+		world_to_raster.m11 = ppu[1];
+		world_to_raster.m20 = target_rect.minx - ppu[0] * task->source_rect.minx;
+		world_to_raster.m21 = target_rect.miny - ppu[1] * task->source_rect.miny;
+	}
 
 	if (auto interface_transformation = dynamic_cast<const TaskInterfaceTransformation*>(this)) {
 		if (auto affine = TransformationAffine::Handle::cast_dynamic(interface_transformation->get_transformation()))
@@ -101,7 +102,7 @@ synfig::rendering::TaskPaintPixelSW::run_task() const
 
 	const int tw = target_rect.get_width();
 	const Vector dx = raster_to_world.axis_x();
-	const Vector dy = raster_to_world.axis_y() - dx*(Real)tw;
+	const Vector dy = raster_to_world.axis_y() - dx * (Real)tw;
 	Vector p = raster_to_world.get_transformed( Vector((Real)target_rect.minx, (Real)target_rect.miny) );
 
 	pre_run(world_to_raster, raster_to_world);
@@ -111,11 +112,11 @@ synfig::rendering::TaskPaintPixelSW::run_task() const
 		return false;
 
 	synfig::Surface::alpha_pen apen(la->get_surface().get_pen(target_rect.minx, target_rect.miny));
-	ColorReal amount = blend ? this->amount : ColorReal(1.0);
+	const ColorReal amount = blend ? this->amount : ColorReal(1.0);
 	apen.set_blend_method(blend ? blend_method : Color::BLEND_COMPOSITE);
 
-	for(int iy = target_rect.miny; iy < target_rect.maxy; ++iy, p += dy, apen.inc_y(), apen.dec_x(tw)) {
-		for(int ix = target_rect.minx; ix < target_rect.maxx; ++ix, p += dx, apen.inc_x()) {
+	for (int iy = target_rect.miny; iy < target_rect.maxy; ++iy, p += dy, apen.inc_y(), apen.dec_x(tw)) {
+		for (int ix = target_rect.minx; ix < target_rect.maxx; ++ix, p += dx, apen.inc_x()) {
 			apen.put_value(get_color(p), amount);
 		}
 	}

--- a/synfig-core/src/synfig/rendering/software/task/taskpaintpixelsw.h
+++ b/synfig-core/src/synfig/rendering/software/task/taskpaintpixelsw.h
@@ -61,12 +61,12 @@ class TaskPaintPixelSW :
 		public TaskInterfaceSplit
 {
 public:
-	//! Called inside run() right before iterating over each pixel.
+	//! Called inside run() right before start iterating over each pixel.
 	//! Useful for computing some parameters that are constant for all iterations.
 	//!
-	//! \param matrix transformation matrix mixing affine and bound transformations
-	//! \param inverse_matrix the inverse of matrix
-	virtual void pre_run(const Matrix3& /*matrix*/, const Matrix3& /*inverse_matrix*/) const {}
+	//! \param world_to_raster full transformation matrix mixing transformation of vector to raster coords and task affine transformation
+	//! \param raster_to_world the inverse of world_to_raster
+	virtual void pre_run(const Matrix3& /*world_to_raster*/, const Matrix3& /*raster_to_world*/) const {}
 
 	//! Fetch color at position p (in synfig units) when antialias is false
 	virtual Color get_color(const Vector& p) const = 0;

--- a/synfig-core/src/synfig/rendering/software/task/taskpaintpixelsw.h
+++ b/synfig-core/src/synfig/rendering/software/task/taskpaintpixelsw.h
@@ -94,8 +94,8 @@ public:
 	//! Called inside run() right before iterating over each pixel.
 	//! Useful for computing some parameters that are constant for all iterations.
 	//!
-	//! \param matrix transformation matrix : raster coordinates to world coordinates
-	virtual void pre_run(const Matrix3& /*matrix*/) const {}
+	//! \param raster_to_world transformation matrix : raster coordinates to world coordinates
+	virtual void pre_run(const Matrix3& /*raster_to_world*/) const {}
 
 	/** Fetch color at position @a p (in synfig units) given a previous Color @a c at same point */
 	virtual Color get_color(const Vector& /*p*/, const Color& c) const = 0;


### PR DESCRIPTION
Let their names according to what they store/represent.