### PR TITLE
fix: undefined behavior when user convert a value, change it, undo tw…

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuedescconvert.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescconvert.cpp
@@ -172,7 +172,8 @@ Action::ValueDescConvert::is_ready()const
 void
 Action::ValueDescConvert::prepare()
 {
-	clear();
+	if (!first_time())
+		return;
 
 	ValueBase value;
 


### PR DESCRIPTION
…ice e redo twice

If user does the following steps, the behavior is not as it is supposed to be:
1. create a converter to a layer parameter
2. change a parameter of this converter
3. undo (the converter parameter change)
4. undo (the converter creation)
5. redo (the converter creation)
6. redo (the converter parameter change)

In the 6th step, the converter of step 5 does not change its value.

The reason is that the converter created in step 5 is a new one, not that one of step 1. In the step 6, however, it changes the parameter of that undone converter of step 1.

This PR avoid this issue by not creating a new converter in step 5, but reusing the one of step 1.