### PR TITLE
refactor: avoid copying variable on left-rotating vector

### DIFF
--- a/synfig-core/src/synfig/savecanvas.cpp
+++ b/synfig-core/src/synfig/savecanvas.cpp
@@ -541,12 +541,8 @@ xmlpp::Element* encode_dynamic_list(xmlpp::Element* root,ValueNode_DynamicList::
 	std::vector<ValueNode_DynamicList::ListEntry> corrected_valuenode_list = value_node->list;
 
 	if (must_rotate_point_list) {
-		if (must_rotate_point_list) {
-			if (corrected_valuenode_list.size() > 0) {
-				auto node = corrected_valuenode_list.front();
-				corrected_valuenode_list.push_back(node);
-				corrected_valuenode_list.erase(corrected_valuenode_list.begin());
-			}
+		if (corrected_valuenode_list.size() > 0) {
+			std::rotate(corrected_valuenode_list.begin(), corrected_valuenode_list.begin() + 1, corrected_valuenode_list.end());
 		}
 	}
 


### PR DESCRIPTION
Problem was in `auto node` (instead of `const auto& node`). Besides, there was a duplicated `if`condition o.O

Error reported by Scan Coverity CID 457160