### PR TITLE
refactor: remove the optional "group" property of layer parameters

### DIFF
--- a/synfig-core/src/modules/lyr_std/mandelbrot.cpp
+++ b/synfig-core/src/modules/lyr_std/mandelbrot.cpp
@@ -233,65 +233,50 @@ Mandelbrot::get_param_vocab()const
 
 	ret.push_back(ParamDesc("distort_inside")
 		.set_local_name(_("Distort Inside"))
-		.set_group(_("Inside"))
 	);
 	ret.push_back(ParamDesc("shade_inside")
 		.set_local_name(_("Shade Inside"))
-		.set_group(_("Inside"))
 	);
 	ret.push_back(ParamDesc("solid_inside")
 		.set_local_name(_("Solid Inside"))
-		.set_group(_("Inside"))
 	);
 	ret.push_back(ParamDesc("invert_inside")
 		.set_local_name(_("Invert Inside"))
-		.set_group(_("Inside"))
 	);
 	ret.push_back(ParamDesc("gradient_inside")
 		.set_local_name(_("Gradient Inside"))
-		.set_group(_("Inside"))
 	);
 	ret.push_back(ParamDesc("gradient_offset_inside")
 		.set_local_name(_("Offset Inside"))
-		.set_group(_("Inside"))
 	);
 	ret.push_back(ParamDesc("gradient_loop_inside")
 		.set_local_name(_("Loop Inside"))
-		.set_group(_("Inside"))
 	);
 
 	ret.push_back(ParamDesc("distort_outside")
 		.set_local_name(_("Distort Outside"))
-		.set_group(_("Outside"))
 	);
 	ret.push_back(ParamDesc("shade_outside")
 		.set_local_name(_("Shade Outside"))
-		.set_group(_("Outside"))
 	);
 	ret.push_back(ParamDesc("solid_outside")
 		.set_local_name(_("Solid Outside"))
-		.set_group(_("Outside"))
 	);
 	ret.push_back(ParamDesc("invert_outside")
 		.set_local_name(_("Invert Outside"))
-		.set_group(_("Outside"))
 	);
 	ret.push_back(ParamDesc("gradient_outside")
 		.set_local_name(_("Gradient outside"))
-		.set_group(_("Outside"))
 	);
 	ret.push_back(ParamDesc("smooth_outside")
 		.set_local_name(_("Smooth Outside"))
 		.set_description(_("Smooth the coloration outside the set"))
-		.set_group(_("Outside"))
 	);
 	ret.push_back(ParamDesc("gradient_offset_outside")
 		.set_local_name(_("Offset Outside"))
-		.set_group(_("Outside"))
 	);
 	ret.push_back(ParamDesc("gradient_scale_outside")
 		.set_local_name(_("Scale Outside"))
-		.set_group(_("Outside"))
 	);
 
 	return ret;

--- a/synfig-core/src/synfig/paramdesc.h
+++ b/synfig-core/src/synfig/paramdesc.h
@@ -75,7 +75,6 @@ private:
    	String name_;			//! The actual parameter name
    	String local_name_; 	//! Localized name
    	String desc_;			//! Short description of parameter (Think tooltops)
-   	String group_;			//! Which group this parameter is a member of (optional)
    	String hint_;			//! Parameter hint
    	String origin_;			//! Parameter origin
    	String connect_;
@@ -128,9 +127,6 @@ public:
 
    	//! Sets the localized description of the parameter.
    	ParamDesc &set_description(const String &d) { desc_=d; return *this; }
-
-   	//! Sets the group that this parameter is a member of
-   	ParamDesc &set_group(const String &n) { group_=n; return *this; }
 
    	//! Sets a "hint" for the parameter.
    	ParamDesc &set_hint(const String &h) { hint_=h; return *this; }
@@ -194,9 +190,6 @@ public:
 
    	//! Returns the localized description of the parameter
    	const String &get_description()const { return desc_; }
-
-   	//! Returns the parameter's group
-   	const String &get_group()const { return group_; }
 
    	//! Returns a "hint" about the parameter, regarding how it is to be displayed to the user
    	const String &get_hint()const { return hint_; }


### PR DESCRIPTION
It isn't used - and exists since the first commit.