### PR TITLE
fix: modifying a bone-linked spline point with split radius / merged angle mutates tangent 2

### DIFF
--- a/synfig-core/src/synfig/valueoperations.cpp
+++ b/synfig-core/src/synfig/valueoperations.cpp
@@ -79,9 +79,9 @@ ValueTransformation::transform(const Transformation &transformation, const Value
 	if (type == type_bline_point)
 	{
 		BLinePoint bp(value.get(BLinePoint()));
-		bp.set_vertex( transformation.transform(bp.get_vertex()) );
-		bp.set_tangent1( transformation.transform(bp.get_tangent1(), false) );
-		bp.set_tangent2( transformation.transform(bp.get_tangent2(), false) );
+		bp.set_vertex(transformation.transform(bp.get_vertex()) );
+		bp.set_tangent2(transformation.transform(bp.get_tangent2(), false));
+		bp.set_tangent1(transformation.transform(bp.get_tangent1(), false));
 		return bp;
 	}
 	else


### PR DESCRIPTION
Fixed a bug where a spline point with Split Radius / Merged Angle that was linked to a skeleton would change Tangent 2 every time the spline point was modified in any way.

Fixes #3554.