### PR TITLE
test: add missing #include <string> in test-base.h

### DIFF
--- a/synfig-core/test/test_base.h
+++ b/synfig-core/test/test_base.h
@@ -28,6 +28,7 @@
 #include <cstdlib> // std::abs
 #include <iostream> // std::cerr
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include <synfig/general.h> // synfig::error , synfig::info

--- a/synfig-studio/test/test_base.h
+++ b/synfig-studio/test/test_base.h
@@ -28,6 +28,7 @@
 #include <cstdlib> // std::abs
 #include <iostream> // std::cerr
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include <synfig/general.h> // synfig::error , synfig::info


### PR DESCRIPTION
Fix #3590