### PR TITLE
fix(bline tool): ignores double-clicking if without any created point

### DIFF
--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -728,6 +728,7 @@ StateBLine_Context::run_()
 	}
 	if(bline_point_list.size()<2)
 	{
+		reset();
 		get_canvas_view()->get_ui_interface()->task(_("Information: You need at least two (2) points to create a spline"));
 		return false;
 	}


### PR DESCRIPTION
On a BLine Tool, double-clicking is used to realize the creation of a new spline.

When no spline being drawn, double-clicking incorrectly makes impossible to draw a new spline - user then would have to press Esc key to be able to draw one more spline (Esc is a shortcut used to cancel an ongoing spline).

Here we make the tool state ignore the double-click in such case, preventing this awkward situation.

Fix #3388