### PR TITLE
fix(bline tool): couldn't create the spline right after user drags the first vertex

### DIFF
--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -1578,6 +1578,8 @@ StateBLine_Context::on_tangent2_change(const studio::Duck& duck, WorkArea::Duck:
 void
 StateBLine_Context::on_first_duck_clicked()
 {
+	if (!curr_duck)
+		return;
 	loop_=true;
 	run();
 }


### PR DESCRIPTION
Steps to reproduce:

1. Select the BLine Tool
2. Click on the Workarea to create the first vertex
3. Click on the Workarea twice to create two other vertices
4. Click on the first vertex (the green handle) and drag it
5. Click on the first vertex again

After step 5, a new (looped) spline is created.
However, user couldn't create a new spline after it without this fix.

Workaround:
* Press Esc after step 5