### PR TITLE
fix: border computation for raster image with Transformation task

### DIFF
--- a/synfig-core/src/synfig/rendering/primitive/transformation.cpp
+++ b/synfig-core/src/synfig/rendering/primitive/transformation.cpp
@@ -86,7 +86,7 @@ Transformation::make_discrete_bounds(const Bounds &bounds)
 		Rect(
 			bounds.rect.get_min() - border,
 			bounds.rect.get_max() + border ),
-		raster_size + VectorInt(border_width, border_width) );
+		raster_size + VectorInt(2*border_width, 2*border_width) );
 }
 
 Matrix2


### PR DESCRIPTION
In vector coordinates, the bounds have a 'border' offset in both sides. So, in raster image, its width (and height) should be increased by 2*border to keep the aspect ratio/resolution.