### PR TITLE
feat: Add support for Angle type to ValueNode_Logarithm (Log converter)

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_log.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_log.cpp
@@ -39,6 +39,8 @@
 #include <synfig/general.h>
 #include <synfig/localization.h>
 #include <synfig/valuenode_registry.h>
+#include <synfig/angle.h>
+#include <synfig/value.h> 
 
 #endif
 
@@ -120,7 +122,22 @@ ValueNode_Logarithm::operator()(Time t)const
 	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
 		"%s:%d operator()\n", __FILE__, __LINE__);
 
-	Real link     = (*link_)    (t).get(Real());
+	ValueBase input_value = (*link_)(t);
+    Real link = 0;
+
+	switch (input_value.get_type())
+	{
+		case ValueBase::TYPE_REAL:
+			link = input_value.get(Real());
+			break;
+		case ValueBase::TYPE_ANGLE:
+			link = input_value.get(Angle()); // Angle → Real
+			break;
+		default:
+			synfig::warning("ValueNode_Logarithm: Unsupported type for input: %d", input_value.get_type());
+			return 0.0;
+	}
+
 	Real epsilon  = (*epsilon_) (t).get(Real());
 	Real infinite = (*infinite_)(t).get(Real());
 
@@ -138,7 +155,7 @@ ValueNode_Logarithm::operator()(Time t)const
 bool
 ValueNode_Logarithm::check_type(Type &type)
 {
-	return type==type_real;
+	return type == type_real || type == type_angle;
 }
 
 LinkableValueNode::Vocab

--- a/synfig-core/src/synfig/valuenodes/valuenode_log.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_log.h
@@ -38,6 +38,15 @@
 
 /* === C L A S S E S & S T R U C T S ======================================= */
 
+/**
+ * \class ValueNode_Logarithm
+ * \brief Computes the natural logarithm (ln) of the input.
+ *
+ * Accepts input of type Real or Angle.
+ * If input is Angle, it is converted to radians before applying log().
+ */
+
+
 namespace synfig {
 
 class ValueNode_Logarithm : public LinkableValueNode
@@ -75,5 +84,3 @@ protected:
 /* === E N D =============================================================== */
 
 #endif
-
-


### PR DESCRIPTION
This PR adds support for the `Angle` type in the Logarithm converter (`ValueNode_Logarithm`). Previously, the converter only accepted `Real` values. With this update, it can now also accept `Angle` inputs, which are internally converted to radians (as `Real`) before applying the logarithmic operation.

### Changes Made

- Modified `operator()` to handle `ValueBase::TYPE_ANGLE` safely.
- Updated `check_type()` to accept both `type_real` and `type_angle`.
- Improved the class documentation in `valuenode_log.h` to reflect the new support for `Angle`.
