### PR TITLE
feat(synfig-core): add multi-threaded image loading for sequences

### DIFF
--- a/synfig-core/src/synfig/loadcanvas.h
+++ b/synfig-core/src/synfig/loadcanvas.h
@@ -174,6 +174,9 @@ private:
 
 	//! Layer Parsing Function
 	etl::handle<Layer> parse_layer(xmlpp::Element *node,Canvas::Handle canvas);
+
+	void process_deferred_layers();
+
 	//! Generic Value Base Parsing Function
 	ValueBase parse_value(xmlpp::Element *node,Canvas::Handle canvas);
 	//! Generic Value Node Parsing Function


### PR DESCRIPTION
Implement parallel image loading to significantly improve performance when processing multiple images in a sequence.

Key details:
- Currently only works for sequences loaded from pre-saved files
- Thread count configurable via `SYNFIG_IMAGE_THREADS` environment variable
- Defaults to single-threaded operation if variable not set