### PR TITLE
feat: new 'IKangle' converter , inverse kinematics bone

### DIFF
--- a/synfig-core/po/POTFILES.in
+++ b/synfig-core/po/POTFILES.in
@@ -384,6 +384,8 @@ src/synfig/valuenodes/valuenode_gradientrotate.cpp
 src/synfig/valuenodes/valuenode_gradientrotate.h
 src/synfig/valuenodes/valuenode_greyed.cpp
 src/synfig/valuenodes/valuenode_greyed.h
+src/synfig/valuenodes/valuenode_ik_angle.cpp
+src/synfig/valuenodes/valuenode_ik_angle.h
 src/synfig/valuenodes/valuenode_integer.cpp
 src/synfig/valuenodes/valuenode_integer.h
 src/synfig/valuenodes/valuenode_intstring.cpp

--- a/synfig-core/src/synfig/layers/layer_skeleton.cpp
+++ b/synfig-core/src/synfig/layers/layer_skeleton.cpp
@@ -113,6 +113,9 @@ Layer_Skeleton::set_param(const String &param, const ValueBase &value)
 	// Skip shape, polygon and composite parameters
 	if (param == "amount")
 		return Layer_Composite::set_param(param,value);
+
+	if (param == "color")
+		return Layer_Shape::set_param(param,value);
 	return Layer::set_param(param,value);
 }
 
@@ -120,12 +123,16 @@ ValueBase
 Layer_Skeleton::get_param(const String &param)const
 {
 	EXPORT_VALUE(param_name);
+	EXPORT_VALUE(color_bones);
 	EXPORT_VALUE(param_bones);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
 
 	// Skip shape, polygon and composite parameters
+	if (param == "color")
+		return Layer_Shape::get_param(param);
+	
 	if (param == "amount")
 		return Layer_Composite::get_param(param);
 	return Layer::get_param(param);
@@ -146,6 +153,11 @@ Layer_Skeleton::get_param_vocab()const
 	ret.push_back(ParamDesc("name")
 		.set_local_name(_("Name"))
 	);
+
+	ret.push_back(ParamDesc("color") 
+		.set_local_name(_("Color bones"))
+	);
+	
 	ret.push_back(ParamDesc("bones")
 		.set_local_name(_("Bones"))
 	);

--- a/synfig-core/src/synfig/layers/layer_skeleton.h
+++ b/synfig-core/src/synfig/layers/layer_skeleton.h
@@ -32,6 +32,7 @@
 
 #include <synfig/bone.h>
 #include "layer_polygon.h"
+#include <synfig/color.h>
 
 /* === M A C R O S ========================================================= */
 
@@ -50,6 +51,7 @@ private:
 	ValueBase param_bones;
 	//!Parameter: (synfig::String) Name of the skeleton
 	ValueBase param_name;
+	ValueBase color_bones;
 
 public:
 	typedef etl::handle<Layer_Skeleton> Handle;

--- a/synfig-core/src/synfig/valuenodes/CMakeLists.txt
+++ b/synfig-core/src/synfig/valuenodes/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(libsynfig
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_gradientcolor.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_gradientrotate.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_greyed.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/valuenode_ik_angle.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_integer.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_intstring.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/valuenode_join.cpp"

--- a/synfig-core/src/synfig/valuenodes/Makefile_insert
+++ b/synfig-core/src/synfig/valuenodes/Makefile_insert
@@ -24,6 +24,7 @@ VALUENODES_HH = \
 	valuenodes/valuenode_gradientcolor.h \
 	valuenodes/valuenode_gradientrotate.h \
 	valuenodes/valuenode_greyed.h \
+	valuenodes/valuenode_ik_angle.h \
 	valuenodes/valuenode_integer.h \
 	valuenodes/valuenode_intstring.h \
 	valuenodes/valuenode_join.h \
@@ -95,6 +96,7 @@ VALUENODES_CC = \
 	valuenodes/valuenode_gradientcolor.cpp \
 	valuenodes/valuenode_gradientrotate.cpp \
 	valuenodes/valuenode_greyed.cpp \
+	valuenodes/valuenode_ik_angle.cpp \
 	valuenodes/valuenode_integer.cpp \
 	valuenodes/valuenode_intstring.cpp \
 	valuenodes/valuenode_join.cpp \

--- a/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.cpp
@@ -1,0 +1,304 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file ValueNode_ik.cpp
+**	\brief Implementation of the "Ik angle" valuenode conversion.
+**
+**	\legal
+**	
+**  Copyright (c) 2025 ZAINAL AB.
+**  Copyright (c) Synfig Contributors
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include "valuenode_ik_angle.h"
+#include "valuenode_const.h"
+#include <synfig/general.h>
+#include <synfig/localization.h>
+#include <synfig/valuenode_registry.h>
+#include <synfig/vector.h>
+#include <synfig/canvas.h>
+
+#endif
+
+/* === U S I N G =========================================================== */
+
+using namespace synfig;
+
+/* === M A C R O S ========================================================= */
+
+/* === G L O B A L S ======================================================= */
+
+REGISTER_VALUENODE(ValueNode_IK, RELEASE_VERSION_0_61_09, "ik", N_("IK angle"))
+
+/* === P R O C E D U R E S ================================================= */
+
+/* === M E T H O D S ======================================================= */
+
+ValueNode_IK::ValueNode_IK(const ValueBase &value):
+	LinkableValueNode(value.get_type())
+{
+	init_children_vocab();
+	if (value.get_type() == type_angle)
+		
+	{
+		set_link("link_pole",ValueNode_Const::create(Vector(Angle::cos(value.get(Angle())).get(),
+														 Angle::sin(value.get(Angle())).get())));
+
+		set_link("link_target",ValueNode_Const::create(Vector(100, 0)));
+		set_link("length_bone1",ValueNode_Const::create(Real(2.0)));
+		set_link("length_bone2",ValueNode_Const::create(Real(2.0)));
+		set_link("length_bone3",ValueNode_Const::create(Real(2.0)));
+		set_link("flip",ValueNode_Const::create(bool(true))); 
+		set_link("joint_bone",ValueNode_Const::create(int(1))); 
+		set_link("t_bone",ValueNode_Const::create(int(1))); 
+		set_link("f_bone",ValueNode_Const::create(int(1))); // 1 = for bone 1 ,2 for bone 2, 3 for bone 3
+		set_link("weight",ValueNode_Const::create(Real(25.0)));
+	}
+	
+}
+
+LinkableValueNode*
+ValueNode_IK::create_new()const
+{
+	return new ValueNode_IK(get_type());
+}
+
+ValueNode_IK*
+ValueNode_IK::create(const ValueBase& x, etl::loose_handle<Canvas>)
+{
+	return new ValueNode_IK(x);
+}
+
+ValueNode_IK::~ValueNode_IK()
+{
+	unlink_all();
+}
+
+ValueBase
+ValueNode_IK::operator()(Time t)const
+{
+	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
+		"%s:%d operator()\n", __FILE__, __LINE__);
+
+    auto hitung_theta2_alpha = [](Real d, Real L1, Real L2, Real p) -> std::pair<Real, Real> {
+	    L1 = (L1 > p) ? L1 : p;
+	    L2 = (L2 > p) ? L2 : p;
+	    Real cos_theta2 = synfig::clamp((d*d - L1*L1 - L2*L2) / (2 * L1 * L2), -1.0, 1.0);
+	    Real theta2 = std::acos(cos_theta2);
+	    Real cos_alpha = synfig::clamp((d*d + L1*L1 - L2*L2) / (2 * d * L1), -1.0, 1.0);
+	    Real alpha = std::acos(cos_alpha);
+	    return std::make_pair(theta2, alpha);
+	};
+    static const Real precision = 0.000000001;
+	Vector origin = (*link_pole_)(t).get(Vector());
+	Vector target = (*link_target_)(t).get(Vector());
+	Real L1 = (*length_bone1_)(Time(0)).get(Real());
+	Real L2 = (*length_bone2_)(Time(0)).get(Real());
+	Real L3 = (*length_bone3_)(Time(0)).get(Real());
+	bool flip = (*flip_)(t).get(bool());
+	int bone2 = (*joint_bone_)(Time(0)).get(int());
+	int type = (*t_bone_)(Time(0)).get(int());
+	int for_bone = (*f_bone_)(Time(0)).get(int());
+	Real weight = synfig::clamp((*weight_)(t).get(Real()), 0.0, 100.0);
+	Vector delta = target - origin;
+	Real dist = delta.mag();
+	// ----- 2-BONE MODE -----
+	if (bone2==1) {
+		dist = std::min(dist, L1 + L2);
+		auto [theta2, alpha] = hitung_theta2_alpha(dist, L1, L2, precision);
+		Real angle_to_target = std::atan2(delta[1], delta[0]);
+		Real theta1 = angle_to_target - alpha;
+		if (flip) {
+			theta2 = -theta2;
+			theta1 = angle_to_target + alpha;
+		}
+		if (for_bone == 1) return Angle::rad(theta1);
+		if (for_bone == 2) return Angle::rad(theta2);
+	}
+	// ----- 3-BONE MODE -----
+	Real x0 = origin[0], y0 = origin[1];
+	Real l1l2 = L1 + L2;
+	Real fmax = l1l2 + L3;
+	Real tomin = l1l2 - (L3 * weight / 100);
+	Real L4 = 0.0;
+	if (L3 >= l1l2) {
+		if (fabs(fmax) > precision){
+			L4 = tomin + (l1l2 - tomin) *dist/fmax;
+		}
+		else L4 = tomin;
+	} else {
+		tomin = L3 - (L3 * weight / 100);
+		Real fmin = (type == 1) ? L3 : 0.0;
+		if (fabs(fmax - fmin) > precision){
+			L4 = tomin + (l1l2 - tomin) * (dist - fmin) / (fmax - fmin);
+		}
+		else L4 = tomin;
+	}
+	Real angle_to_target = std::atan2(delta[1], delta[0]);
+	auto [theta2, alpha] = hitung_theta2_alpha(dist, L4, L3, precision);
+	Real theta1 = angle_to_target - alpha;
+	if ((flip && type !=1) || (!flip && type == 1)) {
+		theta2 = -theta2;
+		theta1 = angle_to_target + alpha;
+	}
+	Real tx = x0 + L4 * std::cos(theta1);
+	Real ty = y0 + L4 * std::sin(theta1);
+	Vector vt(tx, ty);
+	Vector base_to_virtual = vt - origin;
+	Real distb = L4;
+	Real angleb = std::atan2(base_to_virtual[1], base_to_virtual[0]);
+	auto [theta2b, alphab] = hitung_theta2_alpha(distb, L1, L2, precision);
+	Real theta1b = angleb - alphab;
+	if (flip) {
+		theta2b = -theta2b;
+		theta1b = angleb + alphab;
+	}
+	if (for_bone == 1) return Angle::rad(theta1b);
+	if (for_bone == 2) return Angle::rad(theta2b);
+	Real sx = x0 + L1 * std::cos(theta1b);
+	Real sy = y0 + L1 * std::sin(theta1b);
+	Real x2 = tx + L3 * std::cos(theta1 + theta2);
+	Real y2 = ty + L3 * std::sin(theta1 + theta2);
+	Real dx3 = (sx - x0) - (x2 - x0);
+	Real dy3 = (sy - y0) - (y2 - y0);
+	Real dist3 = std::sqrt(dx3 * dx3 + dy3 * dy3);
+	auto [theta3, alphax] = hitung_theta2_alpha(dist3, L2, L3, precision);
+	if ((flip && type !=1) || (!flip && type == 1)) {
+		theta3 = -theta3;
+	}
+	if (for_bone == 3) return Angle::rad(theta3);
+	return Angle::rad(0); // fallback default
+}
+
+bool
+ValueNode_IK::set_link_vfunc(int i,ValueNode::Handle value)
+{
+	assert(i>=0 && i<link_count());
+	switch(i)
+	{
+	case 0: CHECK_TYPE_AND_SET_VALUE(link_pole_, type_vector);
+	case 1: CHECK_TYPE_AND_SET_VALUE(link_target_, type_vector);
+	case 2: CHECK_TYPE_AND_SET_VALUE(length_bone1_, type_real);
+	case 3: CHECK_TYPE_AND_SET_VALUE(length_bone2_, type_real);
+	case 4: CHECK_TYPE_AND_SET_VALUE(length_bone3_, type_real);
+	case 5: CHECK_TYPE_AND_SET_VALUE(flip_, type_bool);
+	case 6: CHECK_TYPE_AND_SET_VALUE(joint_bone_, type_integer);
+	case 7: CHECK_TYPE_AND_SET_VALUE(t_bone_, type_integer);
+	case 8: CHECK_TYPE_AND_SET_VALUE(f_bone_, type_integer);
+	case 9: CHECK_TYPE_AND_SET_VALUE(weight_, type_real);
+	}
+	return false;
+}
+
+ValueNode::LooseHandle
+ValueNode_IK::get_link_vfunc(int i)const
+{
+	assert(i>=0 && i<link_count());
+	if(i==0) return link_pole_;
+	if(i==1) return link_target_;
+	if(i==2) return length_bone1_;
+	if(i==3) return length_bone2_;
+	if(i==4) return length_bone3_;
+	if(i==5) return flip_;
+	if(i==6) return joint_bone_;
+	if(i==7) return t_bone_;
+	if(i==8) return f_bone_;
+	if(i==9) return weight_;
+	return 0;
+}
+
+bool
+ValueNode_IK::check_type(Type &type)
+{
+	return type==type_angle;
+}
+
+LinkableValueNode::Vocab
+ValueNode_IK::get_children_vocab_vfunc()const
+{
+	if(children_vocab.size())
+		return children_vocab;
+
+	LinkableValueNode::Vocab ret;
+	ret.push_back(ParamDesc("link_pole")
+		.set_local_name(_("Link pole"))
+		.set_description(_("Pole position for the IK shoulder"))
+	);
+	ret.push_back(ParamDesc("link_target")
+		.set_local_name(_("Link target"))
+		.set_description(_("Target position for the IK target"))
+	);
+	ret.push_back(ParamDesc("length_bone1")
+		.set_local_name(_("Length bone 1"))
+		.set_description(_("Length of first bone"))
+		.set_static(true)
+	);
+	ret.push_back(ParamDesc("length_bone2")
+		.set_local_name(_("Length bone 2"))
+		.set_description(_("Length of second bone"))
+		.set_static(true)
+	);
+	ret.push_back(ParamDesc("length_bone3")
+		.set_local_name(_("Length bone 3"))
+		.set_description(_("Length of third bone"))
+		.set_static(true)
+	);
+	ret.push_back(ParamDesc("flip")
+		.set_local_name(_("Flip"))
+		.set_description(_("Flip direction IK."))
+	);
+	ret.push_back(ParamDesc("joint_bone")
+		.set_local_name(_("Joint bone"))
+		.set_description(_("Select bone type 2 bones or 3 bones joint bone"))
+		.set_hint("enum")
+		.set_static(true)
+		.add_enum_value(Joint::TWOBONE, "2 bone joint", _("2 Bone joint"))
+		.add_enum_value(Joint::THREEBONE, "3 bone joint", _("3 Bone joint"))
+	);
+	ret.push_back(ParamDesc("t_bone")
+		.set_local_name(_("T bone"))
+		.set_description(_("Select bone hand/human or foot/animal rig only for 3 joint bone."))
+		.set_hint("enum")
+		.set_static(true)
+		.add_enum_value(Jenisbone::HUMAN, "hand", _("Hand"))
+		.add_enum_value(Jenisbone::ANIMAL, "foot", _("Foot"))
+	);
+	ret.push_back(ParamDesc("f_bone")
+		.set_local_name(_("F bone"))
+		.set_description(_("Select for bone 1 = up,2 = mid or 3 = down, down only for 3 joint bone"))
+		.set_hint("enum")
+		.set_static(true)
+		.add_enum_value(Forbone::BONE1, "for bone1", _("For bone1"))
+		.add_enum_value(Forbone::BONE2, "for bone2", _("For bone2"))
+		.add_enum_value(Forbone::BONE3, "for bone3", _("For bone3"))
+	);
+	ret.push_back(ParamDesc("weight")
+		.set_local_name(_("Weight"))
+		.set_description(_("Weight percent IK for 3 bone only. Range value 0 to 100"))
+	);
+	return ret;
+}

--- a/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.cpp
@@ -4,7 +4,7 @@
 **
 **	\legal
 **	
-**  Copyright (c) 2025 ZAINAL AB.
+**  Copyright (c) 2025/2026 ZAINAL AB.
 **  Copyright (c) Synfig Contributors
 **
 **	This file is part of Synfig.
@@ -62,20 +62,30 @@ ValueNode_IK::ValueNode_IK(const ValueBase &value):
 	LinkableValueNode(value.get_type())
 {
 	init_children_vocab();
-	if (value.get_type() == type_angle)
+
+	set_link("link_target",ValueNode_Const::create(Vector(9.0,9.0)));
+	set_link("length_bone1",ValueNode_Const::create(Real(2.0)));
+	set_link("length_bone2",ValueNode_Const::create(Real(2.0)));
+	set_link("length_bone3",ValueNode_Const::create(Real(2.0)));
+	set_link("flip",ValueNode_Const::create(bool(true))); 
+	set_link("joint_bone",ValueNode_Const::create(int(Joint::TWOBONE))); 
+	set_link("t_bone",ValueNode_Const::create(int(RigType::ANIMAL))); 
+	set_link("f_bone",ValueNode_Const::create(int(TargetBone::BONE1)));
+	set_link("weight",ValueNode_Const::create(Real(25.0)));
+
+	if (value.get_type() == type_vector) // for position of elbow
+	{
+		set_link("link_pole",ValueNode_Const::create(value.get(Vector())));
+	} 
+
+	if (value.get_type() == type_angle)  // for angle bone
 	{
 		set_link("link_pole",ValueNode_Const::create(Vector(Angle::cos(value.get(Angle())).get(),
 														 Angle::sin(value.get(Angle())).get())));
-
-		set_link("link_target",ValueNode_Const::create(Vector(100, 0)));
-		set_link("length_bone1",ValueNode_Const::create(Real(2.0)));
-		set_link("length_bone2",ValueNode_Const::create(Real(2.0)));
-		set_link("length_bone3",ValueNode_Const::create(Real(2.0)));
-		set_link("flip",ValueNode_Const::create(bool(true))); 
-		set_link("joint_bone",ValueNode_Const::create(int(Joint::TWOBONE))); 
-		set_link("t_bone",ValueNode_Const::create(int(RigType::ANIMAL))); 
-		set_link("f_bone",ValueNode_Const::create(int(TargetBone::BONE1)));
-		set_link("weight",ValueNode_Const::create(Real(25.0)));
+	}
+	else if(value.get_type() == type_real) // for lenght bone , effect streth bone
+	{
+		set_link("link_pole",ValueNode_Const::create(Vector(0.0,0.0)));
 	}
 	
 }
@@ -102,6 +112,8 @@ ValueNode_IK::operator()(Time t)const
 {
 	DEBUG_LOG("SYNFIG_DEBUG_VALUENODE_OPERATORS",
 		"%s:%d operator()\n", __FILE__, __LINE__);
+
+	Type &type(get_type());
 	
     static const Real precision = 0.000000001;
 	Vector origin = (*link_pole_)(t).get(Vector());
@@ -118,26 +130,69 @@ ValueNode_IK::operator()(Time t)const
 	Real dist = delta.mag();
 	L1 = (L1 > precision) ? L1 : precision;
 	L2 = (L2 > precision) ? L2 : precision;
-	// ----- 2-BONE MODE -----
-	if (joint_mode==Joint::TWOBONE) {
-		dist = std::min(dist, L1 + L2);
-		Real cos_theta2 = synfig::clamp((dist*dist - L1*L1 - L2*L2) / (2 * L1 * L2), -1.0, 1.0);
-	    Real theta2 = std::acos(cos_theta2);
-		Real cos_alpha = synfig::clamp((dist*dist + L1*L1 - L2*L2) / (2 * dist * L1), -1.0, 1.0);
-		Real alpha = std::acos(cos_alpha);
-		Real angle_to_target = std::atan2(delta[1], delta[0]);
-		Real theta1 = angle_to_target - alpha;
-		if (flip) {
-			theta2 = -theta2;
-			theta1 = angle_to_target + alpha;
-		}
-		if (output_bone_index == TargetBone::BONE1) return Angle::rad(theta1);
-		if (output_bone_index == TargetBone::BONE2) return Angle::rad(theta2);
-	}
-	// ----- 3-BONE MODE -----
 	Real x0 = origin[0], y0 = origin[1];
 	Real l1l2 = L1 + L2;
+
+    // ----- 2-BONE JOINT -----
+	if (joint_mode==Joint::TWOBONE) {
+		if (output_bone_index == TargetBone::BONE1){
+			if (type == type_real){	
+				if (dist > l1l2){
+					Real scale = dist / l1l2;
+				    return L1 *= scale;
+				}
+				else return L1;
+			}
+			//dist = std::min(dist, L1 + L2);
+			Real cos_alpha = synfig::clamp((dist*dist + L1*L1 - L2*L2) / (2 * dist * L1), -1.0, 1.0);
+			Real alpha = std::acos(cos_alpha);
+			Real angle_to_target = std::atan2(delta[1], delta[0]);
+			Real theta1 = angle_to_target - alpha;
+			if (flip) {
+				theta1 = angle_to_target + alpha;
+			}
+			if (type == type_angle)return Angle::rad(theta1);
+			if (type == type_vector){
+				if (dist > l1l2) {
+				    Real scale = dist / l1l2;
+				    L1 *= scale;
+				}
+				Real elx = x0 + L1 * std::cos(theta1); // elbow1.x
+				Real ely = y0 + L1 * std::sin(theta1); // elbow1.y
+				return Vector(elx,ely);		
+			}
+		}
+
+		if (output_bone_index == TargetBone::BONE2){
+			if (type == type_angle){
+				Real cos_theta2 = synfig::clamp((dist*dist - L1*L1 - L2*L2) / (2 * L1 * L2), -1.0, 1.0);
+	    		Real theta2 = std::acos(cos_theta2);
+	    		return Angle::rad(flip ? -theta2 : theta2);
+			}
+			if (type == type_real){	
+				if (dist > l1l2) {
+					Real scale = dist / l1l2;
+					return L2 *= scale;
+				}
+				else return L2;
+			}
+			if (type == type_vector)return Vector(0.0,0.0);		// to evoid error user
+		}
+	}
+	// ----- 3-BONE JOINT -----
 	Real fmax = l1l2 + L3;
+
+	if (type == type_real){	
+		Real L(0.0);
+		switch (output_bone_index) {
+		    case TargetBone::BONE1: L = L1; break;
+		    case TargetBone::BONE2: L = L2; break;
+		    case TargetBone::BONE3: L = L3; break;
+		}
+		if (dist <= fmax) return L;
+		Real scale = dist / fmax;
+		return L *= scale;
+	}
 	Real tomin = l1l2 - (L3 * weight / 100);
 	Real L4 = 0.0;
 	if (L3 >= l1l2) {
@@ -153,6 +208,7 @@ ValueNode_IK::operator()(Time t)const
 		}
 		else L4 = tomin;
 	}
+
 	Real angle_to_target = std::atan2(delta[1], delta[0]);
 	L4 = (L4 > precision) ? L4 : precision;
 	L3 = (L3 > precision) ? L3 : precision;
@@ -165,6 +221,7 @@ ValueNode_IK::operator()(Time t)const
 		theta2 = -theta2;
 		theta1 = angle_to_target + alpha;
 	}
+
 	Real tx = x0 + L4 * std::cos(theta1);
 	Real ty = y0 + L4 * std::sin(theta1);
 	Vector vt(tx, ty);
@@ -180,22 +237,55 @@ ValueNode_IK::operator()(Time t)const
 		theta2b = -theta2b;
 		theta1b = angleb + alphab;
 	}
-	if (output_bone_index == TargetBone::BONE1) return Angle::rad(theta1b);
-	if (output_bone_index == TargetBone::BONE2) return Angle::rad(theta2b);
-	Real sx = x0 + L1 * std::cos(theta1b);
-	Real sy = y0 + L1 * std::sin(theta1b);
-	Real x2 = tx + L3 * std::cos(theta1 + theta2);
-	Real y2 = ty + L3 * std::sin(theta1 + theta2);
-	Real dx3 = (sx - x0) - (x2 - x0);
-	Real dy3 = (sy - y0) - (y2 - y0);
-	Real dist3 = std::sqrt(dx3 * dx3 + dy3 * dy3);
-	Real cos_theta3 = synfig::clamp((dist3*dist3 - L2*L2 - L3*L3) / (2 * L2 * L3), -1.0, 1.0);
-	Real theta3 = std::acos(cos_theta3);
-	if (flip != (rig_type == RigType::ANIMAL)){
-		theta3 = -theta3;
+
+	if (output_bone_index == TargetBone::BONE1){
+		if(type == type_angle)return Angle::rad(theta1b);
+		if(type == type_vector){
+			if (dist > fmax) {
+			    Real scale = dist / fmax;
+			    L1 *= scale;
+			}
+		return Vector(x0 + L1 * std::cos(theta1b), y0 + L1 * std::sin(theta1b));// elbow_1
+		}
 	}
-	if (output_bone_index == TargetBone::BONE3) return Angle::rad(theta3);
-	return Angle::rad(0); // fallback default
+
+	if (output_bone_index == TargetBone::BONE2){
+		if (type == type_angle)return Angle::rad(theta2b);
+		if (type == type_vector){
+			if (dist > fmax) {
+			    Real scale = dist / fmax;
+			    L1 *= scale;
+			    L2 *= scale;
+			}
+			Real elbow2x = L2 * std::cos(theta1b+theta2b)+ (x0 + L1 * std::cos(theta1b)); // elbow_2.x
+			Real elbow2y = L2 * std::sin(theta1b+theta2b)+ (y0 + L1 * std::sin(theta1b)); // elbow_2.y
+			return Vector(elbow2x,elbow2y);
+		}
+	}
+
+	if (output_bone_index == TargetBone::BONE3){
+		if (type == type_angle){ 
+			Real sx = x0 + L1 * std::cos(theta1b);
+			Real sy = y0 + L1 * std::sin(theta1b);
+			Real x2 = tx + L3 * std::cos(theta1 + theta2);
+			Real y2 = ty + L3 * std::sin(theta1 + theta2);
+			Real dx3 = (sx - x0) - (x2 - x0);
+			Real dy3 = (sy - y0) - (y2 - y0);
+			Real dist3 = std::sqrt(dx3 * dx3 + dy3 * dy3);
+			Real cos_theta3 = synfig::clamp((dist3*dist3 - L2*L2 - L3*L3) / (2 * L2 * L3), -1.0, 1.0);
+			Real theta3 = std::acos(cos_theta3);
+			if (flip != (rig_type == RigType::ANIMAL)){
+				theta3 = -theta3;
+				}
+			return Angle::rad(theta3);
+		}
+		
+		if (type == type_vector) return Vector(0.0,0.0);// fallback default
+	}
+
+	if (type == type_angle) return Angle::rad(0); // fallback default
+	if (type == type_real) return Real(2.0); // fallback default
+	if (type == type_vector) return Vector(0.0,0.0); // fallback default
 }
 
 bool
@@ -241,7 +331,9 @@ ValueNode_IK::get_link_vfunc(int i)const
 bool
 ValueNode_IK::check_type(Type &type)
 {
-	return type==type_angle;
+	return type==type_vector
+		|| type==type_real
+		|| type==type_angle;
 }
 
 LinkableValueNode::Vocab
@@ -251,6 +343,9 @@ ValueNode_IK::get_children_vocab_vfunc()const
 		return children_vocab;
 
 	LinkableValueNode::Vocab ret;
+
+	Type &type(get_type());
+
 	ret.push_back(ParamDesc("link_pole")
 		.set_local_name(_("Link pole"))
 		.set_description(_("Pole position for the IK shoulder"))
@@ -294,15 +389,33 @@ ValueNode_IK::get_children_vocab_vfunc()const
 		.add_enum_value(RigType::HUMAN, "hand", _("Hand"))
 		.add_enum_value(RigType::ANIMAL, "foot", _("Foot"))
 	);
-	ret.push_back(ParamDesc("f_bone")
-		.set_local_name(_("F bone"))
-		.set_description(_("Select for bone 1 = up,2 = mid or 3 = down, down only for 3 joint bone"))
-		.set_hint("enum")
-		.set_static(true)
-		.add_enum_value(TargetBone::BONE1, "for bone1", _("For bone1"))
-		.add_enum_value(TargetBone::BONE2, "for bone2", _("For bone2"))
-		.add_enum_value(TargetBone::BONE3, "for bone3", _("For bone3"))
-	);
+
+	if (type == type_angle || type == type_real)
+	{
+		ret.push_back(ParamDesc("f_bone")
+			.set_local_name(_("F bone"))
+			.set_description(_("Select for bone 1 = up,2 = mid or 3 = down, down only for 3 joint bone"))
+			.set_hint("enum")
+			.set_static(true)
+			.add_enum_value(TargetBone::BONE1, "for bone1", _("For bone 1"))
+			.add_enum_value(TargetBone::BONE2, "for bone2", _("For bone 2"))
+			.add_enum_value(TargetBone::BONE3, "for bone3", _("For bone 3"))
+		);
+	}
+
+	if (type == type_vector)
+	{
+		ret.push_back(ParamDesc("f_bone")
+			.set_local_name(_("F elbow"))
+			.set_description(_("Select for elbow 1 or elbow 2"))
+			.set_hint("enum")
+			.set_static(true)
+			.add_enum_value(TargetBone::BONE1, "for bone1", _("For elbow 1"))
+			.add_enum_value(TargetBone::BONE2, "for bone2", _("For elbow 2"))
+		);
+
+	}
+
 	ret.push_back(ParamDesc("weight")
 		.set_local_name(_("Weight"))
 		.set_description(_("Weight percent IK for 3 bone only. Range value 0 to 100"))

--- a/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.cpp
@@ -137,10 +137,7 @@ ValueNode_IK::operator()(Time t)const
 	if (joint_mode==Joint::TWOBONE) {
 		if (output_bone_index == TargetBone::BONE1){
 			if (type == type_real){	
-				if (dist > l1l2){
-					Real scale = dist / l1l2;
-				    return L1 *= scale;
-				}
+				if (dist > l1l2) return L1 * (dist / l1l2);
 				else return L1;
 			}
 			//dist = std::min(dist, L1 + L2);
@@ -148,33 +145,25 @@ ValueNode_IK::operator()(Time t)const
 			Real alpha = std::acos(cos_alpha);
 			Real angle_to_target = std::atan2(delta[1], delta[0]);
 			Real theta1 = angle_to_target - alpha;
-			if (flip) {
-				theta1 = angle_to_target + alpha;
-			}
-			if (type == type_angle)return Angle::rad(theta1);
+			if (flip) theta1 = angle_to_target + alpha;
+			if (type == type_angle)return Angle::rad(theta1); // angle bone 1
 			if (type == type_vector){
-				if (dist > l1l2) {
-				    Real scale = dist / l1l2;
-				    L1 *= scale;
-				}
-				Real elx = x0 + L1 * std::cos(theta1); // elbow1.x
-				Real ely = y0 + L1 * std::sin(theta1); // elbow1.y
-				return Vector(elx,ely);		
+				if (dist > l1l2)  L1 *= dist / l1l2;
+				Real elx = x0 + L1 * std::cos(theta1); 
+				Real ely = y0 + L1 * std::sin(theta1); 
+				return Vector(elx,ely);	// pos off elbow 1 	
 			}
 		}
 
 		if (output_bone_index == TargetBone::BONE2){
 			if (type == type_angle){
 				Real cos_theta2 = synfig::clamp((dist*dist - L1*L1 - L2*L2) / (2 * L1 * L2), -1.0, 1.0);
-	    		Real theta2 = std::acos(cos_theta2);
-	    		return Angle::rad(flip ? -theta2 : theta2);
+	    		Real theta2 = std::acos(cos_theta2); 
+	    		return Angle::rad(flip ? -theta2 : theta2); // angle bone 2
 			}
 			if (type == type_real){	
-				if (dist > l1l2) {
-					Real scale = dist / l1l2;
-					return L2 *= scale;
-				}
-				else return L2;
+				if (dist > l1l2) return L2 * (dist / l1l2); // lenght bone 2
+				else return L2; // lenght bone 2
 			}
 			if (type == type_vector)return Vector(0.0,0.0);		// to evoid error user
 		}
@@ -190,8 +179,7 @@ ValueNode_IK::operator()(Time t)const
 		    case TargetBone::BONE3: L = L3; break;
 		}
 		if (dist <= fmax) return L;
-		Real scale = dist / fmax;
-		return L *= scale;
+		return L * (dist / fmax);
 	}
 	Real tomin = l1l2 - (L3 * weight / 100);
 	Real L4 = 0.0;
@@ -239,18 +227,15 @@ ValueNode_IK::operator()(Time t)const
 	}
 
 	if (output_bone_index == TargetBone::BONE1){
-		if(type == type_angle)return Angle::rad(theta1b);
+		if(type == type_angle)return Angle::rad(theta1b); // angle bone 1
 		if(type == type_vector){
-			if (dist > fmax) {
-			    Real scale = dist / fmax;
-			    L1 *= scale;
-			}
-		return Vector(x0 + L1 * std::cos(theta1b), y0 + L1 * std::sin(theta1b));// elbow_1
+			if (dist > fmax) L1 *= dist / fmax;
+		return Vector(x0 + L1 * std::cos(theta1b), y0 + L1 * std::sin(theta1b));// elbow_1 pos 
 		}
 	}
 
 	if (output_bone_index == TargetBone::BONE2){
-		if (type == type_angle)return Angle::rad(theta2b);
+		if (type == type_angle)return Angle::rad(theta2b); // angle bone 2
 		if (type == type_vector){
 			if (dist > fmax) {
 			    Real scale = dist / fmax;
@@ -259,7 +244,7 @@ ValueNode_IK::operator()(Time t)const
 			}
 			Real elbow2x = L2 * std::cos(theta1b+theta2b)+ (x0 + L1 * std::cos(theta1b)); // elbow_2.x
 			Real elbow2y = L2 * std::sin(theta1b+theta2b)+ (y0 + L1 * std::sin(theta1b)); // elbow_2.y
-			return Vector(elbow2x,elbow2y);
+			return Vector(elbow2x,elbow2y); // elbow_2 pos 
 		}
 	}
 
@@ -274,10 +259,8 @@ ValueNode_IK::operator()(Time t)const
 			Real dist3 = std::sqrt(dx3 * dx3 + dy3 * dy3);
 			Real cos_theta3 = synfig::clamp((dist3*dist3 - L2*L2 - L3*L3) / (2 * L2 * L3), -1.0, 1.0);
 			Real theta3 = std::acos(cos_theta3);
-			if (flip != (rig_type == RigType::ANIMAL)){
-				theta3 = -theta3;
-				}
-			return Angle::rad(theta3);
+			if (flip != (rig_type == RigType::ANIMAL)) theta3 = -theta3;
+			return Angle::rad(theta3); // angle bone 3
 		}
 		
 		if (type == type_vector) return Vector(0.0,0.0);// fallback default
@@ -366,7 +349,7 @@ ValueNode_IK::get_children_vocab_vfunc()const
 	);
 	ret.push_back(ParamDesc("length_bone3")
 		.set_local_name(_("Length bone 3"))
-		.set_description(_("Length of third bone"))
+		.set_description(_("Length of third bone, only 3 joints bone mode"))
 		.set_static(true)
 	);
 	ret.push_back(ParamDesc("flip")
@@ -375,7 +358,7 @@ ValueNode_IK::get_children_vocab_vfunc()const
 	);
 	ret.push_back(ParamDesc("joint_bone")
 		.set_local_name(_("Joint bone"))
-		.set_description(_("Select bone type 2 bones or 3 bones joint bone"))
+		.set_description(_("Select bone type 2 bones or 3 bones joints bone"))
 		.set_hint("enum")
 		.set_static(true)
 		.add_enum_value(Joint::TWOBONE, "2 bone joint", _("2 Bone joint"))
@@ -383,13 +366,12 @@ ValueNode_IK::get_children_vocab_vfunc()const
 	);
 	ret.push_back(ParamDesc("t_bone")
 		.set_local_name(_("T bone"))
-		.set_description(_("Select bone hand/human or foot/animal rig only for 3 joint bone."))
+		.set_description(_("Select bone hand/human or foot/animal rig only for 3 joints bone."))
 		.set_hint("enum")
 		.set_static(true)
 		.add_enum_value(RigType::HUMAN, "hand", _("Hand"))
 		.add_enum_value(RigType::ANIMAL, "foot", _("Foot"))
 	);
-
 	if (type == type_angle || type == type_real)
 	{
 		ret.push_back(ParamDesc("f_bone")
@@ -402,7 +384,6 @@ ValueNode_IK::get_children_vocab_vfunc()const
 			.add_enum_value(TargetBone::BONE3, "for bone3", _("For bone 3"))
 		);
 	}
-
 	if (type == type_vector)
 	{
 		ret.push_back(ParamDesc("f_bone")
@@ -415,10 +396,9 @@ ValueNode_IK::get_children_vocab_vfunc()const
 		);
 
 	}
-
 	ret.push_back(ParamDesc("weight")
 		.set_local_name(_("Weight"))
-		.set_description(_("Weight percent IK for 3 bone only. Range value 0 to 100"))
+		.set_description(_("Weight percent IK for 3 joint bone only. Range value 0 to 100"))
 	);
 	return ret;
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.cpp
@@ -118,9 +118,9 @@ ValueNode_IK::operator()(Time t)const
     static const Real precision = 0.000000001;
 	Vector origin = (*link_pole_)(t).get(Vector());
 	Vector target = (*link_target_)(t).get(Vector());
-	Real L1 = (*length_bone1_)(Time(0)).get(Real());
-	Real L2 = (*length_bone2_)(Time(0)).get(Real());
-	Real L3 = (*length_bone3_)(Time(0)).get(Real());
+	Real L1 = (*length_bone1_)(Time(t)).get(Real());
+	Real L2 = (*length_bone2_)(Time(t)).get(Real());
+	Real L3 = (*length_bone3_)(Time(t)).get(Real());
 	bool flip = (*flip_)(t).get(bool());
 	int joint_mode = (*joint_bone_)(Time(0)).get(int());
 	int rig_type = (*t_bone_)(Time(0)).get(int());

--- a/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.h
@@ -1,0 +1,97 @@
+/* === S Y N F I G ========================================================= */
+/*! \file ValueNode_IK.h
+**  \brief Header file for implementation of the "Ik angle" valuenode conversion.
+**
+**  \legal
+**  Copyright (c) 2025 ZAINAL ABID
+**  Copyright (c) Synfig Contributors
+**
+**  This file is part of Synfig.
+**
+**  Synfig is free software: you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation, either version 2 of the License, or
+**  (at your option) any later version.
+**
+**  Synfig is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License
+**  along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**  \endlegal
+*/
+/* ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef __SYNFIG_VALUENODE_IK_H
+#define __SYNFIG_VALUENODE_IK_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <synfig/valuenode.h>
+
+/* === M A C R O S ========================================================= */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace synfig {
+
+class ValueNode_IK : public LinkableValueNode
+{
+
+    enum Joint {
+        TWOBONE = 1,THREEBONE = 2,
+    };
+
+    enum Jenisbone {
+        ANIMAL= 1,HUMAN = 2,
+    };
+
+    enum Forbone {
+        BONE1 = 1,BONE2 = 2, BONE3 = 3,
+    };
+    
+
+    ValueNode::RHandle link_pole_;
+    ValueNode::RHandle link_target_;
+    ValueNode::RHandle length_bone1_;
+    ValueNode::RHandle length_bone2_;
+    ValueNode::RHandle length_bone3_;
+    ValueNode::RHandle flip_;
+    ValueNode::RHandle joint_bone_;
+    ValueNode::RHandle t_bone_;
+    ValueNode::RHandle f_bone_;
+    ValueNode::RHandle weight_;
+
+    ValueNode_IK(const ValueBase &value);
+
+public:
+    typedef etl::handle<ValueNode_IK> Handle;
+    typedef etl::handle<const ValueNode_IK> ConstHandle;
+
+    static ValueNode_IK* create(const ValueBase& x, etl::loose_handle<Canvas> canvas=nullptr);
+    virtual ~ValueNode_IK();
+
+    virtual String get_name() const override;
+    virtual String get_local_name() const override;
+    static bool check_type(Type &type);
+
+    virtual ValueBase operator()(Time t) const override;
+
+protected:
+    LinkableValueNode* create_new() const override;
+
+    virtual bool set_link_vfunc(int i,ValueNode::Handle x) override;
+    virtual ValueNode::LooseHandle get_link_vfunc(int i) const override;
+
+    virtual Vocab get_children_vocab_vfunc() const override;
+}; // END of class ValueNode_IK
+
+}; // END of namespace synfig
+
+/* === E N D =============================================================== */
+
+#endif

--- a/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_ik_angle.h
@@ -1,5 +1,5 @@
 /* === S Y N F I G ========================================================= */
-/*! \file ValueNode_IK.h
+/*! \file valuenode_ik_angle.h
 **  \brief Header file for implementation of the "Ik angle" valuenode conversion.
 **
 **  \legal
@@ -26,8 +26,8 @@
 
 /* === S T A R T =========================================================== */
 
-#ifndef __SYNFIG_VALUENODE_IK_H
-#define __SYNFIG_VALUENODE_IK_H
+#ifndef __SYNFIG_VALUENODE_IK_ANGLE_H
+#define __SYNFIG_VALUENODE_IK_ANGLE_H
 
 /* === H E A D E R S ======================================================= */
 
@@ -46,11 +46,11 @@ class ValueNode_IK : public LinkableValueNode
         TWOBONE = 1,THREEBONE = 2,
     };
 
-    enum Jenisbone {
+    enum RigType {
         ANIMAL= 1,HUMAN = 2,
     };
 
-    enum Forbone {
+    enum TargetBone {
         BONE1 = 1,BONE2 = 2, BONE3 = 3,
     };
     
@@ -94,4 +94,4 @@ protected:
 
 /* === E N D =============================================================== */
 
-#endif
+#endif //__SYNFIG_VALUENODE_IK_ANGLE_H


### PR DESCRIPTION
The new 'IK angle' converter is a simple inverse kinematics solution. In line with the issues discussed in https://github.com/synfig/synfig/issues/3571 or https://forums.synfig.org/t/inverse-kinematic-for-bones/3068, and (https://forums.synfig.org/t/ik-system/4132)it is hoped that inverse kinematics will finally be available for users who have long wanted Synfig to have IK bones.

forum: https://forums.synfig.org/t/bone-like-movement/588, https://forums.synfig.org/t/skeleton-bones-duplication/3650, https://forums.synfig.org/t/inverse-kinematic-for-bones/3068


sample here. https://forums.synfig.org/t/ik-angle-converter-test/16552 and https://youtu.be/kgnKCwXtjIQ

The basic idea behind my **IK Angle** converter is based on the geometric intersection of two circles.

Imagine a simple two-bone chain. The first circle is centered at the root bone with a radius equal to the length of the first bone. The second circle is centered at the target with a radius equal to the length of the second bone.

The intersection of these two circles gives the possible position of the intermediate joint (for example, the elbow or the knee). Once that joint position is known, the rotation angle of each bone can be calculated directly using vector angles.

Because this approach is based on geometry rather than an iterative solver, it produces a stable solution with very little computation. There is no need for repeated iterations such as those used by CCD or FABRIK for a simple two-bone chain.

To support different bending directions, the solver simply chooses one of the two possible intersection points (for example, left/right or up/down), depending on the desired pole direction.

This geometric approach is the core idea behind my IK Angle converter.

The distance between the root and the target determines whether the circles intersect. When they do, there are generally two possible solutions, corresponding to the two possible elbow or knee positions. The converter selects one of these solutions and computes the bone rotations from the resulting vectors.

[interception_cycle_IK.webm](https://github.com/user-attachments/assets/ef66af5e-9b23-43b6-be2d-22224d8e8a5d)

