### PR TITLE
fix(SVG importer): tangents were merged if curve exists after straight line

### DIFF
--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -971,7 +971,7 @@ Svg_parser::parser_path_polygon(const Glib::ustring& polygon_points, const SVGMa
 	std::list<BLine> k0;
 	if(polygon_points.empty())
 		return k0;
-	std::list<Vertex> points;
+	std::vector<Vertex> points;
 	std::vector<String> tokens=get_tokens_path (polygon_points);
 
 	for(unsigned int i=0;i<tokens.size();i++){
@@ -993,7 +993,7 @@ std::list<BLine>
 Svg_parser::parser_path_d(const String& path_d, const SVGMatrix& mtx)
 {
 	std::list<BLine> k;
-	std::list<Vertex> k1;
+	std::vector<Vertex> k1;
 
 	std::vector<String> tokens=get_tokens_path(path_d);
 	String command="M"; //the current command
@@ -1114,6 +1114,8 @@ Svg_parser::parser_path_d(const String& path_d, const SVGMatrix& mtx)
 			coor2vect(&tgx,&tgy);
 			//save
 			k1.back().setTg2(tgx2,tgy2);
+			if (k1.size() == 1 || k1.back().angle1 != k1.back().angle2 || k1.back().radius1 != k1.back().radius2)
+				k1.back().setSplit(true);
 
 			k1.push_back(Vertex(ax,ay));
 			k1.back().setTg1(tgx,tgy);
@@ -1994,7 +1996,7 @@ RadialGradient::RadialGradient(const String& gradient_name, float cx, float cy, 
 	  stops(stops), transform(transform)
 {}
 
-BLine::BLine(std::list<Vertex> points, bool loop)
+BLine::BLine(std::vector<Vertex> points, bool loop)
 	: points(points), loop(loop),
 	  bline_id(GUID().get_string()),
 	  offset_id(GUID().get_string())
@@ -2071,7 +2073,7 @@ Svg_parser::build_vertex(xmlpp::Element* root, const Vertex &p)
 }
 
 void
-Svg_parser::build_bline(xmlpp::Element* root, const std::list<Vertex>& p, bool loop, const String& blineguid)
+Svg_parser::build_bline(xmlpp::Element* root, const std::vector<Vertex>& p, bool loop, const String& blineguid)
 {
 	root->set_attribute("name","bline");
 	xmlpp::Element *child=root->add_child("bline");

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -118,12 +118,12 @@ struct Vertex{
 };
 
 struct BLine {
-	std::list<Vertex> points;
+	std::vector<Vertex> points;
 	bool loop;
 	String bline_id;
 	String offset_id;
 
-	BLine(std::list<Vertex> points, bool loop);
+	BLine(std::vector<Vertex> points, bool loop);
 };
 
 struct Style {
@@ -227,7 +227,7 @@ private:
 		void build_translate(xmlpp::Element* root,float dx,float dy);
 		void build_points(xmlpp::Element* root, const std::list<Vertex>& p);
 		void build_vertex(xmlpp::Element* root, const Vertex& p);
-		void build_bline(xmlpp::Element* root, const std::list<Vertex>& p, bool loop, const String& blineguid);
+		void build_bline(xmlpp::Element* root, const std::vector<Vertex>& p, bool loop, const String& blineguid);
 		void build_param (xmlpp::Element* root, const String& name, const String& type, const String& value);
 		void build_param (xmlpp::Element* root, const String& name, const String& type, float value);
 		void build_param (xmlpp::Element* root, const String& name, const String& type, int value);


### PR DESCRIPTION
Drawing command 'c' or 's' following commands 'h' or 'v' didn't split tangents in the initial vertex of the curve.

Comparison between rendering on Inkscape, Synfig 1.5.3 and this PR:
<img width="545" height="125" alt="image" src="https://github.com/user-attachments/assets/a9045297-d9ee-4943-adb9-dee2cb191bc5" />

Reported-in: https://forums.synfig.org/t/tangets-beeing-merged-when-importing-svg-filles/16714/
Reported-by: MGFP