### PR TITLE
chore: bump synfig versions for issue template & appveyor files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report--version-1-4.md
+++ b/.github/ISSUE_TEMPLATE/bug-report--version-1-4.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **System information:**
  - OS: [Windows, Linux or Mac. If Linux, please tell us your distro]
  - OS version:
- - Synfig version: 1.4.2
+ - Synfig version: 1.4.5
 
 **Additional comments**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report--version-1-5.md
+++ b/.github/ISSUE_TEMPLATE/bug-report--version-1-5.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **System information:**
  - OS: [Windows, Linux or Mac. If Linux, please tell us your distro]
  - OS version:
- - Synfig version: 1.5.1
+ - Synfig version: 1.5.3
 
 **Additional comments**
 Add any other context about the problem here.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build_script:
 # scripts to run after build (working directory and environment changes are persisted from the previous steps)
 after_build:
   - cmd: set SYNFIG_ID="%APPVEYOR_REPO_COMMIT_TIMESTAMP:~0,10%-win%MSYSTEM:~-2%-%APPVEYOR_REPO_COMMIT:~0,5%"
-  - cmd: call 7z a "SynfigStudio-1.5.2-testing-%SYNFIG_ID%.zip" %APPVEYOR_BUILD_FOLDER%\cmake-build\install\*
+  - cmd: call 7z a "SynfigStudio-1.5.3-testing-%SYNFIG_ID%.zip" %APPVEYOR_BUILD_FOLDER%\cmake-build\install\*
 
 artifacts:
   - path: "SynfigStudio-*.zip"

--- a/version-bump.sh
+++ b/version-bump.sh
@@ -45,6 +45,11 @@ sed -i "s|date=\".*\">|date=\"${DATE}\">|" synfig-studio/org.synfig.SynfigStudio
 
 sed -i "s|  \"version\": \"${VERSION_CURRENT}\",|  \"version\": \"${VERSION_NEW}\",|" vcpkg.json
 
+sed -i "s|SynfigStudio-${VERSION_CURRENT}-testing|SynfigStudio-${VERSION_NEW}-testing|" appveyor.yml
+
+sed -i "s| - Synfig version: ${VERSION_CURRENT}| - Synfig version: ${VERSION_NEW}|" .github/ISSUE_TEMPLATE/bug-report--version-1-5.md
+
+
 git add \
 	ETL/configure.ac \
 	synfig-core/configure.ac \
@@ -54,6 +59,8 @@ git add \
 	CMakeLists.txt \
 	synfig-studio/src/gui/CMakeLists.txt \
 	vcpkg.json \
+	appveyor.yml \
+	.github/ISSUE_TEMPLATE/bug-report--version-1-5.md \
 	# end
 
 git commit -m "Bump version to ${VERSION_NEW}"


### PR DESCRIPTION
And fix the missing changes that version_bump.sh script should do.