### PR TITLE
perf(Shade layer): do not insert blur task if none specified

### DIFF
--- a/synfig-core/src/modules/lyr_std/shade.cpp
+++ b/synfig-core/src/modules/lyr_std/shade.cpp
@@ -249,7 +249,7 @@ Layer_Shade::build_composite_fork_task_vfunc(ContextParams /* context_params */,
 
 	rendering::TaskPixelColorMatrix::Handle task_colormatrix(new rendering::TaskPixelColorMatrix());
 	task_colormatrix->matrix = matrix;
-	if (sub_task) {task_colormatrix->sub_task() = sub_task->clone_recursive();}
+	task_colormatrix->sub_task() = sub_task->clone_recursive();
 
 	rendering::TaskTransformationAffine::Handle task_transformation(new rendering::TaskTransformationAffine());
 	task_transformation->transformation->matrix.set_translate(origin);


### PR DESCRIPTION
This PR optimizes the case when the 'Size' parameter of the 'Shade' layer is set to 0.0 (no blur). Previously, it was alway inserting TaskBlur task regardles if there's a need for it. Now it only does that when Size parameter is greater than zero improving perfomance by about 1.78 (Synfig 1.5.3 = 5.446s vs This PR = 3.053s) on this test case file:
[ShadeMemory.zip](https://github.com/user-attachments/files/23141744/ShadeMemory.zip)
