### PR TITLE
fix: prevent negative bline/brush width in rectangle state and constrain the range

### DIFF
--- a/synfig-studio/src/gui/states/state_rectangle.cpp
+++ b/synfig-studio/src/gui/states/state_rectangle.cpp
@@ -480,6 +480,8 @@ StateRectangle_Context::StateRectangle_Context(CanvasView* canvas_view):
 	bline_width_label.set_sensitive(false);
 
 	bline_width_dist.set_tooltip_text(_("Brush size"));
+	bline_width_dist.set_digits(2);
+	bline_width_dist.set_range(0,10000000);
 	bline_width_dist.set_sensitive(false);
 
 	invert_label.set_label(_("Invert"));


### PR DESCRIPTION
Copied from #3622 : 

" I noticed that for all the other states the bline width had it's range constrained and didn't allow for negative values. Specifically through setting it explicitly in the respective state class as follow:

bline_width_dist.set_digits(2);
bline_width_dist.set_range(0,10000000);

The rectangle state however didn't have that and it led to a weird behavior for example when setting the value to be a negative number.

The set_digits part is not absolutely needed but most other tools had it so I kept it for consistency."