### PR TITLE
fix: correct selection after grouping layers

### DIFF
--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -426,7 +426,10 @@ LayerTree::select_layer(synfig::Layer::Handle layer)
 			iter=sorted_layer_tree_store_->convert_child_iter_to_iter(iter);
 
 		Gtk::TreePath path(iter);
-		layer_tree_view().expand_to_path(path);
+		// do not auto expand when selecting a group layer to avoid "opening" it on selection
+		if(!(layer->get_name() == "group"))
+			layer_tree_view().expand_to_path(path);
+
 		layer_tree_view().scroll_to_row(path);
 		layer_tree_view().get_selection()->select(iter);
 	}

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -432,6 +432,7 @@ LayerTree::select_layer(synfig::Layer::Handle layer)
 
 		layer_tree_view().scroll_to_row(path);
 		layer_tree_view().get_selection()->select(iter);
+		layer_tree_view().set_cursor(path);
 	}
 }
 

--- a/synfig-studio/src/synfigapp/actions/layerencapsulate.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerencapsulate.cpp
@@ -160,7 +160,7 @@ Action::LayerEncapsulate::prepare()
 	if(!child_canvas)
 		child_canvas=Canvas::create_inline(get_canvas());
 
-	Layer::Handle new_layer(Layer::create("group"));
+	new_layer=Layer::create("group");
 
 	if (!description.empty())
 		new_layer->set_description(description);
@@ -244,5 +244,15 @@ Action::LayerEncapsulate::prepare()
 
 			add_action(action);
 		}
+	}
+}
+
+void
+Action::LayerEncapsulate::perform()
+{
+	Super::perform();
+	if(new_layer && get_canvas_interface()){
+		get_canvas_interface()->get_selection_manager()->clear_selected_layers();
+		get_canvas_interface()->get_selection_manager()->set_selected_layer(new_layer);
 	}
 }

--- a/synfig-studio/src/synfigapp/actions/layerencapsulate.h
+++ b/synfig-studio/src/synfigapp/actions/layerencapsulate.h
@@ -54,6 +54,7 @@ private:
 	std::list<synfig::Layer::Handle> layers;
         bool children_lock;
 
+	synfig::Layer::Handle new_layer;
 	int lowest_depth()const;
 
 public:
@@ -67,6 +68,7 @@ public:
 	virtual bool is_ready()const;
 
 	virtual void prepare();
+	virtual void perform();
 
 	ACTION_MODULE_EXT
 };


### PR DESCRIPTION
Fixes #3659 

This PR improves the grouping workflow by keeping the selection on the
newly created group layer.