### PR TITLE
feat(guide_lock): Ability to lock the guides + a bit of refactoring

### DIFF
--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -222,7 +222,7 @@ WorkArea::WorkArea(etl::loose_handle<synfigapp::CanvasInterface> canvas_interfac
 	// Create the menu button
 
 	menubutton_box = manage(new Gtk::Button());
-	menubutton_box->set_image_from_icon_name(get_lock_guides()?"changes-prevent-symbolic":"changes-allow-symbolic");
+	menubutton_box->set_image_from_icon_name(get_lock_guides() ? "changes-prevent-symbolic" : "changes-allow-symbolic");
 	menubutton_box->set_relief(Gtk::RELIEF_NONE);
 	menubutton_box->add_events(Gdk::BUTTON_PRESS_MASK);
 	menubutton_box->signal_clicked().connect(sigc::track_obj([this](){
@@ -436,7 +436,7 @@ WorkArea::grab_focus()
 }
 
 bool
-WorkArea::get_bool_from_meta_data(const std::string &metaname, bool &value)
+WorkArea::get_bool_from_meta_data(const std::string& metaname, bool& value)
 {
 	String data = canvas->get_meta_data(metaname);
 	if (data.empty()) return false;
@@ -454,16 +454,16 @@ WorkArea::get_bool_from_meta_data(const std::string &metaname, bool &value)
 void
 WorkArea::load_meta_data()
 {
-    // we need to set locale careful, without calling functions and signals,
-    // otherwise it can affect strings in GUI
-    // ChangeLocale change_locale(LC_NUMERIC, "C");
+	// we need to set locale careful, without calling functions and signals,
+	// otherwise it can affect strings in GUI
+	// ChangeLocale change_locale(LC_NUMERIC, "C");
 
     if(meta_data_lock)
 		return;
 	meta_data_lock=true;
 
 	String data;
-        bool   bool_value; //for get_bool_from_meta_data
+	bool   bool_value; //for get_bool_from_meta_data
 
 	data=canvas->get_meta_data("grid_size");
 	if(!data.empty())
@@ -567,8 +567,7 @@ WorkArea::load_meta_data()
 
 	bool render_required = false;
 	data=canvas->get_meta_data("onion_skin_past");
-	if(!data.empty())
-	{
+	if (!data.empty()) {
 		int past_kf = stratoi(data);
 		if (past_kf > ONION_SKIN_PAST) past_kf = ONION_SKIN_PAST;
 		else if (past_kf < 0) past_kf =  0;
@@ -580,8 +579,7 @@ WorkArea::load_meta_data()
 		}
 	}
 	data=canvas->get_meta_data("onion_skin_future");
-	if(!data.empty())
-	{
+	if (!data.empty()) {
 		int future_kf = stratoi(data);
 		if (future_kf > ONION_SKIN_FUTURE) future_kf = ONION_SKIN_FUTURE;
 		else if (future_kf < 0) future_kf =  0;
@@ -826,7 +824,7 @@ void
 WorkArea::set_lock_guides(bool locked)
 {
 	lock_guides=locked;
-	menubutton_box->set_image_from_icon_name(locked?"changes-prevent-symbolic":"changes-allow-symbolic");
+	menubutton_box->set_image_from_icon_name(locked ? "changes-prevent-symbolic" : "changes-allow-symbolic");
 	save_meta_data();
 	queue_draw();
 }
@@ -1356,26 +1354,26 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 				return true;
 			}
 
-			if(guide_highlighted){
+			if (guide_highlighted) {
 				Gtk::Menu* guide_menu(manage(new Gtk::Menu()));
 				guide_menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), guide_menu));
 				
 				Gtk::MenuItem* item;
-
 				String lock_unlock_msg = get_lock_guides() ? _("_Unlock Guides") : _("_Lock Guides");
-				item = manage(new Gtk::MenuItem(lock_unlock_msg));
-				item->set_use_underline(true);
-				item->show();
-				item->signal_activate().connect(sigc::track_obj([this](){
-					toggle_lock_guides();
-				}, *this));
-				guide_menu->append(*item);
 				
 				item = manage(new Gtk::MenuItem(_("_Edit Guide")));
 				item->set_use_underline(true);
 				item->show();
 				item->signal_activate().connect(
 						sigc::mem_fun(guide_dialog,&Gtk::Widget::show));
+				guide_menu->append(*item);
+				
+				item = manage(new Gtk::MenuItem(lock_unlock_msg));
+				item->set_use_underline(true);
+				item->show();
+				item->signal_activate().connect(sigc::track_obj([this](){
+					toggle_lock_guides();
+				}, *this));
 				guide_menu->append(*item);
 				
 				item = manage(new Gtk::MenuItem(_("_Delete")));

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -438,17 +438,17 @@ WorkArea::grab_focus()
 bool
 WorkArea::get_bool_from_meta_data(const std::string &metaname, bool &value)
 {
-    String data = canvas->get_meta_data(metaname);
-    if (data.empty()) return false;
-    if (data == "1" || data[0] == 't' || data[0] == 'T') {
-	value = true;
-	return true;
-    }
-    if (data == "0" || data[0] == 'f' || data[0] == 'F') {
-	value = false;
-	return true;
-    }
-    return false; // Existing data but unknown format
+	String data = canvas->get_meta_data(metaname);
+	if (data.empty()) return false;
+	if (data == "1" || data[0] == 't' || data[0] == 'T') {
+		value = true;
+		return true;
+	}
+	if (data == "0" || data[0] == 'f' || data[0] == 'F') {
+		value = false;
+		return true;
+	}
+	return false; // Existing data but unknown format
 }
 
 void
@@ -1815,7 +1815,7 @@ WorkArea::on_vruler_event(GdkEvent *event)
 		return true;
 	case GDK_MOTION_NOTIFY:
 		// Guide movement
-		if (get_drag_mode() == DRAG_GUIDE  && !lock_guides) {
+		if (get_drag_mode() == DRAG_GUIDE && !lock_guides) {
 			// Event is in the vruler, which has a slightly different
 			// coordinate system from the canvas.
 			event->motion.x -= vruler->get_width()+2;

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -398,7 +398,7 @@ public:
 	void toggle_show_guides() { set_show_guides(!get_show_guides()); }
 	//! Returns the state of the lock_guides flag
 	bool get_lock_guides()const { return lock_guides; }
-	//! Sets the showing of the grid
+	//! Sets the showing of the guides
 	void set_lock_guides(bool locked);
 	//! Toggles the showing of the guides
 	void toggle_lock_guides() { set_lock_guides(!get_lock_guides()); }

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -196,6 +196,9 @@ private:
 	//! This flag is set if the guides should be drawn
 	bool show_guides;
 
+	//! This flag is set if the guides should be locked
+	bool lock_guides;
+
 	//! Checker background size
 	synfig::Vector background_size;
 	//! Checker background first color
@@ -393,6 +396,13 @@ public:
 	void set_show_guides(bool x);
 	//! Toggles the showing of the guides
 	void toggle_show_guides() { set_show_guides(!get_show_guides()); }
+	//! Returns the state of the lock_guides flag
+	bool get_lock_guides()const { return lock_guides; }
+	//! Sets the showing of the grid
+	void set_lock_guides(bool locked);
+	//! Toggles the showing of the guides
+	void toggle_lock_guides() { set_lock_guides(!get_lock_guides()); }
+
 	//! Toggles the snap of the guides
 	void toggle_guide_snap();
 	//! Sets the color of the guides
@@ -483,6 +493,8 @@ public:
 	void grab_focus();
 
 	Gtk::DrawingArea* get_drawing_area() { return drawing_area; }
+	
+	bool get_bool_from_meta_data(const std::string &metaname, bool &value);
 
 private:
 	/*

--- a/synfig-studio/src/gui/workarea.h
+++ b/synfig-studio/src/gui/workarea.h
@@ -397,7 +397,7 @@ public:
 	//! Toggles the showing of the guides
 	void toggle_show_guides() { set_show_guides(!get_show_guides()); }
 	//! Returns the state of the lock_guides flag
-	bool get_lock_guides()const { return lock_guides; }
+	bool get_lock_guides() const { return lock_guides; }
 	//! Sets the showing of the guides
 	void set_lock_guides(bool locked);
 	//! Toggles the showing of the guides
@@ -494,7 +494,7 @@ public:
 
 	Gtk::DrawingArea* get_drawing_area() { return drawing_area; }
 	
-	bool get_bool_from_meta_data(const std::string &metaname, bool &value);
+	bool get_bool_from_meta_data(const std::string& metaname, bool& value);
 
 private:
 	/*


### PR DESCRIPTION
https://github.com/synfig/synfig/issues/3654

https://www.youtube.com/watch?v=kL7n7XyqmF8

You can Lock/Unlock the Guides
- using the lock button (ex-menu button)
- using the meta
- using the context menu on the guides

If you delete all the Guides while locked, the lcon is deactivated automatically.

The menu is still displayed but using the right-click now.
It is a security to get back the main menu in case that it would be hidden on top of the app window.

Unofficial AppImage available on my GitHub for test