### PR TITLE
test: fix synfig::filesystem::Path test for compare method

### DIFF
--- a/synfig-core/test/filesystem_path.cpp
+++ b/synfig-core/test/filesystem_path.cpp
@@ -258,10 +258,13 @@ test_compare_path_both_has_same_relative_path_size()
 	Path q1("/a/b");
 	Path q2("/a/c");
 	ASSERT_EQUAL(0, q1.compare(q1))
-	ASSERT_EQUAL(-1, q1.compare(q2))
-	ASSERT_EQUAL(1, q2.compare(q1))
+	ASSERT(0 > q1.compare(q2))
+	ASSERT(0 < q2.compare(q1))
 
 	ASSERT(0 > Path("/aa/").compare(Path("/ac/")))
+	ASSERT(0 < Path("/ac/").compare(Path("/aa/")))
+
+	ASSERT(0 > Path("/aa").compare(Path("/ac")))
 	ASSERT(0 < Path("/ac").compare(Path("/aa")))
 
 	ASSERT(0 > Path("aa/abb").compare(Path("aa/c")))


### PR DESCRIPTION
compare() returns 0, negative or positive integer, not fixed to 0, -1 or 1.

Added some minor tests here too.

Detected via Debian Package Auto-Building:
https://buildd.debian.org/status/logs.php?suite=sid&arch=s390x&pkg=synfig&ver=1.5.3%2Bdfsg-1

(check "Maybe-Failed" link)