### PR TITLE
feat(converter): add support for Angle type to Logarithm

### DIFF
--- a/synfig-core/src/synfig/valuenodes/valuenode_log.h
+++ b/synfig-core/src/synfig/valuenodes/valuenode_log.h
@@ -40,6 +40,12 @@
 
 namespace synfig {
 
+/*! \class ValueNode_Logarithm
+**	\brief Computes the natural logarithm (ln) of the input.
+**
+**	Accepts input of type Real or Angle.
+**	If input is Angle, it is converted to radians before applying log().
+*/
 class ValueNode_Logarithm : public LinkableValueNode
 {
 	ValueNode::RHandle link_;


### PR DESCRIPTION
Supersedes #3607
Closes #3582

The Logarithm converter previously only accepted `Real` values. This PR extends it to support `Angle` inputs.

**Changes:**
* Modified `check_type` to accept `type_angle`.
* Modified `operator()` to convert `Angle` inputs to radians (Real) before calculation, then convert the result back to `Angle` if necessary.
* Fixed the logic from the stale PR #3607.
* Added missing class documentation in `valuenode_log.h`.