### PR TITLE
fix: gaussian blur vertical pass

### DIFF
--- a/synfig-core/src/synfig/rendering/software/function/blur.cpp
+++ b/synfig-core/src/synfig/rendering/software/function/blur.cpp
@@ -288,7 +288,7 @@ software::Blur::blur_pattern(const Params &params)
 
 		for(Array<ColorReal, 3>::Iterator src_channel(arr_src_surface_cols), dst_channel(arr_dst_surface_cols); dst_channel; ++src_channel, ++dst_channel)
 			for(Array<ColorReal, 2>::Iterator sr(*src_channel), dr(*dst_channel); dr; ++sr, ++dr)
-				BlurTemplates::blur_pattern(*dr, *sr, arr_row_pattern);
+				BlurTemplates::blur_pattern(*dr, *sr, arr_col_pattern);
 	}
 
 	// copy result surface and restore alpha


### PR DESCRIPTION
Fixes #3631

The object was being cut off because the vertical blur pass reused the row-based blur logic instead of applying the correct vertical behavior.

When  X = 20 and Y = 5

### before :
<img width="1627" height="749" alt="image" src="https://github.com/user-attachments/assets/b7c27f32-78be-412d-9035-7c479501d6e8" />

### After : 
<img width="1785" height="752" alt="image" src="https://github.com/user-attachments/assets/afd6ba39-96c6-4563-8d08-dc75ce6ef832" />
<br><br><br><br>

when X =0 and  Y = 15 
### befor :  
The blur effect only becomes visible when Y ≥ 21.2; values below this produce no blur.
<img width="1130" height="736" alt="image" src="https://github.com/user-attachments/assets/0ad1cc22-3535-4a0b-8ab6-df4f19dd0605" />

### After :
<img width="1135" height="715" alt="image" src="https://github.com/user-attachments/assets/73fd8cfe-e9d3-423c-a60f-22866aadc34d" />


