### PR TITLE
fix: add-skeleton-simple plugin switched naming of "forearm" and "arm"

### DIFF
--- a/synfig-studio/plugins/add-skeleton-simple/stickman.sif
+++ b/synfig-studio/plugins/add-skeleton-simple/stickman.sif
@@ -112,7 +112,7 @@
     </param>
     <param name="canvas">
       <canvas>
-        <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="(stk)-forearm2">
+        <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="(stk)-arm2">
           <param name="z_depth">
             <real value="0.0000000000"/>
           </param>
@@ -596,7 +596,7 @@
             <real value="0.0000000000"/>
           </param>
         </layer>
-        <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="(stk)-arm2">
+        <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="(stk)-forearm2">
           <param name="z_depth">
             <real value="0.0000000000"/>
           </param>
@@ -1690,7 +1690,7 @@
             <real value="0.0000000000"/>
           </param>
         </layer>
-        <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="(stk)-forearm1">
+        <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="(stk)-arm1">
           <param name="z_depth">
             <real value="0.0000000000"/>
           </param>
@@ -2174,7 +2174,7 @@
             <real value="0.0000000000"/>
           </param>
         </layer>
-        <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="(stk)-arm1">
+        <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="(stk)-forearm1">
           <param name="z_depth">
             <real value="0.0000000000"/>
           </param>


### PR DESCRIPTION
Fixes #685 

Switches the names of "forearm" and "arm." Previously, it incorrectly named the upper part of the arm "forearm" and the lower part "arm."

---

This is my first pull request here; it is an extremely simple one. I just wanted something small to do so I could focus on setting up my local environment and building the project.