### PR TITLE
fix: improve preview dialog default quality and FPS

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -3331,7 +3331,7 @@ CanvasView::on_preview_option()
 			if(!po)
 			{
 				po = Dialog_PreviewOptions::create();
-				po->set_fps(r.get_frame_rate()/2);
+				po->set_fps(r.get_frame_rate());
 				set_ext_widget("prevoptions",po);
 			}
 

--- a/synfig-studio/src/gui/resources/ui/preview_options.glade
+++ b/synfig-studio/src/gui/resources/ui/preview_options.glade
@@ -13,7 +13,7 @@
   <object class="GtkAdjustment" id="adj_zoom">
     <property name="lower">0.10000000000000001</property>
     <property name="upper">5</property>
-    <property name="value">0.5</property>
+    <property name="value">1</property>
     <property name="step_increment">0.10000000000000001</property>
     <property name="page_increment">0.20000000000000001</property>
   </object>
@@ -116,11 +116,11 @@
                         <property name="can_focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
-                        <property name="text" translatable="yes">0,50</property>
+                        <property name="text" translatable="yes">1,00</property>
                         <property name="adjustment">adj_zoom</property>
                         <property name="climb_rate">0.10000000000000001</property>
                         <property name="digits">2</property>
-                        <property name="value">0.5</property>
+                        <property name="value">1</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>


### PR DESCRIPTION
fix #3584 
updates the default values of the Preview dialog to provide a more accurate and visually consistent animation preview

<img width="319" height="129" alt="image" src="https://github.com/user-attachments/assets/d0d5b228-2dac-4e62-82e4-0fa258b0c8ed" />

