### PR TITLE
fix: prevent crash in mesh rendering when skeleton deform layer has no bones

### DIFF
--- a/synfig-core/src/synfig/rendering/software/function/mesh.cpp
+++ b/synfig-core/src/synfig/rendering/software/function/mesh.cpp
@@ -421,6 +421,9 @@ software::Mesh::render_polygon(
 	Color::value_type opacity,
 	Color::BlendMethod blend_method )
 {
+	if (mesh.vertices.empty() || mesh.triangles.empty())
+		return;
+
 	render_polygon(
 		target_surface,
 		target_rect,
@@ -505,6 +508,9 @@ software::Mesh::render_mesh(
 	Color::value_type opacity,
 	Color::BlendMethod blend_method )
 {
+	if (mesh.vertices.empty() || mesh.triangles.empty())
+		return;
+
 	render_mesh(
 		target_surface,
 		target_rect,


### PR DESCRIPTION
## Description
Synfig crashes with SIGABRT when a Skeleton Deform Layer is created without any bones assigned and the user switches tools. This happens because `render_polygon()` and `render_mesh()` in `mesh.cpp` call `.front()` on `mesh.vertices` and `mesh.triangles` without checking if they are empty. When no bones are present, `prepare_mesh()` produces an empty mesh, making those calls undefined behavior.

The fix adds an early-return guard `if (mesh.vertices.empty() || mesh.triangles.empty()) return;` to both overloads before any vector access. This makes them consistent with the lower-level overloads that already handle zero-triangle meshes safely by iterating with `triangles_count`.

Fixes #3693