### PR TITLE
feat: Add support for additional audio file extensions

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -2339,9 +2339,18 @@ App::dialog_open_file_ext(const std::string& title, std::vector<synfig::filesyst
 	filter_supported->add_mime_type("audio/x-vorbis+ogg");
 	filter_supported->add_mime_type("audio/mpeg");
 	filter_supported->add_mime_type("audio/x-wav");
+	filter_supported->add_mime_type("audio/flac");
+	filter_supported->add_mime_type("audio/x-flac");
+	filter_supported->add_mime_type("audio/aac");
+	filter_supported->add_mime_type("audio/x-m4a");
+	filter_supported->add_mime_type("audio/opus");
 	filter_supported->add_pattern("*.ogg");
 	filter_supported->add_pattern("*.mp3");
 	filter_supported->add_pattern("*.wav");
+	filter_supported->add_pattern("*.flac");
+	filter_supported->add_pattern("*.aac");
+	filter_supported->add_pattern("*.m4a");
+	filter_supported->add_pattern("*.opus");
 	// 0.4 Video files
 	filter_supported->add_pattern("*.avi");
 	filter_supported->add_pattern("*.mp4");
@@ -2380,13 +2389,22 @@ App::dialog_open_file_ext(const std::string& title, std::vector<synfig::filesyst
 
 	// 3 Audio files
 	Glib::RefPtr<Gtk::FileFilter> filter_audio = Gtk::FileFilter::create();
-	filter_audio->set_name(_("Audio (*.ogg, *.mp3, *.wav)"));
+	filter_audio->set_name(_("Audio (*.ogg, *.mp3, *.wav, *.flac, *.aac, *.m4a, *.opus)"));
 	filter_audio->add_mime_type("audio/x-vorbis+ogg");
 	filter_audio->add_mime_type("audio/mpeg");
 	filter_audio->add_mime_type("audio/x-wav");
+	filter_audio->add_mime_type("audio/flac");
+	filter_audio->add_mime_type("audio/x-flac");
+	filter_audio->add_mime_type("audio/aac");
+	filter_audio->add_mime_type("audio/x-m4a");
+	filter_audio->add_mime_type("audio/opus");
 	filter_audio->add_pattern("*.ogg");
 	filter_audio->add_pattern("*.mp3");
 	filter_audio->add_pattern("*.wav");
+	filter_audio->add_pattern("*.flac");
+	filter_audio->add_pattern("*.aac");
+	filter_audio->add_pattern("*.m4a");
+	filter_audio->add_pattern("*.opus");
 
 	// 4 Video files
 	Glib::RefPtr<Gtk::FileFilter> filter_video = Gtk::FileFilter::create();
@@ -2543,13 +2561,22 @@ App::dialog_open_file_audio(const std::string& title, synfig::filesystem::Path& 
 
 	// Audio files
 	Glib::RefPtr<Gtk::FileFilter> filter_audio = Gtk::FileFilter::create();
-	filter_audio->set_name(_("Audio (*.ogg, *.mp3, *.wav)"));
+	filter_audio->set_name(_("Audio (*.ogg, *.mp3, *.wav, *.flac, *.aac, *.m4a, *.opus)"));
 	filter_audio->add_mime_type("audio/x-vorbis+ogg");
 	filter_audio->add_mime_type("audio/mpeg");
 	filter_audio->add_mime_type("audio/x-wav");
+	filter_audio->add_mime_type("audio/flac");
+	filter_audio->add_mime_type("audio/x-flac");
+	filter_audio->add_mime_type("audio/aac");
+	filter_audio->add_mime_type("audio/x-m4a");
+	filter_audio->add_mime_type("audio/opus");
 	filter_audio->add_pattern("*.ogg");
 	filter_audio->add_pattern("*.mp3");
 	filter_audio->add_pattern("*.wav");
+	filter_audio->add_pattern("*.flac");
+	filter_audio->add_pattern("*.aac");
+	filter_audio->add_pattern("*.m4a");
+	filter_audio->add_pattern("*.opus");
 
 	// Any files
 	Glib::RefPtr<Gtk::FileFilter> filter_any = Gtk::FileFilter::create();

--- a/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_canvasdependencies.cpp
@@ -298,7 +298,7 @@ void Dialog_CanvasDependencies::refresh()
 			std::string ext = Glib::ustring(pair.first.extension().u8string()).lowercase();
 			if (!ext.empty())
 				ext = ext.substr(1);
-			const std::vector<std::string> audio_ext = {"wav", "wave", "mp3", "ogg", "ogm", "oga", "wma", "m4a", "aiff", "aif", "aifc"};
+			const std::vector<std::string> audio_ext = {"wav", "wave", "mp3", "ogg", "ogm", "oga", "wma", "m4a", "aiff", "aif", "aifc", "flac", "aac", "opus"};
 			const std::vector<std::string> image_ext = {"png", "bmp", "jpg", "jpeg", "gif", "tiff", "tif", "dib", "ppm", "pbm", "pgm", "pnm", "webp"};
 			const std::vector<std::string> lipsync_ext = {"pgo", "tsv", "xml"};
 			const std::vector<std::string> video_ext = {"mpg", "mpeg", "mp2", "m2v", "m4v", "mp4", "m4p", "ogv", "avi", "mov", "webm", "wmv", "mkv", "vob", "mng"};

--- a/synfig-studio/src/synfigapp/canvasinterface.cpp
+++ b/synfig-studio/src/synfigapp/canvasinterface.cpp
@@ -806,7 +806,7 @@ CanvasInterface::import(
 		return layer_switch;
 	}
 
-	if (ext=="wav" || ext=="ogg" || ext=="mp3")
+	if (ext=="wav" || ext=="ogg" || ext=="mp3" || ext=="flac" || ext=="aac" || ext=="m4a" || ext=="opus")
 	{
 		Layer::Handle layer = layer_create("sound", get_canvas());
 		if(!layer)


### PR DESCRIPTION
fixed #3689 
adds support for additional audio file extensions
now this extensions aviable in synfig (*.ogg, *.mp3, *.wav, *.flac, *.aac, *.m4a, *.opus).
