### PR TITLE
Refactor undo/redo system for sketch tool and bline tool  

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -3849,6 +3849,10 @@ App::new_instance()
 
 	if (getenv("SYNFIG_ENABLE_NEW_CANVAS_EDIT_PROPERTIES"))
 		instance->find_canvas_view(canvas)->canvas_properties.present();
+
+	// Ensure the selection is recognized globally
+	if (auto canvas_view = instance->find_canvas_view(canvas))
+		App::set_selected_canvas_view(canvas_view);
 }
 
 void
@@ -4053,14 +4057,24 @@ void
 studio::App::undo()
 {
 	if(selected_instance)
+	{
+		auto canvas_view = get_selected_canvas_view();
+		if (canvas_view && canvas_view->get_smach().process_event(EVENT_UNDO) == Smach::RESULT_ACCEPT)
+			return;
 		selected_instance->undo();
+	}
 }
 
 void
 studio::App::redo()
 {
 	if(selected_instance)
+	{
+		auto canvas_view = get_selected_canvas_view();
+		if (canvas_view && canvas_view->get_smach().process_event(EVENT_REDO) == Smach::RESULT_ACCEPT)
+			return;
 		selected_instance->redo();
+	}
 }
 
 Gtk::Box*

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -247,6 +247,8 @@ public:
 	Smach::event_result event_mouse_release_handler(const Smach::event& x);
 	Smach::event_result event_mouse_motion_handler(const Smach::event& x);
 	Smach::event_result event_refresh_tool_options(const Smach::event& x);
+	Smach::event_result event_undo_handler(const Smach::event& x);
+	Smach::event_result event_redo_handler(const Smach::event& x);
 
 	Smach::event_result event_hijack(const Smach::event& /*x*/) { return Smach::RESULT_ACCEPT; }
 
@@ -313,6 +315,8 @@ StateBLine::StateBLine():
 	insert(event_def(EVENT_WORKAREA_MOUSE_MOTION,		&StateBLine_Context::event_mouse_motion_handler));
 	insert(event_def(EVENT_WORKAREA_MOUSE_BUTTON_DRAG,	&StateBLine_Context::event_mouse_motion_handler));
 	insert(event_def(EVENT_REFRESH_TOOL_OPTIONS,		&StateBLine_Context::event_refresh_tool_options));
+	insert(event_def(EVENT_UNDO,						&StateBLine_Context::event_undo_handler));
+	insert(event_def(EVENT_REDO,						&StateBLine_Context::event_redo_handler));
 }
 
 StateBLine::~StateBLine()
@@ -1202,6 +1206,12 @@ StateBLine_Context::event_key_press_handler(const Smach::event& x)
 		if (bline_point_list.size() > 1)
 			run();
 		return Smach::RESULT_ACCEPT;
+
+	case GDK_KEY_z:
+	case GDK_KEY_Z:
+		if (event.modifier & Gdk::CONTROL_MASK)
+			return event_undo_handler(x);
+		break;
 	}
 	return Smach::RESULT_OK;
 }
@@ -1235,6 +1245,27 @@ StateBLine_Context::event_mouse_motion_handler(const Smach::event& x)
 		return Smach::RESULT_ACCEPT;
 	}
 
+	return Smach::RESULT_OK;
+}
+
+Smach::event_result
+StateBLine_Context::event_undo_handler(const Smach::event& /*x*/)
+{
+	if(!bline_point_list.empty())
+	{
+		bline_point_list.pop_back();
+		refresh_ducks(false);
+		get_work_area()->queue_draw();
+		return Smach::RESULT_ACCEPT;
+	}
+	return Smach::RESULT_OK;
+}
+
+
+
+Smach::event_result
+StateBLine_Context::event_redo_handler(const Smach::event& /*x*/)
+{
 	return Smach::RESULT_OK;
 }
 


### PR DESCRIPTION
This Pull Request introduces a Local Tool Undo Hook for the BLine (Spline) Tool in Synfig Studio, addressing the issue where pressing Ctrl+Z during spline creation would undo a global document action instead of removing the last placed point. The solution adds an event interception mechanism in the application, allowing the active tool state to handle undo/redo events locally. Specifically, the BLine tool now intercepts undo events to remove the last spline point, ensuring a more intuitive workflow. Additionally, application initialization is improved to allow tools to hook shortcuts from the first stroke, enhancing usability. This PR partially closes #3695, with the BLine implementation complete and other tools planned for future updates.
### Testing 
We will try to draw a rectangle using a bline, and after that, we will intentionally make a mistake in placing the points.

### before

https://github.com/user-attachments/assets/6342277c-89db-469b-beca-f75765f518e0

### after

https://github.com/user-attachments/assets/9507f293-9157-438a-b49f-8e9e32ce9b7c

