### PR TITLE
[GSoC 26] : New audio backend project

### DIFF
--- a/synfig-core/src/CMakeLists.txt
+++ b/synfig-core/src/CMakeLists.txt
@@ -38,8 +38,30 @@ pkg_check_modules(FRIBIDI REQUIRED IMPORTED_TARGET fribidi)
 pkg_check_modules(HARFBUZZ REQUIRED IMPORTED_TARGET harfbuzz)
 pkg_check_modules(LIBAVFORMAT IMPORTED_TARGET libavcodec libavformat libavutil libswresample libswscale)
 
-if (NOT MLT_FOUND)
-	add_definitions(-DWITHOUT_MLT) # disable MLT if not found
+set(AUDIO_BACKEND "mlt" CACHE STRING "Audio backend: mlt, sdl2, sdl3, none")
+set_property(CACHE AUDIO_BACKEND PROPERTY STRINGS mlt sdl2 sdl3 none)
+message(STATUS "Audio backend selected: ${AUDIO_BACKEND}")
+
+if(AUDIO_BACKEND STREQUAL "mlt")
+    pkg_search_module(MLT REQUIRED IMPORTED_TARGET mlt++-7 mlt++)
+    add_definitions(-DWITH_MLT)
+
+elseif(AUDIO_BACKEND STREQUAL "sdl2")
+    pkg_check_modules(SDL2 REQUIRED IMPORTED_TARGET sdl2)
+    add_definitions(-DWITH_SDL2)
+    add_definitions(-DWITHOUT_MLT)
+
+elseif(AUDIO_BACKEND STREQUAL "sdl3")
+    pkg_check_modules(SDL3 REQUIRED IMPORTED_TARGET sdl3)
+    add_definitions(-DWITH_SDL3)
+    add_definitions(-DWITHOUT_MLT)
+
+elseif(AUDIO_BACKEND STREQUAL "none")
+    add_definitions(-DWITHOUT_MLT)
+    message(STATUS "Audio playback disabled")
+
+else()
+    message(FATAL_ERROR "Unknown AUDIO_BACKEND '${AUDIO_BACKEND}'. Valid: mlt, sdl2, sdl3, none")
 endif()
 
 ##

--- a/synfig-core/src/synfig/CMakeLists.txt
+++ b/synfig-core/src/synfig/CMakeLists.txt
@@ -9,7 +9,6 @@ set_target_properties(libsynfig PROPERTIES PREFIX "")
 
 add_definitions(-DVERSION="${STUDIO_VERSION_MAJOR}.${STUDIO_VERSION_MINOR}.${STUDIO_VERSION_PATCH}")
 
-message(STATUS "MLT DIR: ${MLT_INCLUDE_DIRS}")
 
 # By default, the libtool places its headers in the system directory (/usr/local/include), and
 # compiler automatically finds ltdl.h header. But on MacOS, CMake overrides the system directory
@@ -130,9 +129,16 @@ target_link_libraries(libsynfig PUBLIC
 	${Intl_LIBRARIES}
 )
 
-if (MLT_FOUND)
-	target_link_libraries(libsynfig PUBLIC PkgConfig::MLT)
-endif ()
+if(AUDIO_BACKEND STREQUAL "mlt")
+    target_link_libraries(libsynfig PUBLIC PkgConfig::MLT)
+    message(STATUS "MLT include dirs: ${MLT_INCLUDE_DIRS}")
+elseif(AUDIO_BACKEND STREQUAL "sdl2")
+    target_link_libraries(libsynfig PUBLIC PkgConfig::SDL2)
+    message(STATUS "SDL2 include dirs: ${SDL2_INCLUDE_DIRS}")
+elseif(AUDIO_BACKEND STREQUAL "sdl3")
+    target_link_libraries(libsynfig PUBLIC PkgConfig::SDL3)
+    message(STATUS "SDL3 include dirs: ${SDL3_INCLUDE_DIRS}")
+endif()
 
 ## Install headers
 ## TODO: find a better way to do that, maybe?


### PR DESCRIPTION
Currently `MLT` is silently disabled if not found via `NOT MLT_FOUND.`
This PR makes the backend an explicit user choice via `-DAUDIO_BACKEND=.`

Changes:
-` synfig-core/CMakeLists.txt`: replace silent` MLT `fallback with explicit
 ` AUDIO_BACKEND` option (mlt/sdl2/sdl3/none)
- `synfig/CMakeLists.txt:` conditionalize target_link_libraries on backend

Default remains mlt - no behavior change for existing builds.

now users can build like this :
`cmake -DAUDIO_BACKEND=mlt ..`
or : 
`cmake -DAUDIO_BACKEND=sdl2 ..`
or :
`cmake -DAUDIO_BACKEND=sdl3 ..`
or:
`cmake -DAUDIO_BACKEND=none ..`