### PR TITLE
feat(palette): add "Apply to selected layer" option in palette context menu

### DIFF
--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -33,7 +33,7 @@
 #ifdef HAVE_CONFIG_H
 #	include <config.h>
 #endif
-
+#include <canvasview.h>
 #include "dock_paledit.h"
 
 #include <errno.h>
@@ -380,7 +380,14 @@ Dock_PalEdit::show_menu(int i)
 			i ));
 	menu->append(*item);
 
-	menu->popup(3,gtk_get_current_event_time());
+	item = image_menu_item("type_color_icon", _("Apply to selected layer"), true);
+	item->signal_activate().connect(
+		sigc::bind(
+			sigc::mem_fun(*this,&studio::Dock_PalEdit::apply_color_to_selected_layer),
+			i ));
+	menu->append(*item);
+
+	menu->popup(4,gtk_get_current_event_time());
 }
 
 int
@@ -537,6 +544,50 @@ void
 Dock_PalEdit::select_outline_color(int i)
 {
 	synfigapp::Main::set_outline_color(get_color(i));
+}
+
+void
+Dock_PalEdit::apply_color_to_selected_layer(int i){
+	
+	Color color = get_color(i);
+
+    CanvasView::Handle canvas_view = App::get_selected_canvas_view();
+    if (!canvas_view) 
+		return;
+
+    // Get ALL selected layers 
+    synfigapp::SelectionManager::LayerList layers = canvas_view->canvas_interface()->get_selection_manager()->get_selected_layers();
+    if (layers.empty()) 
+		return;
+
+    synfigapp::Action::PassiveGrouper group(canvas_view->canvas_interface()->get_instance().get(), _("Apply palette color"));
+
+    for (synfig::Layer::Handle layer : layers)
+    {
+        if (!layer) 
+			continue;
+
+		synfig::ValueBase color_param = layer->get_param("color");
+		if (color_param.get_type() == synfig::type_nil)
+    		continue;
+
+        synfig::Canvas::Handle canvas = layer->get_canvas();
+        synfigapp::Action::Handle action = synfigapp::Action::create("LayerParamSet");
+        if (!action) 
+			continue;
+
+        action->set_param("canvas", canvas);
+        action->set_param("canvas_interface", canvas_view->canvas_interface());
+        action->set_param("layer", layer);
+        action->set_param("param", std::string("color"));
+        action->set_param("new_value", synfig::ValueBase(color));
+
+        if (!action->is_ready()) 
+			continue;
+
+        canvas_view->canvas_interface()->get_instance()->perform_action(action);
+    }
+
 }
 
 void

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -387,7 +387,11 @@ Dock_PalEdit::show_menu(int i)
 			i ));
 	menu->append(*item);
 
-	menu->popup(3,gtk_get_current_event_time());
+#if GTK_CHECK_VERSION(3, 22, 0)
+	menu->popup_at_pointer(nullptr);
+#else
+	menu->popup(3, gtk_get_current_event_time());
+#endif
 }
 
 int

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -33,7 +33,6 @@
 #ifdef HAVE_CONFIG_H
 #	include <config.h>
 #endif
-#include <canvasview.h>
 #include "dock_paledit.h"
 
 #include <errno.h>
@@ -45,6 +44,7 @@
 #include <gtkmm/stylecontext.h>
 
 #include <gui/app.h>
+#include <gui/canvasview.h>
 #include <gui/dialogs/dialog_color.h>
 #include <gui/localization.h>
 #include <gui/widgets/widget_color.h>
@@ -383,11 +383,11 @@ Dock_PalEdit::show_menu(int i)
 	item = image_menu_item("type_color_icon", _("Apply to selected layer"), true);
 	item->signal_activate().connect(
 		sigc::bind(
-			sigc::mem_fun(*this,&studio::Dock_PalEdit::apply_color_to_selected_layer),
+			sigc::mem_fun(*this, &studio::Dock_PalEdit::apply_color_to_selected_layer),
 			i ));
 	menu->append(*item);
 
-	menu->popup(4,gtk_get_current_event_time());
+	menu->popup(3,gtk_get_current_event_time());
 }
 
 int
@@ -547,47 +547,48 @@ Dock_PalEdit::select_outline_color(int i)
 }
 
 void
-Dock_PalEdit::apply_color_to_selected_layer(int i){
-	
+Dock_PalEdit::apply_color_to_selected_layer(int i) const
+{
 	Color color = get_color(i);
 
-    CanvasView::Handle canvas_view = App::get_selected_canvas_view();
-    if (!canvas_view) 
+	CanvasView::Handle canvas_view = App::get_selected_canvas_view();
+	if (!canvas_view)
+		return;
+	etl::handle<Instance> instance = canvas_view->get_instance();
+	if (!instance)
 		return;
 
-    // Get ALL selected layers 
-    synfigapp::SelectionManager::LayerList layers = canvas_view->canvas_interface()->get_selection_manager()->get_selected_layers();
-    if (layers.empty()) 
+	// Get ALL selected layers
+	synfigapp::SelectionManager::LayerList layers = canvas_view->get_selection_manager()->get_selected_layers();
+	if (layers.empty())
 		return;
 
-    synfigapp::Action::PassiveGrouper group(canvas_view->canvas_interface()->get_instance().get(), _("Apply palette color"));
+	synfigapp::Action::PassiveGrouper group(instance.get(), _("Apply palette color"));
 
-    for (synfig::Layer::Handle layer : layers)
-    {
-        if (!layer) 
+	for (const synfig::Layer::Handle& layer : layers) {
+		if (!layer)
 			continue;
 
 		synfig::ValueBase color_param = layer->get_param("color");
-		if (color_param.get_type() == synfig::type_nil)
-    		continue;
-
-        synfig::Canvas::Handle canvas = layer->get_canvas();
-        synfigapp::Action::Handle action = synfigapp::Action::create("LayerParamSet");
-        if (!action) 
+		if (color_param.get_type() == type_nil)
 			continue;
 
-        action->set_param("canvas", canvas);
-        action->set_param("canvas_interface", canvas_view->canvas_interface());
-        action->set_param("layer", layer);
-        action->set_param("param", std::string("color"));
-        action->set_param("new_value", synfig::ValueBase(color));
-
-        if (!action->is_ready()) 
+		synfig::Canvas::Handle canvas = layer->get_canvas();
+		synfigapp::Action::Handle action = synfigapp::Action::create("LayerParamSet");
+		if (!action)
 			continue;
 
-        canvas_view->canvas_interface()->get_instance()->perform_action(action);
-    }
+		action->set_param("canvas", canvas);
+		action->set_param("canvas_interface", canvas_view->canvas_interface());
+		action->set_param("layer", layer);
+		action->set_param("param", std::string("color"));
+		action->set_param("new_value", synfig::ValueBase(color));
 
+		if (!action->is_ready())
+			continue;
+
+		instance->perform_action(action);
+	}
 }
 
 void

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
@@ -86,6 +86,7 @@ private:
 	void select_outline_color(int i);
 	synfig::Color get_color(int i)const;
 	void edit_color(int i);
+	void apply_color_to_selected_layer(int i);
 
 public:
 	static Dock_PalEdit* get_instance() { return instance; }

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
@@ -86,7 +86,7 @@ private:
 	void select_outline_color(int i);
 	synfig::Color get_color(int i)const;
 	void edit_color(int i);
-	void apply_color_to_selected_layer(int i);
+	void apply_color_to_selected_layer(int i) const;
 
 public:
 	static Dock_PalEdit* get_instance() { return instance; }


### PR DESCRIPTION
#3674 

This suggestion was proposed here : https://forums.synfig.org/t/16974

I Added a new "Apply to selected layer" entry to the color palette context menu. Right-clicking any color in the palette now shows this option, which directly sets the selected layer's color parameter to the chosen palette color in a single click.

**How it looks now :** 

Note : I didn't now what icon to add so I just put the color icon :)

https://github.com/user-attachments/assets/9201f8b5-f938-48a0-a26d-f9b0333b8248



