### PR TITLE
feat(palette): add palette tab to color picker dialog

### DIFF
--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -127,7 +127,9 @@ Dock_PalEdit::Dock_PalEdit():
 	//palette_settings(new PaletteSettings(this,"colors")),
 	table(2,2,false)
 {
-	instance = this;
+	assert(!instance && "Only one instance of Dock_PalEdit should exist.");
+    instance = this;
+	
 	// Make Palette Editor toolbar buttons small for space efficiency
 	get_style_context()->add_class("synfigstudio-efficient-workspace");
 
@@ -231,7 +233,9 @@ Dock_PalEdit::Dock_PalEdit():
 
 Dock_PalEdit::~Dock_PalEdit()
 {
+	instance = nullptr;
 	//delete palette_settings;
+
 }
 
 void

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -127,8 +127,11 @@ Dock_PalEdit::Dock_PalEdit():
 	//palette_settings(new PaletteSettings(this,"colors")),
 	table(2,2,false)
 {
-	assert(!instance && "Only one instance of Dock_PalEdit should exist.");
-    instance = this;
+	if (instance) {
+		synfig::warning("Dock_PalEdit: only one instance should exist.");
+		return;
+	}
+	instance = this;
 	
 	// Make Palette Editor toolbar buttons small for space efficiency
 	get_style_context()->add_class("synfigstudio-efficient-workspace");

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -55,6 +55,8 @@
 
 #endif
 
+studio::Dock_PalEdit* studio::Dock_PalEdit::instance = nullptr;
+
 /* === U S I N G =========================================================== */
 
 using namespace synfig;
@@ -125,6 +127,7 @@ Dock_PalEdit::Dock_PalEdit():
 	//palette_settings(new PaletteSettings(this,"colors")),
 	table(2,2,false)
 {
+	instance = this;
 	// Make Palette Editor toolbar buttons small for space efficiency
 	get_style_context()->add_class("synfigstudio-efficient-workspace");
 

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
@@ -87,6 +87,7 @@ private:
 	void edit_color(int i);
 
 public:
+	static Dock_PalEdit* instance;
 	void set_palette(const synfig::Palette& x);
 	const synfig::Palette& get_palette()const { return palette_; }
 

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
@@ -75,6 +75,7 @@ class Dock_PalEdit : public Dockable
 
 private:
 	int add_color(const synfig::Color& x);
+	static Dock_PalEdit* instance;
 	bool check_hex_format(const std::string& hexcolor);
 	void add_from_clipboard();
 	void copy_color(int i);
@@ -87,7 +88,7 @@ private:
 	void edit_color(int i);
 
 public:
-	static Dock_PalEdit* instance;
+	static Dock_PalEdit* get_instance() { return instance; }
 	void set_palette(const synfig::Palette& x);
 	const synfig::Palette& get_palette()const { return palette_; }
 

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -46,7 +46,8 @@
 #include <gui/app.h>
 #include <gui/exception_guard.h>
 #include <gui/localization.h>
-
+#include <gui/modules/mod_palette/dock_paledit.h>
+#include <gui/widgets/widget_color.h>
 
 #endif
 
@@ -374,6 +375,16 @@ Widget_ColorEdit::Widget_ColorEdit():
 		notebook->append_page(*yuv_box,_("YUV"));
 		notebook->append_page(*hvs_box,_("HSV"));
 	}
+	{
+        auto pal_box(manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL)));
+		pal_table = manage(new Gtk::Grid());
+		pal_table->set_row_homogeneous(true);
+		pal_table->set_column_homogeneous(true);
+        pal_box->add(*pal_table);
+        notebook->append_page(*pal_box, _("Palette"));
+        notebook->signal_switch_page().connect(
+            sigc::mem_fun(*this, &Widget_ColorEdit::on_palette_tab_switched));
+    }
 
 	color=Color(0,0,0,0);
 
@@ -485,6 +496,73 @@ void Widget_ColorEdit::setHVSColor(const synfig::Color& color)
 	}
 	hvsColorWidget->set_previous_color(hvsColorWidget->get_current_color()); //We can't use it there, cause color changes in realtime.
 	colorHVSChanged = false;
+}
+void Widget_ColorEdit::on_palette_tab_switched(Gtk::Widget*, guint page)
+{
+    if (page != 3) return;
+    refresh_palette_tab();
+}
+
+void Widget_ColorEdit::refresh_palette_tab()
+{
+    if (!pal_table) return;
+
+    // clear existing children
+    for (auto child : pal_table->get_children())
+        pal_table->remove(*child);
+
+    if (!Dock_PalEdit::instance) return;
+
+    const synfig::Palette& palette = Dock_PalEdit::instance->get_palette();
+    const int width = 12;
+    int i = 0;
+
+    for (const auto& item : palette) {
+        Widget_Color* wc = manage(new Widget_Color());
+        wc->set_value(item.color);
+        wc->set_size_request(40, 40);  
+		wc->signal_activate().connect(
+			sigc::bind(
+				sigc::mem_fun(*this, &Widget_ColorEdit::on_palette_color_clicked),
+				item.color));
+		
+		wc->signal_right_click().connect(
+   			sigc::bind(
+        		sigc::mem_fun(*this, &Widget_ColorEdit::on_palette_color_right_clicked),
+        item.color));
+        int col = i % width;
+        int row = i / width;
+        pal_table->attach(*wc, col, row, 1, 1);
+        i++;
+    }
+
+    pal_table->show_all();
+}
+
+void
+Widget_ColorEdit::on_palette_color_right_clicked(const synfig::Color& color)
+{
+    Gtk::Menu* menu(manage(new Gtk::Menu()));
+    menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), menu));
+
+    // Set as fill
+    Gtk::MenuItem* item = manage(new Gtk::MenuItem(_("Set as Fill Color")));
+    item->signal_activate().connect(
+        sigc::bind(
+            sigc::mem_fun(*this, &Widget_ColorEdit::on_palette_color_clicked),
+            color));
+    item->show();
+    menu->append(*item);
+
+
+    menu->popup(2, gtk_get_current_event_time());
+}
+
+void
+Widget_ColorEdit::on_palette_color_clicked(const synfig::Color& color)
+{
+    set_value(color);
+    signal_value_changed_();
 }
 
 void

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -510,8 +510,8 @@ void Widget_ColorEdit::refresh_palette_tab()
 		return;
 
     // clear existing children
-    for (auto child : pal_table->get_children())
-        pal_table->remove(*child);
+	for (auto child : pal_table->get_children())
+    	delete child;
 
     if (!Dock_PalEdit::instance) 
 		return;
@@ -558,7 +558,7 @@ Widget_ColorEdit::on_palette_color_right_clicked(const synfig::Color& color)
     menu->append(*item);
 
 
-    menu->popup(2, gtk_get_current_event_time());
+    menu->popup(3, gtk_get_current_event_time());
 }
 
 void

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -499,19 +499,22 @@ void Widget_ColorEdit::setHVSColor(const synfig::Color& color)
 }
 void Widget_ColorEdit::on_palette_tab_switched(Gtk::Widget*, guint page)
 {
-    if (page != 3) return;
+    if (page != 3) 
+		return;
     refresh_palette_tab();
 }
 
 void Widget_ColorEdit::refresh_palette_tab()
 {
-    if (!pal_table) return;
+    if (!pal_table) 
+		return;
 
     // clear existing children
     for (auto child : pal_table->get_children())
         pal_table->remove(*child);
 
-    if (!Dock_PalEdit::instance) return;
+    if (!Dock_PalEdit::instance) 
+		return;
 
     const synfig::Palette& palette = Dock_PalEdit::instance->get_palette();
     const int width = 12;

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -513,10 +513,10 @@ void Widget_ColorEdit::refresh_palette_tab()
 	for (auto child : pal_table->get_children())
     	delete child;
 
-    if (!Dock_PalEdit::instance) 
+    if (!Dock_PalEdit::get_instance()) 
 		return;
 
-    const synfig::Palette& palette = Dock_PalEdit::instance->get_palette();
+    const synfig::Palette& palette = Dock_PalEdit::get_instance()->get_palette();
     const int width = 12;
     int i = 0;
 

--- a/synfig-studio/src/gui/widgets/widget_coloredit.h
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.h
@@ -38,6 +38,7 @@
 #include <gui/widgets/widget_color.h>
 #include <synfig/color.h>
 
+
 /* === M A C R O S ========================================================= */
 
 /* === T Y P E D E F S ===================================================== */
@@ -183,7 +184,10 @@ public:
 	sigc::signal<void>& signal_value_changed() { return signal_value_changed_; }
 	
 	void on_color_changed();
-
+	void on_palette_color_clicked(const synfig::Color& color);
+	void on_palette_color_right_clicked(const synfig::Color& color);
+	void on_palette_tab_switched(Gtk::Widget*, guint page);
+	void refresh_palette_tab();
 	void activated() { signal_activated_(); }
 	void activate() { signal_activated_(); }
 	void set_value(const synfig::Color &data);
@@ -191,6 +195,9 @@ public:
 	synfig::Color get_value_raw();
 	void set_has_frame(bool x);
 	void set_digits(int x);
+
+	Gtk::Grid* pal_table = nullptr;
+	
 	Widget_ColorEdit();
 	~Widget_ColorEdit();
 


### PR DESCRIPTION
#3674

This suggestion was proposed here : https://forums.synfig.org/t/16974

- I Added a new Palette tab to the Color Picker dialog (`Widget_ColorEdit`) that displays the current palette colors inline.
- The tab reuses the same `Widget_Color` cells used by the Palette panel (`Dock_PalEdit`). 
- A static instance pointer was added to `Dock_PalEdit` so that `Widget_ColorEdit` can access the currently loaded palette directly. This means any changes made in the Palette panel (loading a new palette, adding or deleting colors) are automatically reflected in the Palette tab the next time it is opened.
- Left-clicking a color sets it as the current color in the Color Picker and updates the fill color in real time. Right-clicking shows a small context menu with Set as Fill Color option. 
- Editing and deleting palette colors is intentionally not available in this tab to keep it in simple selection mode, as suggested by @rodolforg 

**How it looks now :** 

https://github.com/user-attachments/assets/7adbca35-3c7b-4223-8f01-b00af7fa2307


