### PR TITLE
feat: add playback speed option for preview

### DIFF
--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -655,7 +655,7 @@ bool Widget_Preview::on_playback_input_focus_out(GdkEventFocus* event)
 void studio::Widget_Preview::update_playback() {
 	Glib::ustring text = playback_input->get_text();
 	try {
-		float value;
+		double value;
 		value = std::stod(text);
 		if(value <= 0) {
 			playback_speed = 1;
@@ -663,6 +663,7 @@ void studio::Widget_Preview::update_playback() {
 			playback_speed = value;
 		}
 	} catch(const std::exception& e) {
+		// when input can't be converted to double, revert to previous value.
 	}
 	char buf[16];
 	snprintf(buf, sizeof(buf), "%.2fx", playback_speed);

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -344,6 +344,7 @@ Widget_Preview::Widget_Preview():
 	scr_time_scrub(adj_time_scrub),
 	b_loop(/*_("Loop")*/),
 	currentindex(-100000),//TODO get the value from canvas setting or preview option
+	playback_speed(1.00),
 	timedisp(-1),
 	//audiotime(0),
 	adj_sound(Gtk::Adjustment::create(0, 0, 4)),
@@ -398,6 +399,17 @@ Widget_Preview::Widget_Preview():
 
 	//2nd row: prevframe play/pause nextframe loop | halt-render re-preview erase-all
 	toolbar = Gtk::manage(new class Gtk::Box());
+
+	// playback rate input (float with 2 decimal places)
+	playback_input = Gtk::manage(new Gtk::Entry());
+	playback_input->set_text("1.00");
+	playback_input->set_width_chars(5);
+	playback_input->set_max_length(6);
+	playback_input->set_alignment(1.0); // right align
+	toolbar->pack_start(*playback_input, Gtk::PACK_SHRINK, 0);
+	playback_input->signal_activate().connect(sigc::mem_fun(*this, &Widget_Preview::update_playback));
+	playback_input->signal_focus_out_event().connect(sigc::mem_fun(*this, &Widget_Preview::on_playback_input_focus_out), false);
+	playback_input->show();
 
 	//prev rendered frame
 	Gtk::Button* prev_framebutton = create_tool_button("animate_seek_prev_frame_icon", _("Seek to previous frame"));
@@ -506,6 +518,8 @@ Widget_Preview::Widget_Preview():
 
 	//3rd row: previewing frame numbering and rendered frame numbering
 	Gtk::Box *status = manage(new Gtk::Box());
+	playback_label = manage(new Gtk::Label("1.00x"));
+	status->pack_start(*playback_label, Gtk::PACK_SHRINK, 5);
 	status->pack_start(l_currenttime, Gtk::PACK_SHRINK, 5);
 	Gtk::Label *separator = manage(new Gtk::Label(" / "));
 	status->pack_start(*separator, Gtk::PACK_SHRINK, 0);
@@ -631,6 +645,33 @@ void studio::Widget_Preview::update()
 	l_currenttime.set_text(timecode);
 
 }
+
+bool Widget_Preview::on_playback_input_focus_out(GdkEventFocus* event)
+{
+    update_playback();
+    return false;
+}
+
+void studio::Widget_Preview::update_playback() {
+	Glib::ustring text = playback_input->get_text();
+	try {
+		float value;
+		value = std::stod(text);
+		if(value <= 0) {
+			playback_speed = 1;
+		} else {
+			playback_speed = value;
+		}
+	} catch(const std::exception& e) {
+	}
+	char buf[16];
+	snprintf(buf, sizeof(buf), "%.2fx", playback_speed);
+	playback_label->set_text(buf);
+	playback_input->set_text(Glib::ustring(buf));
+	play_button->grab_focus();
+	update();
+}
+
 void studio::Widget_Preview::preview_draw()
 {
 	draw_area.queue_draw();
@@ -744,6 +785,7 @@ bool studio::Widget_Preview::redraw(const Cairo::RefPtr<Cairo::Context> &cr)
 bool studio::Widget_Preview::play_update()
 {
 	float diff = timer.pop_time();
+	diff *= playback_speed;
 	//synfig::info("Play update: diff = %.2f",diff);
 
 	if(playing)

--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -353,6 +353,7 @@ Widget_Preview::Widget_Preview():
 	singleframe(),
 	toolbarisshown(),
 	zoom_preview(true),
+	speed_preview(true),
 	toolbar(),
 	play_button(),
 	pause_button(),
@@ -399,17 +400,6 @@ Widget_Preview::Widget_Preview():
 
 	//2nd row: prevframe play/pause nextframe loop | halt-render re-preview erase-all
 	toolbar = Gtk::manage(new class Gtk::Box());
-
-	// playback rate input (float with 2 decimal places)
-	playback_input = Gtk::manage(new Gtk::Entry());
-	playback_input->set_text("1.00");
-	playback_input->set_width_chars(5);
-	playback_input->set_max_length(6);
-	playback_input->set_alignment(1.0); // right align
-	toolbar->pack_start(*playback_input, Gtk::PACK_SHRINK, 0);
-	playback_input->signal_activate().connect(sigc::mem_fun(*this, &Widget_Preview::update_playback));
-	playback_input->signal_focus_out_event().connect(sigc::mem_fun(*this, &Widget_Preview::on_playback_input_focus_out), false);
-	playback_input->show();
 
 	//prev rendered frame
 	Gtk::Button* prev_framebutton = create_tool_button("animate_seek_prev_frame_icon", _("Seek to previous frame"));
@@ -514,12 +504,30 @@ Widget_Preview::Widget_Preview():
 
 	toolbar->pack_end(zoom_preview, Gtk::PACK_SHRINK, 0);
 
+	//playback speed
+	speed_preview.append("0.25x");
+	speed_preview.append("0.5x");
+	speed_preview.append("1.0x");
+	speed_preview.append("1.5x");
+	speed_preview.append("2.0x");
+	Gtk::Entry* speed_entry = speed_preview.get_entry();
+	speed_entry->set_text("1.0x"); //default playback speed
+	speed_entry->set_icon_from_icon_name("animate_mode_on_icon");
+	speed_entry->signal_activate().connect(sigc::mem_fun(*this, &Widget_Preview::update_playback));
+	speed_entry->signal_focus_out_event().connect(sigc::mem_fun(*this, &Widget_Preview::on_playback_speed_focus_out), false);
+	speed_preview.signal_changed().connect(sigc::mem_fun(*this, &Widget_Preview::update_playback));
+
+	//set the speed widget width
+	speed_preview.set_size_request(65, -1);
+	speed_preview.set_margin_end(8);
+	speed_preview.show();
+
+	toolbar->pack_end(speed_preview, Gtk::PACK_SHRINK, 0);
+
 	show_toolbar();
 
 	//3rd row: previewing frame numbering and rendered frame numbering
 	Gtk::Box *status = manage(new Gtk::Box());
-	playback_label = manage(new Gtk::Label("1.00x"));
-	status->pack_start(*playback_label, Gtk::PACK_SHRINK, 5);
 	status->pack_start(l_currenttime, Gtk::PACK_SHRINK, 5);
 	Gtk::Label *separator = manage(new Gtk::Label(" / "));
 	status->pack_start(*separator, Gtk::PACK_SHRINK, 0);
@@ -646,14 +654,15 @@ void studio::Widget_Preview::update()
 
 }
 
-bool Widget_Preview::on_playback_input_focus_out(GdkEventFocus* event)
+bool Widget_Preview::on_playback_speed_focus_out(GdkEventFocus* event)
 {
     update_playback();
     return false;
 }
 
 void studio::Widget_Preview::update_playback() {
-	Glib::ustring text = playback_input->get_text();
+	Gtk::Entry* entry = speed_preview.get_entry();
+	Glib::ustring text = entry->get_text();
 	try {
 		double value;
 		value = std::stod(text);
@@ -667,8 +676,7 @@ void studio::Widget_Preview::update_playback() {
 	}
 	char buf[16];
 	snprintf(buf, sizeof(buf), "%.2fx", playback_speed);
-	playback_label->set_text(buf);
-	playback_input->set_text(Glib::ustring(buf));
+	entry->set_text(Glib::ustring(buf));
 	play_button->grab_focus();
 	update();
 }

--- a/synfig-studio/src/gui/preview.h
+++ b/synfig-studio/src/gui/preview.h
@@ -196,9 +196,11 @@ class Widget_Preview : public Gtk::Table
 	Gtk::Scale		scr_time_scrub;
 	Gtk::ToggleButton*	b_loop;
 	Gtk::ScrolledWindow	preview_window;
+	Gtk::Label*	playback_label;
 	//Glib::RefPtr<Gdk::GC>		gc_area;
 	Glib::RefPtr<Gdk::Pixbuf>	currentbuf;
 	int					currentindex;
+	double 				playback_speed;
 	//double			timeupdate;
 	double				timedisp;
 	//double				audiotime;
@@ -230,6 +232,9 @@ class Widget_Preview : public Gtk::Table
 
 	//bool play_frameupdate();
 	void update();
+	bool on_playback_input_focus_out(GdkEventFocus* event);
+	
+	void update_playback();
 
 	void scrub_updated(double t);
 
@@ -305,6 +310,7 @@ private:
 	Gtk::Box *toolbar;
 	Gtk::Button *play_button;
 	Gtk::Button *pause_button;
+	Gtk::Entry *playback_input;
 	bool on_key_pressed(GdkEventKey*);
 	void on_zoom_entry_activated();
 

--- a/synfig-studio/src/gui/preview.h
+++ b/synfig-studio/src/gui/preview.h
@@ -196,7 +196,6 @@ class Widget_Preview : public Gtk::Table
 	Gtk::Scale		scr_time_scrub;
 	Gtk::ToggleButton*	b_loop;
 	Gtk::ScrolledWindow	preview_window;
-	Gtk::Label*	playback_label;
 	//Glib::RefPtr<Gdk::GC>		gc_area;
 	Glib::RefPtr<Gdk::Pixbuf>	currentbuf;
 	int					currentindex;
@@ -232,7 +231,7 @@ class Widget_Preview : public Gtk::Table
 
 	//bool play_frameupdate();
 	void update();
-	bool on_playback_input_focus_out(GdkEventFocus* event);
+	bool on_playback_speed_focus_out(GdkEventFocus* event);
 	
 	void update_playback();
 
@@ -303,6 +302,7 @@ protected:
 	ModelColumns factors;
 
 	Gtk::ComboBoxText zoom_preview;
+	Gtk::ComboBoxText speed_preview;
 	Glib::RefPtr<Gtk::ListStore> factor_refTreeModel;
 	
 private:
@@ -310,7 +310,6 @@ private:
 	Gtk::Box *toolbar;
 	Gtk::Button *play_button;
 	Gtk::Button *pause_button;
-	Gtk::Entry *playback_input;
 	bool on_key_pressed(GdkEventKey*);
 	void on_zoom_entry_activated();
 


### PR DESCRIPTION
Added the ability to set playback speed in the preview window, allowing playing the rendered animation at different speed.

Issue: https://github.com/synfig/synfig/issues/259

<img width="1097" height="787" alt="image" src="https://github.com/user-attachments/assets/6eb2186f-52ab-443b-9b47-301d607a009b" />

