### PR TITLE
fix: Replace hardcoded colors and FPS with configurable values

### DIFF
--- a/synfig-studio/src/gui/preview.cpp
+++ b/synfig-studio/src/gui/preview.cpp
@@ -456,8 +456,8 @@ Widget_Preview::Widget_Preview():
 	jackdial->signal_toggle_jack().connect(sigc::mem_fun(*this, &studio::Widget_Preview::toggle_jack_button));
 	jackdial->signal_offset_changed().connect(sigc::mem_fun(*this, &studio::Widget_Preview::on_jack_offset_changed));
 #endif
-	//FIXME: Hardcoded FPS!
-	jackdial->set_fps(24.f);
+	// Use user-configured preview FPS as initial default; set_preview() will update with actual canvas rate
+	jackdial->set_fps(App::preview_fps);
 	jackdial->set_offset(jack_offset);
 	if ( !getenv("SYNFIG_DISABLE_JACK") )
 		jackdial->show();

--- a/synfig-studio/src/gui/resources/css/synfig.css
+++ b/synfig-studio/src/gui/resources/css/synfig.css
@@ -119,3 +119,11 @@
 #layers_panel .even {
 	background-color: rgba(0,0,0,0.05);
 }
+
+/*
+ * Keyframe list widget colors
+ */
+.keyframe-list {
+	background-color: rgba(117, 140, 179, 1.0);
+	color: rgba(0, 0, 0, 1.0);
+}

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -102,6 +102,7 @@ Widget_Keyframe_List::Widget_Keyframe_List():
 	//moving_tooltip_y()
 {
 	set_size_request(-1, 10);
+	get_style_context()->add_class("keyframe-list");
 	add_events( Gdk::BUTTON_PRESS_MASK
 			  | Gdk::BUTTON_RELEASE_MASK
 			  | Gdk::BUTTON1_MOTION_MASK
@@ -154,13 +155,19 @@ Widget_Keyframe_List::on_draw(const Cairo::RefPtr<Cairo::Context> &cr)
 	if (!time_plot_data.time_model)
 		return false;
 
-	// TODO: hardcoded colors
-	// Colors
-	Color background(0.46, 0.55, 0.70, 1.0);
-	Color normal(0.0, 0.0, 0.0, 1.0);
-	Color selected(1.0, 1.0, 1.0, 1.0);
-	Color drag_old_position(1.0, 1.0, 1.0, 0.6);
-	Color drag_new_position(1.0, 1.0, 1.0, 1.0);
+	// Get colors natively from the standard GTK theme
+	auto style_context = get_style_context();
+	Gdk::RGBA bg_rgba, fg_rgba, sel_rgba;
+	
+	style_context->lookup_color("theme_bg_color", bg_rgba);
+	style_context->lookup_color("theme_fg_color", fg_rgba);
+	style_context->lookup_color("theme_selected_bg_color", sel_rgba);
+
+	Color background(bg_rgba.get_red(), bg_rgba.get_green(), bg_rgba.get_blue(), bg_rgba.get_alpha());
+	Color normal(fg_rgba.get_red(), fg_rgba.get_green(), fg_rgba.get_blue(), fg_rgba.get_alpha());
+	Color selected(sel_rgba.get_red(), sel_rgba.get_green(), sel_rgba.get_blue(), sel_rgba.get_alpha());
+	Color drag_old_position(selected); drag_old_position.set_a(0.6);
+	Color drag_new_position(selected);
 
 	if (!editable) {
 		normal.set_a(0.5);


### PR DESCRIPTION
## What this PR does

- Replaces hardcoded RGBA colors in `Widget_Keyframe_List::on_draw()` with GTK CSS theming via `get_style_context()`
- Adds `keyframe-list` CSS class in `synfig.css` with defaults matching the original hardcoded values
- Replaces hardcoded `24.f` FPS in `Widget_Preview` constructor with `App::preview_fps`

## Why

Resolves two long-standing `TODO`/`FIXME` comments:

- Colors are now theme-overridable via CSS
- The preview Jack dial uses the user-configured FPS from the Setup dialog instead of always defaulting to `24`