### PR TITLE
feat: applied a dithering filter to gradients to remove banding artifacts

### DIFF
--- a/synfig-core/src/modules/mod_gradient/conicalgradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/conicalgradient.cpp
@@ -115,7 +115,7 @@ public:
 		Real dist(a.mod().get());
 
 		supersample *= 0.5;
-		return compiled_gradient.average(dist - supersample, dist + supersample);
+        return compiled_gradient.average(dist - supersample, dist + supersample, p);
 		//return compiled_gradient.color(dist);
 	}
 };
@@ -132,7 +132,8 @@ ConicalGradient::ConicalGradient():
 	param_gradient(ValueBase(Gradient(Color::black(),Color::white()))),
 	param_center(ValueBase(Point(0,0))),
 	param_angle(ValueBase(Angle::zero())),
-	param_symmetric(ValueBase(false))
+    param_symmetric(ValueBase(false)),
+    param_dithering(ValueBase(true))
 {
 	SET_INTERPOLATION_DEFAULTS();
 	SET_STATIC_DEFAULTS();
@@ -143,8 +144,9 @@ ConicalGradient::set_param(const String & param, const ValueBase &value)
 {
 	IMPORT_VALUE_PLUS(param_gradient, compile());
 	IMPORT_VALUE(param_center);
-	IMPORT_VALUE(param_angle);
-	IMPORT_VALUE_PLUS(param_symmetric, compile());
+    IMPORT_VALUE(param_angle);
+    IMPORT_VALUE_PLUS(param_symmetric, compile());
+    IMPORT_VALUE_PLUS(param_dithering, compile());
 	return Layer_Composite::set_param(param,value);
 }
 
@@ -153,8 +155,9 @@ ConicalGradient::get_param(const String &param)const
 {
 	EXPORT_VALUE(param_gradient);
 	EXPORT_VALUE(param_center);
-	EXPORT_VALUE(param_angle);
-	EXPORT_VALUE(param_symmetric);
+    EXPORT_VALUE(param_angle);
+    EXPORT_VALUE(param_symmetric);
+    EXPORT_VALUE(param_dithering);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
@@ -189,6 +192,11 @@ ConicalGradient::get_param_vocab()const
 		.set_description(_("When checked, the gradient is looped"))
 	);
 
+    ret.push_back(ParamDesc("dithering")
+        .set_local_name(_("Dithering"))
+        .set_description(_("When checked, smooths banding artifacts by applying a dithering filter"))
+    );
+
 	return ret;
 }
 
@@ -198,7 +206,8 @@ ConicalGradient::compile()
 	compiled_gradient.set(
 		param_gradient.get(Gradient()),
 		true,
-		param_symmetric.get(bool()) );
+        param_symmetric.get(bool()),
+        param_dithering.get(bool()) );
 }
 
 inline Color
@@ -213,7 +222,7 @@ ConicalGradient::color_func(const Point &pos, Real supersample)const
 	Real dist(a.mod().get());
 
 	supersample *= 0.5;
-	return compiled_gradient.average(dist - supersample, dist + supersample);
+    return compiled_gradient.average(dist - supersample, dist + supersample, pos);
 }
 
 synfig::Layer::Handle

--- a/synfig-core/src/modules/mod_gradient/conicalgradient.h
+++ b/synfig-core/src/modules/mod_gradient/conicalgradient.h
@@ -52,9 +52,11 @@ private:
 	//! Parameter: (Point)
 	ValueBase param_center;
 	//! Parameter: (Angle)
-	ValueBase param_angle;
-	//! Parameter: (bool)
-	ValueBase param_symmetric;
+    ValueBase param_angle;
+    //! Parameter: (bool)
+    ValueBase param_symmetric;
+    //! Parameter: (bool)
+    ValueBase param_dithering;
 
 	CompiledGradient compiled_gradient;
 

--- a/synfig-core/src/modules/mod_gradient/curvegradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/curvegradient.cpp
@@ -228,7 +228,7 @@ public:
 	Token::Handle get_token() const override { return token.handle(); }
 
 	Color get_color(const Vector& p) const override
-	{
+    {
 		Vector tangent;
 		Point p1;
 		Real thickness;
@@ -382,7 +382,7 @@ public:
 		}
 
 		if (approximate_zero(diff[0]) && approximate_zero(diff[1])) {
-			return compiled_gradient.color(compiled_gradient.get_from_zigzag()? 0.5 : 1.0);
+            return compiled_gradient.color(compiled_gradient.get_from_zigzag()? 0.5 : 1.0, p);
 		}
 
 		const Real mag(diff.inv_mag());
@@ -391,10 +391,10 @@ public:
 		Real supersample = get_units_per_pixel()[0];
 		supersample = synfig::clamp(supersample*mag, 0., 2.);
 		supersample *= 0.5;
-		return compiled_gradient.average(dist - supersample, dist + supersample);
+        return compiled_gradient.average(dist - supersample, dist + supersample, p);
 	}
 
-	bool run(RunParams&) const override {
+    bool run(RunParams&) const override {
 		return run_task();
 	}
 };
@@ -420,7 +420,8 @@ CurveGradient::compile()
 	compiled_gradient.set(
 		param_gradient.get(Gradient()),
 		param_loop.get(bool()),
-		param_zigzag.get(bool()) );
+        param_zigzag.get(bool()),
+        param_dithering.get(bool()) );
 }
 
 
@@ -432,8 +433,9 @@ CurveGradient::CurveGradient():
 	param_gradient(Gradient(Color::black(), Color::white())),
 	param_loop(ValueBase(false)),
 	param_zigzag(ValueBase(false)),
-	param_perpendicular(ValueBase(false)),
-	param_fast(ValueBase(true))
+    param_perpendicular(ValueBase(false)),
+    param_fast(ValueBase(true)),
+    param_dithering(ValueBase(true))
 {
 	std::vector<synfig::BLinePoint> bline;
 	bline.push_back(BLinePoint());
@@ -619,7 +621,7 @@ CurveGradient::color_func(const Point& point_, Real supersample) const
 	}
 
 	if (approximate_zero(diff[0]) && approximate_zero(diff[1])) {
-		return compiled_gradient.color(compiled_gradient.get_from_zigzag()? 0.5 : 1.0);
+        return compiled_gradient.color(compiled_gradient.get_from_zigzag()? 0.5 : 1.0, point_);
 	}
 
 	const Real mag(diff.inv_mag());
@@ -628,7 +630,7 @@ CurveGradient::color_func(const Point& point_, Real supersample) const
 
 	supersample = supersample * mag;
 	supersample *= 0.5;
-	return compiled_gradient.average(dist - supersample, dist + supersample);
+    return compiled_gradient.average(dist - supersample, dist + supersample, point_);
 }
 
 synfig::Layer::Handle
@@ -662,10 +664,11 @@ CurveGradient::set_param(const String & param, const ValueBase &value)
 		return true;
 	}
 	IMPORT_VALUE_PLUS(param_gradient, compile());
-	IMPORT_VALUE_PLUS(param_loop, compile());
-	IMPORT_VALUE_PLUS(param_zigzag, compile());
+    IMPORT_VALUE_PLUS(param_loop, compile());
+    IMPORT_VALUE_PLUS(param_zigzag, compile());
 	IMPORT_VALUE(param_perpendicular);
 	IMPORT_VALUE(param_fast);
+    IMPORT_VALUE_PLUS(param_dithering, compile());
 
 	if(param=="offset")
 		return set_param("origin", value);
@@ -682,8 +685,9 @@ CurveGradient::get_param(const String & param)const
 	EXPORT_VALUE(param_gradient);
 	EXPORT_VALUE(param_loop);
 	EXPORT_VALUE(param_zigzag);
-	EXPORT_VALUE(param_perpendicular);
-	EXPORT_VALUE(param_fast);
+    EXPORT_VALUE(param_perpendicular);
+    EXPORT_VALUE(param_fast);
+    EXPORT_VALUE(param_dithering);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
@@ -731,6 +735,10 @@ CurveGradient::get_param_vocab()const
 				  .set_local_name(_("Fast"))
 				  .set_description(_("When checked, renders quickly but with artifacts"))
 	);
+    ret.push_back(ParamDesc("dithering")
+                  .set_local_name(_("Dithering"))
+                  .set_description(_("When checked, smooths banding artifacts by applying a dithering filter (you may also need to uncheck Fast)"))
+    );
 
 	return ret;
 }

--- a/synfig-core/src/modules/mod_gradient/curvegradient.h
+++ b/synfig-core/src/modules/mod_gradient/curvegradient.h
@@ -62,9 +62,11 @@ private:
 	//! Parameter: (bool)
 	ValueBase param_zigzag;
 	//! Parameter: (bool)
-	ValueBase param_perpendicular;
-	//! Parameter: (bool)
-	ValueBase param_fast;
+    ValueBase param_perpendicular;
+    //! Parameter: (bool)
+    ValueBase param_fast;
+    //! Parameter: (bool)
+    ValueBase param_dithering;
 
 	Real curve_length_;
 	bool bline_loop;

--- a/synfig-core/src/modules/mod_gradient/lineargradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/lineargradient.cpp
@@ -98,7 +98,7 @@ public:
 	Color get_color(const Vector& p) const override
 	{
 		Real dist((p - params.p1)*params.diff);
-		return params.gradient.average(dist - supersample, dist + supersample);
+        return params.gradient.average(dist - supersample, dist + supersample, p);
 		//return params.gradient.color(dist);
 	}
 };
@@ -122,8 +122,9 @@ LinearGradient::LinearGradient():
 	param_p1(ValueBase(Point(1,1))),
 	param_p2(ValueBase(Point(-1,-1))),
 	param_gradient(ValueBase(Gradient(Color::black(), Color::white()))),
-	param_loop(ValueBase(false)),
-	param_zigzag(ValueBase(false))
+    param_loop(ValueBase(false)),
+    param_zigzag(ValueBase(false)),
+    param_dithering(ValueBase(true))
 {
 	SET_INTERPOLATION_DEFAULTS();
 	SET_STATIC_DEFAULTS();
@@ -136,7 +137,8 @@ LinearGradient::fill_params(Params &params)const
 	params.p2=param_p2.get(Point());
 	params.loop=param_loop.get(bool());
 	params.zigzag=param_zigzag.get(bool());
-	params.gradient.set(param_gradient.get(Gradient()), params.loop, params.zigzag);
+    params.dithering=param_dithering.get(bool());
+    params.gradient.set(param_gradient.get(Gradient()), params.loop, params.zigzag, params.dithering);
 	params.calc_diff();
 }
 
@@ -145,7 +147,7 @@ LinearGradient::color_func(const Params &params, const Point &point, synfig::Rea
 {
 	Real dist(point*params.diff - params.p1*params.diff);
 	supersample *= 0.5;
-	return params.gradient.average(dist - supersample, dist + supersample);
+    return params.gradient.average(dist - supersample, dist + supersample, point);
 }
 
 synfig::Layer::Handle
@@ -174,8 +176,10 @@ LinearGradient::set_param(const String & param, const ValueBase &value)
 	IMPORT_VALUE(param_p1);
 	IMPORT_VALUE(param_p2);
 	IMPORT_VALUE(param_gradient);
-	IMPORT_VALUE(param_loop);
-	IMPORT_VALUE(param_zigzag);
+    IMPORT_VALUE(param_loop);
+    IMPORT_VALUE(param_zigzag);
+    IMPORT_VALUE(param_dithering);
+
 	return Layer_Composite::set_param(param,value);
 }
 
@@ -185,8 +189,9 @@ LinearGradient::get_param(const String & param)const
 	EXPORT_VALUE(param_p1);
 	EXPORT_VALUE(param_p2);
 	EXPORT_VALUE(param_gradient);
-	EXPORT_VALUE(param_loop);
-	EXPORT_VALUE(param_zigzag);
+    EXPORT_VALUE(param_loop);
+    EXPORT_VALUE(param_zigzag);
+    EXPORT_VALUE(param_dithering);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
@@ -222,6 +227,10 @@ LinearGradient::get_param_vocab()const
 		.set_local_name(_("ZigZag"))
 		.set_description(_("When checked, the gradient is symmetrical at the center"))
 	);
+    ret.push_back(ParamDesc("dithering")
+        .set_local_name(_("Dithering"))
+        .set_description(_("When checked, smooths banding artifacts by applying a dithering filter"))
+    );
 
 	return ret;
 }

--- a/synfig-core/src/modules/mod_gradient/lineargradient.h
+++ b/synfig-core/src/modules/mod_gradient/lineargradient.h
@@ -54,9 +54,11 @@ private:
 	//! Parameter: (Gradient)
 	ValueBase param_gradient;
 	//! Parameter: (bool)
-	ValueBase param_loop;
-	//! Parameter: (bool)
-	ValueBase param_zigzag;
+    ValueBase param_loop;
+    //! Parameter: (bool)
+    ValueBase param_zigzag;
+    //! Parameter: (bool)
+    ValueBase param_dithering;
 
 	struct Params {
 		Point p1;
@@ -65,6 +67,7 @@ private:
 		CompiledGradient gradient;
 		bool loop;
 		bool zigzag;
+        bool dithering;
 		inline Params(): loop(false), zigzag(false) { }
 		void calc_diff();
 	};

--- a/synfig-core/src/modules/mod_gradient/radialgradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/radialgradient.cpp
@@ -105,7 +105,7 @@ public:
 	{
 		Real dist((p-center).mag()/radius);
 
-		return compiled_gradient.average(dist - supersample, dist + supersample);
+        return compiled_gradient.average(dist - supersample, dist + supersample, p);
 		//return params.gradient.color(dist);
 	}
 };
@@ -122,7 +122,8 @@ RadialGradient::RadialGradient():
 	param_center(ValueBase(Point(0,0))),
 	param_radius(ValueBase(Real(0.5))),
 	param_loop(ValueBase(false)),
-	param_zigzag(ValueBase(false))
+    param_zigzag(ValueBase(false)),
+    param_dithering(ValueBase(true))
 {
 	SET_INTERPOLATION_DEFAULTS();
 	SET_STATIC_DEFAULTS();
@@ -134,8 +135,9 @@ RadialGradient::set_param(const String & param, const ValueBase &value)
 	IMPORT_VALUE_PLUS(param_gradient, compile());
 	IMPORT_VALUE(param_center);
 	IMPORT_VALUE(param_radius);
-	IMPORT_VALUE_PLUS(param_loop, compile());
-	IMPORT_VALUE_PLUS(param_zigzag, compile());
+    IMPORT_VALUE_PLUS(param_loop, compile());
+    IMPORT_VALUE_PLUS(param_zigzag, compile());
+    IMPORT_VALUE_PLUS(param_dithering, compile());
 
 	return Layer_Composite::set_param(param,value);
 }
@@ -146,8 +148,9 @@ RadialGradient::get_param(const String &param)const
 	EXPORT_VALUE(param_gradient);
 	EXPORT_VALUE(param_center);
 	EXPORT_VALUE(param_radius);
-	EXPORT_VALUE(param_loop);
-	EXPORT_VALUE(param_zigzag);
+    EXPORT_VALUE(param_loop);
+    EXPORT_VALUE(param_zigzag);
+    EXPORT_VALUE(param_dithering);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
@@ -188,6 +191,12 @@ RadialGradient::get_param_vocab()const
 		.set_description(_("When checked, the gradient is symmetrical at the center"))
 	);
 
+    ret.push_back(ParamDesc("dithering")
+        .set_local_name(_("Dithering"))
+        .set_description(_("When checked, smooths banding artifacts by applying a dithering filter"))
+    );
+
+
 	return ret;
 }
 
@@ -197,7 +206,8 @@ RadialGradient::compile()
 	compiled_gradient.set(
 		param_gradient.get(Gradient()),
 		param_loop.get(bool()),
-		param_zigzag.get(bool()) );
+        param_zigzag.get(bool()),
+        param_dithering.get(bool()) );
 }
 
 inline Color
@@ -209,7 +219,7 @@ RadialGradient::color_func(const Point &point, Real supersample)const
 	Real dist((point-center).mag()/radius);
 
 	supersample *= 0.5;
-	return compiled_gradient.average(dist - supersample, dist + supersample);
+    return compiled_gradient.average(dist - supersample, dist + supersample, point);
 }
 
 synfig::Layer::Handle

--- a/synfig-core/src/modules/mod_gradient/radialgradient.h
+++ b/synfig-core/src/modules/mod_gradient/radialgradient.h
@@ -56,9 +56,11 @@ private:
 	//! Parameter: (Real)
 	ValueBase param_radius;
 	//! Parameter: (bool)
-	ValueBase param_loop;
-	//! Parameter: (bool)
-	ValueBase param_zigzag;
+    ValueBase param_loop;
+    //! Parameter: (bool)
+    ValueBase param_zigzag;
+    //! Parameter: (bool)
+    ValueBase param_dithering;
 
 	CompiledGradient compiled_gradient;
 

--- a/synfig-core/src/modules/mod_gradient/spiralgradient.cpp
+++ b/synfig-core/src/modules/mod_gradient/spiralgradient.cpp
@@ -118,7 +118,7 @@ public:
 			dist-=Angle::rot(a.mod()).get();
 
 //		supersample *= 0.5;
-		return compiled_gradient.average(dist - supersample, dist + supersample);
+        return compiled_gradient.average(dist - supersample, dist + supersample, p);
 		//return compiled_gradient.color(dist);
 	}
 };
@@ -136,7 +136,8 @@ SpiralGradient::SpiralGradient():
 	param_center(ValueBase(Point(0,0))),
 	param_radius(ValueBase(Real(0.5))),
 	param_angle(ValueBase(Angle::zero())),
-	param_clockwise(ValueBase(false))
+    param_clockwise(ValueBase(false)),
+    param_dithering(ValueBase(true))
 {
 	SET_INTERPOLATION_DEFAULTS();
 	SET_STATIC_DEFAULTS();
@@ -148,8 +149,9 @@ SpiralGradient::set_param(const String & param, const ValueBase &value)
 	IMPORT_VALUE_PLUS(param_gradient, compile());
 	IMPORT_VALUE(param_center);
 	IMPORT_VALUE(param_radius);
-	IMPORT_VALUE(param_angle);
-	IMPORT_VALUE(param_clockwise);
+    IMPORT_VALUE(param_angle);
+    IMPORT_VALUE(param_clockwise);
+    IMPORT_VALUE_PLUS(param_dithering, compile());
 
 	return Layer_Composite::set_param(param,value);
 }
@@ -160,8 +162,9 @@ SpiralGradient::get_param(const String &param)const
 	EXPORT_VALUE(param_gradient);
 	EXPORT_VALUE(param_center);
 	EXPORT_VALUE(param_radius);
-	EXPORT_VALUE(param_angle);
-	EXPORT_VALUE(param_clockwise);
+    EXPORT_VALUE(param_angle);
+    EXPORT_VALUE(param_clockwise);
+    EXPORT_VALUE(param_dithering);
 
 	EXPORT_NAME();
 	EXPORT_VERSION();
@@ -203,12 +206,23 @@ SpiralGradient::get_param_vocab()const
 		.set_description(_("When checked, the spiral turns clockwise"))
 	);
 
+    ret.push_back(ParamDesc("dithering")
+        .set_local_name(_("Dithering"))
+        .set_description(_("When checked, smooths banding artifacts by applying a dithering filter"))
+    );
+
 	return ret;
 }
 
 void
 SpiralGradient::compile()
-	{ compiled_gradient.set(param_gradient.get(Gradient()), true); }
+{
+    compiled_gradient.set(
+        param_gradient.get(Gradient()),
+        true,
+        false,
+        param_dithering.get(bool()) );
+}
 
 inline Color
 SpiralGradient::color_func(const Point &pos, Real supersample)const
@@ -231,7 +245,7 @@ SpiralGradient::color_func(const Point &pos, Real supersample)const
 		dist-=Angle::rot(a.mod()).get();
 
 	supersample *= 0.5;
-	return compiled_gradient.average(dist - supersample, dist + supersample);
+    return compiled_gradient.average(dist - supersample, dist + supersample, pos);
 }
 
 synfig::Layer::Handle

--- a/synfig-core/src/modules/mod_gradient/spiralgradient.h
+++ b/synfig-core/src/modules/mod_gradient/spiralgradient.h
@@ -53,9 +53,11 @@ private:
 	//! Parameter: (Real)
 	ValueBase param_radius;
 	//! Parameter: (Angle)
-	ValueBase param_angle;
-	//! Parameter: (bool)
-	ValueBase param_clockwise;
+    ValueBase param_angle;
+    //! Parameter: (bool)
+    ValueBase param_clockwise;
+    //! Parameter: (bool)
+    ValueBase param_dithering;
 
 	CompiledGradient compiled_gradient;
 

--- a/synfig-core/src/modules/mod_noise/noise.cpp
+++ b/synfig-core/src/modules/mod_noise/noise.cpp
@@ -176,9 +176,9 @@ public:
 			if (approximate_greater(da, 2.))
 				da = 2.;
 			da *= 0.5;
-			color = compiled_gradient.average(amount - da, amount + da);
+            color = compiled_gradient.average(amount - da, amount + da, point);
 		} else {
-			color = compiled_gradient.color(amount);
+            color = compiled_gradient.color(amount, point);
 		}
 
 		if (do_alpha)
@@ -321,9 +321,9 @@ Noise::color_func(const Point &point, float pixel_size,Context /*context*/)const
 
 		if(super_sample && pixel_size) {
 			Real da = std::max(amount3, std::max(amount,amount2)) - std::min(amount3, std::min(amount,amount2));
-			ret = compiled_gradient.average(amount - da, amount + da);
+            ret = compiled_gradient.average(amount - da, amount + da, point);
 		} else {
-			ret = compiled_gradient.color(amount);
+            ret = compiled_gradient.color(amount, point);
 		}
 
 		if(do_alpha)

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -37,6 +37,7 @@
 #include "gradient.h"
 
 #include <algorithm>
+#include <random>
 #include <stdexcept>
 
 #include "general.h"
@@ -273,16 +274,16 @@ CompiledGradient::Entry::Entry(const Accumulator &prev_sum, const GradientCPoint
 
 
 CompiledGradient::CompiledGradient():
-	is_empty(true), repeat(false), zigzag(false)
+    is_empty(true), repeat(false), zigzag(false), dithering(false)
 	{ reset(); };
 
 CompiledGradient::CompiledGradient(const Color &color):
-	is_empty(true), repeat(false), zigzag(false)
+    is_empty(true), repeat(false), zigzag(false), dithering(false)
 	{ set(color); };
 
-CompiledGradient::CompiledGradient(const Gradient &gradient, bool repeat, bool zigzag):
-	is_empty(true), repeat(false), zigzag(false)
-	{ set(gradient, repeat, zigzag); };
+CompiledGradient::CompiledGradient(const Gradient &gradient, bool repeat, bool zigzag, bool dithering):
+    is_empty(true), repeat(false), zigzag(false), dithering(false)
+    { set(gradient, repeat, zigzag, dithering); };
 
 void
 CompiledGradient::set(const Color &color)
@@ -296,7 +297,7 @@ CompiledGradient::set(const Color &color)
 }
 
 void
-CompiledGradient::set(const Gradient &gradient, bool repeat, bool zigzag) {
+CompiledGradient::set(const Gradient &gradient, bool repeat, bool zigzag, bool dithering) {
 	if (gradient.empty())
 		{ reset(); return; }
 	if (gradient.size() == 1)
@@ -326,6 +327,7 @@ CompiledGradient::set(const Gradient &gradient, bool repeat, bool zigzag) {
 	list.clear();
 	this->repeat = repeat;
 	this->zigzag = zigzag;
+    this->dithering = dithering;
 	Accumulator prev_sum = Accumulator(cpoints.front().color)*cpoints.front().pos;
 	for(Gradient::iterator i = cpoints.begin(), j = i + 1; j != cpoints.end();  ++i, ++j) {
 		list.push_back( Entry(prev_sum, *i, *j) );
@@ -349,3 +351,70 @@ CompiledGradient::set(const Gradient &gradient, bool repeat, bool zigzag) {
 	
 	summary_color = find(1.0)->summary(1.0);
 }
+
+// generate a PRNG table
+static std::vector<float>
+make_prng_table()
+{
+    size_t N = 1000;
+    std::vector<float> r(N);
+
+    // for cross-platform consistency, don't use random_device and avoid the use of std::uniform_real_distribution (ie most of <random>).
+    // mersenne twister with default constructor is cross-platform so that's still okay.
+    std::mt19937 gen;
+    for (size_t i=0; i<N; i++)
+    {
+        r[i] = (double)gen() / gen.max();
+    }
+
+    return r;
+};
+
+// pre-generated PRNG table
+// https://xkcd.com/221/
+static const std::vector<float> prng_table = make_prng_table();
+
+Color
+CompiledGradient::apply_dithering(const Color &c, const Vector &seed) const
+{
+    // the PRNG we choose doesn't really need to be random, we just need a good source
+    // of entropy for the dithering. We want it to be deterministic, fast, and random enough to
+    // get a good-looking dither.
+    //
+    // the "PRNG" algorithm here is:
+    // 1. Hash the input by mashing the bits together (not a quality hash, but extremely fast)
+    // 2. Use the hash as a lookup into a pre-generated random table.
+
+    uint64_t rBits = *(const uint32_t*)&c.get_r();
+    uint64_t gBits = *(const uint32_t*)&c.get_g();
+    uint64_t bBits = *(const uint32_t*)&c.get_b();
+    uint64_t s0Bits = *(const uint64_t*)&seed[0];
+    uint64_t s1Bits = *(const uint64_t*)&seed[1];
+
+    size_t hash = (rBits << 0) ^
+                  (gBits << 1) ^
+                  (bBits << 2) ^
+                  (s0Bits << 3) ^
+                  (s1Bits << 4);
+    hash >>= 5;
+    hash = hash % (prng_table.size() - 3);
+
+    // these numbers represent the probability that the corresponding number gets rounded up
+    float pr = prng_table[hash+0];
+    float pg = prng_table[hash+1];
+    float pb = prng_table[hash+2];
+
+    // convert from floating point (0-1) to RGB (0-255), then round either up or down probabilistically based on the decimal point.
+    // ex. if c.get_r() is 62.853 in RGB, that will have a 85.3% chance of rounding up to 63 and an 14.7% chance of rounding down to 62.
+    int r = c.get_r() * 255.0f + pr;
+    int g = c.get_g() * 255.0f + pg; // this branchless implementation actually saves like 15% on the render times compared to an if statement
+    int b = c.get_b() * 255.0f + pb;
+
+    // uncomment these lines to see what the PRNG noise pattern looks like.
+    // r = pr * 255;
+    // g = pg * 255;
+    // b = pb * 255;
+
+    return Color(r / 255.0f, g / 255.0f, b / 255.0f, c.get_a());
+}
+

--- a/synfig-core/src/synfig/gradient.cpp
+++ b/synfig-core/src/synfig/gradient.cpp
@@ -385,11 +385,11 @@ CompiledGradient::apply_dithering(const Color &c, const Vector &seed) const
     // 1. Hash the input by mashing the bits together (not a quality hash, but extremely fast)
     // 2. Use the hash as a lookup into a pre-generated random table.
 
-    uint64_t rBits = *(const uint32_t*)&c.get_r();
-    uint64_t gBits = *(const uint32_t*)&c.get_g();
-    uint64_t bBits = *(const uint32_t*)&c.get_b();
-    uint64_t s0Bits = *(const uint64_t*)&seed[0];
-    uint64_t s1Bits = *(const uint64_t*)&seed[1];
+    uint64_t rBits = *reinterpret_cast<const uint32_t*>(&c.get_r());
+    uint64_t gBits = *reinterpret_cast<const uint32_t*>(&c.get_g());
+    uint64_t bBits = *reinterpret_cast<const uint32_t*>(&c.get_b());
+    uint64_t s0Bits = *reinterpret_cast<const uint64_t*>(&seed[0]);
+    uint64_t s1Bits = *reinterpret_cast<const uint64_t*>(&seed[1]);
 
     size_t hash = (rBits << 0) ^
                   (gBits << 1) ^

--- a/synfig-core/src/synfig/gradient.h
+++ b/synfig-core/src/synfig/gradient.h
@@ -38,6 +38,7 @@
 #include "real.h"
 #include "color.h"
 #include "uniqueid.h"
+#include "vector.h"
 
 /* === M A C R O S ========================================================= */
 
@@ -81,7 +82,7 @@ public:
 	typedef CPointList::reverse_iterator		reverse_iterator;
 
 private:
-	CPointList cpoints;
+    CPointList cpoints;
 
 public:
 	Gradient() { }
@@ -122,7 +123,7 @@ public:
 	Gradient operator*(const ColorReal &rhs) const { return Gradient(*this)*=rhs; }
 	Gradient operator/(const ColorReal &rhs) const { return Gradient(*this)/=rhs; }
 
-	Color operator() (const Real &x) const;
+    Color operator() (const Real &x) const;
 
 	//! Returns average luminance of gradient
 	Real mag() const;
@@ -242,31 +243,34 @@ private:
 	bool is_empty;
 	bool repeat;
 	bool zigzag;
+    bool dithering;
 	List list;
 
 	Accumulator summary_color;
 
 public:
 	CompiledGradient();
-	explicit CompiledGradient(const Color &color);
-	explicit CompiledGradient(const Gradient &gradient, bool repeat = false, bool zigzag = false);
+    explicit CompiledGradient(const Color &color);
+    explicit CompiledGradient(const Gradient &gradient, bool repeat = false, bool zigzag = false, bool dithering = false);
 
-	void set(const Color &color);
-	void set(const Gradient &gradient, bool repeat = false, bool zigzag = false);
+    void set(const Color &color);
+    void set(const Gradient &gradient, bool repeat = false, bool zigzag = false, bool dithering = false);
 	void reset() { set(Color()); }
 
 	bool empty() const { return is_empty; }
 	bool get_repeat() const { return repeat; }
 	/** Tells if the compiled gradient was generated from a zigzag (not if it is zigzag) */
 	bool get_from_zigzag() const { return zigzag; }
+    bool get_dithering() const { return dithering; }
 	const List& get_list() const { return list; }
 
 	inline List::const_iterator find(Real x) const
 		{ return std::lower_bound(list.begin(), list.end()-1, x); }
 
-	inline Color color(Real x) const {
+    inline Color color(Real x, const Vector& dithering_seed) const {
+
 		if (repeat) x -= floor(x);
-		return find(x)->color(x);
+        return dithering ? apply_dithering(find(x)->color(x), dithering_seed) : find(x)->color(x);
 	}
 
 	inline Accumulator summary() const
@@ -284,13 +288,18 @@ public:
 	inline Color average() const
 		{ return summary_color.color(); }
 
-	inline Color average(Real x0, Real x1) const
-	{
+    inline Color average(Real x0, Real x1, const Vector& dithering_seed) const
+    {
 		Real w = x1 - x0;
 		if (std::isnan(w) || std::isinf(w)) return average();
-		if (fabs(w) < real_precision<Real>()) return color(x0);
-		return ((summary(x1) - summary(x0))/w).color();
+        if (fabs(w) < real_precision<Real>()) return color(x0, dithering_seed);
+        Color ret = ((summary(x1) - summary(x0))/w).color();
+
+        return dithering ? apply_dithering(ret, dithering_seed) : ret;
 	}
+
+private:
+    Color apply_dithering(const Color &c, const Vector &seed) const;
 };
 
 }; // END of namespace synfig


### PR DESCRIPTION
Edit: I'm experimenting with other ways to introduce this feature to make it as seamless as possible. I'm open to suggestions.

Added a dithering filter to all gradient layers to remove banding artifacts. This option is enabled by default, and can be disabled on a per-layer basis via the "Dithering" parameter.

Examples:
<img width="600" height="600" alt="linear" src="https://github.com/user-attachments/assets/a90ef192-edc7-433e-a20f-8bdb30a01618" />
<table>
<tr>
<td><img width="300" height="300" alt="radial" src="https://github.com/user-attachments/assets/1b54982c-c722-4bec-993e-ba388d983e30" /> </td>
<td><img width="300" height="300" alt="conical" src="https://github.com/user-attachments/assets/b7a612ac-ac93-425b-8ef7-9cb6dc0a66be" /> </td>
</tr>
<tr>
<td><img width="300" height="300" alt="spiral" src="https://github.com/user-attachments/assets/bcd877d6-5e19-4ff2-b475-323173f2a351" /></td>
<td><img width="300" height="300" alt="curve" src="https://github.com/user-attachments/assets/994bbc68-59fa-41d8-a91a-f6fc1827c32f" /></td>
</tr>
</table>

