### PR TITLE
fix: avoid warning on console when popping up some context menus

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -1630,6 +1630,8 @@ CanvasView::popup_layer_menu(Layer::Handle layer)
 		return;
 
 	Gtk::Menu* menu(&parammenu);
+	if (!menu->get_attach_widget())
+		menu->attach_to_widget(*this);
 	std::vector<Widget*> children = menu->get_children();
 	for(std::vector<Widget*>::iterator i = children.begin(); i != children.end(); ++i)
 		menu->remove(**i);
@@ -1682,6 +1684,8 @@ CanvasView::popup_main_menu()
 	{
 		//menu->set_accel_group(App::ui_manager()->get_accel_group());
 		//menu->accelerate(*this);
+		if (!menu->get_attach_widget())
+			menu->attach_to_widget(*this);
 		menu->popup(0,gtk_get_current_event_time());
 	}
 }
@@ -1915,6 +1919,8 @@ CanvasView::popup_param_menu(ValueDesc value_desc, float location, bool bezier)
 	for(std::vector<Widget*>::iterator i = children.begin(); i != children.end(); ++i)
 		parammenu.remove(**i);
 	get_instance()->make_param_menu(&parammenu,get_canvas(),value_desc,location,bezier);
+	if (!parammenu.get_attach_widget())
+		parammenu.attach_to_widget(*this);
 	parammenu.popup(3,gtk_get_current_event_time());
 }
 
@@ -2643,7 +2649,10 @@ CanvasView::on_waypoint_clicked_canvasview(ValueDesc value_desc,
 	case 2:
 	{
 		Gtk::Menu* waypoint_menu(manage(new Gtk::Menu()));
-		waypoint_menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), waypoint_menu));
+		if (waypoint_menu) {
+			waypoint_menu->attach_to_widget(*this);
+			waypoint_menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), waypoint_menu));
+		}
 
 		Gtk::Menu* interp_menu_in(manage(new Gtk::Menu()));
 		Gtk::Menu* interp_menu_out(manage(new Gtk::Menu()));

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -2649,10 +2649,10 @@ CanvasView::on_waypoint_clicked_canvasview(ValueDesc value_desc,
 	case 2:
 	{
 		Gtk::Menu* waypoint_menu(manage(new Gtk::Menu()));
-		if (waypoint_menu) {
-			waypoint_menu->attach_to_widget(*this);
-			waypoint_menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), waypoint_menu));
-		}
+		if (!waypoint_menu)
+			break;
+		waypoint_menu->attach_to_widget(*this);
+		waypoint_menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), waypoint_menu));
 
 		Gtk::Menu* interp_menu_in(manage(new Gtk::Menu()));
 		Gtk::Menu* interp_menu_out(manage(new Gtk::Menu()));

--- a/synfig-studio/src/gui/docks/dock_layers.cpp
+++ b/synfig-studio/src/gui/docks/dock_layers.cpp
@@ -287,6 +287,10 @@ void Dock_Layers::popup_add_layer_menu()
 	if (!action_new_layer->is_sensitive())
 		return;
 	Gtk::Menu* menu = dynamic_cast<Gtk::Menu*>(App::ui_manager()->get_widget("/popup-layer-new"));
-	if (menu)
+	if (menu) {
+		if (menu->get_attach_widget())
+			menu->detach();
+		menu->attach_to_widget(*this);
 		menu->popup(0, gtk_get_current_event_time());
+	}
 }

--- a/synfig-studio/src/gui/docks/dockbook.cpp
+++ b/synfig-studio/src/gui/docks/dockbook.cpp
@@ -288,7 +288,8 @@ DockBook::tab_button_pressed(GdkEventButton* event, Dockable* dockable)
 	if(event->button!=3)
 		return false;
 
-	Gtk::Menu *tabmenu=manage(new class Gtk::Menu());
+	Gtk::Menu* tabmenu = manage(new class Gtk::Menu());
+	tabmenu->attach_to_widget(*canvas_view);
 	tabmenu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), tabmenu));
 
 	if (get_n_pages() > 1 || (get_parent() && get_parent()->get_children().size() > 1)) {
@@ -306,7 +307,7 @@ DockBook::tab_button_pressed(GdkEventButton* event, Dockable* dockable)
 	item->show();
 	tabmenu->append(*item);
 
-	tabmenu->popup(event->button,gtk_get_current_event_time());
+	tabmenu->popup(event->button, gtk_get_current_event_time());
 
 	return true;
 	SYNFIG_EXCEPTION_GUARD_END_BOOL(true)

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -356,6 +356,8 @@ void
 Dock_PalEdit::show_menu(int i)
 {
 	Gtk::Menu* menu(manage(new Gtk::Menu()));
+	menu->attach_to_widget(*this);
+
 	menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), menu));
 
 	Gtk::MenuItem *item = image_menu_item("type_color_icon", _("_Color"), true);

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -459,6 +459,9 @@ StateBLine_Context::StateBLine_Context(CanvasView* canvas_view):
 {
 	egress_on_selection_change=true;
 
+	if (canvas_view)
+		menu.attach_to_widget(*canvas_view);
+
 	// Toolbox widgets
 	title_label.set_label(_("Spline Tool"));
 	Pango::AttrList list;

--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -809,7 +809,8 @@ StateNormal_Context::event_multiple_ducks_clicked_handler(const Smach::event& x)
 		value_desc_list.push_back(value_desc);
 	}
 
-	Gtk::Menu *menu=manage(new Gtk::Menu());
+	Gtk::Menu* menu=manage(new Gtk::Menu());
+	menu->attach_to_widget(*canvas_view_);
 	menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), menu));
 
 	const EventMouse& event(*reinterpret_cast<const EventMouse*>(&x));

--- a/synfig-studio/src/gui/trees/keyframetree.cpp
+++ b/synfig-studio/src/gui/trees/keyframetree.cpp
@@ -297,12 +297,12 @@ KeyframeTree::on_event(GdkEvent *event)
 				{
 					keyframe_tree_store_->canvas_interface()->set_time(row[model.time]);
 				}
-			} else if (event->button.button == 3)
-			{
-				Gtk::Menu* menu = dynamic_cast<Gtk::Menu*>(App::ui_manager()->get_widget("/menu-keyframe"));
-				if(menu)
-				{
-					menu->popup(event->button.button,gtk_get_current_event_time());
+			} else if (event->button.button == 3) {
+				if (Gtk::Menu* menu = dynamic_cast<Gtk::Menu*>(App::ui_manager()->get_widget("/menu-keyframe"))) {
+					if (menu->get_attach_widget())
+						menu->detach();
+					menu->attach_to_widget(*this);
+					menu->popup_at_pointer(event);
 				}
 			}
 

--- a/synfig-studio/src/gui/trees/keyframetree.cpp
+++ b/synfig-studio/src/gui/trees/keyframetree.cpp
@@ -302,7 +302,11 @@ KeyframeTree::on_event(GdkEvent *event)
 					if (menu->get_attach_widget())
 						menu->detach();
 					menu->attach_to_widget(*this);
+#if GTK_CHECK_VERSION(3,22,0)
 					menu->popup_at_pointer(event);
+#else
+					menu->popup(event->button.button, gtk_get_current_event_time());
+#endif
 				}
 			}
 

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -863,12 +863,14 @@ LayerTree::on_param_tree_event(GdkEvent *event)
 					{
 						synfigapp::ValueDesc value_desc(row[param_model.value_desc]);
 						Gtk::Menu* menu(manage(new Gtk::Menu()));
+						menu->attach_to_widget(param_tree_view_);
 						menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), menu));
 						App::get_instance(param_tree_store_->canvas_interface()->get_canvas())->make_param_menu(menu,param_tree_store_->canvas_interface()->get_canvas(),value_desc,0.5f);
 						menu->popup(event->button.button,gtk_get_current_event_time());
 						return true;
 					}
 					Gtk::Menu* menu(manage(new Gtk::Menu()));
+					menu->attach_to_widget(param_tree_view_);
 					menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), menu));
 					std::list<synfigapp::ValueDesc> value_desc_list;
 					ParamDesc param_desc(row[param_model.param_desc]);

--- a/synfig-studio/src/gui/widgets/widget_coloredit.cpp
+++ b/synfig-studio/src/gui/widgets/widget_coloredit.cpp
@@ -547,6 +547,7 @@ Widget_ColorEdit::on_palette_color_right_clicked(const synfig::Color& color)
 {
     Gtk::Menu* menu(manage(new Gtk::Menu()));
     menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), menu));
+	menu->attach_to_widget(*this);
 
     // Set as fill
     Gtk::MenuItem* item = manage(new Gtk::MenuItem(_("Set as Fill Color")));

--- a/synfig-studio/src/gui/widgets/widget_gradient.cpp
+++ b/synfig-studio/src/gui/widgets/widget_gradient.cpp
@@ -199,6 +199,7 @@ void
 Widget_Gradient::popup_menu(float x)
 {
 	Gtk::Menu* menu(manage(new Gtk::Menu()));
+	menu->attach_to_widget(*this);
 	menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), menu));
 
 	std::vector<Gtk::Widget*> children = menu->get_children();

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -402,8 +402,12 @@ Widget_Keyframe_List::on_event(GdkEvent *event)
 			break;
 		case 3:
 			if (kf) set_selected_keyframe(*kf);
-			if (Gtk::Menu* menu = dynamic_cast<Gtk::Menu*>(App::ui_manager()->get_widget("/menu-keyframe")))
-				menu->popup(event->button.button,gtk_get_current_event_time());
+			if (Gtk::Menu* menu = dynamic_cast<Gtk::Menu*>(App::ui_manager()->get_widget("/menu-keyframe"))) {
+				if (menu->get_attach_widget())
+					menu->detach();
+				menu->attach_to_widget(*this);
+				menu->popup_at_pointer(event);
+			}
 			break;
 		default:
 			return false;

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -406,7 +406,11 @@ Widget_Keyframe_List::on_event(GdkEvent *event)
 				if (menu->get_attach_widget())
 					menu->detach();
 				menu->attach_to_widget(*this);
+#if GTK_CHECK_VERSION(3,22,0)
 				menu->popup_at_pointer(event);
+#else
+				menu->popup(event->button.button, gtk_get_current_event_time());
+#endif
 			}
 			break;
 		default:

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -1353,8 +1353,9 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 				return true;
 			}
 
-			if(guide_highlighted){
+			if (guide_highlighted) {
 				Gtk::Menu* guide_menu(manage(new Gtk::Menu()));
+				guide_menu->attach_to_widget(*this);
 				guide_menu->signal_hide().connect(sigc::bind(sigc::ptr_fun(&delete_widget), guide_menu));
 				Gtk::MenuItem *item = manage(new Gtk::MenuItem(_("_Edit Guide")));
 				item->set_use_underline(true);

--- a/synfig-studio/src/gui/workarea.cpp
+++ b/synfig-studio/src/gui/workarea.cpp
@@ -1370,7 +1370,11 @@ WorkArea::on_drawing_area_event(GdkEvent *event)
 					get_guide_list().erase(this->curr_guide);
 				}, *this));
 				guide_menu->append(*item);
+#if GTK_CHECK_VERSION(3,22,0)
+				guide_menu->popup_at_pointer(event);
+#else
 				guide_menu->popup(3, gtk_get_current_event_time());
+#endif
 				guide_dialog.set_current_guide(curr_guide);
 				return true;
 			}


### PR DESCRIPTION
Gdk-Message: 12:52:35.361: Window 0x55cf62886990 is a temporary window without parent, application will not be able to position it on screen.

(org.synfig.SynfigStudio:907788): Gdk-CRITICAL **: 12:52:35.365: gdk_wayland_window_handle_configure_popup: assertion 'impl->transient_for' failed
Gdk-Message: 12:52:36.593: Window 0x55cf62886990 is a temporary window without parent, application will not be able to position it on screen.