### PR TITLE
fix: allow to select Keyframe at 0s from its left half triangle at Keyframe bar

### DIFF
--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -65,6 +65,11 @@ Widget_Keyframe_List::get_keyframe_around(Time t, bool ignore_disabled)
 	KeyframeList::iterator ret(kf_list->end());
 	Keyframe* kf = nullptr;
 
+	if (kf_list->find(t, ret)) {
+		if (!ignore_disabled || ret->active())
+			return &*ret;
+	}
+
 	Time p_t, n_t;
 	kf_list->find_prev_next(t, p_t, n_t, ignore_disabled);
 


### PR DESCRIPTION
It was not possible by clicking on its left half, making it confusing for user.