### PR TITLE
fix: force redraw of arrow in Keyframe Bar when toggled via context menu

### DIFF
--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -626,7 +626,7 @@ CanvasView::CanvasView(etl::loose_handle<studio::Instance> instance,etl::handle<
 	canvas_interface()->signal_layer_param_changed().connect(
 		sigc::hide(sigc::hide( SLOT_EVENT(EVENT_REFRESH_DUCKS))));
 	canvas_interface()->signal_keyframe_properties().connect(
-		sigc::mem_fun(*this,&CanvasView::show_keyframe_dialog));
+		sigc::mem_fun(*this, &CanvasView::show_dialog_for_selected_keyframe));
 
 	//MUCH TIME STUFF TAKES PLACE IN HERE
 	refresh_rend_desc();
@@ -2955,7 +2955,7 @@ CanvasView::on_keyframe_remove_pressed()
 }
 
 void
-CanvasView::show_keyframe_dialog()
+CanvasView::show_dialog_for_selected_keyframe()
 {
 	Glib::RefPtr<Gtk::TreeSelection> selection(keyframe_tree->get_selection());
 	if(selection->get_selected())
@@ -2970,7 +2970,7 @@ CanvasView::show_keyframe_dialog()
 }
 
 void
-CanvasView::on_keyframe_toggle()
+CanvasView::toggle_selected_keyframe()
 {
 	Glib::RefPtr<Gtk::TreeSelection> selection(keyframe_tree->get_selection());
 	if(selection->get_selected())
@@ -2994,7 +2994,7 @@ CanvasView::on_keyframe_toggle()
 }
 
 void
-CanvasView::on_keyframe_description_set()
+CanvasView::set_description_for_selected_keyframe()
 {
 	Glib::RefPtr<Gtk::TreeSelection> selection(keyframe_tree->get_selection());
 	if(selection->get_selected())

--- a/synfig-studio/src/gui/canvasview.h
+++ b/synfig-studio/src/gui/canvasview.h
@@ -617,9 +617,9 @@ public:
 
 	void add_layer(synfig::String x);
 
-	void show_keyframe_dialog();
-	void on_keyframe_toggle();
-	void on_keyframe_description_set();
+	void show_dialog_for_selected_keyframe();
+	void toggle_selected_keyframe();
+	void set_description_for_selected_keyframe();
 
 	void import_file();
 	void import_sequence();

--- a/synfig-studio/src/gui/docks/dock_keyframes.cpp
+++ b/synfig-studio/src/gui/docks/dock_keyframes.cpp
@@ -102,22 +102,22 @@ Dock_Keyframes::~Dock_Keyframes()
 void
 Dock_Keyframes::show_keyframe_properties()
 {
-	if(get_canvas_view())
-		get_canvas_view()->show_keyframe_dialog();
+	if (get_canvas_view())
+		get_canvas_view()->show_dialog_for_selected_keyframe();
 }
 
 void
 Dock_Keyframes::keyframe_toggle()
 {
-	if(get_canvas_view())
-		get_canvas_view()->on_keyframe_toggle();
+	if (get_canvas_view())
+		get_canvas_view()->toggle_selected_keyframe();
 }
 
 void
 Dock_Keyframes::keyframe_description_set()
 {
-	if(get_canvas_view())
-		get_canvas_view()->on_keyframe_description_set();
+	if (get_canvas_view())
+		get_canvas_view()->set_description_for_selected_keyframe();
 }
 
 /*! \fn Dock_Keyframes::refresh_rend_desc()

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.cpp
@@ -259,6 +259,16 @@ void
 Widget_Keyframe_List::on_keyframe_selected(Keyframe keyframe)
 	{ set_selected_keyframe(keyframe); }
 
+void
+Widget_Keyframe_List::on_keyframe_changed(Keyframe keyframe)
+{
+	if (selected && keyframe == selected_kf) {
+		// Keyframe::operator== only on uniqueid::operator==
+		selected_kf = keyframe;
+	}
+	queue_draw();
+}
+
 bool
 Widget_Keyframe_List::perform_move_kf(bool delta)
 {
@@ -465,14 +475,12 @@ Widget_Keyframe_List::set_canvas_interface(const etl::loose_handle<CanvasInterfa
 				sigc::hide(
 					sigc::mem_fun(*this,&Widget_Keyframe_List::queue_draw) )));
 		keyframe_changed = canvas_interface->signal_keyframe_changed().connect(
-			sigc::hide_return(
-				sigc::hide(
-					sigc::mem_fun(*this,&Widget_Keyframe_List::queue_draw) )));
+			sigc::mem_fun(*this, &Widget_Keyframe_List::on_keyframe_changed) );
 		keyframe_removed = canvas_interface->signal_keyframe_removed().connect(
 			sigc::hide_return(
 				sigc::hide(
 					sigc::mem_fun(*this,&Widget_Keyframe_List::queue_draw) )));
 		keyframe_selected = canvas_interface->signal_keyframe_selected().connect(
-				sigc::mem_fun(*this,&Widget_Keyframe_List::on_keyframe_selected) );
+			sigc::mem_fun(*this, &Widget_Keyframe_List::set_selected_keyframe) );
 	}
 }

--- a/synfig-studio/src/gui/widgets/widget_keyframe_list.h
+++ b/synfig-studio/src/gui/widgets/widget_keyframe_list.h
@@ -146,6 +146,7 @@ protected:
 	bool on_draw(const Cairo::RefPtr<Cairo::Context> &cr);
 	bool on_event(GdkEvent *event);
 	void on_keyframe_selected(synfig::Keyframe keyframe);
+	void on_keyframe_changed(synfig::Keyframe keyframe);
 }; // END of class Keyframe_List
 
 }; // END of namespace studio


### PR DESCRIPTION
When user right-click the selected Keyframe in Keyframe Bar (above the time line) and selects to toggle its status (enabled or not), the arrow that represents it isn't redraw until user selects another keyframe.