### PR TITLE
refactor: reuse Layer_Switch::get_current_layer(); don't recreate it

### DIFF
--- a/synfig-core/src/synfig/layers/layer_switch.cpp
+++ b/synfig-core/src/synfig/layers/layer_switch.cpp
@@ -133,11 +133,11 @@ Layer_Switch::get_current_layer()const
 		String name = param_layer_name.get(String());
 		if (name.empty()) {
 			int depth = param_layer_depth.get(int());
-			for(IndependentContext i = canvas->get_independent_context(); *i; i++)
+			for (IndependentContext i = canvas->get_independent_context(); *i; ++i)
 				if ((*i)->get_depth() == depth)
 					return *i;
 		} else {
-			for(IndependentContext i = canvas->get_independent_context(); *i; i++)
+			for (IndependentContext i = canvas->get_independent_context(); *i; ++i)
 				if ((*i)->get_description() == name)
 					return *i;
 		}

--- a/synfig-studio/src/gui/canvasview.cpp
+++ b/synfig-studio/src/gui/canvasview.cpp
@@ -75,9 +75,9 @@
 #include <gui/workarea.h>
 
 #include <pangomm.h>
-#include <sstream>
 #include <string>
 
+#include <synfig/layers/layer_switch.h>
 #include <synfig/rendering/renderer.h>
 #include <synfig/valuenodes/valuenode_animated.h>
 

--- a/synfig-studio/src/gui/dialogs/vectorizersettings.cpp
+++ b/synfig-studio/src/gui/dialogs/vectorizersettings.cpp
@@ -31,6 +31,7 @@
 #include <gui/resourcehelper.h>
 
 #include <synfig/debug/log.h>
+#include <synfig/layers/layer_switch.h>
 
 #include <synfigapp/action.h>
 #include <synfigapp/canvasinterface.h>

--- a/synfig-studio/src/gui/instance.cpp
+++ b/synfig-studio/src/gui/instance.cpp
@@ -39,8 +39,6 @@
 #include <gui/instance.h>
 
 #include <cassert>
-#include <cerrno>
-#include <fstream>
 #include <giomm.h>
 
 #include <gtkmm/actiongroup.h>
@@ -52,7 +50,6 @@
 #include <gtkmm/stock.h>
 
 #include <gui/app.h>
-#include <gui/autorecover.h>
 #include <gui/canvasview.h>
 #include <gui/docks/dock_toolbox.h>
 #include <gui/iconcontroller.h>
@@ -75,8 +72,6 @@
 #include <synfig/zstreambuf.h>
 
 #include <synfigapp/main.h>
-
-#include <sys/stat.h>
 
 #endif
 
@@ -225,31 +220,6 @@ is_img(const synfig::String& filename)
 	static const std::set<String> img_ext{".jpg",".jpeg",".png",".bmp",".gif",".tiff",".tif",".dib",".ppm",".pbm",".pgm",".pnm",".webp"};
 	return img_ext.find(Glib::ustring(filesystem::Path::filename_extension(filename)).lowercase()) != img_ext.end();
 }
-
-synfig::Layer::Handle
-Instance::layer_inside_switch(synfig::Layer_Switch::Handle paste) const
-{
-	synfig::Layer::Handle child_layer;
-	synfig::Canvas::Handle canvas = paste->get_sub_canvas();
-	if(canvas)
-	{
-		synfig::String active_layer = paste->get_param("layer_name").get(synfig::String());
-
-		if (active_layer.empty()) {
-			int active_layer_index = paste->get_param("layer_depth").get(int());
-			auto layer_iter = canvas->byindex(active_layer_index);
-			if (layer_iter != canvas->end())
-				child_layer = *layer_iter;
-		} else {
-			for (IndependentContext i = canvas->get_independent_context(); *i; i++) {
-				if((*i)->get_description()==active_layer)
-					child_layer = (*i);
-			}
-		}
-	}
-	return child_layer;
-}
-
 
 int
 Instance::get_visible_canvases()const
@@ -1712,7 +1682,7 @@ Instance::gather_uri(std::set<synfig::String> &x, const synfig::Layer::Handle &l
 	
 	// This required to allow "Edit Image/Open File" commands to appear when clicked on a switch group
 	if (etl::handle<Layer_Switch> layer_switch = etl::handle<Layer_Switch>::cast_dynamic(layer))
-		gather_uri(x, layer_inside_switch(layer_switch));
+		gather_uri(x, layer_switch->get_current_layer());
 
 	//if (Layer_PasteCanvas::Handle paste = Layer_PasteCanvas::Handle::cast_dynamic(layer))
 	//	gather_uri(x, paste->get_param("canvas").get(Canvas::Handle()));
@@ -1806,7 +1776,7 @@ Instance::add_special_layer_actions_to_menu(Gtk::Menu *menu, const synfigapp::Se
 
 		if (auto reference_layer = etl::handle<Layer_Switch>::cast_dynamic(layers.front())) {
 			//the layer selected is a switch group
-			layer_bitmap = Layer_Bitmap::Handle::cast_dynamic(layer_inside_switch(reference_layer));
+			layer_bitmap = Layer_Bitmap::Handle::cast_dynamic(reference_layer->get_current_layer());
 		} else {
 			layer_bitmap = Layer_Bitmap::Handle::cast_dynamic(layers.front());
 		}
@@ -1861,7 +1831,7 @@ Instance::add_special_layer_actions_to_group(const Glib::RefPtr<Gtk::ActionGroup
 
 		if (auto reference_layer = etl::handle<Layer_Switch>::cast_dynamic(layers.front())) {
 			//the layer selected is a switch group
-			layer_bitmap = Layer_Bitmap::Handle::cast_dynamic(layer_inside_switch(reference_layer));
+			layer_bitmap = Layer_Bitmap::Handle::cast_dynamic(reference_layer->get_current_layer());
 		} else {
 			layer_bitmap = Layer_Bitmap::Handle::cast_dynamic(layers.front());
 		}

--- a/synfig-studio/src/gui/instance.h
+++ b/synfig-studio/src/gui/instance.h
@@ -37,7 +37,6 @@
 
 #include <synfig/canvas.h>
 #include <synfig/handle.h>
-#include <synfig/layers/layer_switch.h>
 
 #include <synfigapp/instance.h>
 #include <synfigapp/value_desc.h>
@@ -151,8 +150,6 @@ public:
 
 	sigc::signal<void,CanvasView*>& signal_canvas_view_created() { return signal_canvas_view_created_; }
 	sigc::signal<void,CanvasView*>& signal_canvas_view_deleted() { return signal_canvas_view_deleted_; }
-
-	synfig::Layer::Handle layer_inside_switch(synfig::Layer_Switch::Handle paste) const;
 
 	bool get_undo_status()const { return undo_status_; }
 

--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -51,6 +51,7 @@
 #include <gui/workarea.h>
 
 #include <synfig/general.h>
+#include <synfig/layers/layer_switch.h>
 
 #include <synfigapp/main.h>
 #include <synfigapp/actions/layerpaint.h>

--- a/synfig-studio/src/gui/workarearenderer/renderer_bonedeformarea.cpp
+++ b/synfig-studio/src/gui/workarearenderer/renderer_bonedeformarea.cpp
@@ -42,6 +42,7 @@
 #include <gui/workarea.h>
 
 #include <synfig/bone.h>
+#include <synfig/layers/layer_switch.h>
 #include <synfig/pair.h>
 #include <synfig/valuenodes/valuenode_bone.h>
 


### PR DESCRIPTION
A method called `Instance::layer_inside_switch(synfig::Layer_Switch::Handle paste)`
was used only inside Instance class and without using any class member
(variable or method), so it should be static to .cpp, not a class
member.
    
So, initially I moved it to the .cpp file and, then, deleted the line
`#include <layer_switch.h>` in the header file `instance.h`.
Some other files didn't include it directly because they included the
instance header file. So I had to add this line on them.
    
Besides, the goal of this method is to get the currently selected layer
in a Switch group layer. The Layer_Switch already has a method to do it.
In fact, it is the one used to know what (sub)layer render...
Then I removed the (now static) Instance::layer_switch() code entirely,
and replaced it with the existing one.
    
It is used only for vectorizer and open file in extern app.
    
As final touches:
- I changed the `Layer_Switch::get_current_layer()` code
so the `for` loop iterator is pre-increment'ed for efficiency reasons.
- Removed some another unneeded `#include`  directives.