### PR TITLE
fix: embed external child canvases

### DIFF
--- a/synfig-studio/src/synfigapp/actions/layerembed.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerembed.cpp
@@ -64,6 +64,26 @@ ACTION_SET_VERSION(Action::LayerEmbed,"0.0");
 
 /* === P R O C E D U R E S ================================================= */
 
+static bool
+is_external_canvas(Canvas::LooseHandle owner_canvas, Canvas::Handle sub_canvas)
+{
+	return sub_canvas
+		&& !sub_canvas->is_inline()
+		&& (!owner_canvas || sub_canvas->get_root() != owner_canvas->get_root());
+}
+
+static std::string
+get_canvas_export_name(Canvas::Handle canvas)
+{
+	std::string fname;
+	if (canvas && !canvas->is_root())
+		fname = canvas->get_id();
+	if (fname.empty() && canvas)
+		fname = filesystem::Path::filename_sans_extension(filesystem::Path::basename(canvas->get_file_name()));
+
+	return fname;
+}
+
 /* === M E T H O D S ======================================================= */
 
 Action::ParamVocab
@@ -92,7 +112,8 @@ Action::LayerEmbed::is_candidate(const ParamList &x)
 	if (layer_pastecanvas)
 	{
 		Canvas::Handle canvas = layer_pastecanvas->get_sub_canvas();
-		if (canvas && canvas->is_root())
+		Canvas::LooseHandle owner_canvas = x.find("canvas")->second.get_canvas();
+		if (is_external_canvas(owner_canvas, canvas))
 			return true;
 	}
 
@@ -120,7 +141,10 @@ Action::LayerEmbed::set_param(const synfig::String& name, const Action::Param &p
 		if (layer_pastecanvas)
 		{
 			Canvas::Handle canvas = layer_pastecanvas->get_sub_canvas();
-			if (canvas && canvas->is_root())
+			Canvas::LooseHandle owner_canvas = get_canvas();
+			if (!owner_canvas)
+				owner_canvas = layer->get_canvas();
+			if (is_external_canvas(owner_canvas, canvas))
 			{
 				this->layer_pastecanvas = layer_pastecanvas;
 				return true;
@@ -163,7 +187,7 @@ Action::LayerEmbed::prepare()
 		Canvas::Handle sub_canvas = layer_pastecanvas->get_sub_canvas();
 
 		// generate name
-		std::string fname = filesystem::Path::filename_sans_extension(filesystem::Path::basename(sub_canvas->get_file_name()));
+		std::string fname = get_canvas_export_name(sub_canvas);
 		static const char bad_chars[]=" :#@$^&()*";
 		for (std::string::iterator j = fname.begin(); j != fname.end(); ++j)
 			for (const char *k = bad_chars; *k != 0; ++k)

--- a/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
@@ -250,7 +250,7 @@ Action::ValueDescExport::prepare()
 			throw Error(_("Can only export Canvas when used as constant parameter"));
 		Canvas::Handle canvas(value_desc.get_value().get(Canvas::Handle()));
 
-		bool external = !canvas->parent();
+		bool external = !canvas->parent() || canvas->get_root() != get_canvas()->get_root();
 		Canvas::Handle prev_canvas = canvas;
 
 		// clone canvas (all code that clones a canvas has this comment)

--- a/synfig-studio/src/synfigapp/instance.cpp
+++ b/synfig-studio/src/synfigapp/instance.cpp
@@ -88,6 +88,28 @@
 using namespace synfig;
 using namespace synfigapp;
 
+namespace {
+
+bool is_external_canvas(Canvas::LooseHandle owner_canvas, Canvas::Handle sub_canvas)
+{
+	return sub_canvas
+		&& !sub_canvas->is_inline()
+		&& (!owner_canvas || sub_canvas->get_root() != owner_canvas->get_root());
+}
+
+std::string get_canvas_export_name(Canvas::Handle canvas)
+{
+	std::string fname;
+	if (canvas && !canvas->is_root())
+		fname = canvas->get_id();
+	if (fname.empty() && canvas)
+		fname = filesystem::Path::filename_sans_extension(filesystem::Path::basename(canvas->get_file_name()));
+
+	return fname;
+}
+
+}
+
 /* === M A C R O S ========================================================= */
 
 /* === G L O B A L S ======================================================= */
@@ -199,8 +221,7 @@ Instance::import_external_canvas(Canvas::Handle canvas, std::map<Canvas*, Canvas
 		if (!paste_canvas) continue;
 
 		Canvas::Handle sub_canvas = paste_canvas->get_sub_canvas();
-		if (!sub_canvas) continue;
-		if (!sub_canvas->is_root()) continue;
+		if (!is_external_canvas(canvas, sub_canvas)) continue;
 
 		if (imported.count(sub_canvas.get()) != 0) {
 			// link already exported canvas
@@ -227,7 +248,7 @@ Instance::import_external_canvas(Canvas::Handle canvas, std::map<Canvas*, Canvas
 			imported[sub_canvas.get()] = nullptr;
 
 			// generate name
-			std::string fname = filesystem::Path::filename_sans_extension(filesystem::Path::basename(sub_canvas->get_file_name()));
+			std::string fname = get_canvas_export_name(sub_canvas);
 			static const char bad_chars[]=" :#@$^&()*";
 			for (std::string::iterator j = fname.begin(); j != fname.end(); ++j)
 				for (const char* k = bad_chars; *k != 0; ++k)

--- a/synfig-studio/test/CMakeLists.txt
+++ b/synfig-studio/test/CMakeLists.txt
@@ -3,6 +3,11 @@ target_link_libraries(test_app_layerduplicate PRIVATE synfigapp)
 target_include_directories(test_app_layerduplicate PRIVATE ${PROJECT_SOURCE_DIR}/src)
 add_test(NAME test_app_layerduplicate COMMAND test_app_layerduplicate)
 
+add_executable(test_app_layerembed app_layerembed.cpp)
+target_link_libraries(test_app_layerembed PRIVATE synfigapp)
+target_include_directories(test_app_layerembed PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME test_app_layerembed COMMAND test_app_layerembed)
+
 add_executable(test_smach smach.cpp)
 target_link_libraries(test_smach PRIVATE synfigapp libsynfig)
 target_include_directories(test_smach PRIVATE ${PROJECT_SOURCE_DIR}/src)
@@ -10,7 +15,7 @@ add_test(NAME test_smach COMMAND test_smach)
 
 if (NOT WIN32)
 set_target_properties(
-        test_app_layerduplicate test_smach
+        test_app_layerduplicate test_app_layerembed test_smach
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test
 )

--- a/synfig-studio/test/app_layerembed.cpp
+++ b/synfig-studio/test/app_layerembed.cpp
@@ -1,0 +1,130 @@
+/*!	\file test/app_layerembed.cpp
+**	\brief Tests for synfigapp::Action LayerEmbed
+**
+**	\legal
+**	Copyright (c) 2026 Synfig authors
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+
+#include "test_base.h"
+
+#include <synfig/canvas.h>
+#include <synfig/general.h>
+
+#include <synfigapp/action_param.h>
+#include <synfigapp/actions/layerembed.h>
+#include <synfigapp/canvasinterface.h>
+#include <synfigapp/instance.h>
+#include <synfigapp/main.h>
+
+static synfigapp::Action::ParamList
+make_layerembed_params(synfig::Canvas::Handle canvas, synfig::Layer::Handle layer)
+{
+	synfigapp::Action::ParamList params;
+	params.add("canvas", canvas);
+	params.add("layer", layer);
+	return params;
+}
+
+static void
+perform_layerembed(etl::handle<synfigapp::Instance> instance, synfig::Canvas::Handle canvas, synfig::Layer::Handle layer)
+{
+	synfigapp::Action::Handle action = synfigapp::Action::create("LayerEmbed");
+	action->set_param("canvas", canvas);
+	action->set_param("canvas_interface", instance->find_canvas_interface(canvas));
+	action->set_param("layer", layer);
+	ASSERT(action->is_ready())
+	action->perform();
+}
+
+static void
+test_synfigapp_layerembed_rejects_local_child_canvas()
+{
+	synfig::Canvas::Handle canvas = synfig::Canvas::create();
+	canvas->set_id("main");
+
+	synfig::Canvas::Handle child_canvas = canvas->new_child_canvas("child");
+	synfig::Layer::Handle group_layer = synfig::Layer::create("group");
+	group_layer->set_param("canvas", child_canvas);
+	canvas->push_back(group_layer);
+
+	ASSERT_FALSE(synfigapp::Action::LayerEmbed::is_candidate(make_layerembed_params(canvas, group_layer)))
+}
+
+static void
+test_synfigapp_layerembed_embeds_external_child_canvas()
+{
+	synfig::Canvas::Handle canvas = synfig::Canvas::create();
+	canvas->set_id("main");
+	canvas->set_file_name("/tmp/anim.sif");
+	auto instance = synfigapp::Instance::create(canvas, nullptr);
+
+	synfig::Canvas::Handle external_root = synfig::Canvas::create();
+	external_root->set_file_name("/tmp/exported.sif");
+	synfig::Canvas::Handle external_child = external_root->new_child_canvas("canvas");
+
+	synfig::Layer::Handle nested_group = synfig::Layer::create("group");
+	nested_group->set_param("canvas", external_child);
+	external_root->push_back(nested_group);
+
+	synfig::Layer::Handle root_group = synfig::Layer::create("group");
+	root_group->set_param("canvas", external_root);
+	canvas->push_back(root_group);
+
+	perform_layerembed(instance, canvas, root_group);
+
+	synfig::Canvas::Handle embedded_root = root_group->get_param("canvas").get(canvas);
+	ASSERT(embedded_root)
+	ASSERT_NOT_EQUAL(external_root.get(), embedded_root.get())
+	ASSERT_EQUAL(canvas.get(), embedded_root->get_root().get())
+	ASSERT_EQUAL("exported", embedded_root->get_id())
+	ASSERT_EQUAL(1, embedded_root->size())
+
+	synfig::Layer::Handle embedded_nested_group = embedded_root->front();
+	synfig::Canvas::Handle still_external_child = embedded_nested_group->get_param("canvas").get(canvas);
+	ASSERT_EQUAL(external_child.get(), still_external_child.get())
+	ASSERT(synfigapp::Action::LayerEmbed::is_candidate(make_layerembed_params(embedded_root, embedded_nested_group)))
+
+	perform_layerembed(instance, embedded_root, embedded_nested_group);
+
+	synfig::Canvas::Handle embedded_child = embedded_nested_group->get_param("canvas").get(canvas);
+	ASSERT(embedded_child)
+	ASSERT_NOT_EQUAL(external_child.get(), embedded_child.get())
+	ASSERT_EQUAL(canvas.get(), embedded_child->get_root().get())
+	ASSERT_EQUAL(embedded_root.get(), embedded_child->parent().get())
+	ASSERT_EQUAL("canvas", embedded_child->get_id())
+}
+
+int main(int argc, const char* argv[])
+{
+// test binaries are in `bin/test` folder, but for Windows they should be in `bin`
+// folder, because there is no RPATH on Windows, and it can't find required dll's
+#ifdef _WIN32
+	const std::string root_path = synfig::filesystem::Path::absolute_path(std::string(argv[0]) + "/../../");
+#else
+	const std::string root_path = synfig::filesystem::Path::absolute_path(std::string(argv[0]) + "/../../../");
+#endif
+	synfigapp::Main Main(root_path);
+
+	TEST_SUITE_BEGIN()
+		TEST_FUNCTION(test_synfigapp_layerembed_rejects_local_child_canvas)
+		TEST_FUNCTION(test_synfigapp_layerembed_embeds_external_child_canvas)
+	TEST_SUITE_END();
+
+	return tst_exit_status;
+}


### PR DESCRIPTION
Summary

Fixes `LayerEmbed` so imported files that contain exported child canvases can be embedded canvas-by-canvas instead of leaving nested canvases tied to the original external file.

Closes #416

What changed

- Treat non-inline canvases from a different root document as external embed candidates, not only root canvases.
- Preserve exported child canvas value nodes when `ValueDescExport` clones a canvas from another document root.
- Prefer a child canvas ID as the generated embedded canvas name when embedding an external child canvas.
- Add `test_app_layerembed` coverage for rejecting local child canvases and embedding an external child canvas after the imported root canvas is embedded.

Test evidence

- `git diff --check`: passed.
- `cmake -S . -B cmake-build-phase3 -GNinja -DENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=./cmake-build-phase3/install -DCMAKE_BUILD_TYPE=Debug`: configure currently stops locally on missing `glibmm-2.4`; full test suite was not run in this environment.

Screenshots

Not applicable; this is action/model behavior, not a UI rendering change.

Bounty claim: https://www.bountysource.com/issues/48824626-embed-layer-doesn-t-embed-canvases
