### PR TITLE
fix: restore displaying of tool shortcut in the Tool button tooltip

### DIFF
--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -215,7 +215,9 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 		Gtk::AccelKey key;
 		if (Gtk::AccelMap::lookup_entry(std::string("<Actions>/action_group_state_manager/set-state-") + state->get_name(), key)) {
 			tooltip_string += "  ";
-			tooltip_string += gtk_accelerator_get_label(key.get_key(), GdkModifierType(key.get_mod()));
+			gchar* accel_text = gtk_accelerator_get_label(key.get_key(), GdkModifierType(key.get_mod()));
+			tooltip_string += accel_text;
+			g_free(accel_text);
 		}
 		tooltip->set_text(tooltip_string);
 		return true;

--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -213,7 +213,7 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 		std::string tooltip_string = state->get_local_name();
 
 		Gtk::AccelKey key;
-		if (Gtk::AccelMap::lookup_entry(std::string("<Actions>/action_group_state_manager/state-") + state->get_name(), key)) {
+		if (Gtk::AccelMap::lookup_entry(std::string("<Actions>/action_group_state_manager/set-state-") + state->get_name(), key)) {
 			tooltip_string += "  ";
 			tooltip_string += gtk_accelerator_get_label(key.get_key(), GdkModifierType(key.get_mod()));
 		}


### PR DESCRIPTION
missed after 1.5.1 release