### PR TITLE
refactor: decouple StateManager from Dock_Tools

### DIFF
--- a/synfig-studio/src/gui/app.cpp
+++ b/synfig-studio/src/gui/app.cpp
@@ -1754,35 +1754,35 @@ void App::init(const synfig::String& rootpath)
 		// are displayed in toolbox labels
 		studio_init_cb.task(_("Init Tools..."));
 		/* editing tools */
-		state_manager->add_state(&state_normal);
-		state_manager->add_state(&state_smooth_move);
-		state_manager->add_state(&state_scale);
-		state_manager->add_state(&state_rotate);
-		state_manager->add_state(&state_mirror);
+		state_manager->register_state(&state_normal);
+		state_manager->register_state(&state_smooth_move);
+		state_manager->register_state(&state_scale);
+		state_manager->register_state(&state_rotate);
+		state_manager->register_state(&state_mirror);
 
 		/* geometry */
-		state_manager->add_state(&state_circle);
-		state_manager->add_state(&state_rectangle);
-		state_manager->add_state(&state_star);
-		if(!getenv("SYNFIG_DISABLE_POLYGON")) state_manager->add_state(&state_polygon); // Enabled - for working without ducks
-		state_manager->add_state(&state_gradient);
+		state_manager->register_state(&state_circle);
+		state_manager->register_state(&state_rectangle);
+		state_manager->register_state(&state_star);
+		if(!getenv("SYNFIG_DISABLE_POLYGON")) state_manager->register_state(&state_polygon); // Enabled - for working without ducks
+		state_manager->register_state(&state_gradient);
 
 		/* bline tools */
-		state_manager->add_state(&state_bline);
-		if(!getenv("SYNFIG_DISABLE_DRAW"   )) state_manager->add_state(&state_draw ); // Enabled for now.  Let's see whether they're good enough yet.
-		state_manager->add_state(&state_lasso);
-		if(!getenv("SYNFIG_DISABLE_WIDTH"  )) state_manager->add_state(&state_width); // Enabled since 0.61.09
-		state_manager->add_state(&state_fill);
-		state_manager->add_state(&state_eyedrop);
+		state_manager->register_state(&state_bline);
+		if(!getenv("SYNFIG_DISABLE_DRAW"   )) state_manager->register_state(&state_draw ); // Enabled for now.  Let's see whether they're good enough yet.
+		state_manager->register_state(&state_lasso);
+		if(!getenv("SYNFIG_DISABLE_WIDTH"  )) state_manager->register_state(&state_width); // Enabled since 0.61.09
+		state_manager->register_state(&state_fill);
+		state_manager->register_state(&state_eyedrop);
 
 		/* skeleton tool*/
-		state_manager->add_state(&state_bone);
+		state_manager->register_state(&state_bone);
 
 		/* other */
-		state_manager->add_state(&state_text);
-		if(!getenv("SYNFIG_DISABLE_SKETCH" )) state_manager->add_state(&state_sketch);
-		if(!getenv("SYNFIG_DISABLE_BRUSH"  ) && App::enable_experimental_features) state_manager->add_state(&state_brush);
-		state_manager->add_state(&state_zoom);
+		state_manager->register_state(&state_text);
+		if(!getenv("SYNFIG_DISABLE_SKETCH" )) state_manager->register_state(&state_sketch);
+		if(!getenv("SYNFIG_DISABLE_BRUSH"  ) && App::enable_experimental_features) state_manager->register_state(&state_brush);
+		state_manager->register_state(&state_zoom);
 
 
 		device_tracker->load_preferences();

--- a/synfig-studio/src/gui/docks/dock_toolbox.cpp
+++ b/synfig-studio/src/gui/docks/dock_toolbox.cpp
@@ -113,6 +113,9 @@ Dock_Toolbox::Dock_Toolbox():
 	signal_drag_data_received().connect( sigc::mem_fun(*this, &studio::Dock_Toolbox::on_drop_drag_data_received) );
 
 	App::signal_present_all().connect(sigc::mem_fun0(*this,&Dock_Toolbox::present));
+
+	App::get_state_manager()->signal_state_registered().connect(sigc::mem_fun(*this, &Dock_Toolbox::add_state));
+	App::get_state_manager()->signal_state_selected().connect(sigc::mem_fun(*this, &Dock_Toolbox::change_state_));
 }
 
 Dock_Toolbox::~Dock_Toolbox()
@@ -198,7 +201,7 @@ Dock_Toolbox::add_state(const Smach::state_base *state)
 {
 	assert(state);
 
-	String name=state->get_name();
+	const String name = state->get_name();
 
 	Gtk::RadioToolButton *tool_button = manage(new Gtk::RadioToolButton());
 	tool_button->set_group(radio_tool_button_group);

--- a/synfig-studio/src/gui/statemanager.cpp
+++ b/synfig-studio/src/gui/statemanager.cpp
@@ -40,8 +40,9 @@
 #include <gtkmm/radioaction.h>
 #include <gtkmm/stock.h>
 
+#include <synfig/general.h>
+
 #include <gui/app.h>
-#include <gui/docks/dock_toolbox.h>
 
 #endif
 
@@ -79,15 +80,28 @@ StateManager::change_state_(const Glib::RefPtr<Gtk::RadioAction>& current, const
 	auto state_action = Glib::RefPtr<Gtk::RadioAction>::cast_static(state_group->get_action(String("state-") + state->get_name()));
 	if (state_action) {
 		if (state_action == current) {
-			App::dock_toolbox->change_state_(state);
+			signal_state_selected_.emit(state);
 		}
 	}
 }
 
 void
-StateManager::add_state(const Smach::state_base *state)
+StateManager::change_state(const Smach::state_base* state)
 {
-	String name(state->get_name());
+	if (state) {
+		signal_state_selected_.emit(state);
+	}
+}
+
+void
+StateManager::register_state(const Smach::state_base* state)
+{
+	if (!state) {
+		synfig::error(_("Internal error: registering a null state."));
+		return;
+	}
+
+	const String name(state->get_name());
 
 	Glib::RefPtr<Gtk::RadioAction> action(
 		Gtk::RadioAction::create_with_icon_name(radio_action_group,
@@ -102,11 +116,13 @@ StateManager::add_state(const Smach::state_base *state)
 
 	action->signal_changed().connect(
 		sigc::bind(
-			sigc::mem_fun(*this,&studio::StateManager::change_state_),
+			sigc::mem_fun(*this, &StateManager::change_state_),
 			state
 		)
 	);
 
+	// this action is to be used in menus only.
+	// Regular type to not show the radio indicator in the menu item
 	Glib::RefPtr<Gtk::Action> regular_action(
 		Gtk::Action::create_with_icon_name("set-state-"+name,
 											state_icon_name(name),
@@ -119,10 +135,10 @@ StateManager::add_state(const Smach::state_base *state)
 
 	regular_action->signal_activate().connect(
 		sigc::bind(
-			sigc::mem_fun(*App::dock_toolbox, &studio::Dock_Toolbox::change_state_),
+			sigc::mem_fun(*this, &StateManager::change_state),
 			state
-			)
-		);
+		)
+	);
 
 	String uid_def;
 	uid_def = "<ui><popup action='menu-main'><menu action='menu-toolbox'><menuitem action='set-state-"+name+"' /></menu></popup></ui>";
@@ -132,7 +148,7 @@ StateManager::add_state(const Smach::state_base *state)
 
 	App::ui_manager()->ensure_update();
 
-	App::dock_toolbox->add_state(state);
+	signal_state_registered_.emit(state);
 }
 
 Glib::RefPtr<Gtk::ActionGroup>

--- a/synfig-studio/src/gui/statemanager.h
+++ b/synfig-studio/src/gui/statemanager.h
@@ -69,8 +69,9 @@ public:
 
 	Glib::RefPtr<Gtk::ActionGroup> get_action_group();
 
-	sigc::signal<void, const Smach::state_base*> signal_state_registered() { return signal_state_registered_; };
-	sigc::signal<void, const Smach::state_base*> signal_state_selected() { return signal_state_selected_; };
+	sigc::signal<void, const Smach::state_base*>& signal_state_registered() { return signal_state_registered_; };
+
+	sigc::signal<void, const Smach::state_base*>& signal_state_selected() { return signal_state_selected_; };
 };
 
 }; // END of namespace studio

--- a/synfig-studio/src/gui/statemanager.h
+++ b/synfig-studio/src/gui/statemanager.h
@@ -25,8 +25,8 @@
 
 /* === S T A R T =========================================================== */
 
-#ifndef __SYNFIG_STATEMANAGER_H
-#define __SYNFIG_STATEMANAGER_H
+#ifndef SYNFIG_STUDIO_STATEMANAGER_H
+#define SYNFIG_STUDIO_STATEMANAGER_H
 
 /* === H E A D E R S ======================================================= */
 
@@ -44,7 +44,8 @@
 typedef unsigned int guint;
 
 namespace studio {
-	class StateManager
+
+class StateManager
 {
 private:
 	Glib::RefPtr<Gtk::ActionGroup> state_group;
@@ -54,15 +55,22 @@ private:
 	std::vector<guint> merge_id_list;
 
 	void change_state_(const Glib::RefPtr<Gtk::RadioAction>& current, const Smach::state_base* state);
+	void change_state(const Smach::state_base* state);
+
+	sigc::signal<void, const Smach::state_base*> signal_state_registered_;
+	sigc::signal<void, const Smach::state_base*> signal_state_selected_;
 
 public:
 	StateManager();
 
 	~StateManager();
 
-	void add_state(const Smach::state_base *state);
+	void register_state(const Smach::state_base* state);
 
 	Glib::RefPtr<Gtk::ActionGroup> get_action_group();
+
+	sigc::signal<void, const Smach::state_base*> signal_state_registered() { return signal_state_registered_; };
+	sigc::signal<void, const Smach::state_base*> signal_state_selected() { return signal_state_selected_; };
 };
 
 }; // END of namespace studio


### PR DESCRIPTION
Dock_Tools should depends of StateManager, but not vice-versa. So now StateManager does not depend on Dock_Tools, but use signals to report stuff:
- state (tool) registered
- state (tool) activated/selected