### PR TITLE
fix: resolve bounty issue #426 — embed layer ValueBase nodes

### DIFF
--- a/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
+++ b/synfig-studio/src/synfigapp/actions/valuedescexport.cpp
@@ -217,7 +217,7 @@ void Action::ValueDescExport::scan_linkable_value_node(synfig::Canvas::Handle pr
 		{
 			if (link->get_parent_canvas() == prev_canvas)
 			{
-				// create action
+				// create action to reconnect exported valuenode from prev_canvas to its cloned version in new_canvas
 				Action::Handle action(ValueDescConnect::create());
 				action->set_param("canvas",get_canvas());
 				action->set_param("canvas_interface",get_canvas_interface());
@@ -226,8 +226,10 @@ void Action::ValueDescExport::scan_linkable_value_node(synfig::Canvas::Handle pr
 				assert(action->is_ready());
 				add_action(action);
 			}
-			if (!link->get_parent_canvas())
+			else
 			{
+				// Recursively scan exported valuenodes from OTHER canvases (not prev_canvas and not null)
+				// for their own external links that may need reconnection
 				LinkableValueNode::Handle sub_linkable_value_node = LinkableValueNode::Handle::cast_dynamic(link);
 				if (sub_linkable_value_node)
 					scan_linkable_value_node(prev_canvas, new_canvas, sub_linkable_value_node);


### PR DESCRIPTION
## Summary
Fix for [BOUNTY $100] "Embed layer" doesn't embed ValueBase nodes — Issue #426

## Root cause
When embedding a canvas that contains exported valuenodes, the  function in  only recursed into valuenodes with no parent canvas (null). It didn't recurse into exported valuenodes from OTHER canvases, so their internal links to the original canvas were never reconnected to the cloned valuenodes in the embedded canvas.

## Fix
Changed the condition in  from:
```cpp
if (!link->get_parent_canvas())  // only null parent canvases
```
to:
```cpp
else  // any non-prev_canvas (including exported from other canvases)
```

This ensures that exported valuenodes from any non-prev_canvas are recursively scanned for their own external links that may need reconnection.

## Changes
- Modified: 
  - : Changed recursive scan condition to handle all non-prev_canvas cases

## Testing
The fix follows the same pattern used in  which already correctly handles skeleton bone valuenodes during layer duplication.

Closes #426