### PR TITLE
fix(SVG importer): parse gradient spreadMethod (pad, repeat, reflect)

### DIFF
--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -1823,8 +1823,12 @@ Svg_parser::build_linearGradient(xmlpp::Element* root, const LinearGradient& dat
 	child_stops->set_attribute("name","gradient");
 	child_stops->set_attribute("guid",GUID::hasher(data.name).get_string());
 	build_stop_color (child_stops->add_child("gradient"),data.stops);
-	build_param (gradient->add_child("param"),"loop","bool","false");
-	build_param (gradient->add_child("param"),"zigzag","bool","false");
+
+	const bool loop = data.spread_method != SVGGradient::SpreadMethod::PAD;
+	const bool zigzag = data.spread_method == SVGGradient::SpreadMethod::REFLECT;
+
+	build_param(gradient->add_child("param"), "loop", loop);
+	build_param(gradient->add_child("param"), "zigzag", zigzag);
 }
 
 void
@@ -1881,9 +1885,12 @@ Svg_parser::build_radialGradient(xmlpp::Element* root, const RadialGradient& dat
 	r=r/kux;
 	build_vector (gradient->add_child("param"),"center",cx,cy);
 	build_param (gradient->add_child("param"),"radius","real",r);
+	
+	const bool loop = data.spread_method != SVGGradient::SpreadMethod::PAD;
+	const bool zigzag = data.spread_method == SVGGradient::SpreadMethod::REFLECT;
 
-	build_param (gradient->add_child("param"),"loop","bool","false");
-	build_param (gradient->add_child("param"),"zigzag","bool","false");
+	build_param(gradient->add_child("param"), "loop", loop);
+	build_param(gradient->add_child("param"), "zigzag", zigzag);
 }
 
 void
@@ -1897,6 +1904,7 @@ Svg_parser::parser_linearGradient(const xmlpp::Node* node)
 		float y2			=atof(nodeElement->get_attribute_value("y2").data());
 		Glib::ustring link	=nodeElement->get_attribute_value("href");
 		Glib::ustring transform	=nodeElement->get_attribute_value("gradientTransform");
+		const std::string spread_method_string = nodeElement->get_attribute_value("spreadMethod");
 
 		if(link.empty())
 			link = nodeElement->get_attribute_value("href","xlink");			
@@ -1928,8 +1936,11 @@ Svg_parser::parser_linearGradient(const xmlpp::Node* node)
     			}
 			}
 		}
-		if (!stops.empty())
-			lg.push_back(LinearGradient(id,x1,y1,x2,y2,stops,mtx));
+		if (!stops.empty()) {
+			LinearGradient linear_gradient(id,x1,y1,x2,y2,stops,mtx);
+			linear_gradient.spread_method = SVGGradient::parse_spread_method(spread_method_string);
+			lg.push_back(linear_gradient);
+		}
 	}
 }
 
@@ -1945,6 +1956,7 @@ Svg_parser::parser_radialGradient(const xmlpp::Node* node)
 		float r				=atof(nodeElement->get_attribute_value("r").data());
 		Glib::ustring link	=nodeElement->get_attribute_value("href");//basic
 		Glib::ustring transform	=nodeElement->get_attribute_value("gradientTransform");
+		const std::string spread_method_string = nodeElement->get_attribute_value("spreadMethod");
 
 		if(link.empty())
 			link = nodeElement->get_attribute_value("href","xlink");
@@ -1960,10 +1972,32 @@ Svg_parser::parser_radialGradient(const xmlpp::Node* node)
 		if(!link.empty()){
 			//inkscape always use link, i don't need parser stops here, but it's possible
 			std::list<ColorStop> stops = get_colorStop(link);
-			if (!stops.empty())
-				rg.push_back(RadialGradient(id,cx,cy,r,stops,mtx));
+			if (!stops.empty()) {
+				RadialGradient radial_gradient(id,cx,cy,r,stops,mtx);
+				radial_gradient.spread_method = SVGGradient::parse_spread_method(spread_method_string);
+				rg.push_back(radial_gradient);
+			}
 		}
 	}
+}
+
+SVGGradient::SpreadMethod
+SVGGradient::parse_spread_method(const std::string& x)
+{
+	if (x.empty())
+		return SpreadMethod::PAD;
+
+	std::string s = x;
+	synfig::strtolower(s);
+	if (s == "pad")
+		return SpreadMethod::PAD;
+	if (s == "repeat")
+		return SpreadMethod::REPEAT;
+	if (s == "reflect")
+		return SpreadMethod::REFLECT;
+
+	synfig::error(_("Unknown gradient spreadMethod: %s. Assuming 'pad'"), x.c_str());
+	return SpreadMethod::PAD;
 }
 
 ColorStop::ColorStop(const String& color, float opacity, const Gamma& gamma, float pos)
@@ -2136,6 +2170,15 @@ Svg_parser::build_param(xmlpp::Element* root, const String& name, const String& 
 	}else{
 		root->get_parent()->remove_child(root);
 	}
+}
+
+void
+synfig::Svg_parser::build_param(xmlpp::Element* root, const String& name, bool value)
+{
+	if (!name.empty())
+		root->set_attribute("name", name);
+	xmlpp::Element* child = root->add_child("bool");
+	child->set_attribute("value", value ? "true" : "false");
 }
 
 void

--- a/synfig-core/src/modules/mod_svg/svg_parser.h
+++ b/synfig-core/src/modules/mod_svg/svg_parser.h
@@ -76,8 +76,21 @@ struct ColorStop {
 	 ColorStop(const String& color, float opacity, const Gamma& gamma, float pos);
 };
 
-struct LinearGradient{
+struct SVGGradient
+{
+	enum class SpreadMethod {
+		PAD = 1,
+		REFLECT = 2,
+		REPEAT = 3,
+	} spread_method = SpreadMethod::PAD;
+
+	static SpreadMethod parse_spread_method(const std::string& x);
+};
+
+struct LinearGradient : public SVGGradient
+{
 	std::string name;
+
 	float x1,x2,y1,y2;
 	std::list<ColorStop> stops;
 	SVGMatrix transform;
@@ -85,7 +98,8 @@ struct LinearGradient{
 	LinearGradient(const String &name, float x1, float y1, float x2, float y2, std::list<ColorStop> stops, SVGMatrix transform);
 };
 
-struct RadialGradient{
+struct RadialGradient: public SVGGradient
+{
 	std::string name;
 	float cx,cy;//center point
 	//float fx,fy; //not supported by Synfig
@@ -231,6 +245,7 @@ private:
 		void build_param (xmlpp::Element* root, const String& name, const String& type, const String& value);
 		void build_param (xmlpp::Element* root, const String& name, const String& type, float value);
 		void build_param (xmlpp::Element* root, const String& name, const String& type, int value);
+		void build_param (xmlpp::Element* root, const String& name, bool value);
 		void build_integer (xmlpp::Element* root, const String& name, int value);
 		void build_real (xmlpp::Element* root, const String& name, float value);
 		void build_vector (xmlpp::Element* root, const String& name, float x, float y);


### PR DESCRIPTION
it was completely ignored before.

SVG example file for linearGradient (from [Mozilla tutorials](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Gradients))
```svg
<svg width="220" height="150" xmlns="http://www.w3.org/2000/svg">
  <defs>
    <linearGradient id="PadGradient" x1="33%" x2="67%">
      <stop offset="0%" stop-color="fuchsia" />
      <stop offset="100%" stop-color="orange" />
    </linearGradient>
    <linearGradient
      id="ReflectGradient"
      spreadMethod="reflect"
      x1="33%"
      x2="67%">
      <stop offset="0%" stop-color="fuchsia" />
      <stop offset="100%" stop-color="orange" />
    </linearGradient>
    <linearGradient id="RepeatGradient" spreadMethod="repeat" x1="33%" x2="67%">
      <stop offset="0%" stop-color="fuchsia" />
      <stop offset="100%" stop-color="orange" />
    </linearGradient>
  </defs>

  <rect fill="url(#PadGradient)" x="10" y="0" width="200" height="40" />
  <rect fill="url(#ReflectGradient)" x="10" y="50" width="200" height="40" />
  <rect fill="url(#RepeatGradient)" x="10" y="100" width="200" height="40" />
</svg>
```