### PR TITLE
fix(SVG importer): Rect or Circle shapes with gradient leak the fill

### DIFF
--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -508,7 +508,7 @@ Svg_parser::parser_graphics(const xmlpp::Node* node, xmlpp::Element* root, Style
 		// If it has stroke, render as a region, instead of standard shape, to be able to link to outline
 		if(typeFill != FILL_TYPE_NONE && typeStroke == FILL_TYPE_NONE) {
 			if (nodename.compare("rect") == 0 || nodename.compare("circle") == 0) {
-				if (!mtx.is_identity())
+				if (!mtx.is_identity() || typeFill == FILL_TYPE_GRADIENT)
 					child_layer = initializeGroupLayerNode(root->add_child("layer"), label);
 				child_fill=child_layer;
 


### PR DESCRIPTION
It didn't constrain the gradient to the shape inner region only. Now it's properly encapsulated with a Group layer as it is done with other SVG tags like 'd'.