### PR TITLE
fix: incorrect @param names in filesystem_path.h

### DIFF
--- a/synfig-core/src/synfig/filesystem_path.h
+++ b/synfig-core/src/synfig/filesystem_path.h
@@ -72,7 +72,7 @@ public:
 
 	/**
 	 * Store a file system path from a string in native encoding.
-	 * @param path the path in native encoding
+	 * @param native_path the path in native encoding
 	 */
 	static Path from_native(const string_type& native_path);
 
@@ -314,7 +314,7 @@ private:
 	static string_type utf8_to_native(const std::string& utf8);
 	/**
 	 * Converts a path to its normal form
-	 * @param utf8 the path in UTF-8 encoding
+	 * @param path the path in UTF-8 encoding
 	 * @return the normalized path in UTF-8 encoding
 	 */
 	static std::string normalize(std::string path);


### PR DESCRIPTION
## Description

Two Doxygen `@param` comments in `synfig/filesystem_path.h` reference parameter names that do not match their function signatures:

- `Path::from_native(const string_type& native_path)` documents `@param path` instead of `native_path`.
- `Path::normalize(std::string path)` documents `@param utf8` (apparently copied from the neighbouring `utf8_to_native`) instead of `path`.

This corrects the documented names to match the signatures. Documentation-only change; no behaviour is affected.
