### PR TITLE
refactor: add BLinePoint::set_tangents and use it where both tangents are modified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ endif(MSVC)
 
 message("-- CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
+set(ENABLE_TESTS OFF CACHE BOOL "Enable testing")
 if (${ENABLE_TESTS})
 	enable_testing()
 endif()

--- a/synfig-core/src/modules/mod_svg/svg_parser.cpp
+++ b/synfig-core/src/modules/mod_svg/svg_parser.cpp
@@ -780,8 +780,7 @@ Svg_parser::build_outline(xmlpp::Node* root, Style style, const std::list<BLine>
 			for (const auto& point : k.front().points) {
 				v.push_back(BLinePoint());
 				v.back().set_vertex(synfig::Point(point.x, point.y));
-				v.back().set_tangent1(synfig::Point(point.radius1, point.angle1));
-				v.back().set_tangent2(synfig::Point(point.radius2, point.angle2));
+				v.back().set_tangents(synfig::Point(point.radius1, point.angle1), synfig::Point(point.radius2, point.angle2));
 				v.back().set_split_tangent_angle(point.split_angle);
 				v.back().set_split_tangent_radius(point.split_radius);
 			}

--- a/synfig-core/src/synfig/blinepoint.h
+++ b/synfig-core/src/synfig/blinepoint.h
@@ -98,6 +98,7 @@ public:
 		return tangent2_angle_split_;
 	}
 	void set_tangent(const Vector& x) { tangent_[0]=tangent_[1]=x; update_tangent2(); }
+	void set_tangents(Vector t1, Vector t2) { tangent_[0]=t1; tangent_[1]=t2; update_tangent2(); }
 	void set_tangent1(const Vector& x) { tangent_[0]=x; update_tangent2(); }
 	void set_tangent2(const Vector& x) { tangent_[1]=x; update_tangent2(); }
 

--- a/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_bline.cpp
@@ -536,8 +536,7 @@ ValueNode_BLine::create_list_entry(int index, Time time, Real origin)
 		bline_point.set_width((next.get_width()-prev.get_width())*origin+prev.get_width());
 		bline_point.set_split_tangent_radius(true);
 		bline_point.set_split_tangent_angle(false);
-		bline_point.set_tangent1((left[2]-left[3])*-3);
-		bline_point.set_tangent2((right[1]-right[0])*3);
+		bline_point.set_tangents((left[2]-left[3])*-3, (right[1]-right[0])*3);
 		bline_point.set_origin(origin);
 	}
 	ret.index=index;
@@ -597,8 +596,7 @@ ValueNode_BLine::operator()(Time t)const
 				ret_list.push_back(curr);
 
 				ret_list.back().set_split_tangent_both(true);
-				ret_list.back().set_tangent2(curr.get_tangent2());
-				ret_list.back().set_tangent1(curr.get_tangent1()*next_scale);
+				ret_list.back().set_tangents(curr.get_tangent1()*next_scale, curr.get_tangent2());
 
 				next_scale=1.0f;
 			}
@@ -714,8 +712,7 @@ ValueNode_BLine::operator()(Time t)const
 			// where will our tangents point (all assuming that we hadn't vanished)
 			blp_here_off.set_vertex(curve(blp_here_on.get_origin()));
 			blp_here_off.set_width((blp_next_off.get_width()-blp_prev_off.get_width())*blp_here_on.get_origin()+blp_prev_off.get_width());
-			blp_here_off.set_tangent1(curve.derivative(blp_here_on.get_origin()));
-			blp_here_off.set_tangent2(curve.derivative(blp_here_on.get_origin()));
+			blp_here_off.set_tangents(curve.derivative(blp_here_on.get_origin()), curve.derivative(blp_here_on.get_origin()));
 
 			float prev_tangent_scalar(1.0f);
 			float next_tangent_scalar(1.0f);
@@ -990,8 +987,7 @@ ValueNode_BLine::get_blinepoint(std::vector<ListEntry>::const_iterator current, 
 	tt1[1]=t1.mag()*Angle::sin(beta1).get();
 	tt2[0]=t2.mag()*Angle::cos(beta2).get();
 	tt2[1]=t2.mag()*Angle::sin(beta2).get();
-	bpcurr.set_tangent1(tt1);
-	bpcurr.set_tangent2(tt2);
+	bpcurr.set_tangents(tt1, tt2);
 
 	return bpcurr;
 }

--- a/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
+++ b/synfig-core/src/synfig/valuenodes/valuenode_composite.cpp
@@ -262,8 +262,7 @@ synfig::ValueNode_Composite::operator()(Time t)const
 		ret.set_split_tangent_both((*components[3])(t).get(bool()));
 		ret.set_split_tangent_radius((*components[6])(t).get(bool()));
 		ret.set_split_tangent_angle((*components[7])(t).get(bool()));
-		ret.set_tangent1((*components[4])(t).get(Vector()));
-		ret.set_tangent2((*components[5])(t).get(Vector()));
+		ret.set_tangents((*components[4])(t).get(Vector()), (*components[5])(t).get(Vector()));
 		return ret;
 	}
 	else

--- a/synfig-core/src/synfig/valueoperations.cpp
+++ b/synfig-core/src/synfig/valueoperations.cpp
@@ -79,9 +79,9 @@ ValueTransformation::transform(const Transformation &transformation, const Value
 	if (type == type_bline_point)
 	{
 		BLinePoint bp(value.get(BLinePoint()));
-		bp.set_vertex(transformation.transform(bp.get_vertex()) );
-		bp.set_tangent2(transformation.transform(bp.get_tangent2(), false));
-		bp.set_tangent1(transformation.transform(bp.get_tangent1(), false));
+		bp.set_vertex(transformation.transform(bp.get_vertex()));
+		bp.set_tangents(transformation.transform(bp.get_tangent1(), false),
+						transformation.transform(bp.get_tangent2(), false));
 		return bp;
 	}
 	else
@@ -127,9 +127,9 @@ ValueAverage::add(const ValueBase &value_a, const ValueBase &value_b, const Valu
 	{
 		BLinePoint res(value_a.get(BLinePoint()));
 		const BLinePoint &b = value_b.get(BLinePoint());
-		res.set_vertex( res.get_vertex() + b.get_vertex() );
-		res.set_tangent1( res.get_tangent1() + b.get_tangent1() );
-		res.set_tangent2( res.get_tangent2() + b.get_tangent2() );
+		res.set_vertex(res.get_vertex() + b.get_vertex());
+		res.set_tangents(res.get_tangent1() + b.get_tangent1(),
+						 res.get_tangent2() + b.get_tangent2());
 		return res;
 	}
 	else
@@ -176,9 +176,9 @@ ValueAverage::multiply(const ValueBase &value, Real amplifier)
 	if (type == type_bline_point)
 	{
 		BLinePoint res(value.get(BLinePoint()));
-		res.set_vertex( res.get_vertex() * amplifier );
-		res.set_tangent1( res.get_tangent1() * amplifier );
-		res.set_tangent2( res.get_tangent2() * amplifier );
+		res.set_vertex(res.get_vertex() * amplifier);
+		res.set_tangents(res.get_tangent1() * amplifier,
+						 res.get_tangent2() * amplifier);
 		return res;
 	}
 	else

--- a/synfig-core/test/bline.cpp
+++ b/synfig-core/test/bline.cpp
@@ -813,6 +813,128 @@ test_calc_vertex_on_vertex_exact_positions_for_looped_curve_with_two_vertices_on
 	ASSERT_VECTOR_APPROX_EQUAL_MICRO(bpoints[0].vertex, vertex)
 }
 
+void test_blinepoint_merged() {
+	BLinePoint bp;
+	bp.set_merge_tangent_both();
+
+	// default state: merged angle, split radius
+	ASSERT_FALSE(bp.get_split_tangent_both())
+	ASSERT_FALSE(bp.get_split_tangent_angle())
+	ASSERT_FALSE(bp.get_split_tangent_radius());
+	ASSERT(bp.get_merge_tangent_both())
+
+	bp.set_tangent(Vector{3, 0});
+	ASSERT_EQUAL((Vector{3, 0}), bp.get_tangent1())
+	ASSERT_EQUAL((Vector{3, 0}), bp.get_tangent2())
+
+	bp.set_tangent1(Vector{0, 3});
+	bp.set_tangent2(Vector{1, 1});
+	ASSERT_EQUAL((Vector{0, 3}), bp.get_tangent1())
+	ASSERT_EQUAL((Vector{0, 3}), bp.get_tangent2())
+
+	bp.set_tangents(bp.get_tangent2(), bp.get_tangent1());
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, 3}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, 3}), bp.get_tangent2())
+}
+
+void test_blinepoint_split_radius() {
+	BLinePoint bp;
+
+	// this is the default state, no assignment necessary
+	ASSERT_FALSE(bp.get_split_tangent_both())
+	ASSERT_FALSE(bp.get_split_tangent_angle())
+	ASSERT(bp.get_split_tangent_radius())
+	ASSERT_FALSE(bp.get_merge_tangent_both())
+
+	bp.set_tangent(Vector{3, 0});
+	ASSERT_EQUAL((Vector{3, 0}), bp.get_tangent1())
+	ASSERT_EQUAL((Vector{3, 0}), bp.get_tangent2())
+
+	bp.set_tangent1(Vector{5, 0});
+	bp.set_tangent2(Vector{0, 1});
+	ASSERT_EQUAL((Vector{5, 0}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{1, 0}), bp.get_tangent2())
+
+	bp.set_tangents(Vector{4, 0}, Vector{0, 2});
+	ASSERT_EQUAL((Vector{4, 0}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{2, 0}), bp.get_tangent2())
+
+	bp.set_tangents(bp.get_tangent1(), Vector{-3, 0});
+	ASSERT_EQUAL((Vector{4, 0}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{3, 0}), bp.get_tangent2())
+
+	bp.set_tangents(Vector{0, -5}, bp.get_tangent2());
+	ASSERT_EQUAL((Vector{0, -5}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, -3}), bp.get_tangent2())
+
+	bp.set_tangents(bp.get_tangent2(), bp.get_tangent1());
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, -3}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, -5}), bp.get_tangent2())
+}
+
+void test_blinepoint_split_angle() {
+	BLinePoint bp;
+	bp.set_split_tangent_angle(true);
+	bp.set_split_tangent_radius(false);
+
+	ASSERT_FALSE(bp.get_split_tangent_both())
+	ASSERT(bp.get_split_tangent_angle())
+	ASSERT_FALSE(bp.get_split_tangent_radius())
+	ASSERT_FALSE(bp.get_merge_tangent_both())
+
+	bp.set_tangent(Vector{3, 0});
+	ASSERT_EQUAL((Vector{3, 0}), bp.get_tangent1())
+	ASSERT_EQUAL((Vector{3, 0}), bp.get_tangent2())
+
+	bp.set_tangent1(Vector{5, 0});
+	bp.set_tangent2(Vector{0, 1});
+	ASSERT_EQUAL((Vector{5, 0}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, 5}), bp.get_tangent2())
+
+	bp.set_tangents(Vector{4, 0}, Vector{0, 2});
+	ASSERT_EQUAL((Vector{4, 0}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, 4}), bp.get_tangent2())
+
+	bp.set_tangents(bp.get_tangent1(), Vector{-3, 0});
+	ASSERT_EQUAL((Vector{4, 0}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{-4, 0}), bp.get_tangent2())
+
+	bp.set_tangents(Vector{0, -5}, bp.get_tangent2());
+	ASSERT_EQUAL((Vector{0, -5}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{-5, 0}), bp.get_tangent2())
+
+	bp.set_tangents(bp.get_tangent2(), bp.get_tangent1());
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{-5, 0}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, -5}), bp.get_tangent2())
+}
+
+void test_blinepoint_split_both() {
+	BLinePoint bp;
+	bp.set_split_tangent_both();
+
+	ASSERT(bp.get_split_tangent_both())
+	ASSERT(bp.get_split_tangent_angle())
+	ASSERT(bp.get_split_tangent_radius())
+	ASSERT_FALSE(bp.get_merge_tangent_both())
+
+	bp.set_tangent(Vector{3, 0});
+	ASSERT_EQUAL((Vector{3, 0}), bp.get_tangent1())
+	ASSERT_EQUAL((Vector{3, 0}), bp.get_tangent2())
+
+	bp.set_tangent1(Vector{5, 0});
+	bp.set_tangent2(Vector{0, 1});
+	ASSERT_EQUAL((Vector{5, 0}), bp.get_tangent1())
+	ASSERT_EQUAL((Vector{0, 1}), bp.get_tangent2())
+
+	bp.set_tangents(Vector{4, 0}, Vector{0, 2});
+	ASSERT_EQUAL((Vector{4, 0}), bp.get_tangent1())
+	ASSERT_EQUAL((Vector{0, 2}), bp.get_tangent2())
+
+	bp.set_tangents(bp.get_tangent2(), bp.get_tangent1());
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{0, 2}), bp.get_tangent1())
+	ASSERT_VECTOR_APPROX_EQUAL((Vector{4, 0}), bp.get_tangent2())
+}
+
 int main() {
 	Type::subsys_init();
 
@@ -845,6 +967,11 @@ int main() {
 	TEST_FUNCTION(test_calc_vertex_for_open_rectangle);
 	TEST_FUNCTION(test_calc_vertex_for_closed_rectangle);
 	TEST_FUNCTION(test_calc_vertex_on_vertex_exact_positions_for_looped_curve_with_two_vertices_on_same_coords);
+
+	TEST_FUNCTION(test_blinepoint_merged)
+	TEST_FUNCTION(test_blinepoint_split_radius)
+	TEST_FUNCTION(test_blinepoint_split_angle)
+	TEST_FUNCTION(test_blinepoint_split_both)
 
 	TEST_SUITE_END();
 

--- a/synfig-core/test/test_base.h
+++ b/synfig-core/test/test_base.h
@@ -134,6 +134,13 @@ std::ostream& operator<<(std::ostream& os, std::nullptr_t)
 	} \
 }
 
+#define ASSERT_VECTOR_APPROX_EQUAL(expected, value) {\
+	if (!synfig::approximate_equal_lp(expected[0], value[0]) || \
+		!synfig::approximate_equal_lp(expected[1], value[1])) { \
+		ERROR_MESSAGE_TWO_VALUES(expected, value) \
+	} \
+}
+
 #define ASSERT_VECTOR_APPROX_EQUAL_MICRO(expected, value) {\
 	if (std::isnan(value[0]) != std::isnan(expected[0]) || std::isnan(value[1]) != std::isnan(expected[1]) \
 		|| std::abs(expected[0] - value[0]) > 2e-6 || std::abs(expected[1] - value[1]) > 2e-6) { \

--- a/synfig-studio/src/gui/duckmatic.cpp
+++ b/synfig-studio/src/gui/duckmatic.cpp
@@ -513,18 +513,8 @@ Duckmatic::update_ducks()
 							}
 							else if(index==t2_index && (*iter)->get_value_desc().get_index()!=t2_index)
 							{
-								// Create a new BLinePoint
-								BLinePoint nbp;
-								// Terporary set the flags for the new BLinePoint to all split
-								nbp.set_split_tangent_both(true);
-								// Now we can set the tangents. Tangent2 won't be modified by tangent1
-								nbp.set_tangent1(c1->get_point());
-								nbp.set_tangent2(bp.get_tangent1());
-								// Now update the flags
-								nbp.set_split_tangent_radius(bp.get_split_tangent_radius());
-								nbp.set_split_tangent_angle(bp.get_split_tangent_angle());
-								// Now retrieve the updated tangent2 (which will be stored as t1, see below)
-								Vector t1(nbp.get_tangent2());
+								bp.set_tangents(c1->get_point(), bp.get_tangent1());
+								Vector t1(bp.get_tangent2());
 								(*iter)->set_point(Point(t1));
 							}
 						}
@@ -561,18 +551,8 @@ Duckmatic::update_ducks()
 							}
 							else if(index==t2_index && (*iter)->get_value_desc().get_index()!=t2_index)
 							{
-								// Create a new BLinePoint
-								BLinePoint nbp;
-								// Terporary set the flags for the new BLinePoint to all split
-								nbp.set_split_tangent_both(true);
-								// Now we can set the tangents. Tangent2 won't be modified by tangent1
-								nbp.set_tangent1(c2->get_point());
-								nbp.set_tangent2(bp.get_tangent1());
-								// Now update the flags
-								nbp.set_split_tangent_radius(bp.get_split_tangent_radius());
-								nbp.set_split_tangent_angle(bp.get_split_tangent_angle());
-								// Now retrieve the updated tangent2 (which will be stored as t1, see below)
-								Vector t1(nbp.get_tangent2());
+								bp.set_tangents(c2->get_point(), bp.get_tangent1());
+								Vector t1(bp.get_tangent2());
 								(*iter)->set_point(Point(t1));
 							}
 						}
@@ -708,18 +688,8 @@ Duckmatic::update_ducks()
 										}
 										else if(index==t2_index && (*iter)->get_value_desc().get_index()!=t2_index)
 										{
-											// Create a new BLinePoint
-											BLinePoint nbp;
-											// Terporary set the flags for the new BLinePoint to all split
-											nbp.set_split_tangent_both(true);
-											// Now we can set the tangents. Tangent2 won't be modified by tangent1
-											nbp.set_tangent1(duck->get_point());
-											nbp.set_tangent2(bp.get_tangent1());
-											// Now update the flags
-											nbp.set_split_tangent_radius(bp.get_split_tangent_radius());
-											nbp.set_split_tangent_angle(bp.get_split_tangent_angle());
-											// Now retrieve the updated tangent2 (which will be stored as t1, see below)
-											Vector t1(nbp.get_tangent2());
+											bp.set_tangents(duck->get_point(), bp.get_tangent1());
+											Vector t1(bp.get_tangent2());
 											(*iter)->set_point(Point(t1));
 										}
 									}
@@ -1143,13 +1113,11 @@ Duckmatic::on_duck_changed(const studio::Duck &duck,const synfigapp::ValueDesc& 
 			else
 			if (point.get_split_tangent_angle())
 			{
-				point.set_tangent1( Point(duck.get_point().mag(), point.get_tangent1().angle()) );
-				point.set_tangent2(duck.get_point());
+				point.set_tangents(Point(duck.get_point().mag(), point.get_tangent1().angle()), duck.get_point());
 			}
 			else
 			{
-				point.set_tangent1( Point(point.get_tangent1().mag(), duck.get_point().angle()) );
-				point.set_tangent2(duck.get_point());
+				point.set_tangents(Point(point.get_tangent1().mag(), duck.get_point().angle()), duck.get_point());
 			}
 			break;
 		default:

--- a/synfig-studio/src/gui/states/state_bline.cpp
+++ b/synfig-studio/src/gui/states/state_bline.cpp
@@ -739,13 +739,10 @@ StateBLine_Context::run_()
 			BLinePoint bline_point((*iter)->get_value().get(BLinePoint()));
 			Point new_vertex(transform.unperform(bline_point.get_vertex()));
 
-			bline_point.set_tangent1(
+			bline_point.set_tangents(
 				transform.unperform(
 					bline_point.get_tangent1()+bline_point.get_vertex()
-				) -new_vertex
-			);
-
-			bline_point.set_tangent2(
+				) -new_vertex,
 				transform.unperform(
 					bline_point.get_tangent2()+bline_point.get_vertex()
 				) -new_vertex
@@ -1546,12 +1543,10 @@ StateBLine_Context::on_tangent2_change(const studio::Duck& duck, WorkArea::Duck:
 		bline_point.set_tangent2(duck.get_point());
 	} else
 	if (split_angle && !split_radius) {
-		bline_point.set_tangent1(Vector(duck.get_point().mag(), bline_point.get_tangent1().angle()));
-		bline_point.set_tangent2(duck.get_point());
+		bline_point.set_tangents(Vector(duck.get_point().mag(), bline_point.get_tangent1().angle()), duck.get_point());
 	} else
 	if (!split_angle && split_radius) {
-		bline_point.set_tangent1(Vector(bline_point.get_tangent1().mag(), duck.get_point().angle()));
-		bline_point.set_tangent2(duck.get_point());
+		bline_point.set_tangents(Vector(bline_point.get_tangent1().mag(), duck.get_point().angle()), duck.get_point());
 	} else
 	if (!split_angle && !split_radius) {
 		bline_point.set_tangent1(duck.get_point());

--- a/synfig-studio/src/gui/states/state_draw.cpp
+++ b/synfig-studio/src/gui/states/state_draw.cpp
@@ -1208,13 +1208,10 @@ StateDraw_Context::new_bline(std::list<synfig::BLinePoint> bline,std::list<synfi
 			BLinePoint bline_point(*iter);
 			Point new_vertex(transform.unperform(bline_point.get_vertex()));
 
-			bline_point.set_tangent1(
+			bline_point.set_tangents(
 				transform.unperform(
 					bline_point.get_tangent1()+bline_point.get_vertex()
-				) -new_vertex
-			);
-
-			bline_point.set_tangent2(
+				) -new_vertex,
 				transform.unperform(
 					bline_point.get_tangent2()+bline_point.get_vertex()
 				) -new_vertex

--- a/synfig-studio/src/gui/states/state_lasso.cpp
+++ b/synfig-studio/src/gui/states/state_lasso.cpp
@@ -1124,13 +1124,10 @@ StateLasso_Context::new_bline(std::list<synfig::BLinePoint> bline,std::list<synf
 			BLinePoint bline_point(*iter);
 			Point new_vertex(transform.unperform(bline_point.get_vertex()));
 
-			bline_point.set_tangent1(
+			bline_point.set_tangents(
 				transform.unperform(
 					bline_point.get_tangent1()+bline_point.get_vertex()
-				) -new_vertex
-			);
-
-			bline_point.set_tangent2(
+				) -new_vertex,
 				transform.unperform(
 					bline_point.get_tangent2()+bline_point.get_vertex()
 				) -new_vertex

--- a/synfig-studio/test/test_base.h
+++ b/synfig-studio/test/test_base.h
@@ -134,6 +134,13 @@ std::ostream& operator<<(std::ostream& os, std::nullptr_t)
 	} \
 }
 
+#define ASSERT_VECTOR_APPROX_EQUAL(expected, value) {\
+	if (!synfig::approximate_equal_lp(expected[0], value[0]) || \
+		!synfig::approximate_equal_lp(expected[1], value[1])) { \
+		ERROR_MESSAGE_TWO_VALUES(expected, value) \
+	} \
+}
+
 #define ASSERT_VECTOR_APPROX_EQUAL_MICRO(expected, value) {\
 	if (std::isnan(value[0]) != std::isnan(expected[0]) || std::isnan(value[1]) != std::isnan(expected[1]) \
 		|| std::abs(expected[0] - value[0]) > 2e-6 || std::abs(expected[1] - value[1]) > 2e-6) { \


### PR DESCRIPTION
Work originally done by @mosasauridae in PR #3591 for fixing "split radius spline (bug)" #3554.