### PR TITLE
feat: allow user to set a custom default color palette

### DIFF
--- a/synfig-studio/src/gui/dialogs/dialog_setup.cpp
+++ b/synfig-studio/src/gui/dialogs/dialog_setup.cpp
@@ -48,6 +48,7 @@
 #include <gui/canvasview.h>
 #include <gui/duck.h>
 #include <gui/localization.h>
+#include <gui/modules/mod_palette/dock_paledit.h>
 #include <gui/resourcehelper.h>
 #include <gui/widgets/widget_enum.h>
 #include <gui/autorecover.h>
@@ -985,6 +986,10 @@ Dialog_Setup::on_restore_pressed()
 		toggle_handle_tooltip_transformation.set_active(false);
 		toggle_handle_tooltip_transfo_name.set_active(false);
 		toggle_handle_tooltip_transfo_value.set_active(false);
+
+		// Palette
+		if (Dock_PalEdit* pal_edit = Dock_PalEdit::get_instance())
+			pal_edit->restore_default_palette();
 
 		// Keyboard accels
 		auto accel_rows = treeview_accels->get_model()->children();

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -35,6 +35,7 @@
 #endif
 #include "dock_paledit.h"
 
+#include <cstdio>
 #include <errno.h>
 #include <sys/stat.h>
 
@@ -189,7 +190,18 @@ Dock_PalEdit::Dock_PalEdit():
 	),
 		sigc::mem_fun(
 			*this,
-			&Dock_PalEdit::set_default_palette
+			&Dock_PalEdit::load_default_palette
+		)
+	);
+	action_group->add(Gtk::Action::create_with_icon_name(
+		"palette-save-as-default",
+		"document-save-as",
+		_("Set as default"),
+		_("Save current palette as the default palette")
+	),
+		sigc::mem_fun(
+			*this,
+			&Dock_PalEdit::on_set_as_default_pressed
 		)
 	);
 
@@ -204,6 +216,7 @@ Dock_PalEdit::Dock_PalEdit():
 	"	<toolitem action='palette-save' />"
 	"	<toolitem action='palette-load' />"
 	"	<toolitem action='palette-set-default' />"
+	"	<toolitem action='palette-save-as-default' />"
 	"	</toolbar>"
 	"</ui>"
 	;
@@ -229,7 +242,7 @@ Dock_PalEdit::Dock_PalEdit():
 	add(table);
 	table.set_homogeneous(true);
 
-	set_default_palette();
+	load_default_palette();
 
 	show_all_children();
 }
@@ -340,6 +353,18 @@ Dock_PalEdit::on_open_pressed()
 		break;
 	}
 	refresh();
+}
+
+void
+Dock_PalEdit::on_set_as_default_pressed()
+{
+	synfig::filesystem::Path filename = App::get_config_file("default.spal");
+	try {
+		palette_.save_to_file(filename);
+	} catch (const std::string& err) {
+		synfig::error(err);
+		App::dialog_message_1b("ERROR", err, "details", _("Close"));
+	}
 }
 
 static Gtk::MenuItem*
@@ -607,8 +632,17 @@ Dock_PalEdit::apply_color_to_selected_layer(int i) const
 }
 
 void
-Dock_PalEdit::set_default_palette()
+Dock_PalEdit::load_default_palette()
 {
+	synfig::filesystem::Path custom_path = App::get_config_file("default.spal");
+	try {
+		palette_ = synfig::Palette::load_from_file(custom_path);
+		refresh();
+		return;
+	} catch (...) {
+		// If loading fails (e.g. file does not exist), fall back to the hardcoded palette below
+	}
+
 	int width=12;
 
 	palette_.clear();
@@ -682,6 +716,35 @@ Dock_PalEdit::set_default_palette()
 	}
 	*/
 	refresh();
+}
+
+void
+Dock_PalEdit::restore_default_palette()
+{
+	synfig::filesystem::Path custom_path = App::get_config_file("default.spal");
+	synfig::filesystem::Path backup_path = custom_path;
+	backup_path.concat(".bak");
+
+	int suffix = 1;
+#if _WIN32
+	struct _stat s;
+	while (_wstat(backup_path.c_str(), &s) == 0) {
+#else
+	struct stat s;
+	while (stat(backup_path.c_str(), &s) == 0) {
+#endif
+		backup_path = custom_path;
+		backup_path.concat(".bak" + std::to_string(suffix));
+		suffix++;
+	}
+
+#if _WIN32
+	_wrename(custom_path.c_str(), backup_path.c_str());
+#else
+	rename(custom_path.c_str(), backup_path.c_str());
+#endif
+
+	load_default_palette();
 }
 
 int

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.cpp
@@ -35,7 +35,6 @@
 #endif
 #include "dock_paledit.h"
 
-#include <cstdio>
 #include <errno.h>
 #include <sys/stat.h>
 
@@ -50,6 +49,7 @@
 #include <gui/localization.h>
 #include <gui/widgets/widget_color.h>
 
+#include <synfig/filesystemnative.h>
 #include <synfig/general.h>
 #include <synfigapp/main.h>
 #include <synfigapp/uimanager.h>
@@ -726,23 +726,13 @@ Dock_PalEdit::restore_default_palette()
 	backup_path.concat(".bak");
 
 	int suffix = 1;
-#if _WIN32
-	struct _stat s;
-	while (_wstat(backup_path.c_str(), &s) == 0) {
-#else
-	struct stat s;
-	while (stat(backup_path.c_str(), &s) == 0) {
-#endif
+	while (synfig::FileSystemNative::instance()->is_file(backup_path.u8string())) {
 		backup_path = custom_path;
 		backup_path.concat(".bak" + std::to_string(suffix));
 		suffix++;
 	}
 
-#if _WIN32
-	_wrename(custom_path.c_str(), backup_path.c_str());
-#else
-	rename(custom_path.c_str(), backup_path.c_str());
-#endif
+	synfig::FileSystemNative::instance()->file_rename(custom_path.u8string(), backup_path.u8string());
 
 	load_default_palette();
 }

--- a/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
+++ b/synfig-studio/src/gui/modules/mod_palette/dock_paledit.h
@@ -68,6 +68,8 @@ class Dock_PalEdit : public Dockable
 
 	void on_open_pressed();
 
+	void on_set_as_default_pressed();
+
 	void show_menu(int i);
 
 	sigc::signal<void> signal_changed_;
@@ -96,7 +98,9 @@ public:
 
 	int size()const;
 
-	void set_default_palette();
+	void load_default_palette();
+
+	void restore_default_palette();
 
 	void refresh();
 


### PR DESCRIPTION
## Summary

Implements the first two items of #3773:

- On startup, Synfig now checks for a `default.spal` file in the user's config folder (via `App::get_config_file()`). If it exists, it's loaded instead of the hardcoded default palette.
- Added a "Set as default" button to the Palette Editor toolbar, which saves the current palette to `default.spal`.

If no custom `default.spal` exists, or if loading it fails for any reason, Synfig falls back to the original hardcoded palette — existing behavior is fully preserved.

## Not included

The third item from the issue — deciding whether "Restore Defaults" (in the Settings dialog) should delete or rename the custom `default.spal` — is left open for discussion. I've left a comment on the issue with my initial thoughts (leaning towards renaming to `default.spal.bak` rather than a hard delete, to avoid accidental data loss). Happy to follow up with that in this PR or a separate one once we agree on the approach.

## Testing

Built and tested locally on Windows (MSYS2/MinGW64). Verified:

- Editing the palette and clicking "Set as default" persists the change across restarts
- Clicking "Load default" reloads the custom palette when `default.spal` exists
- Behavior falls back correctly to the hardcoded palette when no `default.spal` exists

