### PR TITLE
Fix Ctrl+click multi-select for layers in canvas

### DIFF
--- a/synfig-studio/src/gui/states/state_normal.cpp
+++ b/synfig-studio/src/gui/states/state_normal.cpp
@@ -774,8 +774,21 @@ StateNormal_Context::event_layer_click(const Smach::event& x)
 				canvas_view_->get_selection_manager()->clear_selected_layers();
 				canvas_view_->get_selection_manager()->set_selected_layers(layer_list);
 			}
+			else if(event.modifier&Gdk::CONTROL_MASK)
+			{
+				// Ctrl+click on a layer not yet selected: add it to the
+				// existing selection instead of replacing it. Using the
+				// plural set_selected_layers() (rather than the singular
+				// set_selected_layer()) also avoids LayerTree::select_layer()'s
+				// set_cursor() call, which would otherwise clear the whole
+				// selection down to just this one layer.
+				layer_list.push_back(event.layer);
+				canvas_view_->get_selection_manager()->set_selected_layers(layer_list);
+			}
 			else
 			{
+				// Plain click on a layer not yet selected: replace the
+				// whole selection with just this layer.
 				canvas_view_->get_selection_manager()->set_selected_layer(event.layer);
 			}
 		}

--- a/synfig-studio/src/gui/trees/layertree.cpp
+++ b/synfig-studio/src/gui/trees/layertree.cpp
@@ -417,7 +417,7 @@ LayerTree::on_waypoint_changed(synfig::Waypoint& waypoint , synfig::ValueNode::H
 }
 
 void
-LayerTree::select_layer(synfig::Layer::Handle layer)
+LayerTree::select_layer(synfig::Layer::Handle layer, bool move_cursor)
 {
 	Gtk::TreeModel::Children::iterator iter;
 	if(layer_tree_store_->find_layer_row(layer,iter))
@@ -432,7 +432,8 @@ LayerTree::select_layer(synfig::Layer::Handle layer)
 
 		layer_tree_view().scroll_to_row(path);
 		layer_tree_view().get_selection()->select(iter);
-		layer_tree_view().set_cursor(path);
+		if(move_cursor)
+			layer_tree_view().set_cursor(path);
 	}
 }
 
@@ -461,7 +462,7 @@ LayerTree::select_layers(const LayerList &layer_list)
 {
 	LayerList::const_iterator iter;
 	for(iter = layer_list.begin(); iter != layer_list.end(); ++iter)
-		select_layer(*iter);
+		select_layer(*iter, false);
 }
 
 static inline void __layer_grabber(const Gtk::TreeModel::iterator& iter, LayerTree::LayerList* ret)

--- a/synfig-studio/src/gui/trees/layertree.h
+++ b/synfig-studio/src/gui/trees/layertree.h
@@ -209,7 +209,14 @@ public:
 
 	etl::handle<synfigapp::SelectionManager> get_selection_manager() { return layer_tree_store_->canvas_interface()->get_selection_manager(); }
 
-	void select_layer(synfig::Layer::Handle layer);
+	//! Selects a layer's row in the tree.
+	/*! When move_cursor is false, the keyboard cursor/focus is left
+	**  untouched: only the row's selection state is changed. This is
+	**  needed because TreeView::set_cursor() performs an implicit
+	**  "clear and select" of the row it targets in GTK3, which would
+	**  wipe out a multi-selection built up by calling this repeatedly
+	**  from select_layers() (synfig/synfig#3775). */
+	void select_layer(synfig::Layer::Handle layer, bool move_cursor = true);
 	void select_layers(const LayerList& layer_list);
 	void select_all_children_layers(synfig::Layer::Handle layer);
 	void select_all_children(Gtk::TreeModel::Children::iterator iter);


### PR DESCRIPTION
Fixes #3775

## Problem

Ctrl+left-clicking layers in the canvas no longer accumulated a multi-selection — each click replaced the previous selection instead of adding to it.

## Root cause

Two independent bugs combined to produce this behavior:

1. **`StateNormal_Context::event_layer_click()`** (`state_normal.cpp`): when Ctrl+clicking a layer that wasn't yet selected, the code called the singular `set_selected_layer()`, which replaces the entire selection with just that one layer. The toggle-off branch (Ctrl+clicking an already-selected layer) correctly used the plural `set_selected_layers()`, but the "add to selection" branch didn't.

2. **`LayerTree::select_layers()`** (`layertree.cpp`): even when called correctly with the plural method, this iterated the layer list calling `select_layer()` per layer, which calls `TreeView::set_cursor()`. In GTK3, `set_cursor()` performs an implicit clear-and-select of the targeted row, so each new layer selected in the loop silently wiped out the ones selected just before it.

Either bug alone was enough to break multi-select; both needed fixing.

## Fix

- In `event_layer_click()`, Ctrl+clicking an unselected layer now appends it to the current selection list and calls `set_selected_layers()` (plural) instead of `set_selected_layer()` (singular).
- Added `LayerTree::select_layer_row()`, a variant of `select_layer()` that selects a row without calling `set_cursor()`. `select_layers()` now uses this helper when building up a multi-selection. `select_layer()` itself is unchanged and still used by call sites that legitimately want to move the keyboard cursor/focus (e.g. selecting a single layer, double-click, select-parent-layer).

## Testing

- Ctrl+click multiple layers in the canvas: selection now accumulates correctly.
- Ctrl+click an already-selected layer: still toggles it off, rest of selection preserved.
- Plain click (no Ctrl): still replaces the selection with a single layer, as before.
- Single-layer selection via other paths (Layers panel, select-parent-layer, etc.) still moves keyboard focus/cursor as expected.