### PR TITLE
fix: Bevel highlight direction back to v1.0.2 algorithm; keep old files rendering unchanged

### DIFF
--- a/synfig-core/po/POTFILES.in
+++ b/synfig-core/po/POTFILES.in
@@ -4,6 +4,8 @@ src/modules/lyr_freetype/lyr_freetype.h
 src/modules/lyr_freetype/main.cpp
 src/modules/lyr_std/bevel.cpp
 src/modules/lyr_std/bevel.h
+src/modules/lyr_std/bevel_deprecated.cpp
+src/modules/lyr_std/bevel_deprecated.h
 src/modules/lyr_std/booleancurve.cpp
 src/modules/lyr_std/booleancurve.h
 src/modules/lyr_std/clamp.cpp

--- a/synfig-core/src/modules/lyr_std/CMakeLists.txt
+++ b/synfig-core/src/modules/lyr_std/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(lyr_std MODULE
         "${CMAKE_CURRENT_LIST_DIR}/bevel.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/bevel_deprecated.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/booleancurve.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/clamp.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/curvewarp.cpp"

--- a/synfig-core/src/modules/lyr_std/Makefile.am
+++ b/synfig-core/src/modules/lyr_std/Makefile.am
@@ -21,6 +21,8 @@ liblyr_std_la_SOURCES = \
 	booleancurve.cpp \
 	bevel.cpp \
 	bevel.h \
+	bevel_deprecated.cpp \
+	bevel_deprecated.h \
 	shade.cpp \
 	shade.h \
 	twirl.cpp \

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -58,7 +58,7 @@ SYNFIG_LAYER_INIT(Layer_Bevel);
 SYNFIG_LAYER_SET_NAME(Layer_Bevel,"bevel");
 SYNFIG_LAYER_SET_LOCAL_NAME(Layer_Bevel,N_("Bevel"));
 SYNFIG_LAYER_SET_CATEGORY(Layer_Bevel,N_("Stylize"));
-SYNFIG_LAYER_SET_VERSION(Layer_Bevel,"0.3");
+SYNFIG_LAYER_SET_VERSION(Layer_Bevel,"0.4");
 
 /* === P R O C E D U R E S ================================================= */
 

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -312,9 +312,9 @@ public:
 		const Point ftarget_max = transformation_matrix.get_transformed(source_rect.get_max());
 		const PointInt target_min = {round_to_int(ftarget_min[0]), round_to_int(ftarget_min[1])};
 		const PointInt target_max = {round_to_int(ftarget_max[0]), round_to_int(ftarget_max[1])};
-		int v = halfsizey+std::abs(offset_v) + target_min[1];
+		int v = halfsizey+std::abs(offset_v);
 		for (int iy = target_min[1]; iy < target_max[1]; ++iy, ++v) {
-			int u = halfsizex+std::abs(offset_u) + target_min[0];
+			int u = halfsizex+std::abs(offset_u);
 			for (int ix = target_min[0]; ix < target_max[0]; ++ix, ++u) {
 
 				Real alpha(0);

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -62,6 +62,36 @@ SYNFIG_LAYER_SET_VERSION(Layer_Bevel,"0.3");
 
 /* === P R O C E D U R E S ================================================= */
 
+// Half-size of the border added around the render region to accommodate the blur.
+// Used both to size the work surface (set_coords_sub_tasks) and to index it (run),
+// so the two never drift.
+static void
+bevel_calc_halfsize(Real size_x, Real size_y, int type, Real pw, Real ph,
+                    int& halfsizex, int& halfsizey)
+{
+	const Real GAUSSIAN_ADJUSTMENT = 0.05;
+
+	halfsizex = (int)(std::fabs(size_x*.5/pw) + 3);
+	halfsizey = (int)(std::fabs(size_y*.5/ph) + 3);
+
+	switch(type)
+	{
+		case Blur::DISC:
+		case Blur::BOX:
+		case Blur::CROSS:
+		case Blur::FASTGAUSSIAN:
+			halfsizex = std::max(1, halfsizex);
+			halfsizey = std::max(1, halfsizey);
+			break;
+		case Blur::GAUSSIAN:
+			halfsizex = (int)(size_x*GAUSSIAN_ADJUSTMENT/std::fabs(pw*pw) + 0.5);
+			halfsizey = (int)(size_y*GAUSSIAN_ADJUSTMENT/std::fabs(ph*ph) + 0.5);
+			halfsizex = (halfsizex + 1)/2;
+			halfsizey = (halfsizey + 1)/2;
+			break;
+	}
+}
+
 /* === M E T H O D S ======================================================= */
 
 Layer_Bevel::Layer_Bevel():
@@ -187,43 +217,13 @@ TaskBevel::set_coords_sub_tasks()
 	const Vector size(softness,softness);
 
 	//expand the working surface to accommodate the blur
-
-	//the expanded size = 1/2 the size in each direction rounded up
-	int	halfsizex = (int) (std::fabs(size[0]*.5/pw) + 3),
-		halfsizey = (int) (std::fabs(size[1]*.5/(ph)) + 3);
+	int halfsizex, halfsizey;
+	bevel_calc_halfsize(size[0], size[1], type, pw, ph, halfsizex, halfsizey);
 
 	const int offset_u(round_to_int(offset[0]/pw));
 	const int offset_v(round_to_int(offset[1]/(ph)));
 	const int offset_w(w+std::abs(offset_u)*2);
 	const int offset_h(h+std::abs(offset_v)*2);
-
-	//expand by 1/2 size in each direction on either side
-	switch(type)
-	{
-		case Blur::DISC:
-		case Blur::BOX:
-		case Blur::CROSS:
-		case Blur::FASTGAUSSIAN:
-		{
-			halfsizex = std::max(1, halfsizex);
-			halfsizey = std::max(1, halfsizey);
-			break;
-		}
-		case Blur::GAUSSIAN:
-		{
-		#define GAUSSIAN_ADJUSTMENT		(0.05)
-
-			Real pw2 = pw * pw;
-			Real ph2 = ph * ph;
-
-			halfsizex = (int)(size[0]*GAUSSIAN_ADJUSTMENT/std::fabs(pw2) + 0.5);
-			halfsizey = (int)(size[1]*GAUSSIAN_ADJUSTMENT/std::fabs(ph2) + 0.5);
-
-			halfsizex = (halfsizex + 1)/2;
-			halfsizey = (halfsizey + 1)/2;
-			break;
-		}
-	}
 
 	Real delta_x = -std::abs(offset_u) - halfsizex;
 	Real delta_y = -std::abs(offset_v) - halfsizey;
@@ -293,8 +293,8 @@ public:
 		const Vector ppu = get_pixels_per_unit();
 		const Real pw = 1/ppu[0];
 		const Real ph = 1/ppu[1];
-		const int halfsizex = (int) (std::fabs(size[0]*.5/pw) + 3);
-		const int halfsizey = (int) (std::fabs(size[1]*.5/ph) + 3);
+		int halfsizex, halfsizey;
+		bevel_calc_halfsize(size[0], size[1], type, pw, ph, halfsizex, halfsizey);
 
 		const int offset_u(round_to_int(offset[0]/pw)),offset_v(round_to_int(offset[1]/ph));
 

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -323,9 +323,9 @@ public:
 				alpha += -blurred.linear_sample(u+u0, v+v0);
 				alpha -= -blurred.linear_sample(u-u0, v-v0);
 				alpha += -blurred.linear_sample(u+u1, v+v1)*0.5f;
-				alpha += -blurred.linear_sample(u+v1, v-u1)*0.5f;
+				alpha -= -blurred.linear_sample(u+v1, v-u1)*0.5f;
 				alpha -= -blurred.linear_sample(u-u1, v-v1)*0.5f;
-				alpha -= -blurred.linear_sample(u-v1, v+u1)*0.5f;
+				alpha += -blurred.linear_sample(u-v1, v+u1)*0.5f;
 
 				if(solid)
 				{

--- a/synfig-core/src/modules/lyr_std/bevel.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel.cpp
@@ -71,23 +71,21 @@ bevel_calc_halfsize(Real size_x, Real size_y, int type, Real pw, Real ph,
 {
 	const Real GAUSSIAN_ADJUSTMENT = 0.05;
 
-	halfsizex = (int)(std::fabs(size_x*.5/pw) + 3);
-	halfsizey = (int)(std::fabs(size_y*.5/ph) + 3);
-
 	switch(type)
 	{
-		case Blur::DISC:
-		case Blur::BOX:
-		case Blur::CROSS:
-		case Blur::FASTGAUSSIAN:
-			halfsizex = std::max(1, halfsizex);
-			halfsizey = std::max(1, halfsizey);
-			break;
 		case Blur::GAUSSIAN:
 			halfsizex = (int)(size_x*GAUSSIAN_ADJUSTMENT/std::fabs(pw*pw) + 0.5);
 			halfsizey = (int)(size_y*GAUSSIAN_ADJUSTMENT/std::fabs(ph*ph) + 0.5);
 			halfsizex = (halfsizex + 1)/2;
 			halfsizey = (halfsizey + 1)/2;
+			break;
+		case Blur::DISC:
+		case Blur::BOX:
+		case Blur::CROSS:
+		case Blur::FASTGAUSSIAN:
+		default:
+			halfsizex = std::max(1, (int)(std::fabs(size_x*.5/pw) + 3));
+			halfsizey = std::max(1, (int)(std::fabs(size_y*.5/ph) + 3));
 			break;
 	}
 }

--- a/synfig-core/src/modules/lyr_std/bevel_deprecated.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel_deprecated.cpp
@@ -1,0 +1,480 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file bevel_deprecated.cpp
+**	\brief Implementation of the "Bevel (Deprecated)" layer
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	Copyright (c) 2012-2013 Carlos López
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include "bevel_deprecated.h"
+
+#include <synfig/localization.h>
+#include <synfig/general.h>
+
+#include <synfig/blur.h>
+#include <synfig/context.h>
+#include <synfig/rendering/software/task/tasksw.h>
+#include <synfig/rendering/software/function/blur.h>
+
+
+#endif
+
+/* === U S I N G =========================================================== */
+
+using namespace synfig;
+using namespace modules;
+using namespace lyr_std;
+
+/* === G L O B A L S ======================================================= */
+
+SYNFIG_LAYER_INIT(Layer_BevelDeprecated);
+SYNFIG_LAYER_SET_NAME(Layer_BevelDeprecated,"bevel_deprecated");
+SYNFIG_LAYER_SET_LOCAL_NAME(Layer_BevelDeprecated,N_("Bevel (Deprecated)"));
+SYNFIG_LAYER_SET_CATEGORY(Layer_BevelDeprecated,N_("Stylize"));
+SYNFIG_LAYER_SET_VERSION(Layer_BevelDeprecated,"0.3");
+
+/* === P R O C E D U R E S ================================================= */
+
+/* === M E T H O D S ======================================================= */
+
+Layer_BevelDeprecated::Layer_BevelDeprecated():
+	Layer_CompositeFork(0.75,Color::BLEND_ONTO),
+	param_type(ValueBase(int(Blur::FASTGAUSSIAN))),
+	param_softness (ValueBase(Real(0.1))),
+	param_color1(ValueBase(Color::white())),
+	param_color2(ValueBase(Color::black())),
+	param_depth(ValueBase(Real(0.2)))
+{
+	param_angle=ValueBase(Angle::deg(135));
+	calc_offset();
+	param_use_luma=ValueBase(false);
+	param_solid=ValueBase(false);
+
+	SET_INTERPOLATION_DEFAULTS();
+	SET_STATIC_DEFAULTS();
+}
+
+void
+Layer_BevelDeprecated::calc_offset()
+{
+	Angle angle=param_angle.get(Angle());
+	Real depth=param_depth.get(Real());
+	
+	offset[0]=Angle::cos(angle).get()*depth;
+	offset[1]=Angle::sin(angle).get()*depth;
+
+	offset45[0]=Angle::cos(angle-Angle::deg(45)).get()*depth*0.707106781;
+	offset45[1]=Angle::sin(angle-Angle::deg(45)).get()*depth*0.707106781;
+}
+
+bool
+Layer_BevelDeprecated::set_param(const String &param, const ValueBase &value)
+{
+	IMPORT_VALUE_PLUS(param_softness,
+		{
+			Real softness=param_softness.get(Real());
+			softness=softness>0?softness:0;
+			param_softness.set(softness);
+		}
+		);
+	IMPORT_VALUE(param_color1);
+	IMPORT_VALUE(param_color2);
+	IMPORT_VALUE_PLUS(param_depth,calc_offset());
+	IMPORT_VALUE_PLUS(param_angle,calc_offset());
+	IMPORT_VALUE(param_type);
+	IMPORT_VALUE(param_use_luma);
+	IMPORT_VALUE(param_solid);
+	if (param == "fake_origin")
+		return true;
+
+	return Layer_Composite::set_param(param,value);
+}
+
+ValueBase
+Layer_BevelDeprecated::get_param(const String &param)const
+{
+	EXPORT_VALUE(param_type);
+	EXPORT_VALUE(param_softness);
+	EXPORT_VALUE(param_color1);
+	EXPORT_VALUE(param_color2);
+	EXPORT_VALUE(param_depth);
+	EXPORT_VALUE(param_angle);
+	EXPORT_VALUE(param_use_luma);
+	EXPORT_VALUE(param_solid);
+	if (param == "fake_origin")
+	{
+		return Vector();
+	}
+
+	EXPORT_NAME();
+	EXPORT_VERSION();
+
+	return Layer_Composite::get_param(param);
+}
+
+Color
+Layer_BevelDeprecated::get_color(Context context, const Point &pos)const
+{
+	Real softness=param_softness.get(Real());
+	int type=param_type.get(int());
+	Color color1=param_color1.get(Color());
+	Color color2=param_color2.get(Color());
+	
+	const Vector size(softness,softness);
+	Point blurpos = Blur(size,type)(pos);
+
+	if(get_amount()==0.0)
+		return context.get_color(pos);
+
+	Color shade;
+
+	Real hi_alpha(1.0f-context.get_color(blurpos+offset).get_a());
+	Real lo_alpha(1.0f-context.get_color(blurpos-offset).get_a());
+
+	Real shade_alpha(hi_alpha-lo_alpha);
+	if(shade_alpha>0)
+		shade=color1,shade.set_a(shade_alpha);
+	else
+		shade=color2,shade.set_a(-shade_alpha);
+
+	return Color::blend(shade,context.get_color(pos),get_amount(),get_blend_method());
+}
+
+void
+TaskBevelDeprecated::set_coords_sub_tasks()
+{
+	if (!sub_task(0)) {
+		trunc_to_zero();
+		return;
+	}
+	if (!is_valid_coords()) {
+		sub_task(0)->set_coords_zero();
+		return;
+	}
+
+	const int w = target_rect.get_width();
+	const int h = target_rect.get_height();
+	const Real pw = get_units_per_pixel()[0];
+	const Real ph = get_units_per_pixel()[1];
+
+	const Vector size(softness,softness);
+
+	//expand the working surface to accommodate the blur
+
+	//the expanded size = 1/2 the size in each direction rounded up
+	int	halfsizex = (int) (std::fabs(size[0]*.5/pw) + 3),
+		halfsizey = (int) (std::fabs(size[1]*.5/(ph)) + 3);
+
+	const int offset_u(round_to_int(offset[0]/pw));
+	const int offset_v(round_to_int(offset[1]/(ph)));
+	const int offset_w(w+std::abs(offset_u)*2);
+	const int offset_h(h+std::abs(offset_v)*2);
+
+	//expand by 1/2 size in each direction on either side
+	switch(type)
+	{
+		case Blur::DISC:
+		case Blur::BOX:
+		case Blur::CROSS:
+		case Blur::FASTGAUSSIAN:
+		{
+			halfsizex = std::max(1, halfsizex);
+			halfsizey = std::max(1, halfsizey);
+			break;
+		}
+		case Blur::GAUSSIAN:
+		{
+		#define GAUSSIAN_ADJUSTMENT		(0.05)
+
+			Real pw2 = pw * pw;
+			Real ph2 = ph * ph;
+
+			halfsizex = (int)(size[0]*GAUSSIAN_ADJUSTMENT/std::fabs(pw2) + 0.5);
+			halfsizey = (int)(size[1]*GAUSSIAN_ADJUSTMENT/std::fabs(ph2) + 0.5);
+
+			halfsizex = (halfsizex + 1)/2;
+			halfsizey = (halfsizey + 1)/2;
+			break;
+		}
+	}
+
+	Real delta_x = -std::abs(offset_u) - halfsizex;
+	Real delta_y = -std::abs(offset_v) - halfsizey;
+	Real new_w = offset_w + 2*halfsizex;
+	Real new_h = offset_h + 2*halfsizey;
+
+	Rect new_sub_source_rect(source_rect.minx + pw*delta_x, source_rect.miny + ph*delta_y, source_rect.minx + pw*delta_x + pw*new_w, source_rect.miny + ph*delta_y + ph*new_h);
+
+
+	sub_task(0)->set_coords(new_sub_source_rect, VectorInt(new_w, new_h));
+}
+
+Rect
+TaskBevelDeprecated::calc_bounds() const
+{
+	if (!sub_task(0))
+		return Rect::zero();
+
+	Rect bounds = sub_task(0)->get_bounds();
+	Vector size = Vector(softness,softness) * rendering::software::Blur::get_extra_size(rendering::Blur::Type(type));
+	size[0] = fabs(size[0]) + 1.0;
+	size[1] = fabs(size[1]) + 1.0;
+	bounds.minx -= size[0];
+	bounds.miny -= size[1];
+	bounds.maxx += size[0];
+	bounds.maxy += size[1];
+
+	return bounds;
+}
+
+SYNFIG_EXPORT rendering::Task::Token TaskBevelDeprecated::token(
+	DescAbstract<TaskBevelDeprecated>("BevelDeprecated") );
+
+class TaskBevelDeprecatedSW : public TaskBevelDeprecated, public synfig::rendering::TaskSW
+{
+public:
+	typedef etl::handle<TaskBevelDeprecated> Handle;
+	SYNFIG_EXPORT static Token token;
+	Token::Handle get_token() const override { return token.handle(); }
+
+	bool run(RunParams&) const override {
+		if (!is_valid())
+			return true;
+		if (!sub_task(0))
+			return false;
+
+		Rect common_source_rect;
+		rect_set_intersect(common_source_rect, source_rect, sub_task(0)->source_rect);
+		if (!common_source_rect.is_valid())
+			return false;
+
+		LockWrite la(this);
+		if (!la)
+			return false;
+
+		synfig::surface<float> blurred;
+
+		const Vector size(softness,softness);
+
+		{
+			synfig::surface<float> alpha_surface;
+			get_alpha_surface(alpha_surface);
+			//blur the image
+			Blur(size, type)(alpha_surface, sub_task(0)->source_rect.get_size(), blurred);
+		}
+
+		const Vector ppu = get_pixels_per_unit();
+		const Real pw = 1/ppu[0];
+		const Real ph = 1/ppu[1];
+		const int halfsizex = (int) (std::fabs(size[0]*.5/pw) + 3);
+		const int halfsizey = (int) (std::fabs(size[1]*.5/ph) + 3);
+
+		const int offset_u(round_to_int(offset[0]/pw)),offset_v(round_to_int(offset[1]/ph));
+
+		const float u0(offset[0]/pw),   v0(offset[1]/ph);
+		const float u1(offset45[0]/pw), v1(offset45[1]/ph);
+
+		// convert vector-coordinates to raster-coordinates (i.e. source rect to target rect)
+		Matrix transformation_matrix;
+		transformation_matrix.m00 = ppu[0];
+		transformation_matrix.m11 = ppu[1];
+		transformation_matrix.m20 = target_rect.minx - source_rect.minx*ppu[0];
+		transformation_matrix.m21 = target_rect.miny - source_rect.miny*ppu[1];
+
+		const Point ftarget_min = transformation_matrix.get_transformed(source_rect.get_min());
+		const Point ftarget_max = transformation_matrix.get_transformed(source_rect.get_max());
+		const PointInt target_min = {round_to_int(ftarget_min[0]), round_to_int(ftarget_min[1])};
+		const PointInt target_max = {round_to_int(ftarget_max[0]), round_to_int(ftarget_max[1])};
+		int v = halfsizey+std::abs(offset_v) + target_min[1];
+		for (int iy = target_min[1]; iy < target_max[1]; ++iy, ++v) {
+			int u = halfsizex+std::abs(offset_u) + target_min[0];
+			for (int ix = target_min[0]; ix < target_max[0]; ++ix, ++u) {
+
+				Real alpha(0);
+				Color shade;
+
+				alpha += -blurred.linear_sample(u+u0, v+v0);
+				alpha -= -blurred.linear_sample(u-u0, v-v0);
+				alpha += -blurred.linear_sample(u+u1, v+v1)*0.5f;
+				alpha += -blurred.linear_sample(u+v1, v-u1)*0.5f;
+				alpha -= -blurred.linear_sample(u-u1, v-v1)*0.5f;
+				alpha -= -blurred.linear_sample(u-v1, v+u1)*0.5f;
+
+				if(solid)
+				{
+					alpha/=4.0f;
+					alpha+=0.5f;
+					shade=Color::blend(color1,color2,alpha,Color::BLEND_STRAIGHT);
+				}
+				else
+				{
+					alpha/=2;
+					if(alpha>0)
+						shade=color1,shade.set_a(shade.get_a()*alpha);
+					else
+						shade=color2,shade.set_a(shade.get_a()*-alpha);
+				}
+
+				if (shade.get_a())
+					la->get_surface()[iy][ix] = shade;
+				else
+					la->get_surface()[iy][ix] = Color::alpha();
+			}
+		}
+		return true;
+	}
+
+private:
+	bool get_alpha_surface(synfig::surface<float>& output) const
+	{
+		LockRead lb(sub_tasks[0]);
+		if (!lb)
+			return false;
+
+		const Surface& context = lb->get_surface();
+		synfig::surface<float>& alpha_surface = output;
+		alpha_surface.set_wh(context.get_w(), context.get_h());
+		if (!use_luma) {
+			for (int y = 0; y < context.get_h(); ++y) {
+				for (int x = 0; x < context.get_w(); ++x) {
+					alpha_surface[y][x] = context[y][x].get_a();
+				}
+			}
+		} else {
+			for (int y = 0; y < context.get_h(); ++y) {
+				for (int x = 0; x < context.get_w(); ++x) {
+					const auto& value = context[y][x];
+					alpha_surface[y][x] = value.get_a() * value.get_y();
+				}
+			}
+		}
+
+		return true;
+	}
+};
+
+SYNFIG_EXPORT rendering::Task::Token TaskBevelDeprecatedSW::token(
+	DescReal<TaskBevelDeprecatedSW, TaskBevelDeprecated>("BevelDeprecatedSW") );
+
+////
+
+Layer::Vocab
+Layer_BevelDeprecated::get_param_vocab(void)const
+{
+	Layer::Vocab ret(Layer_Composite::get_param_vocab());
+
+	ret.push_back(ParamDesc("type")
+		.set_local_name(_("Type"))
+		.set_description(_("Type of blur to use"))
+		.set_hint("enum")
+		.set_static(true)
+		.add_enum_value(Blur::BOX,"box",_("Box Blur"))
+		.add_enum_value(Blur::FASTGAUSSIAN,"fastgaussian",_("Fast Gaussian Blur"))
+		.add_enum_value(Blur::CROSS,"cross",_("Cross-Hatch Blur"))
+		.add_enum_value(Blur::GAUSSIAN,"gaussian",_("Gaussian Blur"))
+		.add_enum_value(Blur::DISC,"disc",_("Disc Blur"))
+	);
+
+	ret.push_back(ParamDesc("color1")
+		.set_local_name(_("Hi-Color"))
+	);
+	ret.push_back(ParamDesc("color2")
+		.set_local_name(_("Lo-Color"))
+	);
+	ret.push_back(ParamDesc("angle")
+		.set_local_name(_("Light Angle"))
+		.set_origin("fake_origin")
+	);
+	ret.push_back(ParamDesc("depth")
+		.set_is_distance()
+		.set_local_name(_("Depth of Bevel"))
+		.set_origin("fake_origin")
+	);
+	ret.push_back(ParamDesc("softness")
+		.set_is_distance()
+		.set_local_name(_("Softness"))
+		.set_origin("fake_origin")
+	);
+	ret.push_back(ParamDesc("use_luma")
+		.set_local_name(_("Use Luma"))
+	);
+	ret.push_back(ParamDesc("solid")
+		.set_local_name(_("Solid"))
+	);
+
+	ret.push_back(ParamDesc("fake_origin")
+		.hidden()
+	);
+
+	return ret;
+}
+
+Rect
+Layer_BevelDeprecated::get_full_bounding_rect(Context context)const
+{
+	Real softness=param_softness.get(Real());
+	Real depth=param_depth.get(Real());
+
+	if(is_disabled())
+		return context.get_full_bounding_rect();
+
+	Rect under(context.get_full_bounding_rect());
+
+	if(Color::is_onto(get_blend_method()))
+		return under;
+
+	Rect bounds(under.expand(softness));
+	bounds.expand_x(std::fabs(depth));
+	bounds.expand_y(std::fabs(depth));
+
+	return bounds;
+}
+
+rendering::Task::Handle
+Layer_BevelDeprecated::build_composite_fork_task_vfunc(ContextParams /*context_params*/, rendering::Task::Handle sub_task) const
+{
+	if (!sub_task)
+		return sub_task;
+
+	TaskBevelDeprecated::Handle task_bevel(new TaskBevelDeprecated());
+	task_bevel->softness = param_softness.get(Real());
+	task_bevel->type = param_type.get(int());
+	task_bevel->color1 = param_color1.get(Color());
+	task_bevel->color2 = param_color2.get(Color());
+	task_bevel->use_luma = param_use_luma.get(bool());
+	task_bevel->solid = param_solid.get(bool());
+
+	task_bevel->offset = offset;
+	task_bevel->offset45 = offset45;
+
+	task_bevel->sub_task(0) = sub_task->clone_recursive();
+
+	return task_bevel;
+}

--- a/synfig-core/src/modules/lyr_std/bevel_deprecated.cpp
+++ b/synfig-core/src/modules/lyr_std/bevel_deprecated.cpp
@@ -57,7 +57,7 @@ using namespace lyr_std;
 SYNFIG_LAYER_INIT(Layer_BevelDeprecated);
 SYNFIG_LAYER_SET_NAME(Layer_BevelDeprecated,"bevel_deprecated");
 SYNFIG_LAYER_SET_LOCAL_NAME(Layer_BevelDeprecated,N_("Bevel (Deprecated)"));
-SYNFIG_LAYER_SET_CATEGORY(Layer_BevelDeprecated,N_("Stylize"));
+SYNFIG_LAYER_SET_CATEGORY(Layer_BevelDeprecated,CATEGORY_DO_NOT_USE);//Hide this layer in the menu
 SYNFIG_LAYER_SET_VERSION(Layer_BevelDeprecated,"0.3");
 
 /* === P R O C E D U R E S ================================================= */

--- a/synfig-core/src/modules/lyr_std/bevel_deprecated.h
+++ b/synfig-core/src/modules/lyr_std/bevel_deprecated.h
@@ -1,0 +1,117 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file bevel_deprecated.h
+**	\brief Header file for implementation of the "Bevel (Deprecated)" layer
+**
+**	\legal
+**	Copyright (c) 2002-2005 Robert B. Quattlebaum Jr., Adrian Bentley
+**	Copyright (c) 2008 Chris Moore
+**	Copyright (c) 2012-2013 Carlos López
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifndef __SYNFIG_LAYER_BEVEL_DEPRECATED_H__
+#define __SYNFIG_LAYER_BEVEL_DEPRECATED_H__
+
+/* -- H E A D E R S --------------------------------------------------------- */
+
+#include <synfig/layers/layer_composite_fork.h>
+
+namespace synfig
+{
+namespace modules
+{
+namespace lyr_std
+{
+
+class Layer_BevelDeprecated : public Layer_CompositeFork
+{
+	SYNFIG_LAYER_MODULE_EXT
+private:
+	//!Parameter: (int) type of blur to use
+	ValueBase param_type;
+	//!Parameter: (Real) amount of blur
+	ValueBase param_softness;
+	//!Parameter: (Color) light color
+	ValueBase param_color1;
+	//!Parameter: (Color) dark color
+	ValueBase param_color2;
+	//!Parameter: (Angle) angle of the light source
+	ValueBase param_angle;
+	//!Parameter: (Real) depth of the bevel
+	ValueBase param_depth;
+	//!Parameter: (bool) use luma
+	ValueBase param_use_luma;
+	//!Parameter: (bool) solid
+	ValueBase param_solid;
+
+	Vector	offset;
+	Vector	offset45;
+
+	void calc_offset();
+public:
+	Layer_BevelDeprecated();
+
+	bool set_param(const String& param, const ValueBase& value) override;
+
+	ValueBase get_param(const String& param) const override;
+
+	Color get_color(Context context, const Point& pos) const override;
+
+	Rect get_full_bounding_rect(Context context) const override;
+	Vocab get_param_vocab() const override;
+	bool reads_context() const override { return true; }
+
+protected:
+	rendering::Task::Handle build_composite_fork_task_vfunc(ContextParams, rendering::Task::Handle sub_task) const override;
+}; // END of class Layer_BevelDeprecated
+
+// TaskBevelDeprecated performs Blur internally, and the behavior of
+// applying skew transformation before or after the blur is not the same.
+// Therefore, we can't inherit synfig::rendering::TaskInterfaceTransformationPass here
+class TaskBevelDeprecated: public rendering::Task//, rendering::TaskInterfaceTransformationPass
+{
+public:
+	typedef etl::handle<TaskBevelDeprecated> Handle;
+	SYNFIG_EXPORT static Token token;
+	Token::Handle get_token() const override { return token.handle(); }
+
+	Real softness;
+	int type;
+	Color color1;
+	Color color2;
+	bool use_luma;
+	bool solid;
+
+	Vector offset, offset45;
+
+	void set_coords_sub_tasks() override;
+	Rect calc_bounds() const override;
+};
+
+}; // END of namespace lyr_std
+}; // END of namespace modules
+}; // END of namespace synfig
+
+/* -- E X T E R N S --------------------------------------------------------- */
+
+/* -- E N D ----------------------------------------------------------------- */
+
+#endif

--- a/synfig-core/src/modules/lyr_std/main.cpp
+++ b/synfig-core/src/modules/lyr_std/main.cpp
@@ -60,6 +60,7 @@
 
 #include "shade.h"
 #include "bevel.h"
+#include "bevel_deprecated.h"
 
 #include "perspective.h"
 #include "timeloop.h"
@@ -100,6 +101,7 @@ MODULE_INVENTORY_BEGIN(liblyr_std)
 		LAYER(Twirl)
 		LAYER(Layer_Shade)
 		LAYER(Layer_Bevel)
+		LAYER(Layer_BevelDeprecated)
 		LAYER(Layer_TimeLoop)
 		LAYER(Layer_Stroboscope)
 		LAYER(Layer_SphereDistort)

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -2780,7 +2780,7 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 			lyr_ver = element->get_attribute("version")->get_value();
 		if (lyr_ver >= "0.2" && lyr_ver < "0.4" && canvas->get_version() >= "1.1") {
 			layer_type = "bevel_deprecated";
-			warning(element, strprintf(_("Bevel layer (version %s) converted to \"bevel_deprecated\""), lyr_ver.c_str()));
+			warning(element, strprintf(_("Bevel layer (version %s) converted to \"bevel_deprecated\" to preserve its render result. Use \"Upgrade Layer\" in the layer context menu to update it."), lyr_ver.c_str()));
 		}
 	}
 

--- a/synfig-core/src/synfig/loadcanvas.cpp
+++ b/synfig-core/src/synfig/loadcanvas.cpp
@@ -2767,9 +2767,24 @@ CanvasParser::parse_layer(xmlpp::Element *element,Canvas::Handle canvas)
 		error(element,_("Missing \"type\" attribute to \"layer\" element"));
 		return Layer::Handle();
 	}
-	if(element->get_attribute("type")->get_value() == "filled_rectangle")
-	layer=Layer::create("rectangle");
-	else layer=Layer::create(element->get_attribute("type")->get_value());
+	String layer_type = element->get_attribute("type")->get_value();
+
+	// load-time layer-type normalization before instantiation.
+	if (layer_type == "filled_rectangle")
+		layer_type = "rectangle"; // legacy alias
+	else if (layer_type == "bevel") {
+		// Old bevel (v0.2-0.3) -> bevel_deprecated to preserve its legacy render
+		// result on canvas v1.1+.
+		String lyr_ver;
+		if (element->get_attribute("version"))
+			lyr_ver = element->get_attribute("version")->get_value();
+		if (lyr_ver >= "0.2" && lyr_ver < "0.4" && canvas->get_version() >= "1.1") {
+			layer_type = "bevel_deprecated";
+			warning(element, strprintf(_("Bevel layer (version %s) converted to \"bevel_deprecated\""), lyr_ver.c_str()));
+		}
+	}
+
+	layer = Layer::create(layer_type);
 	layer->set_canvas(canvas);
 
 	if(element->get_attribute("group"))

--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -102,6 +102,7 @@ set(ICONS
 	action_innerrounded_interpolation_icon
 	action_set_layer_description_icon
 	action_squared_interpolation_icon
+	action_layer_upgrade_icon
 	action_unexport_icon
 	clear_redo_icon
 	clear_undo_icon

--- a/synfig-studio/images/CMakeLists.txt
+++ b/synfig-studio/images/CMakeLists.txt
@@ -173,6 +173,7 @@ set(ICONS
 	layer_other_timeloop_icon
 	layer_other_xorpattern_icon
 	layer_stylize_bevel_icon
+	layer_stylize_bevel_deprecated_icon
 	layer_stylize_shade_icon
 	layer_transform_rotate_icon
 	layer_transform_scale_icon

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -142,6 +142,7 @@ EXTRA_DIST = \
 	layer_other_timeloop_icon.sif \
 	layer_other_xorpattern_icon.sif \
 	layer_stylize_bevel_icon.sif \
+	layer_stylize_bevel_deprecated_icon.sif \
 	layer_stylize_shade_icon.sif \
 	layer_transform_rotate_icon.sif \
 	layer_transform_scale_icon.sif \
@@ -359,6 +360,7 @@ ICONS = \
 	layer_other_timeloop_icon.$(EXT) \
 	layer_other_xorpattern_icon.$(EXT) \
 	layer_stylize_bevel_icon.$(EXT) \
+	layer_stylize_bevel_deprecated_icon.$(EXT) \
 	layer_stylize_shade_icon.$(EXT) \
 	layer_transform_rotate_icon.$(EXT) \
 	layer_transform_scale_icon.$(EXT) \

--- a/synfig-studio/images/Makefile.am
+++ b/synfig-studio/images/Makefile.am
@@ -86,6 +86,7 @@ EXTRA_DIST = \
 	action_rounded_interpolation_icon.sif \
 	action_innerrounded_interpolation_icon.sif \
 	action_squared_interpolation_icon.sif \
+	action_layer_upgrade_icon.sif \
 	\
 	action_doc_icons.sif \
 	\
@@ -292,6 +293,7 @@ ICONS = \
 	action_rounded_interpolation_icon.$(EXT) \
 	action_innerrounded_interpolation_icon.$(EXT) \
 	action_squared_interpolation_icon.$(EXT) \
+	action_layer_upgrade_icon.$(EXT) \
 	\
 	action_doc_new_icon.$(EXT) \
 	action_doc_open_icon.$(EXT) \

--- a/synfig-studio/images/action_layer_upgrade_icon.sif
+++ b/synfig-studio/images/action_layer_upgrade_icon.sif
@@ -1,0 +1,1955 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.0" width="128" height="128" xres="2834.645752" yres="2834.645752" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>action_layer_upgrade_icon.sif</name>
+  <desc>Placed in the Public Domain in 2010 by Yu Chen (jcome)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="0"/>
+  <meta name="grid_size" content="0.250000 0.250000"/>
+  <meta name="grid_snap" content="1"/>
+  <meta name="guide" content="-1.648061*-0.554099*0.000000 0.003770*-0.795141*1.570796 0.034747*0.001507*0.000000 "/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="1"/>
+  <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
+  <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
+  <defs>
+    <color id="outline">
+      <r>0.097626</r>
+      <g>0.016710</g>
+      <b>0.000000</b>
+      <a>1.000000</a>
+    </color>
+    <canvas id="Layer" xres="2952.755900" yres="2952.755900" bgcolor="0.500000 0.500000 0.500000 1.000000">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="0.5000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.1000000015</x>
+            <y>-0.1000000015</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="0E9B2667D534FC5927B7997AA6B094CD">
+                <x>-0.8000000119</x>
+                <y>0.8000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="DFAF5E2C666C5D0C0499103406DBF9B7">
+                <x>-0.8000000119</x>
+                <y>-0.2000000030</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="1C65EB09609AC7A5E54183EF06D77C83">
+                <x>0.2000000030</x>
+                <y>-0.2000000030</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="91956C584F32860367BE765522964C0F">
+                <x>0.2000000030</x>
+                <y>0.8000000119</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="1"/>
+        </param>
+        <param name="size">
+          <vector>
+            <x>0.0684381425</x>
+            <y>0.0684381425</y>
+          </vector>
+        </param>
+        <param name="type">
+          <integer value="1"/>
+        </param>
+      </layer>
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="09CBB6B3D7CD9F50E0701A0CF076EA28">
+                <x>-0.8000000119</x>
+                <y>0.8000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="743E7EC495F292EE41FE6FB175478536">
+                <x>-0.8000000119</x>
+                <y>-0.2000000030</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="8DE8A66770495A4FD9B649DC543A50A7">
+                <x>0.2000000030</x>
+                <y>-0.2000000030</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="6C97043A597A035EC1E190A604155B1D">
+                <x>0.2000000030</x>
+                <y>0.8000000119</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>1.000000</r>
+            <g>0.900000</g>
+            <b>0.600000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="09414466E7929BFFBE2A65CB8A658F2A">
+                <x>-0.6999999881</x>
+                <y>0.6999999881</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="8502E6D14BCEA1D89539DD0BEBB3AE6A">
+                <x>-0.6999999881</x>
+                <y>-0.1000000015</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="586DCC94004A14F95FA082246B97F2C1">
+                <x>0.1000000015</x>
+                <y>-0.1000000015</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="13C526200C2440C13B65BE316EA5C458">
+                <x>0.1000000015</x>
+                <y>0.6999999881</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+    </canvas>
+  </defs>
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="shadow">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0"/>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0187403243</x>
+            <y>-0.0242630430</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
+    </param>
+    <param name="canvas">
+      <canvas width="24" height="24" xres="2952.755900" yres="2952.755900">
+        <layer type="solid_color" active="false" exclude_from_rendering="false" version="0.1">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+        </layer>
+        <layer type="radial_gradient" active="true" exclude_from_rendering="false" version="0.2">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0"/>
+          </param>
+          <param name="gradient">
+            <gradient>
+              <color pos="0.000000">
+                <r>0.012686</r>
+                <g>0.000000</g>
+                <b>0.001167</b>
+                <a>0.700000</a>
+              </color>
+              <color pos="1.000000">
+                <r>1.000000</r>
+                <g>1.000000</g>
+                <b>1.000000</b>
+                <a>0.000000</a>
+              </color>
+            </gradient>
+          </param>
+          <param name="center">
+            <vector guid="3932F399D50014C71954B55ABEA98F38">
+              <x>0.0000000000</x>
+              <y>-0.8020833135</y>
+            </vector>
+          </param>
+          <param name="radius">
+            <real value="0.9816616975"/>
+          </param>
+          <param name="loop">
+            <bool value="false"/>
+          </param>
+          <param name="zigzag">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="stretch" active="true" exclude_from_rendering="false" version="0.1">
+          <param name="amount">
+            <vector>
+              <x>0.8697916865</x>
+              <y>0.1302083284</y>
+            </vector>
+          </param>
+          <param name="center">
+            <vector guid="3932F399D50014C71954B55ABEA98F38">
+              <x>0.0000000000</x>
+              <y>-0.8020833135</y>
+            </vector>
+          </param>
+        </layer>
+      </canvas>
+    </param>
+    <param name="time_dilation">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
+    </param>
+  </layer>
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="caution">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0054593994</x>
+            <y>-0.1123186275</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>0.6858878136</x>
+            <y>0.6858878136</y>
+          </vector>
+        </scale>
+      </composite>
+    </param>
+    <param name="canvas">
+      <canvas>
+        <layer type="region" active="true" exclude_from_rendering="false" version="0.1">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>0.885758</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector guid="F9A0A267E7E056B8284F727BAA55E4AB">
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="EE53A8EBB73628E10C42E035EA03C143" type="bline_point" loop="true">
+              <entry>
+                <composite guid="95D8B9173E3140A206927832AB8971DB" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5379897844"/>
+                      </radius>
+                      <theta>
+                        <angle value="92.211281"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="30A37B782723F3F91BCEE5CC7DBD2E63" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0104936240</x>
+                      <y>1.2753171921</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.4634028998"/>
+                      </radius>
+                      <theta>
+                        <angle value="-2.218392"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="4FC7EAA1259E93580B5DE4A8C0A669B7" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="-135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5644972083"/>
+                      </radius>
+                      <theta>
+                        <angle value="-123.065529"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="Contour 001 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector guid="F9A0A267E7E056B8284F727BAA55E4AB">
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="EE53A8EBB73628E10C42E035EA03C143" type="bline_point" loop="true">
+              <entry>
+                <composite guid="95D8B9173E3140A206927832AB8971DB" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5379897844"/>
+                      </radius>
+                      <theta>
+                        <angle value="92.211281"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="30A37B782723F3F91BCEE5CC7DBD2E63" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0104936240</x>
+                      <y>1.2753171921</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.4634028998"/>
+                      </radius>
+                      <theta>
+                        <angle value="-2.218392"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="4FC7EAA1259E93580B5DE4A8C0A669B7" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="-135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5644972083"/>
+                      </radius>
+                      <theta>
+                        <angle value="-123.065529"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.2343750000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="true"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="Contour 001 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.659224</r>
+              <g>0.000023</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point" loop="true">
+              <entry>
+                <composite guid="956DE7C51271F416BE7A24B87FF0F607" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5379897844"/>
+                      </radius>
+                      <theta>
+                        <angle value="92.211281"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="301625AA0B63474DA326B946A9C4A9BF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0104936240</x>
+                      <y>1.2753171921</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.4634028998"/>
+                      </radius>
+                      <theta>
+                        <angle value="-2.218392"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="4F72B47309DE27ECB3B5B82214DFEE6B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="-135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5644972083"/>
+                      </radius>
+                      <theta>
+                        <angle value="-123.065529"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.1562500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="true"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="advanced_outline" active="true" exclude_from_rendering="false" version="0.3" desc="Dot Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>-0.5468750000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="0EEDADFC06A43B064826F9D58C91E230" type="bline_point" loop="true">
+              <entry>
+                <composite guid="F2C23B27A505E38EEC1408E320047846" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3198028845"/>
+                      </radius>
+                      <theta>
+                        <angle value="-180.339569"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="C8505A9527DA28A7729267C3ACF9D280" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3236101737"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.928058"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3236101737"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.928058"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.2500000000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="start_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="end_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="cusp_type">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="smoothness">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="homogeneous">
+            <bool value="true" static="true"/>
+          </param>
+          <param name="wplist">
+            <wplist type="width_point">
+              <entry>
+                <composite guid="D6847118BCC653A5CD5416D1BBB16E2C" type="width_point">
+                  <position>
+                    <real value="0.1000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A05C5D20BE3B078A87B80BA344E26E2B" type="width_point">
+                  <position>
+                    <real value="0.9000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+            </wplist>
+          </param>
+          <param name="dash_enabled">
+            <bool value="false"/>
+          </param>
+          <param name="dilist">
+            <dilist type="dash_item">
+              <entry>
+                <composite guid="699523667FE0ACDAFD692FBF81E5AB44" type="dash_item">
+                  <offset>
+                    <real value="0.1000000000"/>
+                  </offset>
+                  <length>
+                    <real value="0.1000000000"/>
+                  </length>
+                  <side_before>
+                    <integer value="4" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="4" static="true"/>
+                  </side_after>
+                </composite>
+              </entry>
+            </dilist>
+          </param>
+          <param name="dash_offset">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+        <layer type="advanced_outline" active="true" exclude_from_rendering="false" version="0.3" desc="Dot Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.659224</r>
+              <g>0.000023</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>-0.5468750000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="44E99522F4816B715187740E94E9677A" type="bline_point" loop="true">
+              <entry>
+                <composite guid="B8C603F95720B3F9F5B58538387CFD0C" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3198028845"/>
+                      </radius>
+                      <theta>
+                        <angle value="-180.339569"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="8254624BD5FF78D06B33EA18B48157CA" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3236101737"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.928058"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3236101737"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.928058"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.1562500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="start_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="end_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="cusp_type">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="smoothness">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="homogeneous">
+            <bool value="true" static="true"/>
+          </param>
+          <param name="wplist">
+            <wplist type="width_point">
+              <entry>
+                <composite guid="9C8049C64EE303D2D4F59B0AA3C9EB66" type="width_point">
+                  <position>
+                    <real value="0.1000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="EA5865FE4C1E57FD9E1986785C9AEB61" type="width_point">
+                  <position>
+                    <real value="0.9000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+            </wplist>
+          </param>
+          <param name="dash_enabled">
+            <bool value="false"/>
+          </param>
+          <param name="dilist">
+            <dilist type="dash_item">
+              <entry>
+                <composite guid="23911BB88DC5FCADE4C8A264999D2E0E" type="dash_item">
+                  <offset>
+                    <real value="0.1000000000"/>
+                  </offset>
+                  <length>
+                    <real value="0.1000000000"/>
+                  </length>
+                  <side_before>
+                    <integer value="4" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="4" static="true"/>
+                  </side_after>
+                </composite>
+              </entry>
+            </dilist>
+          </param>
+          <param name="dash_offset">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+        <layer type="advanced_outline" active="true" exclude_from_rendering="false" version="0.3" desc="Line Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>-0.0781250000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="CC5DF434764C390A94BF69395ADF0274" type="bline_point" loop="true">
+              <entry>
+                <composite guid="307262EFD5EDE182308D980FF64A9802" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.7031250000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3379121108"/>
+                      </radius>
+                      <theta>
+                        <angle value="-0.218008"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3379121108"/>
+                      </radius>
+                      <theta>
+                        <angle value="-0.218008"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="0AE0035D57322AABAE0BF72F7AB732C4" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3918030810"/>
+                      </radius>
+                      <theta>
+                        <angle value="179.945038"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.1327066136"/>
+                      </radius>
+                      <theta>
+                        <angle value="155.853287"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.2812500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="start_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="end_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="cusp_type">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="smoothness">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="homogeneous">
+            <bool value="true" static="true"/>
+          </param>
+          <param name="wplist">
+            <wplist type="width_point">
+              <entry>
+                <composite guid="143428D0CC2E51A911CD863D6DFF8E68" type="width_point">
+                  <position>
+                    <real value="0.1000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="62EC04E8CED305865B219B4F92AC8E6F" type="width_point">
+                  <position>
+                    <real value="0.9000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+            </wplist>
+          </param>
+          <param name="dash_enabled">
+            <bool value="false"/>
+          </param>
+          <param name="dilist">
+            <dilist type="dash_item">
+              <entry>
+                <composite guid="AB257AAE0F08AED621F0BF5357AB4B00" type="dash_item">
+                  <offset>
+                    <real value="0.1000000000"/>
+                  </offset>
+                  <length>
+                    <real value="0.1000000000"/>
+                  </length>
+                  <side_before>
+                    <integer value="4" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="4" static="true"/>
+                  </side_after>
+                </composite>
+              </entry>
+            </dilist>
+          </param>
+          <param name="dash_offset">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+        <layer type="advanced_outline" active="true" exclude_from_rendering="false" version="0.3" desc="Line Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.659224</r>
+              <g>0.000023</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>-0.0781250000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="C5154184772A84858267A2D8252FBF72" type="bline_point" loop="true">
+              <entry>
+                <composite guid="393AD75FD48B5C0D265553EE89BA2504" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.7031250000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3379121108"/>
+                      </radius>
+                      <theta>
+                        <angle value="-0.218008"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3379121108"/>
+                      </radius>
+                      <theta>
+                        <angle value="-0.218008"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="03A8B6ED56549724B8D33CCE05478FC2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3918030810"/>
+                      </radius>
+                      <theta>
+                        <angle value="179.945038"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.1327066136"/>
+                      </radius>
+                      <theta>
+                        <angle value="155.853287"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.1875000000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="start_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="end_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="cusp_type">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="smoothness">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="homogeneous">
+            <bool value="true" static="true"/>
+          </param>
+          <param name="wplist">
+            <wplist type="width_point">
+              <entry>
+                <composite guid="1D7C9D60CD48EC2607154DDC120F336E" type="width_point">
+                  <position>
+                    <real value="0.1000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6BA4B158CFB5B8094DF950AEED5C3369" type="width_point">
+                  <position>
+                    <real value="0.9000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+            </wplist>
+          </param>
+          <param name="dash_enabled">
+            <bool value="false"/>
+          </param>
+          <param name="dilist">
+            <dilist type="dash_item">
+              <entry>
+                <composite guid="A26DCF1E0E6E1359372874B2285BF606" type="dash_item">
+                  <offset>
+                    <real value="0.1000000000"/>
+                  </offset>
+                  <length>
+                    <real value="0.1000000000"/>
+                  </length>
+                  <side_before>
+                    <integer value="4" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="4" static="true"/>
+                  </side_after>
+                </composite>
+              </entry>
+            </dilist>
+          </param>
+          <param name="dash_offset">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+      </canvas>
+    </param>
+    <param name="time_dilation">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
+    </param>
+  </layer>
+</canvas>

--- a/synfig-studio/images/layer_stylize_bevel_deprecated_icon.sif
+++ b/synfig-studio/images/layer_stylize_bevel_deprecated_icon.sif
@@ -1,0 +1,2418 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<canvas version="1.0" width="128" height="128" xres="2834.645752" yres="2834.645752" gamma-r="2.200000" gamma-g="2.200000" gamma-b="2.200000" view-box="-1.000000 1.000000 1.000000 -1.000000" antialias="1" fps="30.000" begin-time="0f" end-time="0f" bgcolor="0.500000 0.500000 0.500000 1.000000">
+  <name>Synfig Studio: Layer: Bevel Icon</name>
+  <desc>Placed in the Public Domain in 2010 by Yu Chen (jcome)</desc>
+  <meta name="background_first_color" content="0.880000 0.880000 0.880000"/>
+  <meta name="background_rendering" content="0"/>
+  <meta name="background_second_color" content="0.650000 0.650000 0.650000"/>
+  <meta name="background_size" content="15.000000 15.000000"/>
+  <meta name="grid_color" content="0.623529 0.623529 0.623529"/>
+  <meta name="grid_show" content="0"/>
+  <meta name="grid_size" content="0.250000 0.250000"/>
+  <meta name="grid_snap" content="1"/>
+  <meta name="guide" content="-1.648061*-0.554099*0.000000 0.003770*-0.795141*1.570796 0.034747*0.001507*0.000000 "/>
+  <meta name="guide_color" content="0.435294 0.435294 1.000000"/>
+  <meta name="guide_show" content="1"/>
+  <meta name="guide_snap" content="0"/>
+  <meta name="jack_offset" content="0.000000"/>
+  <meta name="onion_skin" content="0"/>
+  <meta name="onion_skin_future" content="0"/>
+  <meta name="onion_skin_keyframes" content="1"/>
+  <meta name="onion_skin_past" content="1"/>
+  <meta name="status_ruler" content="1"/>
+  <defs>
+    <color id="outline">
+      <r>0.097626</r>
+      <g>0.016710</g>
+      <b>0.000000</b>
+      <a>1.000000</a>
+    </color>
+    <canvas id="Layer" xres="2952.755900" yres="2952.755900" bgcolor="0.500000 0.500000 0.500000 1.000000">
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="0.5000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.1000000015</x>
+            <y>-0.1000000015</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="0E9B2667D534FC5927B7997AA6B094CD">
+                <x>-0.8000000119</x>
+                <y>0.8000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="DFAF5E2C666C5D0C0499103406DBF9B7">
+                <x>-0.8000000119</x>
+                <y>-0.2000000030</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="1C65EB09609AC7A5E54183EF06D77C83">
+                <x>0.2000000030</x>
+                <y>-0.2000000030</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="91956C584F32860367BE765522964C0F">
+                <x>0.2000000030</x>
+                <y>0.8000000119</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+      <layer type="blur" active="true" exclude_from_rendering="false" version="0.3">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="1"/>
+        </param>
+        <param name="size">
+          <vector>
+            <x>0.0684381425</x>
+            <y>0.0684381425</y>
+          </vector>
+        </param>
+        <param name="type">
+          <integer value="1"/>
+        </param>
+      </layer>
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>0.000000</r>
+            <g>0.000000</g>
+            <b>0.000000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="09CBB6B3D7CD9F50E0701A0CF076EA28">
+                <x>-0.8000000119</x>
+                <y>0.8000000119</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="743E7EC495F292EE41FE6FB175478536">
+                <x>-0.8000000119</x>
+                <y>-0.2000000030</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="8DE8A66770495A4FD9B649DC543A50A7">
+                <x>0.2000000030</x>
+                <y>-0.2000000030</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="6C97043A597A035EC1E190A604155B1D">
+                <x>0.2000000030</x>
+                <y>0.8000000119</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+      <layer type="polygon" active="true" exclude_from_rendering="false" version="0.1">
+        <param name="z_depth">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="amount">
+          <real value="1.0000000000"/>
+        </param>
+        <param name="blend_method">
+          <integer value="0"/>
+        </param>
+        <param name="color">
+          <color>
+            <r>1.000000</r>
+            <g>0.900000</g>
+            <b>0.600000</b>
+            <a>1.000000</a>
+          </color>
+        </param>
+        <param name="origin">
+          <vector>
+            <x>0.0000000000</x>
+            <y>0.0000000000</y>
+          </vector>
+        </param>
+        <param name="invert">
+          <bool value="false"/>
+        </param>
+        <param name="antialias">
+          <bool value="true"/>
+        </param>
+        <param name="feather">
+          <real value="0.0000000000"/>
+        </param>
+        <param name="blurtype">
+          <integer value="1"/>
+        </param>
+        <param name="winding_style">
+          <integer value="0"/>
+        </param>
+        <param name="vector_list">
+          <dynamic_list type="vector">
+            <entry>
+              <vector guid="09414466E7929BFFBE2A65CB8A658F2A">
+                <x>-0.6999999881</x>
+                <y>0.6999999881</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="8502E6D14BCEA1D89539DD0BEBB3AE6A">
+                <x>-0.6999999881</x>
+                <y>-0.1000000015</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="586DCC94004A14F95FA082246B97F2C1">
+                <x>0.1000000015</x>
+                <y>-0.1000000015</y>
+              </vector>
+            </entry>
+            <entry>
+              <vector guid="13C526200C2440C13B65BE316EA5C458">
+                <x>0.1000000015</x>
+                <y>0.6999999881</y>
+              </vector>
+            </entry>
+          </dynamic_list>
+        </param>
+      </layer>
+    </canvas>
+  </defs>
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="shadow">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0"/>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.0260416660</x>
+            <y>0.0000000000</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
+    </param>
+    <param name="canvas">
+      <canvas width="24" height="24" xres="2952.755900" yres="2952.755900">
+        <layer type="solid_color" active="false" exclude_from_rendering="false" version="0.1">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>1.000000</g>
+              <b>1.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+        </layer>
+        <layer type="radial_gradient" active="true" exclude_from_rendering="false" version="0.2">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0"/>
+          </param>
+          <param name="gradient">
+            <gradient>
+              <color pos="0.000000">
+                <r>0.012686</r>
+                <g>0.000000</g>
+                <b>0.001167</b>
+                <a>0.700000</a>
+              </color>
+              <color pos="1.000000">
+                <r>1.000000</r>
+                <g>1.000000</g>
+                <b>1.000000</b>
+                <a>0.000000</a>
+              </color>
+            </gradient>
+          </param>
+          <param name="center">
+            <vector guid="3932F399D50014C71954B55ABEA98F38">
+              <x>0.0000000000</x>
+              <y>-0.8020833135</y>
+            </vector>
+          </param>
+          <param name="radius">
+            <real value="0.9816616975"/>
+          </param>
+          <param name="loop">
+            <bool value="false"/>
+          </param>
+          <param name="zigzag">
+            <bool value="false"/>
+          </param>
+        </layer>
+        <layer type="stretch" active="true" exclude_from_rendering="false" version="0.1">
+          <param name="amount">
+            <vector>
+              <x>0.8697916865</x>
+              <y>0.1302083284</y>
+            </vector>
+          </param>
+          <param name="center">
+            <vector guid="3932F399D50014C71954B55ABEA98F38">
+              <x>0.0000000000</x>
+              <y>-0.8020833135</y>
+            </vector>
+          </param>
+        </layer>
+      </canvas>
+    </param>
+    <param name="time_dilation">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
+    </param>
+  </layer>
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.2" desc="bevel">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0"/>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>-0.1510416716</x>
+            <y>-0.1197916642</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>1.0000000000</x>
+            <y>1.0000000000</y>
+          </vector>
+        </scale>
+      </composite>
+    </param>
+    <param name="canvas">
+      <canvas width="24" height="24">
+        <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="circle">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0"/>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="transformation">
+            <composite type="transformation">
+              <offset>
+                <vector>
+                  <x>0.1509433985</x>
+                  <y>0.1320754737</y>
+                </vector>
+              </offset>
+              <angle>
+                <angle value="0.000000"/>
+              </angle>
+              <skew_angle>
+                <angle value="0.000000"/>
+              </skew_angle>
+              <scale>
+                <vector>
+                  <x>1.0000000000</x>
+                  <y>1.0000000000</y>
+                </vector>
+              </scale>
+            </composite>
+          </param>
+          <param name="canvas">
+            <canvas>
+              <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle056">
+                <param name="z_depth">
+                  <real value="0.0000000000"/>
+                </param>
+                <param name="amount">
+                  <real value="1.0000000000"/>
+                </param>
+                <param name="blend_method">
+                  <integer value="0"/>
+                </param>
+                <param name="color">
+                  <color>
+                    <r>0.280124</r>
+                    <g>0.098689</g>
+                    <b>0.000023</b>
+                    <a>1.000000</a>
+                  </color>
+                </param>
+                <param name="radius">
+                  <real value="0.9333333447"/>
+                </param>
+                <param name="feather">
+                  <real value="0.0000000000"/>
+                </param>
+                <param name="origin">
+                  <vector guid="7712464BF57FCE67F6855520D6270952">
+                    <x>0.0000000000</x>
+                    <y>0.0351379104</y>
+                  </vector>
+                </param>
+                <param name="invert">
+                  <bool value="false"/>
+                </param>
+              </layer>
+              <layer type="circle" active="false" exclude_from_rendering="false" version="0.2" desc="Circle056">
+                <param name="z_depth">
+                  <real value="0.0000000000"/>
+                </param>
+                <param name="amount">
+                  <real value="1.0000000000"/>
+                </param>
+                <param name="blend_method">
+                  <integer value="0"/>
+                </param>
+                <param name="color">
+                  <color>
+                    <r>1.000000</r>
+                    <g>1.000000</g>
+                    <b>1.000000</b>
+                    <a>1.000000</a>
+                  </color>
+                </param>
+                <param name="radius">
+                  <real value="0.8500000089"/>
+                </param>
+                <param name="feather">
+                  <real value="0.0000000000"/>
+                </param>
+                <param name="origin">
+                  <vector guid="7712464BF57FCE67F6855520D6270952">
+                    <x>0.0000000000</x>
+                    <y>0.0351379104</y>
+                  </vector>
+                </param>
+                <param name="invert">
+                  <bool value="false"/>
+                </param>
+              </layer>
+              <layer type="group" active="true" exclude_from_rendering="false" version="0.3">
+                <param name="z_depth">
+                  <real value="0.0000000000"/>
+                </param>
+                <param name="amount">
+                  <real value="1.0000000000"/>
+                </param>
+                <param name="blend_method">
+                  <integer value="0"/>
+                </param>
+                <param name="origin">
+                  <vector>
+                    <x>0.0000000000</x>
+                    <y>0.0000000000</y>
+                  </vector>
+                </param>
+                <param name="transformation">
+                  <composite type="transformation">
+                    <offset>
+                      <vector>
+                        <x>0.0000000000</x>
+                        <y>0.0000000000</y>
+                      </vector>
+                    </offset>
+                    <angle>
+                      <angle value="0.000000"/>
+                    </angle>
+                    <skew_angle>
+                      <angle value="0.000000"/>
+                    </skew_angle>
+                    <scale>
+                      <vector>
+                        <x>1.0000000000</x>
+                        <y>1.0000000000</y>
+                      </vector>
+                    </scale>
+                  </composite>
+                </param>
+                <param name="canvas">
+                  <canvas>
+                    <layer type="circle" active="true" exclude_from_rendering="false" version="0.2" desc="Circle056">
+                      <param name="z_depth">
+                        <real value="0.0000000000"/>
+                      </param>
+                      <param name="amount">
+                        <real value="1.0000000000"/>
+                      </param>
+                      <param name="blend_method">
+                        <integer value="0"/>
+                      </param>
+                      <param name="color">
+                        <color>
+                          <r>0.819964</r>
+                          <g>0.493616</g>
+                          <b>0.157281</b>
+                          <a>1.000000</a>
+                        </color>
+                      </param>
+                      <param name="radius">
+                        <real value="0.7291238847"/>
+                      </param>
+                      <param name="feather">
+                        <real value="0.0000000000"/>
+                      </param>
+                      <param name="origin">
+                        <vector guid="7712464BF57FCE67F6855520D6270952">
+                          <x>0.0000000000</x>
+                          <y>0.0351379104</y>
+                        </vector>
+                      </param>
+                      <param name="invert">
+                        <bool value="false"/>
+                      </param>
+                    </layer>
+                    <layer type="group" active="true" exclude_from_rendering="false" version="0.3">
+                      <param name="z_depth">
+                        <real value="0.0000000000"/>
+                      </param>
+                      <param name="amount">
+                        <real value="1.0000000000"/>
+                      </param>
+                      <param name="blend_method">
+                        <integer value="13"/>
+                      </param>
+                      <param name="origin">
+                        <vector>
+                          <x>0.0000000000</x>
+                          <y>0.0000000000</y>
+                        </vector>
+                      </param>
+                      <param name="transformation">
+                        <composite type="transformation">
+                          <offset>
+                            <vector>
+                              <x>0.0000000000</x>
+                              <y>0.0000000000</y>
+                            </vector>
+                          </offset>
+                          <angle>
+                            <angle value="0.000000"/>
+                          </angle>
+                          <skew_angle>
+                            <angle value="0.000000"/>
+                          </skew_angle>
+                          <scale>
+                            <vector>
+                              <x>1.0000000000</x>
+                              <y>1.0000000000</y>
+                            </vector>
+                          </scale>
+                        </composite>
+                      </param>
+                      <param name="canvas">
+                        <canvas xres="2952.755900" yres="2952.755900">
+                          <layer type="radial_gradient" active="true" exclude_from_rendering="false" version="0.2">
+                            <param name="z_depth">
+                              <real value="0.0000000000"/>
+                            </param>
+                            <param name="amount">
+                              <real value="1.0000000000"/>
+                            </param>
+                            <param name="blend_method">
+                              <integer value="0"/>
+                            </param>
+                            <param name="gradient">
+                              <gradient>
+                                <color pos="0.000000">
+                                  <r>0.280124</r>
+                                  <g>0.098689</g>
+                                  <b>0.000023</b>
+                                  <a>1.000000</a>
+                                </color>
+                                <color pos="1.000000">
+                                  <r>0.819964</r>
+                                  <g>0.493616</g>
+                                  <b>0.157281</b>
+                                  <a>1.000000</a>
+                                </color>
+                              </gradient>
+                            </param>
+                            <param name="center">
+                              <vector>
+                                <x>-1.0000000000</x>
+                                <y>1.0000000000</y>
+                              </vector>
+                            </param>
+                            <param name="radius">
+                              <real value="2.8284271247"/>
+                            </param>
+                            <param name="loop">
+                              <bool value="false"/>
+                            </param>
+                            <param name="zigzag">
+                              <bool value="false"/>
+                            </param>
+                          </layer>
+                        </canvas>
+                      </param>
+                      <param name="time_dilation">
+                        <real value="1.0000000000"/>
+                      </param>
+                      <param name="time_offset">
+                        <time value="0s"/>
+                      </param>
+                      <param name="children_lock">
+                        <bool value="false" static="true"/>
+                      </param>
+                      <param name="outline_grow">
+                        <real value="0.0000000000"/>
+                      </param>
+                      <param name="z_range">
+                        <bool value="false" static="true"/>
+                      </param>
+                      <param name="z_range_position">
+                        <real value="0.0000000000"/>
+                      </param>
+                      <param name="z_range_depth">
+                        <real value="0.0000000000"/>
+                      </param>
+                      <param name="z_range_blur">
+                        <real value="0.0000000000"/>
+                      </param>
+                    </layer>
+                  </canvas>
+                </param>
+                <param name="time_dilation">
+                  <real value="1.0000000000"/>
+                </param>
+                <param name="time_offset">
+                  <time value="0s"/>
+                </param>
+                <param name="children_lock">
+                  <bool value="false" static="true"/>
+                </param>
+                <param name="outline_grow">
+                  <real value="0.0000000000"/>
+                </param>
+                <param name="z_range">
+                  <bool value="false" static="true"/>
+                </param>
+                <param name="z_range_position">
+                  <real value="0.0000000000"/>
+                </param>
+                <param name="z_range_depth">
+                  <real value="0.0000000000"/>
+                </param>
+                <param name="z_range_blur">
+                  <real value="0.0000000000"/>
+                </param>
+              </layer>
+            </canvas>
+          </param>
+          <param name="time_dilation">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="time_offset">
+            <time value="0s"/>
+          </param>
+          <param name="children_lock">
+            <bool value="false" static="true"/>
+          </param>
+          <param name="outline_grow">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="z_range">
+            <bool value="false" static="true"/>
+          </param>
+          <param name="z_range_position">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="z_range_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="z_range_blur">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+        <layer type="bevel" active="true" exclude_from_rendering="false" version="0.3">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="13"/>
+          </param>
+          <param name="type">
+            <integer value="1"/>
+          </param>
+          <param name="color1">
+            <color>
+              <r>0.926019</r>
+              <g>0.824315</g>
+              <b>0.672393</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="color2">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="angle">
+            <angle value="135.000000"/>
+          </param>
+          <param name="depth">
+            <real value="0.3333333431"/>
+          </param>
+          <param name="softness">
+            <real value="0.1250000036"/>
+          </param>
+          <param name="use_luma">
+            <bool value="false"/>
+          </param>
+          <param name="solid">
+            <bool value="false"/>
+          </param>
+          <param name="fake_origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+        </layer>
+      </canvas>
+    </param>
+    <param name="time_dilation">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
+    </param>
+  </layer>
+  <layer type="group" active="true" exclude_from_rendering="false" version="0.3" desc="caution">
+    <param name="z_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="amount">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="blend_method">
+      <integer value="0" static="true"/>
+    </param>
+    <param name="origin">
+      <vector>
+        <x>0.0000000000</x>
+        <y>0.0000000000</y>
+      </vector>
+    </param>
+    <param name="transformation">
+      <composite type="transformation">
+        <offset>
+          <vector>
+            <x>0.2657480240</x>
+            <y>-0.4685039222</y>
+          </vector>
+        </offset>
+        <angle>
+          <angle value="0.000000"/>
+        </angle>
+        <skew_angle>
+          <angle value="0.000000"/>
+        </skew_angle>
+        <scale>
+          <vector>
+            <x>0.4967888296</x>
+            <y>0.4967888296</y>
+          </vector>
+        </scale>
+      </composite>
+    </param>
+    <param name="canvas">
+      <canvas>
+        <layer type="region" active="true" exclude_from_rendering="false" version="0.1">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>1.000000</r>
+              <g>0.885758</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector guid="F9A0A267E7E056B8284F727BAA55E4AB">
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="EE53A8EBB73628E10C42E035EA03C143" type="bline_point" loop="true">
+              <entry>
+                <composite guid="30A37B782723F3F91BCEE5CC7DBD2E63" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0104936240</x>
+                      <y>1.2753171921</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.4634028998"/>
+                      </radius>
+                      <theta>
+                        <angle value="-2.218392"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="4FC7EAA1259E93580B5DE4A8C0A669B7" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="-135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5644972083"/>
+                      </radius>
+                      <theta>
+                        <angle value="-123.065529"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="95D8B9173E3140A206927832AB8971DB" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5379897844"/>
+                      </radius>
+                      <theta>
+                        <angle value="92.211281"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="Contour 001 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector guid="F9A0A267E7E056B8284F727BAA55E4AB">
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="EE53A8EBB73628E10C42E035EA03C143" type="bline_point" loop="true">
+              <entry>
+                <composite guid="30A37B782723F3F91BCEE5CC7DBD2E63" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0104936240</x>
+                      <y>1.2753171921</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.4634028998"/>
+                      </radius>
+                      <theta>
+                        <angle value="-2.218392"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="4FC7EAA1259E93580B5DE4A8C0A669B7" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="-135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5644972083"/>
+                      </radius>
+                      <theta>
+                        <angle value="-123.065529"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="95D8B9173E3140A206927832AB8971DB" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5379897844"/>
+                      </radius>
+                      <theta>
+                        <angle value="92.211281"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.2343750000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="true"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="outline" active="true" exclude_from_rendering="false" version="0.3" desc="Contour 001 Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.659224</r>
+              <g>0.000023</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>0.0000000000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline type="bline_point" loop="true">
+              <entry>
+                <composite guid="301625AA0B63474DA326B946A9C4A9BF" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0104936240</x>
+                      <y>1.2753171921</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.4634028998"/>
+                      </radius>
+                      <theta>
+                        <angle value="-2.218392"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="4F72B47309DE27ECB3B5B82214DFEE6B" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="-135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5644972083"/>
+                      </radius>
+                      <theta>
+                        <angle value="-123.065529"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="956DE7C51271F416BE7A24B87FF0F607" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>-1.2500000000</x>
+                      <y>-0.7812500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="135.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.5379897844"/>
+                      </radius>
+                      <theta>
+                        <angle value="92.211281"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.1562500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="sharp_cusps">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[0]">
+            <bool value="true"/>
+          </param>
+          <param name="round_tip[1]">
+            <bool value="true"/>
+          </param>
+          <param name="homogeneous_width">
+            <bool value="true"/>
+          </param>
+        </layer>
+        <layer type="advanced_outline" active="true" exclude_from_rendering="false" version="0.3" desc="Dot Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>-0.5468750000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="0EEDADFC06A43B064826F9D58C91E230" type="bline_point" loop="true">
+              <entry>
+                <composite guid="C8505A9527DA28A7729267C3ACF9D280" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3236101737"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.928058"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3236101737"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.928058"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="F2C23B27A505E38EEC1408E320047846" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3198028845"/>
+                      </radius>
+                      <theta>
+                        <angle value="-180.339569"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.2500000000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="start_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="end_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="cusp_type">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="smoothness">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="homogeneous">
+            <bool value="true" static="true"/>
+          </param>
+          <param name="wplist">
+            <wplist type="width_point">
+              <entry>
+                <composite guid="D6847118BCC653A5CD5416D1BBB16E2C" type="width_point">
+                  <position>
+                    <real value="0.1000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="A05C5D20BE3B078A87B80BA344E26E2B" type="width_point">
+                  <position>
+                    <real value="0.9000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+            </wplist>
+          </param>
+          <param name="dash_enabled">
+            <bool value="false"/>
+          </param>
+          <param name="dilist">
+            <dilist type="dash_item">
+              <entry>
+                <composite guid="699523667FE0ACDAFD692FBF81E5AB44" type="dash_item">
+                  <offset>
+                    <real value="0.1000000000"/>
+                  </offset>
+                  <length>
+                    <real value="0.1000000000"/>
+                  </length>
+                  <side_before>
+                    <integer value="4" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="4" static="true"/>
+                  </side_after>
+                </composite>
+              </entry>
+            </dilist>
+          </param>
+          <param name="dash_offset">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+        <layer type="advanced_outline" active="true" exclude_from_rendering="false" version="0.3" desc="Dot Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.659224</r>
+              <g>0.000023</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>-0.5468750000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="44E99522F4816B715187740E94E9677A" type="bline_point" loop="true">
+              <entry>
+                <composite guid="8254624BD5FF78D06B33EA18B48157CA" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3236101737"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.928058"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3236101737"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.928058"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="B8C603F95720B3F9F5B58538387CFD0C" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.1562500000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3198028845"/>
+                      </radius>
+                      <theta>
+                        <angle value="-180.339569"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.0000000000"/>
+                      </radius>
+                      <theta>
+                        <angle value="0.000000"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.1562500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="start_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="end_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="cusp_type">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="smoothness">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="homogeneous">
+            <bool value="true" static="true"/>
+          </param>
+          <param name="wplist">
+            <wplist type="width_point">
+              <entry>
+                <composite guid="9C8049C64EE303D2D4F59B0AA3C9EB66" type="width_point">
+                  <position>
+                    <real value="0.1000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="EA5865FE4C1E57FD9E1986785C9AEB61" type="width_point">
+                  <position>
+                    <real value="0.9000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+            </wplist>
+          </param>
+          <param name="dash_enabled">
+            <bool value="false"/>
+          </param>
+          <param name="dilist">
+            <dilist type="dash_item">
+              <entry>
+                <composite guid="23911BB88DC5FCADE4C8A264999D2E0E" type="dash_item">
+                  <offset>
+                    <real value="0.1000000000"/>
+                  </offset>
+                  <length>
+                    <real value="0.1000000000"/>
+                  </length>
+                  <side_before>
+                    <integer value="4" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="4" static="true"/>
+                  </side_after>
+                </composite>
+              </entry>
+            </dilist>
+          </param>
+          <param name="dash_offset">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+        <layer type="advanced_outline" active="true" exclude_from_rendering="false" version="0.3" desc="Line Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.000000</r>
+              <g>0.000000</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>-0.0781250000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="CC5DF434764C390A94BF69395ADF0274" type="bline_point" loop="true">
+              <entry>
+                <composite guid="0AE0035D57322AABAE0BF72F7AB732C4" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3918030810"/>
+                      </radius>
+                      <theta>
+                        <angle value="179.945038"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.1327066136"/>
+                      </radius>
+                      <theta>
+                        <angle value="155.853287"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="307262EFD5EDE182308D980FF64A9802" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.7031250000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3379121108"/>
+                      </radius>
+                      <theta>
+                        <angle value="-0.218008"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3379121108"/>
+                      </radius>
+                      <theta>
+                        <angle value="-0.218008"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.2812500000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="start_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="end_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="cusp_type">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="smoothness">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="homogeneous">
+            <bool value="true" static="true"/>
+          </param>
+          <param name="wplist">
+            <wplist type="width_point">
+              <entry>
+                <composite guid="143428D0CC2E51A911CD863D6DFF8E68" type="width_point">
+                  <position>
+                    <real value="0.1000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="62EC04E8CED305865B219B4F92AC8E6F" type="width_point">
+                  <position>
+                    <real value="0.9000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+            </wplist>
+          </param>
+          <param name="dash_enabled">
+            <bool value="false"/>
+          </param>
+          <param name="dilist">
+            <dilist type="dash_item">
+              <entry>
+                <composite guid="AB257AAE0F08AED621F0BF5357AB4B00" type="dash_item">
+                  <offset>
+                    <real value="0.1000000000"/>
+                  </offset>
+                  <length>
+                    <real value="0.1000000000"/>
+                  </length>
+                  <side_before>
+                    <integer value="4" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="4" static="true"/>
+                  </side_after>
+                </composite>
+              </entry>
+            </dilist>
+          </param>
+          <param name="dash_offset">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+        <layer type="advanced_outline" active="true" exclude_from_rendering="false" version="0.3" desc="Line Outline">
+          <param name="z_depth">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="amount">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="blend_method">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="color">
+            <color>
+              <r>0.659224</r>
+              <g>0.000023</g>
+              <b>0.000000</b>
+              <a>1.000000</a>
+            </color>
+          </param>
+          <param name="origin">
+            <vector>
+              <x>0.0000000000</x>
+              <y>-0.0781250000</y>
+            </vector>
+          </param>
+          <param name="invert">
+            <bool value="false"/>
+          </param>
+          <param name="antialias">
+            <bool value="true"/>
+          </param>
+          <param name="feather">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="blurtype">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="winding_style">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="bline">
+            <bline guid="C5154184772A84858267A2D8252FBF72" type="bline_point" loop="true">
+              <entry>
+                <composite guid="03A8B6ED56549724B8D33CCE05478FC2" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.0000000000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3918030810"/>
+                      </radius>
+                      <theta>
+                        <angle value="179.945038"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.1327066136"/>
+                      </radius>
+                      <theta>
+                        <angle value="155.853287"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="393AD75FD48B5C0D265553EE89BA2504" type="bline_point">
+                  <point>
+                    <vector>
+                      <x>0.0000000000</x>
+                      <y>0.7031250000</y>
+                    </vector>
+                  </point>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <origin>
+                    <real value="0.5000000000"/>
+                  </origin>
+                  <split>
+                    <bool value="false"/>
+                  </split>
+                  <t1>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3379121108"/>
+                      </radius>
+                      <theta>
+                        <angle value="-0.218008"/>
+                      </theta>
+                    </radial_composite>
+                  </t1>
+                  <t2>
+                    <radial_composite type="vector">
+                      <radius>
+                        <real value="0.3379121108"/>
+                      </radius>
+                      <theta>
+                        <angle value="-0.218008"/>
+                      </theta>
+                    </radial_composite>
+                  </t2>
+                  <split_radius>
+                    <bool value="false"/>
+                  </split_radius>
+                  <split_angle>
+                    <bool value="false"/>
+                  </split_angle>
+                </composite>
+              </entry>
+            </bline>
+          </param>
+          <param name="width">
+            <real value="0.1875000000"/>
+          </param>
+          <param name="expand">
+            <real value="0.0000000000"/>
+          </param>
+          <param name="start_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="end_tip">
+            <integer value="1" static="true"/>
+          </param>
+          <param name="cusp_type">
+            <integer value="0" static="true"/>
+          </param>
+          <param name="smoothness">
+            <real value="1.0000000000"/>
+          </param>
+          <param name="homogeneous">
+            <bool value="true" static="true"/>
+          </param>
+          <param name="wplist">
+            <wplist type="width_point">
+              <entry>
+                <composite guid="1D7C9D60CD48EC2607154DDC120F336E" type="width_point">
+                  <position>
+                    <real value="0.1000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+              <entry>
+                <composite guid="6BA4B158CFB5B8094DF950AEED5C3369" type="width_point">
+                  <position>
+                    <real value="0.9000000000"/>
+                  </position>
+                  <width>
+                    <real value="1.0000000000"/>
+                  </width>
+                  <side_before>
+                    <integer value="0" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="0" static="true"/>
+                  </side_after>
+                  <lower_bound>
+                    <real value="0.0000000000" static="true"/>
+                  </lower_bound>
+                  <upper_bound>
+                    <real value="1.0000000000" static="true"/>
+                  </upper_bound>
+                </composite>
+              </entry>
+            </wplist>
+          </param>
+          <param name="dash_enabled">
+            <bool value="false"/>
+          </param>
+          <param name="dilist">
+            <dilist type="dash_item">
+              <entry>
+                <composite guid="A26DCF1E0E6E1359372874B2285BF606" type="dash_item">
+                  <offset>
+                    <real value="0.1000000000"/>
+                  </offset>
+                  <length>
+                    <real value="0.1000000000"/>
+                  </length>
+                  <side_before>
+                    <integer value="4" static="true"/>
+                  </side_before>
+                  <side_after>
+                    <integer value="4" static="true"/>
+                  </side_after>
+                </composite>
+              </entry>
+            </dilist>
+          </param>
+          <param name="dash_offset">
+            <real value="0.0000000000"/>
+          </param>
+        </layer>
+      </canvas>
+    </param>
+    <param name="time_dilation">
+      <real value="1.0000000000"/>
+    </param>
+    <param name="time_offset">
+      <time value="0s"/>
+    </param>
+    <param name="children_lock">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="outline_grow">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range">
+      <bool value="false" static="true"/>
+    </param>
+    <param name="z_range_position">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_depth">
+      <real value="0.0000000000"/>
+    </param>
+    <param name="z_range_blur">
+      <real value="0.0000000000"/>
+    </param>
+  </layer>
+</canvas>

--- a/synfig-studio/po/POTFILES.in
+++ b/synfig-studio/po/POTFILES.in
@@ -416,6 +416,8 @@ src/synfigapp/actions/layerresetpose.cpp
 src/synfigapp/actions/layersetdesc.cpp
 src/synfigapp/actions/layersetdesc.h
 src/synfigapp/actions/layersetexcludefromrendering.cpp
+src/synfigapp/actions/layerupgrade.cpp
+src/synfigapp/actions/layerupgrade.h
 src/synfigapp/actions/layerzdepthrangeset.cpp
 src/synfigapp/actions/timepointscopy.cpp
 src/synfigapp/actions/timepointscopy.h

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -286,6 +286,7 @@ static const std::map<std::string, std::string> layer_icon_names = {
 	{"xor_pattern",  "layer_other_xorpattern_icon"},
 	// Stylize Layers
 	{"bevel",        "layer_stylize_bevel_icon"},
+	{"bevel_deprecated", "layer_stylize_bevel_deprecated_icon"},
 	{"shade",        "layer_stylize_shade_icon"},
 	// Transform Layers
 	{"rotate",       "layer_transform_rotate_icon"},

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -142,6 +142,7 @@ static const std::map<std::string, std::pair<const char*, const char*>> known_ic
 	{"encapsulate_switch", {"layer_other_switch_icon", N_("Group into Switch")}},
 	{"encapsulate_filter", {"layer_other_filtergroup_icon", N_("Group into Filter")}},
 	{"select_all_child_layers", {"select_all_child_layers_icon", N_("Select All Child Layers")}},
+	{"upgrade", {"action_layer_upgrade_icon", N_("Upgrade Layer")}},
 
 	{"clear_undo", {"clear_undo_icon", N_("Clear Undo Stack")}},
 	{"clear_redo", {"clear_redo_icon", N_("Clear Redo Stack")}},

--- a/synfig-studio/src/gui/iconcontroller.cpp
+++ b/synfig-studio/src/gui/iconcontroller.cpp
@@ -286,9 +286,9 @@ static const std::map<std::string, std::string> layer_icon_names = {
 	{"timeloop",     "layer_other_timeloop_icon"},
 	{"xor_pattern",  "layer_other_xorpattern_icon"},
 	// Stylize Layers
-	{"bevel",        "layer_stylize_bevel_icon"},
+	{"bevel",            "layer_stylize_bevel_icon"},
 	{"bevel_deprecated", "layer_stylize_bevel_deprecated_icon"},
-	{"shade",        "layer_stylize_shade_icon"},
+	{"shade",            "layer_stylize_shade_icon"},
 	// Transform Layers
 	{"rotate",       "layer_transform_rotate_icon"},
 	{"translate",    "layer_transform_translate_icon"},

--- a/synfig-studio/src/synfigapp/Makefile.am
+++ b/synfig-studio/src/synfigapp/Makefile.am
@@ -17,6 +17,7 @@ LAYER_ACTION_HH = \
 	actions/layerencapsulateswitch.h \
 	actions/layerextract.h \
 	actions/layerfit.h \
+	actions/layerupgrade.h \
 	actions/layerlower.h \
 	actions/layermove.h \
 	actions/layermakebline.h \
@@ -47,6 +48,7 @@ LAYER_ACTION_CC = \
 	actions/layerencapsulateswitch.cpp \
 	actions/layerextract.cpp \
 	actions/layerfit.cpp \
+	actions/layerupgrade.cpp \
 	actions/layerlower.cpp \
 	actions/layermove.cpp \
 	actions/layermakebline.cpp \

--- a/synfig-studio/src/synfigapp/action.cpp
+++ b/synfig-studio/src/synfigapp/action.cpp
@@ -48,6 +48,7 @@
 #include "actions/layeractivate.h"
 #include "actions/layercopy.h"
 #include "actions/layerfit.h"
+#include "actions/layerupgrade.h"
 #include "actions/layermakebline.h"
 #include "actions/layerparamset.h"
 #include "actions/layerparamsetstatic.h"
@@ -201,6 +202,7 @@ Action::Main::Main()
 	ADD_ACTION(Action::LayerMakeOutline);
 	ADD_ACTION(Action::LayerMakeAdvancedOutline);
 	ADD_ACTION(Action::LayerMakeRegion);
+	ADD_ACTION(Action::LayerUpgrade);
 	auto layer_iter = synfig::Layer::book().find("curve_gradient");
 	if (layer_iter != synfig::Layer::book().end())
 		ADD_ACTION(Action::LayerMakeCurveGradient)

--- a/synfig-studio/src/synfigapp/actions/CMakeLists.txt
+++ b/synfig-studio/src/synfigapp/actions/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(synfigapp
         "${CMAKE_CURRENT_LIST_DIR}/layerencapsulateswitch.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layerextract.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layerfit.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/layerupgrade.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layerlower.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layermove.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/layermakebline.cpp"

--- a/synfig-studio/src/synfigapp/actions/layerupgrade.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerupgrade.cpp
@@ -1,0 +1,248 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file layerupgrade.cpp
+**	\brief Upgrade a deprecated layer to its current replacement
+**
+**	\legal
+**	Copyright (C) 2026 Synfig Contributors
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === H E A D E R S ======================================================= */
+
+#ifdef USING_PCH
+#	include "pch.h"
+#else
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#include <algorithm>
+#include <utility>
+
+#include <synfig/general.h>
+
+#include "layerupgrade.h"
+
+#include <synfigapp/canvasinterface.h>
+#include <synfigapp/localization.h>
+
+#endif
+
+using namespace synfig;
+using namespace synfigapp;
+using namespace Action;
+
+/* === M A C R O S ========================================================= */
+
+ACTION_INIT(Action::LayerUpgrade);
+ACTION_SET_NAME(Action::LayerUpgrade,"LayerUpgrade");
+ACTION_SET_LOCAL_NAME(Action::LayerUpgrade,N_("Upgrade Layer"));
+ACTION_SET_TASK(Action::LayerUpgrade,"upgrade");
+ACTION_SET_CATEGORY(Action::LayerUpgrade,Action::CATEGORY_LAYER);
+ACTION_SET_PRIORITY(Action::LayerUpgrade,0);
+ACTION_SET_VERSION(Action::LayerUpgrade,"0.0");
+
+/* === G L O B A L S ======================================================= */
+
+/* === P R O C E D U R E S ================================================= */
+
+/* === M E T H O D S ======================================================= */
+
+// ponytail: the deprecated->current layer name map. Add a pair here to enable
+// its upgrade; no other code in this file needs to change. Linear scan of a
+// tiny list is fine while pairs stay few -- switch to std::map if it grows.
+synfig::String
+Action::LayerUpgrade::get_target_layer_name(const synfig::String &source_layer_name)
+{
+	static const std::pair<const char*, const char*> table[] = {
+		{ "bevel_deprecated", "bevel" }
+	};
+	for(const auto &entry : table)
+		if(source_layer_name == entry.first)
+			return synfig::String(entry.second);
+	return synfig::String();
+}
+
+Action::ParamVocab
+Action::LayerUpgrade::get_param_vocab()
+{
+	ParamVocab ret(Action::CanvasSpecific::get_param_vocab());
+
+	ret.push_back(ParamDesc("layer",Param::TYPE_LAYER)
+		.set_local_name(_("Layer"))
+		.set_desc(_("Deprecated layer to upgrade"))
+		.set_supports_multiple()
+	);
+
+	return ret;
+}
+
+bool
+Action::LayerUpgrade::is_candidate(const ParamList &x)
+{
+	if(!candidate_check(get_param_vocab(),x))
+		return false;
+
+	// Candidate only when EVERY selected layer has a known upgrade target.
+	std::pair<ParamList::const_iterator, ParamList::const_iterator> range(x.equal_range("layer"));
+	if(range.first==range.second)
+		return false;
+	for(ParamList::const_iterator it(range.first); it!=range.second; ++it)
+	{
+		if(it->second.get_type()!=Param::TYPE_LAYER)
+			return false;
+		const Layer::Handle layer(it->second.get_layer());
+		if(!layer || get_target_layer_name(layer->get_name()).empty())
+			return false;
+	}
+	return true;
+}
+
+bool
+Action::LayerUpgrade::set_param(const synfig::String& name, const Action::Param &param)
+{
+	if(name=="layer" && param.get_type()==Param::TYPE_LAYER)
+	{
+		layers.push_back(param.get_layer());
+		return true;
+	}
+
+	return Action::CanvasSpecific::set_param(name,param);
+}
+
+bool
+Action::LayerUpgrade::is_ready()const
+{
+	if(layers.empty())
+		return false;
+	return Action::CanvasSpecific::is_ready();
+}
+
+void
+Action::LayerUpgrade::prepare()
+{
+	if(!first_time())
+		return;
+
+	if(layers.empty())
+		throw Error(_("No layers to upgrade"));
+
+	// ponytail: process descending by depth so mutations at higher indices
+	// never shift the captured depth of lower layers (multi-select drift guard).
+	layers.sort([](const Layer::Handle &a, const Layer::Handle &b)
+		{ return a->get_depth() > b->get_depth(); });
+
+	for(const Layer::Handle &layer : layers)
+	{
+		const String target_name(get_target_layer_name(layer->get_name()));
+		if(target_name.empty())
+			continue; // shouldn't happen -- is_candidate already filtered
+		prepare_upgrade_layer(layer, target_name);
+	}
+}
+
+void
+Action::LayerUpgrade::prepare_upgrade_layer(const synfig::Layer::Handle &layer, const synfig::String &target_name)
+{
+	if(!layer)
+		return;
+
+	Canvas::Handle subcanvas(layer->get_canvas());
+
+	// Find the iterator for the layer
+	Canvas::iterator iter(find(subcanvas->begin(),subcanvas->end(),layer));
+
+	// If we couldn't find the layer in the canvas, then bail
+	if(*iter!=layer)
+		throw Error(_("This layer doesn't exist anymore."));
+
+	// If the subcanvas isn't the same as the canvas,
+	// then it had better be an inline canvas. If not, bail.
+	if(get_canvas()!=subcanvas && !subcanvas->is_inline())
+		throw Error(_("This layer doesn't belong to this canvas anymore"));
+
+	const int depth(layer->get_depth());
+
+	// create the replacement layer and carry over its state.
+	// Deprecated and current layers are expected to share an identical
+	// parameter vocabulary, so set_param_list transfers everything
+	// (amount, blend_method, z_depth, type, colors, angle, ...). name__/
+	// version__ are not part of the vocab, so the new layer keeps its own
+	// register identity.
+	Layer::Handle new_layer(Layer::create(target_name));
+	new_layer->set_canvas(subcanvas);
+	get_canvas_interface()->layer_set_defaults(new_layer);
+	new_layer->set_param_list(layer->get_param_list());
+
+	// description: keep only user-set values; an empty description falls back
+	// to the new layer's local name. Drop text that equals the old layer's
+	// default display name too, so the upgrade is invisible.
+	const String &desc(layer->get_description());
+	if(!desc.empty() && desc != layer->get_local_name())
+		new_layer->set_description(desc);
+
+	new_layer->set_active(layer->active());
+	new_layer->set_exclude_from_rendering(layer->get_exclude_from_rendering());
+
+	// group membership: group_ is synced into the canvas group_db_ when the
+	// layer is inserted (Canvas::insert), so setting it before LayerAdd is enough.
+	if(!layer->get_group().empty())
+		new_layer->add_to_group(layer->get_group());
+
+	// Reconnect animated (dynamic) parameters by SHARING the value nodes,
+	// not cloning them, so exported/animated links stay referenced.
+	for(const auto &dp : layer->dynamic_param_list())
+	{
+		Action::Handle action(Action::create("LayerParamConnect"));
+		action->set_param("canvas",subcanvas);
+		action->set_param("canvas_interface",get_canvas_interface());
+		action->set_param("layer",new_layer);
+		action->set_param("param",dp.first);
+		action->set_param("value_node",ValueNode::Handle(dp.second));
+		add_action(action);
+	}
+
+	// add the new layer
+	{
+		Action::Handle action(Action::create("LayerAdd"));
+		action->set_param("canvas",subcanvas);
+		action->set_param("canvas_interface",get_canvas_interface());
+		action->set_param("new",new_layer);
+		add_action(action);
+	}
+
+	// move it into the old layer's position
+	{
+		Action::Handle action(Action::create("LayerMove"));
+		action->set_param("canvas",subcanvas);
+		action->set_param("canvas_interface",get_canvas_interface());
+		action->set_param("layer",new_layer);
+		action->set_param("new_index",depth);
+		add_action(action);
+	}
+
+	// finally, remove the deprecated layer
+	{
+		Action::Handle action(Action::create("LayerRemove"));
+		action->set_param("canvas",subcanvas);
+		action->set_param("canvas_interface",get_canvas_interface());
+		action->set_param("layer",layer);
+		add_action(action);
+	}
+}

--- a/synfig-studio/src/synfigapp/actions/layerupgrade.cpp
+++ b/synfig-studio/src/synfigapp/actions/layerupgrade.cpp
@@ -68,12 +68,12 @@ ACTION_SET_VERSION(Action::LayerUpgrade,"0.0");
 // its upgrade; no other code in this file needs to change. Linear scan of a
 // tiny list is fine while pairs stay few -- switch to std::map if it grows.
 synfig::String
-Action::LayerUpgrade::get_target_layer_name(const synfig::String &source_layer_name)
+Action::LayerUpgrade::get_target_layer_name(const synfig::String& source_layer_name)
 {
 	static const std::pair<const char*, const char*> table[] = {
 		{ "bevel_deprecated", "bevel" }
 	};
-	for(const auto &entry : table)
+	for(const auto& entry : table)
 		if(source_layer_name == entry.first)
 			return synfig::String(entry.second);
 	return synfig::String();
@@ -94,7 +94,7 @@ Action::LayerUpgrade::get_param_vocab()
 }
 
 bool
-Action::LayerUpgrade::is_candidate(const ParamList &x)
+Action::LayerUpgrade::is_candidate(const ParamList& x)
 {
 	if(!candidate_check(get_param_vocab(),x))
 		return false;
@@ -115,7 +115,7 @@ Action::LayerUpgrade::is_candidate(const ParamList &x)
 }
 
 bool
-Action::LayerUpgrade::set_param(const synfig::String& name, const Action::Param &param)
+Action::LayerUpgrade::set_param(const synfig::String& name, const Action::Param& param)
 {
 	if(name=="layer" && param.get_type()==Param::TYPE_LAYER)
 	{
@@ -145,10 +145,10 @@ Action::LayerUpgrade::prepare()
 
 	// ponytail: process descending by depth so mutations at higher indices
 	// never shift the captured depth of lower layers (multi-select drift guard).
-	layers.sort([](const Layer::Handle &a, const Layer::Handle &b)
+	layers.sort([](const Layer::Handle& a, const Layer::Handle& b)
 		{ return a->get_depth() > b->get_depth(); });
 
-	for(const Layer::Handle &layer : layers)
+	for(const Layer::Handle& layer : layers)
 	{
 		const String target_name(get_target_layer_name(layer->get_name()));
 		if(target_name.empty())
@@ -158,7 +158,7 @@ Action::LayerUpgrade::prepare()
 }
 
 void
-Action::LayerUpgrade::prepare_upgrade_layer(const synfig::Layer::Handle &layer, const synfig::String &target_name)
+Action::LayerUpgrade::prepare_upgrade_layer(const synfig::Layer::Handle& layer, const synfig::String& target_name)
 {
 	if(!layer)
 		return;
@@ -193,7 +193,7 @@ Action::LayerUpgrade::prepare_upgrade_layer(const synfig::Layer::Handle &layer, 
 	// description: keep only user-set values; an empty description falls back
 	// to the new layer's local name. Drop text that equals the old layer's
 	// default display name too, so the upgrade is invisible.
-	const String &desc(layer->get_description());
+	const String& desc(layer->get_description());
 	if(!desc.empty() && desc != layer->get_local_name())
 		new_layer->set_description(desc);
 
@@ -207,7 +207,7 @@ Action::LayerUpgrade::prepare_upgrade_layer(const synfig::Layer::Handle &layer, 
 
 	// Reconnect animated (dynamic) parameters by SHARING the value nodes,
 	// not cloning them, so exported/animated links stay referenced.
-	for(const auto &dp : layer->dynamic_param_list())
+	for(const auto& dp : layer->dynamic_param_list())
 	{
 		Action::Handle action(Action::create("LayerParamConnect"));
 		action->set_param("canvas",subcanvas);

--- a/synfig-studio/src/synfigapp/actions/layerupgrade.h
+++ b/synfig-studio/src/synfigapp/actions/layerupgrade.h
@@ -1,0 +1,80 @@
+/* === S Y N F I G ========================================================= */
+/*!	\file layerupgrade.h
+**	\brief Upgrade a deprecated layer to its current replacement
+**
+**	\legal
+**	Copyright (C) 2026 Synfig Contributors
+**
+**	This file is part of Synfig.
+**
+**	Synfig is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 2 of the License, or
+**	(at your option) any later version.
+**
+**	Synfig is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with Synfig.  If not, see <https://www.gnu.org/licenses/>.
+**	\endlegal
+*/
+/* ========================================================================= */
+
+/* === S T A R T =========================================================== */
+
+#ifndef __SYNFIG_APP_ACTION_LAYERUPGRADE_H
+#define __SYNFIG_APP_ACTION_LAYERUPGRADE_H
+
+/* === H E A D E R S ======================================================= */
+
+#include <list>
+#include <synfig/layer.h>
+#include <synfigapp/action.h>
+
+/* === M A C R O S ========================================================= */
+
+/* === T Y P E D E F S ===================================================== */
+
+/* === C L A S S E S & S T R U C T S ======================================= */
+
+namespace synfigapp {
+
+namespace Action {
+
+// Replaces a deprecated layer with its current equivalent, carrying over
+// parameters, animated (dynamic) links, description, z-depth, group and
+// active state. Driven by a deprecated->current name map, so adding a new
+// upgrade pair needs no code changes beyond the map (see get_target_layer_name).
+class LayerUpgrade :
+	public Super
+{
+private:
+	std::list<synfig::Layer::Handle> layers;
+
+	void prepare_upgrade_layer(const synfig::Layer::Handle &layer, const synfig::String &target_name);
+
+	// Returns the current layer name for a deprecated one, or empty if unknown.
+	static synfig::String get_target_layer_name(const synfig::String &source_layer_name);
+
+public:
+
+	static ParamVocab get_param_vocab();
+	static bool is_candidate(const ParamList &x);
+
+	virtual bool set_param(const synfig::String& name, const Param &);
+	virtual bool is_ready()const;
+
+	virtual void prepare();
+
+	ACTION_MODULE_EXT
+};
+
+}; // END of namespace Action
+}; // END of namespace synfigapp
+
+/* === E N D =============================================================== */
+
+#endif

--- a/synfig-studio/src/synfigapp/actions/layerupgrade.h
+++ b/synfig-studio/src/synfigapp/actions/layerupgrade.h
@@ -54,17 +54,17 @@ class LayerUpgrade :
 private:
 	std::list<synfig::Layer::Handle> layers;
 
-	void prepare_upgrade_layer(const synfig::Layer::Handle &layer, const synfig::String &target_name);
+	void prepare_upgrade_layer(const synfig::Layer::Handle& layer, const synfig::String& target_name);
 
 	// Returns the current layer name for a deprecated one, or empty if unknown.
-	static synfig::String get_target_layer_name(const synfig::String &source_layer_name);
+	static synfig::String get_target_layer_name(const synfig::String& source_layer_name);
 
 public:
 
 	static ParamVocab get_param_vocab();
-	static bool is_candidate(const ParamList &x);
+	static bool is_candidate(const ParamList& x);
 
-	virtual bool set_param(const synfig::String& name, const Param &);
+	virtual bool set_param(const synfig::String& name, const Param&);
 	virtual bool is_ready()const;
 
 	virtual void prepare();


### PR DESCRIPTION
Fixes https://github.com/synfig/synfig/issues/3769

The Bevel layer renders its highlight (Hi-Color) rotated ~30° CW compared to Synfig 1.0.2 — and has done so since ~v1.3.11 (bisect in #3769). This PR restores the original 1.0.2-era algorithm as Bevel v0.4, fixes two genuinely Cobra-era indexing defects, and keeps old project files rendering exactly as before.

### Part 1. Bevel algorithm fixes (bevel.cpp → v0.4)

**1. Highlight direction rotated ~30° CW (the main issue, #3769) — long-standing, not Cobra-era**
- Symptom: the highlight is rotated ~27–37° CW compared to Synfig 1.0.2, in old-renderer and Cobra builds alike.
- Mechanism: the 6-tap gradient estimate takes central differences along `d0` (angle `a`), `d1` (`a−45°`) and `d2` (perpendicular). As written, the two `d2` taps make the sampling fan asymmetric — {θ−135°, θ−45°, θ} instead of {θ−45°, θ, θ+45°} — skewing the estimated bevel axis by ~30°.
- Fix: swapped `+=`/`-=` on the two `d2` lines, restoring the symmetric fan. Verified by the render matrix above: v0.4 matches 1.0.2.
- Note: the `d2` lines are textually unchanged since 1.0.2, so the regression's exact origin between 1.3.10 and 1.3.11 is not in the layer itself (no semantic changes in that window in bevel.cpp, blur.cpp, or renddesc). The render matrix is the ground truth this fix is validated against. (Commit message "correct highlight direction after Cobra port" misattributes the origin — the port only preserved the pre-existing behavior.)

**2. Wrong indexing with `target_min`** (Cobra-era)
- Symptom: the bevel drifts or distorts in tiled rendering and for layers with shifted bounds.
- Cause: `TaskBevelSW::run` started its loop at `u = halfsizex + abs(offset_u) + target_min[0]` (same for `v`). But `blurred` is indexed from zero relative to the expanded work surface, while `target_min` is the absolute origin of the target rectangle. The correct start at `ix = target_min[0]` is exactly `halfsizex + abs(offset_u)` — without `target_min`. The bug is invisible when `target_rect.min == 0` (single full-canvas render), which is why it slipped through.
- Fix: removed `+ target_min[0]` / `+ target_min[1]` from the `u`/`v` initialization.

**3. Half-size mismatch for GAUSSIAN blur** (Cobra-era)
- Symptom: with `Blur::GAUSSIAN` the bevel was computed with wrong geometry.
- Cause: `set_coords_sub_tasks` sized the buffer with the `GAUSSIAN_ADJUSTMENT` formula, but `run()` indexed it with the generic `fabs(size*.5/pw)+3` formula. The half-size logic was duplicated in two places and drifted apart. (The default FASTGAUSSIAN type was unaffected — the formulas match there.)
- Fix: extracted one helper `bevel_calc_halfsize()` used both to size the buffer and to index it. No duplication left, so they cannot drift again.

### Part 2. Backward compatibility (loadcanvas.cpp + bevel_deprecated)

- The 1.3.x–1.5.5 rendering is what existing artwork actually looks like, so it is preserved as a new layer type `bevel_deprecated` (an unchanged copy of the v0.3 layer); Bevel itself is bumped to v0.4 with the 1.0.2-era algorithm.
- Migration on load: `CanvasParser::parse_layer` normalizes the layer type in one block (following the `filled_rectangle` → `rectangle` pattern). A bevel of version 0.2–0.3 on canvas ≥ 1.1 is loaded as `bevel_deprecated`, preserving its old render result; otherwise it loads as the new `bevel`. This implements the plan from #3769: canvas ≥ 1.1 ⟺ Synfig ≥ 1.3.12, i.e. the era with the rotated highlight.
- `bevel_deprecated` is hidden from the New Layer menu (`CATEGORY_DO_NOT_USE`, same as `svg_layer`) and from the CLI layer list, while remaining instantiable by name for loading and for the Upgrade action.
- A warning is shown, mentioning that the layer can be updated via "Upgrade Layer" in the layer context menu.

### Part 3. New "Upgrade Layer" action (synfig-studio)

- A generic context-menu action (task `upgrade`), driven by a data map deprecated → current (currently `bevel_deprecated` → `bevel`). Adding a new pair is one line in `get_target_layer_name()`.
- Behavior: appears in the layer context menus when **all** selected layers are in the map. Carries over parameters (`set_param_list` — the vocab is identical), description (user-set only; a default one falls back to the new layer's name), active state, `exclude_from_rendering`, group membership (`Canvas::insert` syncs `group_db_`), and animated parameters (ValueNodes are **shared**, not cloned, so exported/animated links stay referenced). Full undo/redo via the action super-class.
- Multi-select safety: layers are processed in descending depth order so index shifts never affect pending conversions.

### Part 4. Icons

- New `action_layer_upgrade_icon` (`.sif` asset) wired into `known_icon_list` (iconcontroller.cpp), so the `upgrade` task gets its stock icon; added to `images/CMakeLists.txt` and `Makefile.am` for the .sif → .png render.
- The `bevel_deprecated` layer reuses the old bevel icon with an exclamation mark added, to visually mark it as deprecated.


<img width="399" height="239" alt="image" src="https://github.com/user-attachments/assets/891cfa50-b2b4-4a4e-abf3-22551e648349" />
<img width="274" height="162" alt="image" src="https://github.com/user-attachments/assets/6f76f506-cd64-491a-b6be-024a0c33bba1" />
<img width="323" height="563" alt="image" src="https://github.com/user-attachments/assets/1e8724a4-1808-4b9e-b8a6-ceb7157af2f6" />
<img width="268" height="341" alt="image" src="https://github.com/user-attachments/assets/1fcdac27-f2d8-418c-89ee-87dbbd26a194" />
