### PR TITLE
Install metainfo file to correct location

### DIFF
--- a/synfig-studio/Makefile.am
+++ b/synfig-studio/Makefile.am
@@ -72,7 +72,7 @@ mimeinfodir              = $(datadir)/mime-info
 mimeinfo_DATA            = synfigstudio.keys synfigstudio.mime
 
 # Appdata
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 appdata_DATA = org.synfig.SynfigStudio.appdata.xml
 @INTLTOOL_XML_RULE@
 


### PR DESCRIPTION
Appdata files used to be installed to `/usr/share/appdata`. However, this location has been changed to `/usr/share/metainfo` in recent versions of the [AppStream specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location).