### PR TITLE
fix: wrong computation of total length of strokes (it could crash)

### DIFF
--- a/synfig-studio/src/synfigapp/wplistconverter.cpp
+++ b/synfig-studio/src/synfigapp/wplistconverter.cpp
@@ -104,7 +104,7 @@ WPListConverter::operator()(std::list<synfig::WidthPoint> &wp_out, const std::li
 	if (synfig::approximate_zero(distances[n-1])) {
 		norm_distances.push_back(0.);
 	} else {
-		int total_length = distances[n-1];
+		Real total_length = distances[n-1];
 		for(i=0;i<n;i++)
 			norm_distances.push_back(distances[i]/total_length);
 	}


### PR DESCRIPTION
short strokes with Advanced Outline would have a total_length of 0, leading to NaN positions and crash in `synfig::hom_to_std()` on debug build.

fix #3771