### PR TITLE
fix: avoid ambiguity when calling synfig::GUID::hasher

### DIFF
--- a/synfig-studio/src/gui/states/state_brush.cpp
+++ b/synfig-studio/src/gui/states/state_brush.cpp
@@ -1310,7 +1310,7 @@ StateBrush_Context::find_or_create_layer()
 		initial_surface->clear();
 		layer->rendering_surface = new rendering::SurfaceResource(
 			new rendering::SurfaceSW(*initial_surface, true));
-		layer->add_surface_modification_id(GUID::hasher("brush_created"));
+		layer->add_surface_modification_id(synfig::GUID::hasher("brush_created"));
 		// generate name based on description
 		String description, filename, filename_param;
 		get_canvas_interface()


### PR DESCRIPTION
When brush work landed in master it broke cmake build because calling GUID::hasher without specifying synfig namespace is considered an ambiguity. See this post for an error screenshot: https://github.com/synfig/synfig/pull/2756#issuecomment-5551155179